### PR TITLE
made list example consistent with others

### DIFF
--- a/synapseclient/activity.py
+++ b/synapseclient/activity.py
@@ -203,9 +203,9 @@ class Activity(dict):
 
         List example::
         
-            used( [ 'syn12345', 'syn23456', entity,
-                    {'reference':{'target':'syn100009', 'targetVersion':2}, 'wasExecuted':True},
-                    'http://mydomain.com/my/awesome/data.RData' ] )
+            activity.used(['syn12345', 'syn23456', entity,
+                          {'reference':{'target':'syn100009', 'targetVersion':2}, 'wasExecuted':True},
+                          'http://mydomain.com/my/awesome/data.RData'])
         """
 
         # -- A list of targets


### PR DESCRIPTION
Minor update to Activity docs to make the list example consistent with others: `activity.used(...)` instead of `used(...)`.