### PR TITLE
Py3 4 dreamtools

### DIFF
--- a/synapseclient/__init__.py
+++ b/synapseclient/__init__.py
@@ -103,7 +103,7 @@ and also downloads the file to a local cache::
 
 View the entity's metadata in the Python console::
 
-    print entity
+    print(entity)
 
 This is one simple way to read in a small matrix::
 
@@ -231,7 +231,7 @@ Synapse supports a `SQL-like query language <https://sagebionetworks.jira.com/wi
     results = syn.query('SELECT id, name FROM entity WHERE parentId=="syn1899495"')
 
     for result in results['results']:
-        print result['entity.id'], result['entity.name']
+        print(result['entity.id'], result['entity.name'])
 
 Querying for my projects. Finding projects owned by the current user::
 
@@ -239,7 +239,7 @@ Querying for my projects. Finding projects owned by the current user::
     results = syn.query('SELECT id, name FROM project WHERE project.createdByPrincipalId==%s' % profile['ownerId'])
 
     for result in results['results']:
-        print result['project.id'], result['project.name']
+        print(result['project.id'], result['project.name'])
 
 See:
 
@@ -290,23 +290,28 @@ see `synapseclient.check_for_updates() <Versions.html#synapseclient.version_chec
 
 import json
 import pkg_resources
-__version__ = json.loads(pkg_resources.resource_string('synapseclient', 'synapsePythonClient'))['latestVersion']
+try:
+    # python 2.7
+    __version__ = json.loads(pkg_resources.resource_string('synapseclient', 'synapsePythonClient'))['latestVersion']
+except:
+    __version__ = pkg_resources.require("synapseclient")[0].version
+
 
 import requests
 USER_AGENT = {'User-Agent':'synapseclient/%s %s' % (__version__, requests.utils.default_user_agent())}
 import logging 
 logging.getLogger("requests").setLevel(logging.WARNING)
 
-from client import Synapse, login
-from activity import Activity
-from entity import Entity, Project, Folder, File
-from evaluation import Evaluation, Submission, SubmissionStatus
-from table import Schema, Column, RowSet, Row, as_table_columns, Table
-from team import Team, UserProfile, UserGroupHeader, TeamMember
-from wiki import Wiki
+from .client import Synapse, login
+from .activity import Activity
+from .entity import Entity, Project, Folder, File
+from .evaluation import Evaluation, Submission, SubmissionStatus
+from .table import Schema, Column, RowSet, Row, as_table_columns, Table
+from .team import Team, UserProfile, UserGroupHeader, TeamMember
+from .wiki import Wiki
 
-from version_check import check_for_updates
-from version_check import release_notes
+from .version_check import check_for_updates
+from .version_check import release_notes
 
-from client import PUBLIC, AUTHENTICATED_USERS
-from client import ROOT_ENTITY
+from .client import PUBLIC, AUTHENTICATED_USERS
+from .client import ROOT_ENTITY

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -70,6 +70,11 @@ import json
 import getpass
 from synapseclient.exceptions import *
 
+# python2/3 compat
+try:
+    basestring
+except NameError:
+    basestring = str
 
 def query(args, syn):
     try:
@@ -711,7 +716,12 @@ def login_with_prompt(syn, user, password, rememberMe=False, silent=False, force
     except SynapseNoCredentialsError:
         # if there were no credentials in the cache nor provided, prompt the user and try again
         if user is None:
-            user = raw_input("Synapse username: ")
+            try:
+                user = raw_input("Synapse username: ")
+            except:
+                # python3
+                user = input("Synapse username: ")
+
         passwd = getpass.getpass("Password for " + user + ": ")
         syn.login(user, passwd, rememberMe=rememberMe, forced=forced)
 

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -64,7 +64,7 @@ import shutil
 import sys
 import synapseclient
 from synapseclient import Activity
-import utils
+from . import utils
 import signal
 import json
 import getpass
@@ -121,7 +121,7 @@ def _recursiveGet(id, path, syn):
             except OSError as err:
                 if err.errno!=17:
                     raise
-            print 'making dir', new_path
+            print('making dir', new_path)
             _recursiveGet(result['entity.id'], new_path, syn)
         else:
             syn.get(result['entity.id'], downloadLocation=path)
@@ -143,15 +143,17 @@ def get(args, syn):
         if isinstance(args.id, basestring) and os.path.isfile(args.id):
             entity = syn.get(args.id, version=args.version, limitSearch=args.limitSearch, downloadFile=False)
             if "path" in entity and entity.path is not None and os.path.exists(entity.path):
-                print "Associated file: %s with synapse ID %s" % (entity.path, entity.id)
+                print("Associated file: %s with synapse ID %s" % (entity.path,
+                    entity.id))
         ## normal syn.get operation
         else:
             entity = syn.get(args.id, version=args.version, downloadLocation='.')
             if "path" in entity and entity.path is not None and os.path.exists(entity.path):
-                print "Downloaded file: %s" % os.path.basename(entity.path)
+                print("Downloaded file: %s" % os.path.basename(entity.path))
             else:
-                print 'WARNING: No files associated with entity %s\n' % entity.id
-                print entity
+                print('WARNING: No files associated with entity %s\n' %
+                      entity.id)
+                print(entity)
 
 
 def store(args, syn):
@@ -182,7 +184,7 @@ def store(args, syn):
     used = _convertProvenanceList(args.used, args.limitSearch, syn)
     executed = _convertProvenanceList(args.executed, args.limitSearch, syn)
     entity = syn.store(entity, used=used, executed=executed)
-    print 'Created/Updated entity: %s\t%s' %(entity['id'], entity['name'])
+    print('Created/Updated entity: %s\t%s' %(entity['id'], entity['name']))
 
     # After creating/updating, if there are annotations to add then
     # add them
@@ -197,7 +199,7 @@ def move(args, syn):
     ent = syn.get(args.id, downloadFile=False)
     ent.parentId= args.parentid
     ent = syn.store(ent, forceVersion=False)
-    print 'Moved %s to %s' %(ent.id, ent.parentId)
+    print('Moved %s to %s' %(ent.id, ent.parentId))
 
 
 def associate(args, syn):
@@ -213,9 +215,9 @@ def associate(args, syn):
         try:
             ent = syn.get(fp, limitSearch=args.limitSearch)
         except SynapseFileNotFoundError:
-            print 'WARNING: The file %s is not available in Synapse' %fp
+            print('WARNING: The file %s is not available in Synapse' %fp)
         else:
-            print '%s.%i\t%s' %(ent.id, ent.versionNumber, fp)
+            print('%s.%i\t%s' %(ent.id, ent.versionNumber, fp))
 
 
 def cat(args, syn):
@@ -249,18 +251,18 @@ def show(args, syn):
     sys.stdout.write('Provenance:\n')
     try:
         prov = syn.getProvenance(ent)
-        print prov
+        print(prov)
     except SynapseHTTPError:
-        print '  No Activity specified.\n'
+        print('  No Activity specified.\n')
 
 
 def delete(args, syn):
 	if args.version:
 	    syn.delete(args.id, args.version)	
-	    print 'Deleted entity %s, version %s' % (args.id, args.version)
+	    print('Deleted entity %s, version %s' % (args.id, args.version))
 	else:
 	    syn.delete(args.id)
-	    print 'Deleted entity: %s' % args.id
+	    print('Deleted entity: %s' % args.id)
 
 
 def create(args, syn):
@@ -269,7 +271,7 @@ def create(args, syn):
             'description':args.description,
             'concreteType': u'org.sagebionetworks.repo.model.%s' %args.type}
     entity=syn.createEntity(entity)
-    print 'Created entity: %s\t%s\n' %(entity['id'],entity['name'])
+    print('Created entity: %s\t%s\n' %(entity['id'],entity['name']))
 
 
 def onweb(args, syn):
@@ -308,14 +310,15 @@ def setProvenance(args, syn):
                 f.write(json.dumps(activity))
                 f.write('\n')
     else:
-        print 'Set provenance record %s on entity %s\n' % (str(activity['id']), str(args.id))
+        print('Set provenance record %s on entity %s\n' % (str(activity['id']),
+                str(args.id)))
 
 
 def getProvenance(args, syn):
     activity = syn.getProvenance(args.id, args.version)
 
     if args.output is None or args.output=='STDOUT':
-        print json.dumps(activity,sort_keys=True, indent=2)
+        print(json.dumps(activity,sort_keys=True, indent=2))
     else:
         with open(args.output, 'w') as f:
             f.write(json.dumps(activity))
@@ -355,7 +358,7 @@ def getAnnotations(args, syn):
     annotations = syn.getAnnotations(args.id)
 
     if args.output is None or args.output=='STDOUT':
-        print json.dumps(annotations,sort_keys=True, indent=2)
+        print(json.dumps(annotations,sort_keys=True, indent=2))
     else:
         with open(args.output, 'w') as f:
             f.write(json.dumps(annotations))

--- a/synapseclient/activity.py
+++ b/synapseclient/activity.py
@@ -72,9 +72,15 @@ Activity
 
 import collections
 
+try:
+      basestring
+except NameError:
+      basestring = str
+
 from synapseclient.utils import is_url, id_of
 from synapseclient.entity import is_synapse_entity
 from synapseclient.exceptions import *
+
 
 
 def is_used_entity(x):

--- a/synapseclient/cache.py
+++ b/synapseclient/cache.py
@@ -161,7 +161,7 @@ class Cache():
             if path is not None:
                 ## If we're given a path to a directory, look for a cached file in that directory
                 if os.path.isdir(path):
-                    for cached_file_path, cached_time in cache_map.iteritems():
+                    for cached_file_path, cached_time in cache_map.items():
                         if path == os.path.dirname(cached_file_path):
                             return cached_file_path if compare_timestamps(_get_modified_time(cached_file_path), cached_time) else None
 
@@ -264,7 +264,7 @@ class Cache():
             ## OK to purge directories in the cache that have no .cacheMap file
             if before_date > _get_modified_time(os.path.join(cache_dir, self.cache_map_file_name)):
                 if dry_run:
-                    print cache_dir
+                    print(cache_dir)
                 else:
                     shutil.rmtree(cache_dir)
                 count += 1

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1408,9 +1408,6 @@ class Synapse:
                 raise StopIteration
 
             # Build the sub-query
-            print(limit)
-            print(remaining)
-            print(offset)
             subqueryStr = "%s limit %d offset %d" % (queryStr, limit if limit < remaining else remaining, offset)
 
             try:

--- a/synapseclient/dict_object.py
+++ b/synapseclient/dict_object.py
@@ -9,7 +9,7 @@ class DictObject(dict):
 
     @classmethod
     def getByNameURI(cls, name):
-        print '%s can\'t be retrieved by name' %cls
+        print('%s can\'t be retrieved by name' %cls)
         raise ValueError
 
 

--- a/synapseclient/retry.py
+++ b/synapseclient/retry.py
@@ -48,7 +48,8 @@ def _with_retry(function, verbose=False, \
         if response is not None:
             if response.status_code in retry_status_codes:
                 if verbose:
-                    print "retrying on status code: " + str(response.status_code)
+                    print("retrying on status code: " +
+                            str(response.status_code))
                 retry = True
 
             elif response.status_code not in range(200,299):
@@ -58,24 +59,29 @@ def _with_retry(function, verbose=False, \
                         json = response.json()
                         ## special case for message throttling
                         if 'Please slow down.  You may send a maximum of 10 message' in json.get('reason', None):
-                            if verbose: print "retrying", json.get('reason', None)
+                            if verbose:
+                                print("retrying", json.get('reason', None))
                             retry = True
                             wait = 16
                         elif any([msg.lower() in json.get('reason', None).lower() for msg in retry_errors]):
-                            if verbose: print "retrying", json.get('reason', None)
+                            if verbose: 
+                                print("retrying", json.get('reason', None))
                             retry = True
                     except (AttributeError, ValueError) as ex:
                         pass
 
                 ## if the response is not JSON, look for retryable errors in its text content
-                elif any([msg.lower() in response.content.lower() for msg in retry_errors]):
-                    if verbose: print "retrying", response.content
+                elif any([msg.lower() in str(response.content).lower() for msg in retry_errors]):
+                    if verbose: 
+                        print("retrying", str(response.content))
                     retry = True
 
         # Check if we got a retry-able exception
         if exc_info is not None:
             if exc_info[1].__class__.__name__ in retry_exceptions or any([msg.lower() in str(exc_info[1]).lower() for msg in retry_errors]):
-                if verbose: print "retrying exception: ", exc_info[1].__class__.__name__, str(exc_info[1])
+                if verbose: 
+                    print("retrying exception: ",
+                            exc_info[1].__class__.__name__, str(exc_info[1]))
                 retry = True
 
         # Wait then retry
@@ -91,5 +97,10 @@ def _with_retry(function, verbose=False, \
         # Out of retries, re-raise the exception or return the response
         if exc_info:
             # Re-raise exception, preserving original stack trace
-            raise exc_info[0], exc_info[1], exc_info[2]
+            # not python3 compatible
+            # raise exc_info[0], exc_info[1], exc_info[2]
+            print("unexpected error:", sys.exc_info()[0])
+            print("traceback:", sys.exc_info()[2])
+            raise exc_info[1]
+
         return response

--- a/synapseclient/team.py
+++ b/synapseclient/team.py
@@ -1,4 +1,4 @@
-from dict_object import DictObject
+from .dict_object import DictObject
 
 class UserProfile(DictObject):
     def __init__(self, **kwargs):

--- a/synapseclient/utils.py
+++ b/synapseclient/utils.py
@@ -724,7 +724,7 @@ def humanizeBytes(bytes):
         if bytes<1024:
             return '%3.1f%s' %(bytes, units[i])
         else:
-            bytes /= 1024
+            bytes //= 1024
     return 'Oops larger than Exabytes'
 
 

--- a/synapseclient/utils.py
+++ b/synapseclient/utils.py
@@ -50,7 +50,27 @@ Testing
 
 import cgi
 import errno
-import math, os, sys, urllib, urlparse, hashlib, re
+import math, os, sys, urllib, hashlib, re
+
+try:
+    from urllib import urlencode
+except:
+    from urllib.parse import urlencode
+
+try:
+    import urlparse
+except:
+    # python3
+    from urllib import parse as urlparse
+
+
+# python2/3 compat
+try:
+    basestring
+except NameError:
+    basestring = str
+
+
 import random
 import requests
 import collections
@@ -237,11 +257,11 @@ def as_url(s):
     url_parts = urlparse.urlsplit(s)
     ## Windows drive letter?
     if len(url_parts.scheme)==1 and url_parts.scheme.isalpha():
-        return 'file:///%s' % unicode(s).replace("\\","/")
+        return 'file:///%s' % str(s).replace("\\","/")
     if url_parts.scheme:
         return url_parts.geturl()
     else:
-        return 'file://%s' % unicode(s)
+        return 'file://%s' % str(s)
 
 
 def guess_file_name(string):
@@ -249,7 +269,7 @@ def guess_file_name(string):
 
     path = urlparse.urlparse(string).path
     path = normalize_path(path)
-    tokens = filter(lambda x: x != '', path.split('/'))
+    tokens = list(filter(lambda x: x != '', path.split('/')))
     if len(tokens) > 0:
         return tokens[-1]
 
@@ -358,7 +378,7 @@ def make_bogus_data_file(n=100, seed=None):
         random.seed(seed)
     data = [random.gauss(mu=0.0, sigma=1.0) for i in range(n)]
 
-    f = tempfile.NamedTemporaryFile(suffix=".txt", delete=False)
+    f = tempfile.NamedTemporaryFile("wt", suffix=".txt", delete=False)
     try:
         f.write(", ".join((str(n) for n in data)))
         f.write("\n")
@@ -567,7 +587,7 @@ def _synapse_error_msg(ex):
     if isinstance(ex, basestring):
         return ex
 
-    return '\n' + ex.__class__.__name__ + ': ' + unicode(ex) + '\n\n'
+    return '\n' + ex.__class__.__name__ + ': ' + str(ex) + '\n\n'
 
 
 def _limit_and_offset(uri, limit=None, offset=None):
@@ -584,7 +604,7 @@ def _limit_and_offset(uri, limit=None, offset=None):
         query.pop('offset', None)
     else:
         query['offset'] = offset
-    new_query_string = urllib.urlencode(query, doseq=True)
+    new_query_string = urlencode(query, doseq=True)
     return urlparse.urlunparse(urlparse.ParseResult(
         scheme=parts.scheme,
         netloc=parts.netloc,
@@ -658,7 +678,7 @@ def timing(f):
         time1 = time.time()
         ret = f(*args)
         time2 = time.time()
-        print 'function %s took %0.3f ms' % (f.func_name, (time2-time1)*1000.0)
+        print('function %s took %0.3f ms' % (f.func_name, (time2-time1)*1000.0))
         return ret
     return wrap
 

--- a/synapseclient/version_check.py
+++ b/synapseclient/version_check.py
@@ -70,9 +70,9 @@ def version_check(current_version=None, version_url=_VERSION_URL, check_for_poin
                 sys.stderr.write(version_info['releaseNotes'] + '\n\n')
             return False
 
-    except Exception, e:
+    except Exception as err:
         # Don't prevent the client from running if something goes wrong
-        sys.stderr.write("Exception in version check: %s\n" % (str(e),))
+        sys.stderr.write("Exception in version check: %s\n" % (str(err),))
         return False
 
     return True
@@ -96,7 +96,7 @@ def check_for_updates():
     sys.stderr.write('latest development version: %s\n' % dev_version_info['latestVersion'])
 
     if _version_tuple(synapseclient.__version__, levels=3) < _version_tuple(release_version_info['latestVersion'], levels=3):
-        print ("\nUPGRADE AVAILABLE\n\nA more recent version of the Synapse Client (%s) is available. "
+        print("\nUPGRADE AVAILABLE\n\nA more recent version of the Synapse Client (%s) is available. "
                "Your version (%s) can be upgraded by typing:\n"
                "    pip install --upgrade synapseclient\n\n") % (release_version_info['latestVersion'], synapseclient.__version__,)
     else:
@@ -128,7 +128,7 @@ def _version_tuple(version, levels=2):
     Take a version number as a string delimited by periods and return a tuple
     with the desired number of levels. For example::
 
-        print version_tuple('0.5.1.dev1', levels=2)
+        print(version_tuple('0.5.1.dev1', levels=2))
         ('0', '5')
     """
     v = _strip_dev_suffix(version).split('.')
@@ -150,8 +150,8 @@ def _get_version_info(version_url=_VERSION_URL):
 # If this file is run as a script, print current version
 # then perform version check
 if __name__ == "__main__":
-    print "Version check"
-    print "============="
+    print("Version check")
+    print("=============")
     print("Python Synapse Client version %s" % synapseclient.__version__)
 
     print("Check against production version:")

--- a/synapseclient/wiki.py
+++ b/synapseclient/wiki.py
@@ -127,7 +127,7 @@ class Wiki(DictObject):
 
     def json(self):
         """Returns the JSON representation of the Wiki object."""
-        return json.dumps({k:v for k,v in self.iteritems()
+        return json.dumps({k:v for k,v in self.items()
                            if k in self.__PROPERTIES})
 
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -11,21 +11,26 @@ import os
 import sys
 import shutil 
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
 from synapseclient import Entity, Project, Folder, File, Evaluation
 import synapseclient
 import synapseclient.utils as utils
 
 
 def setup_module(module):
-    print "Python version:", sys.version
+    print("Python version:", sys.version)
 
     syn = synapseclient.Synapse(debug=True, skip_checks=True)
 
-    print "Testing against endpoints:"
-    print "  " + syn.repoEndpoint
-    print "  " + syn.authEndpoint
-    print "  " + syn.fileHandleEndpoint
-    print "  " + syn.portalEndpoint + "\n"
+    print("Testing against endpoints:")
+    print("  " + syn.repoEndpoint)
+    print("  " + syn.authEndpoint)
+    print("  " + syn.fileHandleEndpoint)
+    print("  " + syn.portalEndpoint + "\n")
 
     syn.login()
     module.syn = syn
@@ -56,7 +61,7 @@ def cleanup(items):
                 if hasattr(ex, 'response') and ex.response.status_code in [404, 403]:
                     pass
                 else:
-                    print "Error cleaning up entity: " + str(ex)
+                    print("Error cleaning up entity: " + str(ex))
         elif isinstance(item, basestring):
             if os.path.exists(item):
                 try:
@@ -65,6 +70,6 @@ def cleanup(items):
                     else: #Assum that remove will work on antyhing besides folders
                         os.remove(item)
                 except Exception as ex:
-                    print ex
+                    print(ex)
         else:
             sys.stderr.write('Don\'t know how to clean: %s' % str(item))

--- a/tests/integration/integration_test.py
+++ b/tests/integration/integration_test.py
@@ -1,6 +1,10 @@
 import tempfile, os, sys, filecmp, shutil, requests, json, time
 import uuid, random, base64
-import ConfigParser
+try:
+    import ConfigParser
+except:
+    import configparser as ConfigParser
+
 from datetime import datetime
 from nose.tools import assert_raises, assert_equals
 from nose.plugins.attrib import attr
@@ -22,10 +26,10 @@ from integration import schedule_for_cleanup
 
 
 def setup(module):
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
     module.syn = integration.syn
     module.project = integration.project
 
@@ -90,7 +94,7 @@ def test_login():
         syn.login(username, silent=True)
         syn.logout(forgetMe=True)
     except ConfigParser.Error:
-        print "To fully test the login method, please supply a username and password in the configuration file"
+        print("To fully test the login method, please supply a username and password in the configuration file")
 
     finally:
         # Login with config file
@@ -106,7 +110,7 @@ def testCustomConfigFile():
         syn2 = synapseclient.Synapse(configPath=configPath)
         syn2.login()
     else:
-        print "To fully test the login method a configuration file is required"
+        print("To fully test the login method a configuration file is required")
 
 
 def test_entity_version():
@@ -215,7 +219,7 @@ def test_uploadFileEntity():
     # Download and verify
     entity = syn.downloadEntity(entity)
 
-    print entity['files']
+    print(entity['files'])
     assert entity['files'][0] == os.path.basename(fname)
     assert filecmp.cmp(fname, entity['path'])
 
@@ -232,7 +236,7 @@ def test_uploadFileEntity():
 
     # Download and verify that it is the same file
     entity = syn.downloadEntity(entity)
-    print entity['files']
+    print(entity['files'])
     assert_equals(entity['files'][0], os.path.basename(fname))
     assert filecmp.cmp(fname, entity['path'])
 

--- a/tests/integration/integration_test_Entity.py
+++ b/tests/integration/integration_test_Entity.py
@@ -16,10 +16,10 @@ from integration import schedule_for_cleanup
 
 
 def setup(module):
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
     module.syn = integration.syn
     module.project = integration.project
 

--- a/tests/integration/test_caching.py
+++ b/tests/integration/test_caching.py
@@ -1,7 +1,16 @@
 import filecmp, os, sys, traceback, logging, requests, uuid
-import thread, time, random
+try:
+    import thread
+except:
+    import _thread as thread
+
+import time, random
 from threading import Lock
-from Queue import Queue
+
+try:
+    from Queue import Queue
+except:
+    from queue import Queue
 
 import synapseclient
 import synapseclient.utils as utils
@@ -14,10 +23,10 @@ import integration
 from integration import schedule_for_cleanup
 
 def setup(module):
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
     module.syn = integration.syn
     module.project = integration.project
     
@@ -50,7 +59,7 @@ def test_threaded_access():
     requests_originalLevel = requests_log.getEffectiveLevel()
     requests_log.setLevel(logging.WARNING)
     
-    print "Starting threads"
+    print("Starting threads")
     store_thread = wrap_function_as_child_thread(thread_keep_storing_one_File)
     get_thread = wrap_function_as_child_thread(thread_get_files_from_Project)
     update_thread = wrap_function_as_child_thread(thread_get_and_update_file_from_Project)
@@ -68,7 +77,7 @@ def test_threaded_access():
     # Give the threads some time to wreak havoc on the cache
     time.sleep(20)
     
-    print "Terminating threads"
+    print("Terminating threads")
     syn.test_keepRunning = False
     while syn.test_threadsRunning > 0:
         time.sleep(1)
@@ -189,3 +198,5 @@ def store_catch_412_HTTPError(entity):
         if err.response.status_code == 412:
             return None
         raise
+
+

--- a/tests/integration/test_chunked_upload.py
+++ b/tests/integration/test_chunked_upload.py
@@ -12,17 +12,17 @@ from integration import schedule_for_cleanup
 
 
 def setup(module):
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
     module.syn = integration.syn
     module.project = integration.project
 
 def test_round_trip():
     fh = None
     filepath = utils.make_bogus_binary_file(6*MB + 777771)
-    print 'Made bogus file: ', filepath
+    print('Made bogus file: ', filepath)
     try:
         fh = syn._chunkedUploadFile(filepath)
         # print 'FileHandle:'
@@ -39,11 +39,11 @@ def test_round_trip():
             if 'junk' in locals():
                 syn.delete(junk)
         except Exception:
-            print traceback.format_exc()
+            print(traceback.format_exc())
         try:
             os.remove(filepath)
         except Exception:
-            print traceback.format_exc()
+            print(traceback.format_exc())
         # if fh:
         #     # print 'Deleting fileHandle', fh['id']
         #     syn._deleteFileHandle(fh)
@@ -77,7 +77,7 @@ def test_upload_string():
     f.close()
     filepath=f.name
         
-    print 'Made bogus file: ', filepath
+    print('Made bogus file: ', filepath)
     try:
         fh = syn._uploadStringToFile(content)
         # print 'FileHandle:'
@@ -94,9 +94,9 @@ def test_upload_string():
             if 'junk' in locals():
                 syn.delete(junk)
         except Exception:
-            print traceback.format_exc()
+            print(traceback.format_exc())
         try:
             os.remove(filepath)
         except Exception:
-            print traceback.format_exc()
+            print(traceback.format_exc())
             

--- a/tests/integration/test_chunked_upload.py
+++ b/tests/integration/test_chunked_upload.py
@@ -72,7 +72,7 @@ def test_upload_string():
     
     fh = None
     content = "My dog has fleas.\n"
-    f = tempfile.NamedTemporaryFile(suffix=".txt", delete=False)
+    f = tempfile.NamedTemporaryFile('wt', suffix=".txt", delete=False)
     f.write(content)
     f.close()
     filepath=f.name

--- a/tests/integration/test_command_line_client.py
+++ b/tests/integration/test_command_line_client.py
@@ -4,7 +4,11 @@ import re
 import sys
 import uuid
 import json
-from cStringIO import StringIO
+
+try:
+    from cStringIO import StringIO
+except:
+    from io import StringIO
 from nose.plugins.attrib import attr
 from nose.tools import assert_raises, assert_equals
 import tempfile
@@ -20,10 +24,10 @@ from integration import schedule_for_cleanup
 
 
 def setup_module(module):
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
     module.syn = integration.syn
     module.parser = cmdline.build_parser()
 
@@ -35,7 +39,7 @@ def run(*command):
     :returns: The STDOUT output of the command.
     """
     
-    print ' '.join(command)
+    print(' '.join(command))
     old_stdout = sys.stdout
     capturedSTDOUT = StringIO()
     try:
@@ -49,7 +53,7 @@ def run(*command):
         sys.stdout = old_stdout
         
     capturedSTDOUT = capturedSTDOUT.getvalue()
-    print capturedSTDOUT
+    print(capturedSTDOUT)
     return capturedSTDOUT
     
 
@@ -547,7 +551,7 @@ def test_command_get_recursive_and_query():
     new_paths.append(os.path.join('.', os.path.basename(uploaded_paths[-1])))
     schedule_for_cleanup(folder_entity.name)
     for downloaded, uploaded in zip(new_paths, uploaded_paths):
-        print uploaded, downloaded
+        print(uploaded, downloaded)
         assert os.path.exists(downloaded)
         assert filecmp.cmp(downloaded, uploaded)
     schedule_for_cleanup(new_paths[0])
@@ -560,7 +564,7 @@ def test_command_get_recursive_and_query():
     #Verify that we downloaded files:
     new_paths = [os.path.join('.', os.path.basename(f)) for f in uploaded_paths[:-1]]
     for downloaded, uploaded in zip(new_paths, uploaded_paths[:-1]):
-        print uploaded, downloaded
+        print(uploaded, downloaded)
         assert os.path.exists(downloaded)
         assert filecmp.cmp(downloaded, uploaded)
         schedule_for_cleanup(downloaded)
@@ -590,7 +594,7 @@ def test_command_line_using_paths():
     output = run('synapse', '--skip-checks', 'get', 
                  '--limitSearch', folder_entity.id, 
                  filename)
-    print "output = \"", output, "\""
+    print("output = \"", output, "\"")
     id = parse(r'Associated file: .* with synapse ID (syn\d+)', output)
     name = parse(r'Associated file: (.*) with synapse ID syn\d+', output)
     assert_equals(file_entity.id, id)

--- a/tests/integration/test_command_line_client.py
+++ b/tests/integration/test_command_line_client.py
@@ -19,6 +19,12 @@ import synapseclient.utils as utils
 import synapseclient.__main__ as cmdline
 from synapseclient.evaluation import Evaluation
 
+
+try:
+    basestring
+except NameError:
+    basestring = str
+
 import integration
 from integration import schedule_for_cleanup
 

--- a/tests/integration/test_evaluations.py
+++ b/tests/integration/test_evaluations.py
@@ -50,7 +50,7 @@ def test_evaluations():
         
         # -- Get the Evaluation by project
         evalProj = syn.getEvaluationByContentSource(project)
-        evalProj = evalProj.next()
+        evalProj = next(evalProj)
         assert ev['contentSource'] == evalProj['contentSource']
         assert ev['createdOn'] == evalProj['createdOn']
         assert ev['description'] == evalProj['description']
@@ -135,7 +135,7 @@ def test_evaluations():
 
             # Make a file to submit
             fd, filename = tempfile.mkstemp()
-            os.write(fd, str(random.gauss(0,1)) + '\n')
+            os.write(fd, str(random.gauss(0,1)).encode('utf-8') + b'\n')
             os.close(fd)
             f = File(filename, parentId=other_project.id,
                      name='Submission 999',
@@ -168,7 +168,7 @@ def test_evaluations():
         print("Creating Submissions")
         for i in range(num_of_submissions):
             fd, filename = tempfile.mkstemp()
-            os.write(fd, str(random.gauss(0,1)) + '\n')
+            os.write(fd, str(random.gauss(0,1)).encode('utf-8') + b'\n')
             os.close(fd)
 
             f = File(filename, parentId=project.id, name='entry-%02d' % i,

--- a/tests/integration/test_evaluations.py
+++ b/tests/integration/test_evaluations.py
@@ -3,7 +3,10 @@ import uuid, random, base64
 from datetime import datetime
 from nose.tools import assert_raises
 
-import ConfigParser
+try:
+    import ConfigParser
+except:
+    import configparser as ConfigParser
 import synapseclient.client as client
 import synapseclient.utils as utils
 from synapseclient.exceptions import *
@@ -17,10 +20,10 @@ from integration import schedule_for_cleanup
 
 
 def setup(module):
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
     module.syn = integration.syn
     module.project = integration.project
 
@@ -105,7 +108,7 @@ def test_evaluations():
             other_user = {}
             other_user['username'] = config.get('test-authentication', 'username')
             other_user['password'] = config.get('test-authentication', 'password')
-            print "Testing SYNR-541"
+            print("Testing SYNR-541")
 
             # Login as the test user
             testSyn = client.Synapse(skip_checks=True)
@@ -154,14 +157,15 @@ def test_evaluations():
 
 
         except ConfigParser.Error:
-            print 'Skipping test for SYNR-541: No [test-authentication] in %s' % client.CONFIG_FILE
+            print('Skipping test for SYNR-541: No [test-authentication] in %s' %
+                    client.CONFIG_FILE)
 
         # Increase this to fully test paging by getEvaluationSubmissions
         # not to be less than 2
         num_of_submissions = 2
 
         # Create a bunch of Entities and submit them for scoring
-        print "Creating Submissions"
+        print("Creating Submissions")
         for i in range(num_of_submissions):
             fd, filename = tempfile.mkstemp()
             os.write(fd, str(random.gauss(0,1)) + '\n')
@@ -174,7 +178,7 @@ def test_evaluations():
 
         # Score the submissions
         submissions = syn.getSubmissions(ev, limit=num_of_submissions-1)
-        print "Scoring Submissions"
+        print("Scoring Submissions")
         for submission in submissions:
             assert re.match('Submission \d+', submission['name'])
             status = syn.getSubmissionStatus(submission)
@@ -188,7 +192,7 @@ def test_evaluations():
             syn.store(status)
 
         # Annotate the submissions
-        print "Annotating Submissions"
+        print("Annotating Submissions")
         bogosity = {}
         submissions = syn.getSubmissions(ev)
         b = 123
@@ -216,18 +220,18 @@ def test_evaluations():
         attempts = 2
         while attempts > 0:
             try:
-                print "Querying for submissions"
+                print("Querying for submissions")
                 results = syn.restGET("/evaluation/submission/query?query=SELECT+*+FROM+evaluation_%s" % ev.id)
-                print results
+                print(results)
                 assert results[u'totalNumberOfResults'] == num_of_submissions+1
 
                 results = syn.restGET("/evaluation/submission/query?query=SELECT+*+FROM+evaluation_%s where bogosity > 200" % ev.id)
-                print results
+                print(results)
                 assert results[u'totalNumberOfResults'] == num_of_submissions
             except AssertionError as ex1:
-                print "failed query: ", ex1
+                print("failed query: ", ex1)
                 attempts -= 1
-                if attempts > 0: print "retrying..."
+                if attempts > 0: print("retrying...")
                 time.sleep(2)
             else:
                 attempts = 0

--- a/tests/integration/test_permissions.py
+++ b/tests/integration/test_permissions.py
@@ -1,4 +1,7 @@
-import ConfigParser
+try:
+    import ConfigParser
+except:
+    import configparser as ConfigParser
 import json
 import mock
 import os
@@ -16,10 +19,10 @@ from integration import schedule_for_cleanup
 
 
 def setup(module):
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
     module.syn = integration.syn
     module.project = integration.project
 
@@ -32,7 +35,7 @@ def setup(module):
         other_user['password'] = config.get('test-authentication', 'password')
         other_user['principalId'] = config.get('test-authentication', 'principalId')
     except ConfigParser.Error:
-        print "[test-authentication] section missing from the configuration file"
+        print("[test-authentication] section missing from the configuration file")
 
     if 'principalId' not in other_user:
         # Fall back on the synapse-test user

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -8,10 +8,10 @@ from integration import schedule_for_cleanup
 
 
 def setup(module):
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
     module.syn = integration.syn
     module.project = integration.project
 

--- a/tests/integration/test_sftp_upload.py
+++ b/tests/integration/test_sftp_upload.py
@@ -2,7 +2,11 @@ import filecmp
 import os, sys, traceback
 import json
 import uuid 
-import urlparse
+try:
+    import urlparse
+except:
+    from urllib import parse as urlparse
+
 from nose.tools import assert_raises
 import tempfile
 import shutil
@@ -33,10 +37,10 @@ DESTINATIONS =  [{"uploadType": "SFTP",
 
 
 def setup(module):
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
     module.syn = integration.syn
     module.project = integration.project
     #Create the upload destinations
@@ -59,19 +63,19 @@ def test_synStore_sftpIntegration():
         try:
             os.remove(filepath)
         except Exception:
-            print traceback.format_exc()
+            print(traceback.format_exc())
 
 
 def test_synGet_sftpIntegration():
     #Create file by uploading directly to sftp and creating entity from URL
     serverURL='sftp://ec2-54-212-85-156.us-west-2.compute.amazonaws.com/public/'+str(uuid.uuid1())
     filepath = utils.make_bogus_binary_file(1*MB - 777771)
-    print '\n\tMade bogus file: ', filepath
+    print('\n\tMade bogus file: ', filepath)
     
     url = syn._sftpUploadFile(filepath, url=serverURL)
     file = syn.store(File(path=url, parent=project, synapseStore=False))
 
-    print '\nDownloading file', os.getcwd(), filepath
+    print('\nDownloading file', os.getcwd(), filepath)
     junk = syn.get(file, downloadLocation=os.getcwd(), downloadFile=True)
     filecmp.cmp(filepath, junk.path)
 
@@ -84,23 +88,23 @@ def test_utils_sftp_upload_and_download():
     tempdir = tempfile.mkdtemp()
 
     try:
-        print '\n\tMade bogus file: ', filepath
+        print('\n\tMade bogus file: ', filepath)
         url = syn._sftpUploadFile(filepath, url=serverURL)
-        print '\tStored URL:', url
-        print '\tDownloading',
+        print('\tStored URL:', url)
+        print('\tDownloading'),
         #Get with a specified localpath
         junk = syn._sftpDownloadFile(url, tempdir)
-        print '\tComparing:', junk, filepath
+        print('\tComparing:', junk, filepath)
         filecmp.cmp(filepath, junk)
         #Get without specifying path
-        print '\tDownloading',
+        print('\tDownloading'),
         junk2 = syn._sftpDownloadFile(url)
-        print '\tComparing:', junk2, filepath
+        print('\tComparing:', junk2, filepath)
         filecmp.cmp(filepath, junk2)
         #Get with a specified localpath as file
-        print '\tDownloading',
+        print('\tDownloading'),
         junk3 = syn._sftpDownloadFile(url, os.path.join(tempdir, 'bar.dat'))
-        print '\tComparing:', junk3, filepath
+        print('\tComparing:', junk3, filepath)
         filecmp.cmp(filepath, junk3)
     finally:
         try:
@@ -108,15 +112,15 @@ def test_utils_sftp_upload_and_download():
             if 'junk2' in locals(): os.remove(junk2)
             if 'junk3' in locals(): os.remove(junk3)
         except Exception:
-            print traceback.format_exc()
+            print(traceback.format_exc())
         try:
             os.remove(filepath)
         except Exception:
-            print traceback.format_exc()
+            print(traceback.format_exc())
         try:
             shutil.rmtree(tempdir)
         except Exception:
-            print traceback.format_exc()
+            print(traceback.format_exc())
 
 
 

--- a/tests/integration/test_tables.py
+++ b/tests/integration/test_tables.py
@@ -8,7 +8,6 @@ import sys
 import tempfile
 import time
 import uuid
-from itertools import izip
 from nose.tools import assert_raises
 from datetime import datetime
 from mock import patch
@@ -26,14 +25,14 @@ from integration import schedule_for_cleanup
 
 
 def setup(module):
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
     module.syn = integration.syn
     module.project = integration.project
 
-    print "Crank up timeout on async calls"
+    print("Crank up timeout on async calls")
     module.syn.table_query_timeout = 423
 
 
@@ -51,14 +50,14 @@ def test_rowset_tables():
 
     schema1 = syn.store(Schema(name='Foo Table', columns=cols, parent=project))
 
-    print "Table Schema:", schema1.id
+    print("Table Schema:", schema1.id)
 
     ## Get columns associated with the given table
     retrieved_cols = list(syn.getTableColumns(schema1))
 
     ## Test that the columns we get are the same as the ones we stored
     assert len(retrieved_cols) == len(cols)
-    for retrieved_col, col in izip(retrieved_cols, cols):
+    for retrieved_col, col in zip(retrieved_cols, cols):
         assert retrieved_col.name == col.name
         assert retrieved_col.columnType == col.columnType
 
@@ -87,7 +86,7 @@ def test_rowset_tables():
 
     ## test that the values made the round trip
     expected = sorted(data1 + data2)
-    for expected_values, row in izip(expected, results):
+    for expected_values, row in zip(expected, results):
         assert expected_values == row['values'], 'got %s but expected %s' % (row['values'], expected_values)
 
     ## To modify rows, we have to select then first.
@@ -122,7 +121,7 @@ def test_rowset_tables():
 
     ## put data in new column
     bdays = ('2013-3-15', '2008-1-3', '1973-12-8', '1969-4-28')
-    for bday, row in izip(bdays, rs.rows):
+    for bday, row in zip(bdays, rs.rows):
         row['values'][5] = bday
     row_reference_set = syn.store(rs)
 
@@ -139,14 +138,14 @@ def test_rowset_tables():
         sys.stderr.write('Pandas is apparently not installed, skipping part of test_rowset_tables.\n\n')
 
     results = syn.tableQuery('select birthday from %s where cartoon=false order by age' % schema1.id, resultsAs="rowset")
-    for bday, row in izip(bdays, results):
+    for bday, row in zip(bdays, results):
         assert row['values'][0] == datetime.strptime(bday, "%Y-%m-%d"), "got %s but expected %s" % (row['values'][0], bday)
 
     try:
         import pandas as pd
         results = syn.tableQuery("select foo, MAX(x), COUNT(foo), MIN(age) from %s group by foo order by foo" % schema1.id, resultsAs="rowset")
         df = results.asDataFrame()
-        print df
+        print(df)
         assert df.shape == (3,4)
         assert all(df.iloc[:,0] == ["bar", "bat", "foo"])
         assert all(df.iloc[:,1] == [88.888, 88.888, 88.888])
@@ -201,7 +200,7 @@ def test_tables_csv():
     results = syn.tableQuery("select * from %s" % table.schema.id, resultsAs="csv", includeRowIdAndRowVersion=False)
 
     ## Test that CSV file came back as expected
-    for expected_row, row in izip(data, results):
+    for expected_row, row in zip(data, results):
         assert expected_row == row, "expected %s but got %s" % (expected_row, row)
 
     try:
@@ -247,8 +246,8 @@ def test_tables_csv():
 
     ## test that CSV file now has more jazz guys
     results = syn.tableQuery("select * from %s" % table.schema.id, resultsAs="csv")
-    for expected_row, row in izip(data+more_jazz_guys, results):
-        for field, expected_field in izip(row[2:], expected_row):
+    for expected_row, row in zip(data+more_jazz_guys, results):
+        for field, expected_field in zip(row[2:], expected_row):
             if type(field) is float and math.isnan(field):
                 assert type(expected_field) is float and math.isnan(expected_field)
             elif type(expected_field) is float and math.isnan(expected_field):
@@ -275,7 +274,7 @@ def test_tables_csv():
         import pandas as pd
         results = syn.tableQuery("select * from %s where Born=1930" % table.schema.id, resultsAs="csv")
         df = results.asDataFrame()
-        print "\nUpdated hipness to 8.5", df
+        print("\nUpdated hipness to 8.5", df)
         all(df['Born'].values == 1930)
         all(df['Hipness'].values == 8.5)
 
@@ -367,7 +366,7 @@ def test_download_table_files():
     ## retrieve the files for each row and verify that they are identical to the originals
     results = syn.tableQuery('select artist, album, year, catalog, cover from %s'%schema.id, resultsAs="rowset")
     for i, row in enumerate(results):
-        print "%s_%s" % (row.rowId, row.versionNumber), row.values
+        print("%s_%s" % (row.rowId, row.versionNumber), row.values)
         file_info = syn.downloadTableFile(results, rowId=row.rowId, versionNumber=row.versionNumber, column='cover')
         assert filecmp.cmp(original_files[i], file_info['path'])
         schedule_for_cleanup(file_info['path'])
@@ -379,7 +378,7 @@ def test_download_table_files():
 
         results = syn.tableQuery("select artist, album, year, catalog, cover from %s where artist = 'John Coltrane'"%schema.id, resultsAs="rowset")
         for i, row in enumerate(results):
-            print "%s_%s" % (row.rowId, row.versionNumber), row.values
+            print("%s_%s" % (row.rowId, row.versionNumber), row.values)
             file_info = syn.downloadTableFile(results, rowId=row.rowId, versionNumber=row.versionNumber, column='cover')
             assert filecmp.cmp(original_files[i], file_info['path'])
 
@@ -407,8 +406,8 @@ def dontruntest_big_tables():
 
     table1 = syn.store(Schema(name='Big Table', columns=cols, parent=project))
 
-    print "Created table:", table1.id
-    print "with columns:", table1.columnIds
+    print("Created table:", table1.id)
+    print("with columns:", table1.columnIds)
 
     rows_per_append = 10
 
@@ -417,21 +416,21 @@ def dontruntest_big_tables():
         for j in range(rows_per_append):
             foo = cols[1].enumValues[random.randint(0,2)]
             rows.append(Row(('Robot ' + str(i*rows_per_append + j), foo, random.random()*200.0, random.randint(0,100), random.random()>=0.5)))
-        print "added %d rows" % rows_per_append
+        print("added %d rows" % rows_per_append)
         rowset1 = syn.store(RowSet(columns=cols, schema=table1, rows=rows))
 
     results = syn.tableQuery("select * from %s" % table1.id)
-    print "etag:", results.etag
-    print "tableId:", results.tableId
+    print("etag:", results.etag)
+    print("tableId:", results.tableId)
 
     for row in results:
-        print row
+        print(row)
 
     results = syn.tableQuery("select n, COUNT(n), MIN(x), AVG(x), MAX(x), SUM(x) from %s group by n" % table1.id)
     df = results.asDataFrame()
 
-    print df.shape
-    print df
+    print(df.shape)
+    print(df)
 
 
 def dontruntest_big_csvs():
@@ -444,8 +443,8 @@ def dontruntest_big_csvs():
 
     schema1 = syn.store(Schema(name='Big Table', columns=cols, parent=project))
 
-    print "Created table:", schema1.id
-    print "with columns:", schema1.columnIds
+    print("Created table:", schema1.id)
+    print("with columns:", schema1.columnIds)
 
     ## write rows to CSV file
     with tempfile.NamedTemporaryFile(delete=False) as temp:
@@ -457,16 +456,16 @@ def dontruntest_big_csvs():
             for j in range(100):
                 foo = cols[1].enumValues[random.randint(0,2)]
                 writer.writerow(('Robot ' + str(i*100 + j), foo, random.random()*200.0, random.randint(0,100), random.random()>=0.5))
-            print "wrote 100 rows to disk"
+            print("wrote 100 rows to disk")
 
     ## upload CSV
     UploadToTableResult = syn._uploadCsv(filepath=temp.name, schema=schema1)
 
     from synapseclient.table import CsvFileTable
     results = CsvFileTable.from_table_query(syn, "select * from %s" % schema1.id)
-    print "etag:", results.etag
-    print "tableId:", results.tableId
+    print("etag:", results.etag)
+    print("tableId:", results.tableId)
 
     for row in results:
-        print row
+        print(row)
 

--- a/tests/integration/test_wikis.py
+++ b/tests/integration/test_wikis.py
@@ -11,10 +11,10 @@ from integration import schedule_for_cleanup
 
 
 def setup(module):
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
     module.syn = integration.syn
     module.project = integration.project
 

--- a/tests/load/test_large_file_upload.py
+++ b/tests/load/test_large_file_upload.py
@@ -12,10 +12,10 @@ syn = None
 
 
 def setup(module):
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
     module.syn = synapseclient.Synapse()
     module.syn.login()
 
@@ -30,12 +30,12 @@ def test_large_file_upload(file_to_upload_size=11*utils.KB, filepath=None):
             ## keep a file around so we don't have to regenerate it.
             if not os.path.exists(filepath):
                 filepath = utils.make_bogus_binary_file(file_to_upload_size, filepath=filepath, printprogress=True)
-                print 'Made bogus file: ', filepath
+                print('Made bogus file: ', filepath)
         else:
             ## generate a temporary file and clean it up when we're done
             clean_up_file = True
             filepath = utils.make_bogus_binary_file(file_to_upload_size, printprogress=True)
-            print 'Made bogus file: ', filepath
+            print('Made bogus file: ', filepath)
 
         try:
             junk = syn.store(File(filepath, parent=project))
@@ -48,19 +48,19 @@ def test_large_file_upload(file_to_upload_size=11*utils.KB, filepath=None):
                 if 'junk' in locals():
                     syn.delete(junk)
             except Exception:
-                print traceback.format_exc()
+                print(traceback.format_exc())
     finally:
         try:
             if 'filepath' in locals() and clean_up_file:
                 os.remove(filepath)
         except Exception:
-            print traceback.format_exc()
+            print(traceback.format_exc())
 
 
 def main():
 
 
-    print "\n\n\ntesting large file upload...\n\n\n"
+    print("\n\n\ntesting large file upload...\n\n\n")
 
 
     global syn
@@ -94,7 +94,7 @@ def main():
     synapseclient.USER_AGENT['User-Agent'] = "test-large-file-upload " + synapseclient.USER_AGENT['User-Agent']
     syn = synapseclient.Synapse(debug=args.debug, skip_checks=args.skip_checks)
     if args.staging:
-        print "switching to STAGING endpoints"
+        print("switching to STAGING endpoints")
         syn.setEndpoints(**synapseclient.client.STAGING_ENDPOINTS)
     syn.login(args.user, args.password, silent=True)
 

--- a/tests/load/test_speed_upload.py
+++ b/tests/load/test_speed_upload.py
@@ -13,10 +13,10 @@ syn = None
 
 
 def setup(module):
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
     module.syn = synapseclient.Synapse()
     module.syn.login()
 
@@ -27,7 +27,7 @@ def test_upload_speed(uploadSize=60 + 777771, threadCount=5):
     import time
     fh = None
     filepath = utils.make_bogus_binary_file(uploadSize*MB)
-    print 'Made bogus file: ', filepath
+    print('Made bogus file: ', filepath)
     try:
         t0 = time.time()
         fh = syn._chunkedUploadFile(filepath, threadCount=threadCount)
@@ -36,7 +36,7 @@ def test_upload_speed(uploadSize=60 + 777771, threadCount=5):
         try:
             os.remove(filepath)
         except Exception:
-            print traceback.format_exc()
+            print(traceback.format_exc())
         if fh:
             syn._deleteFileHandle(fh)
     return dt
@@ -57,8 +57,8 @@ def main():
     for size in sizes:
         for thread in threads:
             results.ix[size,thread] = test_upload_speed(size, thread)
-            print results
-        print 
+            print(results)
+        print()
 
 
 if __name__ == "__main__":

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -7,7 +7,7 @@ import synapseclient
 
 
 def setup_module(module):
-    print "Python version:", sys.version
+    print("Python version:", sys.version)
 
     syn = synapseclient.Synapse(debug=False, skip_checks=True)
     module.syn = syn

--- a/tests/unit/unit_test_Cache.py
+++ b/tests/unit/unit_test_Cache.py
@@ -11,10 +11,10 @@ import synapseclient.utils as utils
 
 
 def setup():
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
 
 
 def test_cache_concurrent_access():
@@ -45,7 +45,7 @@ def test_cache_concurrent_access():
     for file_handle_id in file_handle_ids:
         cache_map = my_cache._read_cache_map(my_cache.get_cache_dir(file_handle_id))
         process_ids = set()
-        for path, iso_time in cache_map.iteritems():
+        for path, iso_time in cache_map.items():
             m = re.match("file_handle_%d_process_(\d+).junk" % file_handle_id, os.path.basename(path))
             if m:
                 process_ids.add(int(m.group(1)))
@@ -68,9 +68,10 @@ def test_parse_cache_entry_into_seconds():
     timestamps["2001-09-09T01:46:40.000Z"] = 1000000000
     timestamps["2286-11-20T17:46:40.375Z"] = 10000000000.375
     timestamps["2286-11-20T17:46:40.999Z"] = 10000000000.999
-    print "\n\n"
+    print("\n\n")
     for stamp in timestamps.keys():
-        print "Input = %s | Parsed = %f" % (stamp, cache.iso_time_to_epoch(stamp))
+        print("Input = %s | Parsed = %f" % (stamp,
+            cache.iso_time_to_epoch(stamp)))
         assert_equal(cache.iso_time_to_epoch(stamp), timestamps[stamp])
         assert_equal(cache.epoch_time_to_iso(cache.iso_time_to_epoch(stamp)), stamp)
 
@@ -261,7 +262,7 @@ def test_cache_rules():
     ## test case 2b.
     assert_is_none( my_cache.get(file_handle_id=101202) )
 
-    print "\nCache dirs"
+    print("\nCache dirs")
     for d in my_cache._cache_dirs():
-        print d, synapseclient.cache._get_modified_time(d)
+        print(d, synapseclient.cache._get_modified_time(d))
 

--- a/tests/unit/unit_test_DictObject.py
+++ b/tests/unit/unit_test_DictObject.py
@@ -3,10 +3,10 @@ from synapseclient.dict_object import DictObject
 
 
 def setup():
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
 
 def test_DictObject():
     """Test creation and property access on DictObjects"""
@@ -18,8 +18,8 @@ def test_DictObject():
     assert d.nerds==['chris','jen','janey']
     assert d['nerds']==['chris','jen','janey']
 
-    print d.keys()
+    print(d.keys())
     assert all([key in d.keys() for key in ['args_working?', 'a', 'b', 'nerds']])
-    print d
+    print(d)
     d.new_key = 'new value!'
     assert d['new_key'] == 'new value!'

--- a/tests/unit/unit_test_Entity.py
+++ b/tests/unit/unit_test_Entity.py
@@ -6,10 +6,10 @@ from nose.tools import assert_raises
 
 
 def setup():
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
 
 
 def test_Entity():

--- a/tests/unit/unit_test_annotations.py
+++ b/tests/unit/unit_test_annotations.py
@@ -12,10 +12,10 @@ from synapseclient.exceptions import *
 
 
 def setup():
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print( '\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
 
 def test_annotations():
     """Test string annotations"""
@@ -56,7 +56,7 @@ def test_more_annotations():
              test_boolean=True,
              test_mo_booleans=[False, True, True, False])
     sa = to_synapse_annotations(a)
-    print sa
+    print(sa)
     assert sa['longAnnotations']['foo'] == [1234]
     assert sa['doubleAnnotations']['zoo'] == [123.1, 456.2, 789.3]
     assert sa['stringAnnotations']['species'] == ['Platypus']
@@ -108,7 +108,7 @@ def test_submission_status_annotations_round_trip():
     april_28_1969 = Datetime(1969,4,28)
     a = dict(screen_name='Bullwinkle', species='Moose', lucky=13, pi=pi, birthday=april_28_1969)
     sa = to_submission_status_annotations(a)
-    print sa
+    print(sa)
     assert set(['screen_name','species']) == set([kvp['key'] for kvp in sa['stringAnnos']])
     assert set(['Bullwinkle','Moose']) == set([kvp['value'] for kvp in sa['stringAnnos']])
 

--- a/tests/unit/unit_test_chunks.py
+++ b/tests/unit/unit_test_chunks.py
@@ -7,10 +7,10 @@ from synapseclient.utils import GB, MB, KB, nchunks, get_chunk
 
 
 def setup():
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
 
 
 def test_chunks():

--- a/tests/unit/unit_test_client.py
+++ b/tests/unit/unit_test_client.py
@@ -9,10 +9,10 @@ from synapseclient import Evaluation
 
 
 def setup(module):
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
     module.syn = unit.syn
 
 
@@ -65,16 +65,16 @@ def test_getWithEntityBundle(download_file_mock):
 
     fileHandle = bundle['fileHandles'][0]['id']
     cacheDir = syn.cache.get_cache_dir(fileHandle)
-    print "cacheDir=", cacheDir
+    print("cacheDir=", cacheDir)
 
     # Make sure the .cacheMap file does not already exist
     cacheMap = os.path.join(cacheDir, '.cacheMap')
     if os.path.exists(cacheMap):
-        print "removing cacheMap file: ", cacheMap
+        print("removing cacheMap file: ", cacheMap)
         os.remove(cacheMap)
 
     def _downloadFileEntity(entity, path, submission):
-        print "mock downloading file to:", path
+        print("mock downloading file to:", path)
         ## touch file at path
         with open(path, 'a'):
             os.utime(path, None)
@@ -88,12 +88,12 @@ def test_getWithEntityBundle(download_file_mock):
     # download file to an alternate location
 
     temp_dir1 = tempfile.mkdtemp()
-    print "temp_dir1=", temp_dir1
+    print("temp_dir1=", temp_dir1)
 
     e = syn._getWithEntityBundle(entityBundle=bundle,
                                  downloadLocation=temp_dir1,
                                  ifcollision="overwrite.local")
-    print e
+    print(e)
 
     assert e.name == bundle["entity"]["name"]
     assert e.parentId == bundle["entity"]["parentId"]
@@ -105,7 +105,7 @@ def test_getWithEntityBundle(download_file_mock):
     # get without specifying downloadLocation
     e = syn._getWithEntityBundle(entityBundle=bundle, ifcollision="overwrite.local")
 
-    print e
+    print(e)
 
     assert e.name == bundle["entity"]["name"]
     assert e.parentId == bundle["entity"]["parentId"]
@@ -118,8 +118,8 @@ def test_getWithEntityBundle(download_file_mock):
     e = syn._getWithEntityBundle(entityBundle=bundle,
                                  downloadLocation=temp_dir2,
                                  ifcollision="overwrite.local")
-    print "temp_dir2=", temp_dir2
-    print e
+    print("temp_dir2=", temp_dir2)
+    print(e)
 
     assert_in(bundle["fileHandles"][0]["fileName"], e.files)
     assert e.path is not None
@@ -187,4 +187,4 @@ def test_submit(*mocks):
     assert submission.name == 'George'
     assert submission.submitterAlias == 'Team X'
 
-    print submission
+    print(submission)

--- a/tests/unit/unit_test_lock.py
+++ b/tests/unit/unit_test_lock.py
@@ -8,10 +8,10 @@ from synapseclient.lock import Lock
 
 
 def setup():
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
 
 
 def test_lock():

--- a/tests/unit/unit_test_retry.py
+++ b/tests/unit/unit_test_retry.py
@@ -8,10 +8,10 @@ from synapseclient.exceptions import *
 
 
 def setup(module):
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
     module.syn = unit.syn
 
 

--- a/tests/unit/unit_test_tables.py
+++ b/tests/unit/unit_test_tables.py
@@ -3,19 +3,20 @@ import csv
 import os
 import sys
 import tempfile
-from itertools import izip
 from mock import MagicMock
 from nose.tools import assert_raises
+
+
 
 import synapseclient
 from synapseclient.table import Column, Schema, CsvFileTable, TableQueryResult, cast_values, as_table_columns, Table, RowSet, SelectColumn
 
 
 def setup(module):
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
 
 
 def test_cast_values():
@@ -171,12 +172,12 @@ def test_pandas_to_table():
 
         df = pd.DataFrame(dict(a=[1,2,3], b=["c", "d", "e"]))
         schema = Schema(name="Baz", parent="syn12345", columns=as_table_columns(df))
-        print "\n", df, "\n\n"
+        print("\n", df, "\n\n")
 
         ## A dataframe with no row id and version
         table = Table(schema, df)
         for i, row in enumerate(table):
-            print row
+            print(row)
             assert row[0]==(i+1)
             assert row[1]==["c", "d", "e"][i]
 
@@ -187,18 +188,18 @@ def test_pandas_to_table():
         ## ,,3,e
         table = Table(schema, df, includeRowIdAndRowVersion=True)
         for i, row in enumerate(table):
-            print row
+            print(row)
             assert row[0] is None
             assert row[1] is None
             assert row[2]==(i+1)
 
         ## A dataframe with no row id and version
         df = pd.DataFrame(index=["1_7","2_7","3_8"], data=dict(a=[100,200,300], b=["c", "d", "e"]))
-        print "\n", df, "\n\n"
+        print("\n", df, "\n\n")
 
         table = Table(schema, df)
         for i, row in enumerate(table):
-            print row
+            print(row)
             assert row[0]==["1","2","3"][i]
             assert row[1]==["7","7","8"][i]
             assert row[2]==(i+1)*100
@@ -206,11 +207,11 @@ def test_pandas_to_table():
 
         ## A dataframe with row id and version in columns
         df = pd.DataFrame(dict(ROW_ID=["0","1","2"], ROW_VERSION=["8","9","9"], a=[100,200,300], b=["c", "d", "e"]))
-        print "\n", df, "\n\n"
+        print("\n", df, "\n\n")
 
         table = Table(schema, df)
         for i, row in enumerate(table):
-            print row
+            print(row)
             assert row[0]==["0","1","2"][i]
             assert row[1]==["8","9","9"][i]
             assert row[2]==(i+1)*100
@@ -246,7 +247,9 @@ def test_csv_table():
 
     try:
         ## create CSV file
-        with tempfile.NamedTemporaryFile(delete=False) as temp:
+
+        
+        with tempfile.NamedTemporaryFile('wt', delete=False) as temp:
             writer = csv.writer(temp, quoting=csv.QUOTE_NONNUMERIC, lineterminator=os.linesep)
             writer.writerow(['ROW_ID', 'ROW_VERSION'] + [col.name for col in cols])
             filename = temp.name
@@ -264,13 +267,13 @@ def test_csv_table():
 
         ## test iterator
         # print "\n\nJazz Guys"
-        for table_row, expected_row in izip(table, data):
+        for table_row, expected_row in zip(table, data):
             # print table_row, expected_row
             assert table_row==expected_row
 
         ## test asRowSet
         rowset = table.asRowSet()
-        for rowset_row, expected_row in izip(rowset.rows, data):
+        for rowset_row, expected_row in zip(rowset.rows, data):
             #print rowset_row, expected_row
             assert rowset_row['values']==expected_row[2:]
             assert rowset_row['rowId']==expected_row[0]
@@ -298,7 +301,7 @@ def test_csv_table():
                 else:
                     os.remove(filename)
             except Exception as ex:
-                print ex
+                print(ex)
         raise
 
 
@@ -323,11 +326,11 @@ def test_list_of_rows_table():
     ## need columns to do cast_values w/o storing
     table = Table(schema1, data, headers=[SelectColumn.from_column(col) for col in cols])
 
-    for table_row, expected_row in izip(table, data):
+    for table_row, expected_row in zip(table, data):
         assert table_row==expected_row
 
     rowset = table.asRowSet()
-    for rowset_row, expected_row in izip(rowset.rows, data):
+    for rowset_row, expected_row in zip(rowset.rows, data):
         assert rowset_row['values']==expected_row
 
     table.columns = cols

--- a/tests/unit/unit_tests.py
+++ b/tests/unit/unit_tests.py
@@ -13,10 +13,10 @@ from synapseclient.exceptions import *
 
 
 def setup():
-    print '\n'
-    print '~' * 60
-    print os.path.basename(__file__)
-    print '~' * 60
+    print('\n')
+    print('~' * 60)
+    print(os.path.basename(__file__))
+    print('~' * 60)
 
 def test_activity_creation_from_dict():
     """test that activities are created correctly from a dictionary"""
@@ -272,7 +272,7 @@ def test_is_json():
 
 def test_unicode_output():
     a = "ȧƈƈḗƞŧḗḓ uʍop-ǝpısdn ŧḗẋŧ ƒǿř ŧḗşŧīƞɠ"
-    print a.encode('utf-8')
+    print( a.encode('utf-8'))
 
 def test_normalize_whitespace():
     assert "zip tang pow a = 2" == utils.normalize_whitespace("   zip\ttang   pow   \n    a = 2   ")
@@ -282,7 +282,7 @@ def test_normalize_whitespace():
 
 def test_query_limit_and_offset():
     query, limit, offset = utils.query_limit_and_offset("select foo from bar where zap > 2 limit 123 offset 456")
-    print query, limit, offset
+    print(query, limit, offset)
     assert query == "select foo from bar where zap > 2"
     assert limit == 123
     assert offset == 456
@@ -315,14 +315,14 @@ def test_time_manipulation():
                                 utils.from_unix_epoch_time_secs(
                                     utils.to_unix_epoch_time_secs(
                                         utils.iso_to_datetime("2014-12-10T19:09:34.000Z"))))
-    print round_tripped_datetime
+    print(round_tripped_datetime)
     assert "2014-12-10T19:09:34.000Z" == round_tripped_datetime, round_tripped_datetime
 
     round_tripped_datetime = utils.datetime_to_iso(
                                 utils.from_unix_epoch_time_secs(
                                     utils.to_unix_epoch_time_secs(
                                         utils.iso_to_datetime("1969-04-28T23:48:34.123Z"))))
-    print round_tripped_datetime
+    print(round_tripped_datetime)
     assert "1969-04-28T23:48:34.123Z" == round_tripped_datetime, round_tripped_datetime
 
     ## check that rounding to milliseconds works
@@ -330,7 +330,7 @@ def test_time_manipulation():
                                 utils.from_unix_epoch_time_secs(
                                     utils.to_unix_epoch_time_secs(
                                         utils.iso_to_datetime("1969-04-28T23:48:34.999499Z"))))
-    print round_tripped_datetime
+    print(round_tripped_datetime)
     assert "1969-04-28T23:48:34.999Z" == round_tripped_datetime, round_tripped_datetime
 
     ## check that rounding to milliseconds works
@@ -338,5 +338,5 @@ def test_time_manipulation():
                                 utils.from_unix_epoch_time_secs(
                                     utils.to_unix_epoch_time_secs(
                                         utils.iso_to_datetime("1969-04-27T23:59:59.999999Z"))))
-    print round_tripped_datetime
+    print(round_tripped_datetime)
     assert "1969-04-28T00:00:00.000Z" == round_tripped_datetime, round_tripped_datetime


### PR DESCRIPTION
Dear all,

I have to make dreamtools python3 compatible and realised that synapseclient is not. I therefore forked and fix the code. This may not be 100% safe but all tests passed on python 3.4 and 2.7 except for :

- tests that uses raw_input/input in nosetests, which seems to be a known issue/feature in nose with python3.
- and a couple of tests that requires specific credentials.

thanks
thomas
