### PR TITLE
Changes so that username and password are prompted for if not provided.

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -264,7 +264,7 @@ class Synapse:
         self.portalEndpoint     = endpoints['portalEndpoint']
 
 
-    def login(self, email=None, password=None, apiKey=None, sessionToken=None, rememberMe=False, silent=False):
+    def login(self, email=None, password=None, apiKey=None, sessionToken=None, rememberMe=False, silent=False, forced=False):
         """
         Authenticates the user using the given credentials (in order of preference):
 
@@ -282,6 +282,7 @@ class Synapse:
         :param rememberMe: Whether the authentication information should be cached locally
                            for usage across sessions and clients.
         :param silent:     Defaults to False.  Suppresses the "Welcome ...!" message.
+        :param forced:     Defaults to False.  Bypass the credential cache if set. 
 
         Example::
 
@@ -323,7 +324,7 @@ class Synapse:
 
         # If supplied arguments are not enough
         # Try fetching the information from the API key cache
-        if self.apiKey is None:
+        if self.apiKey is None and not forced:
             cachedSessions = self._readSessionCache()
 
             if email is None and "<mostRecent>" in cachedSessions:
@@ -370,8 +371,8 @@ class Synapse:
                             raise SynapseAuthenticationError("No credentials provided.  Note: the session token within your configuration file has expired.")
 
         # Final check on login success
-        if self.username is not None and self.apiKey is None:
-            raise SynapseAuthenticationError("No credentials provided.")
+        if self.apiKey is None:
+            raise SynapseNoCredentialsError("No credentials provided.")
 
         # Save the API key in the cache
         if rememberMe:

--- a/synapseclient/exceptions.py
+++ b/synapseclient/exceptions.py
@@ -28,6 +28,9 @@ class SynapseTimeoutError(SynapseError):
 class SynapseAuthenticationError(SynapseError):
     """Unauthorized access."""
 
+class SynapseNoCredentialsError(SynapseAuthenticationError):
+    """No credentials for authentication"""
+
 class SynapseFileCacheError(SynapseError):
     """Error related to local file storage."""
 


### PR DESCRIPTION
How do you feel about receiving pull requests?  

This is a bit of a cosmetic change to make the "synapse" command handle authentication in a slightly more interactive way.  (Although I can imagine one could debate how it should work.)

I have an aversion to putting passwords in scripts, so I didn't want to use "syn.login("username", "secret")"

I then read I could cache credentials with the command line client via "synapse login -u username -p secret --remember-me" but I have an aversion to typing passwords as arguments (it means the password is visible in the output of "ps -o args")   In this case, the process is so short lived, it's not a real threat, but I prefer to be prompted for passwords with no echo.

I introduced changes so that if no credentials are cached, it prompts for username/password.  If the username is provided, it only prompts for the password.  

On a related note, the examples on the synapse site for the command line give the following for downloading a file:

    # Login
    synapse -u synapse_username -p synapse_password

    # Download file
    synapse get syn5007782

However, that gave me an error, saying not enough arguments.  I believe the example should be:

    # Login
    synapse -u synapse_username -p synapse_password login --remember-me

    # Download file
    synapse get syn5007782

or after my change, you can just do:
    synapse login --remember-me

(I also think --remember-me should always be true, because the "login" command doesn't really do anything if it's not caching credentials.  All other operations appear to automatically login before performing the operation.)
