### PR TITLE
Comment out all usage of syn._deleteFileHandle()

### DIFF
--- a/tests/integration/integration_test.py
+++ b/tests/integration/integration_test.py
@@ -404,7 +404,7 @@ def test_wikiAttachment():
     # assert filecmp.cmp(original_path, path)
 
     # Clean up
-    syn._deleteFileHandle(fileHandle)
+    # syn._deleteFileHandle(fileHandle)
     syn.delete(wiki)
     syn.delete(subwiki)
     assert_raises(SynapseHTTPError, syn.getWiki, project)

--- a/tests/integration/test_chunked_upload.py
+++ b/tests/integration/test_chunked_upload.py
@@ -43,9 +43,9 @@ def test_round_trip():
             os.remove(filepath)
         except Exception:
             print traceback.format_exc()
-        if fh:
-            # print 'Deleting fileHandle', fh['id']
-            syn._deleteFileHandle(fh)
+        # if fh:
+        #     # print 'Deleting fileHandle', fh['id']
+        #     syn._deleteFileHandle(fh)
 
 def manually_check_retry_on_key_does_not_exist():
     ## This is a manual test -- don't know how to automate this one.


### PR DESCRIPTION
Trash canning will break test usage of this method.
