### PR TITLE
Fix synapse cat printing extra line breaks

### DIFF
--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -169,9 +169,9 @@ def cat(args, syn):
         pass
     entity = syn.get(args.id)
     if 'files' in entity:
-        for file in entity['files']:
-            with open(os.path.join(entity['cacheDir'], file)) as input:
-                for line in input:
+        for filepath in entity['files']:
+            with open(os.path.join(entity['cacheDir'], filepath)) as inputfile:
+                for line in inputfile:
                     sys.stdout.write(line)
 
 

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -172,7 +172,7 @@ def cat(args, syn):
         for file in entity['files']:
             with open(os.path.join(entity['cacheDir'], file)) as input:
                 for line in input:
-                    print line
+                    sys.stdout.write(line)
 
 
 def ls(args, syn):


### PR DESCRIPTION
Updated 'synapse cat' to use sys.stdout to write instead of print, so extra line breaks are not added.

Also changed a couple of variable names ('file' to 'filepath', 'input' to 'inputfile') as 'file' and 'input' are reserved Python built-ins or names.