### PR TITLE
Bug fixes

### DIFF
--- a/synapseclient/retry.py
+++ b/synapseclient/retry.py
@@ -40,7 +40,7 @@ class RetryRequest(object):
                         a = a.__wrapped__
                     else:
                         a = None
-                print 'tag chain=',tags
+                print 'RetryRequest wrappers=',tags
 
             ## retry 'til we succeed or run out of tries
             while True:
@@ -86,9 +86,9 @@ class RetryRequest(object):
                 ## check if we got a retryable exception
                 if exc_info is not None:
                     ## might need fully qualified names? ex.__class__.__module__ + "." + ex.__class__.__name__
-                    if any([exc_info.__class__.__name__==retryable_exception for retryable_exception in self.retry_exceptions]):
+                    if exc_info[1].__class__.__name__ in self.retry_exceptions:
                         if self.verbose=='debug':
-                            print '[%s] exception=' % with_retry.tag, exc_info.__class__.__name__
+                            print '[%s] exception=' % with_retry.tag, exc_info[1].__class__.__name__
                         retry = True
 
                 ## wait then retry

--- a/tests/integration/test_chunked_upload.py
+++ b/tests/integration/test_chunked_upload.py
@@ -23,19 +23,24 @@ def test_round_trip():
     filepath = utils.make_bogus_binary_file(6*MB + 777771, verbose=True)
     print 'Made bogus file: ', filepath
     try:
-        fh = syn._chunkedUploadFile(filepath, verbose=True)
+        fh = syn._chunkedUploadFile(filepath, verbose=False)
 
-        print "=" * 60
-        print "FileHandle:"
+        print '=' * 60
+        print 'FileHandle:'
         syn.printEntity(fh)
 
+        print 'creating project and file'
         project = create_project()
         junk = File(filepath, parent=project, dataFileHandleId=fh['id'])
         junk.properties.update(syn._createEntity(junk.properties))
 
+        print 'downloading file'
         junk.update(syn._downloadFileEntity(junk))
 
+        print 'comparing files'
         assert filecmp.cmp(filepath, junk.path)
+
+        print 'ok!'
 
     finally:
         try:
@@ -57,14 +62,14 @@ def manually_check_retry_on_key_does_not_exist():
     ## We're testing the retrying of key-does-not-exist errors from S3.
 
     ## Expected behavior: Retries several times, getting a error message:
-    ## "The specified key does not exist.", then fails with a stack trace.
+    ## 'The specified key does not exist.', then fails with a stack trace.
     i = 1
     filepath = utils.make_bogus_binary_file(6*MB, verbose=True)
 
     try:
-        token = syn._createChunkedFileUploadToken(filepath, "application/octet-stream")
+        token = syn._createChunkedFileUploadToken(filepath, 'application/octet-stream')
         chunkRequest, url = syn._createChunkedFileUploadChunkURL(i, token)
-        ## never upload the chunk, so we will get an error "The specified key does not exist."
+        ## never upload the chunk, so we will get an error 'The specified key does not exist.'
         chunkResult = syn._addChunkToFile(chunkRequest, verbose=True)
     finally:
         os.remove(filepath)

--- a/tests/integration/test_command_line_client.py
+++ b/tests/integration/test_command_line_client.py
@@ -38,7 +38,7 @@ def run(command, **kwargs):
         raise
 
 def parse(regex, output):
-    m = re.match(regex, output)
+    m = re.search(regex, output)
     if m:
         if len(m.groups()) > 0:
             return m.group(1).strip()


### PR DESCRIPTION
handle governance access restrictions in syn.get
fixed bug in RetryRequest
fixed bug in syn.setPermissions()
added kwargs to the rest methods, although I didn't end up using it
made test_command_line_client more robust.
