### PR TITLE
Partial solution for SYNPY-298 fileNameOverride

### DIFF
--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -341,11 +341,12 @@ def getProvenance(args, syn):
     activity = syn.getProvenance(args.id, args.version)
 
     if args.output is None or args.output=='STDOUT':
-        print(json.dumps(activity,sort_keys=True, indent=2))
+        print(json.dumps(activity, sort_keys=True, indent=2, ensure_ascii=False))
     else:
         with open(args.output, 'w') as f:
             f.write(json.dumps(activity))
             f.write('\n')
+
 
 def setAnnotations(args, syn):
     """Method to set annotations on an entity.
@@ -381,7 +382,7 @@ def getAnnotations(args, syn):
     annotations = syn.getAnnotations(args.id)
 
     if args.output is None or args.output=='STDOUT':
-        print(json.dumps(annotations,sort_keys=True, indent=2))
+        print(json.dumps(annotations, sort_keys=True, indent=2, ensure_ascii=False))
     else:
         with open(args.output, 'w') as f:
             f.write(json.dumps(annotations))

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -771,7 +771,7 @@ class Synapse:
                     entity.md5 = handle.get('contentMd5', '')
                     entity.fileSize = handle.get('contentSize', None)
                     entity.contentType = handle.get('contentType', None)
-                    fileName = handle['fileName']
+                    fileName = properties['fileNameOverride'] if 'fileNameOverride' in properties else handle['fileName']
                     if handle['concreteType'] == 'org.sagebionetworks.repo.model.file.ExternalFileHandle':
                         entity['externalURL'] = handle['externalURL']
                         #Determine if storage location for this entity matches the url of the

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -612,7 +612,7 @@ class Synapse:
         if utils.is_synapse_id(entity):
             entity = self._getEntity(entity)
         try:
-            print(json.dumps(entity, sort_keys=True, indent=2))
+            print(json.dumps(entity, sort_keys=True, indent=2, ensure_ascii=False))
         except TypeError:
             print(str(entity))
 

--- a/synapseclient/dict_object.py
+++ b/synapseclient/dict_object.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+from builtins import str
 
 import collections
 import json
@@ -27,7 +28,7 @@ class DictObject(dict):
 
 
     def __str__(self):
-        return json.dumps(self, sort_keys=True, indent=2)
+        return json.dumps(self, sort_keys=True, indent=2, ensure_ascii=False)
 
 
     def json(self):

--- a/synapseclient/entity.py
+++ b/synapseclient/entity.py
@@ -118,13 +118,14 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+from future.utils import python_2_unicode_compatible
 from builtins import str
 import six
 
 import collections
 import itertools
 if six.PY2:
-    from cStringIO import StringIO
+    from StringIO import StringIO
 else:
     from io import StringIO
 
@@ -151,6 +152,7 @@ class Versionable(object):
 ## - giving up on the dot notation (implemented in Entity2.py in commit e441fcf5a6963118bcf2b5286c67fc66c004f2b5 in the entity_object branch)
 ## - giving up on hiding the difference between properties and annotations
 
+@python_2_unicode_compatible
 class Entity(collections.MutableMapping):
     """
     A Synapse entity is an object that has metadata, access control, and

--- a/synapseclient/entity.py
+++ b/synapseclient/entity.py
@@ -507,7 +507,7 @@ class File(Entity, Versionable):
         data = syn.store(data)
     """
 
-    _property_keys = Entity._property_keys + Versionable._property_keys + ['dataFileHandleId']
+    _property_keys = Entity._property_keys + Versionable._property_keys + ['dataFileHandleId', 'fileNameOverride']
     _local_keys = Entity._local_keys + ['path', 'cacheDir', 'files', 'synapseStore', 'externalURL', 'md5', 'fileSize', 'contentType']
     _synapse_entity_type = 'org.sagebionetworks.repo.model.FileEntity'
 

--- a/tests/integration/integration_test_Entity.py
+++ b/tests/integration/integration_test_Entity.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from builtins import str
 
-import uuid, filecmp, os, sys, requests, time
+import uuid, filecmp, os, sys, requests, tempfile, time
 from datetime import datetime as Datetime
 from nose.tools import assert_raises
 from nose.plugins.attrib import attr
@@ -126,6 +126,19 @@ def test_Entity():
     # Make sure we can still get the older version of file
     old_random_data = syn.get(a_file.id, version=1)
     assert filecmp.cmp(old_random_data.path, path)
+
+    tmpdir = tempfile.mkdtemp()
+    schedule_for_cleanup(tmpdir)
+
+    ## test file name override
+    a_file.fileNameOverride = "peaches_en_regalia.zoinks"
+    syn.store(a_file)
+    ## TODO We haven't defined how filename override interacts with
+    ## TODO previously cached files so, side-step that for now by
+    ## TODO making sure the file is not in the cache!
+    syn.cache.remove(a_file.dataFileHandleId, delete=True)
+    a_file_retreived = syn.get(a_file, downloadLocation=tmpdir)
+    assert os.path.basename(a_file_retreived.path) == a_file.fileNameOverride, os.path.basename(a_file_retreived.path)
 
 
 def test_special_characters():

--- a/tests/integration/test_command_line_client.py
+++ b/tests/integration/test_command_line_client.py
@@ -32,7 +32,7 @@ import integration
 from integration import schedule_for_cleanup
 
 if six.PY2:
-    from cStringIO import StringIO
+    from StringIO import StringIO
 else:
     from io import StringIO
 
@@ -61,12 +61,13 @@ def run(*command, **kwargs):
         sys.stdout = capturedSTDOUT
         sys.argv = [item for item in command]
         args = parser.parse_args()
+        args.debug = True
         cmdline.perform_main(args, kwargs.get('syn',syn))
     except SystemExit:
         pass # Prevent the test from quitting prematurely
     finally:
         sys.stdout = old_stdout
-        
+
     capturedSTDOUT = capturedSTDOUT.getvalue()
     print(capturedSTDOUT)
     return capturedSTDOUT
@@ -74,7 +75,6 @@ def run(*command, **kwargs):
 
 def parse(regex, output):
     """Returns the first match."""
-    
     m = re.search(regex, output)
     if m:
         if len(m.groups()) > 0:
@@ -192,6 +192,7 @@ def test_command_line_client():
                  'get-provenance', 
                  '--id', 
                  file_entity_id)
+
     activity = json.loads(output)
     assert activity['name'] == 'TestActivity'
     assert activity['description'] == 'A very excellent provenance'

--- a/tests/integration/test_sftp_upload.py
+++ b/tests/integration/test_sftp_upload.py
@@ -66,6 +66,19 @@ def test_synStore_sftpIntegration():
         file = syn.store(File(filepath, parent=project))
         file2  = syn.get(file)
         assert file.externalURL==file2.externalURL and urlparse(file2.externalURL).scheme=='sftp'
+
+        tmpdir = tempfile.mkdtemp()
+        schedule_for_cleanup(tmpdir)
+
+        ## test filename override
+        file2.fileNameOverride = "whats_new_in_baltimore.data"
+        file2 = syn.store(file2)
+        ## TODO We haven't defined how filename override interacts with
+        ## TODO previously cached files so, side-step that for now by
+        ## TODO making sure the file is not in the cache!
+        syn.cache.remove(file2.dataFileHandleId, delete=True)
+        file3 = syn.get(file, downloadLocation=tmpdir)
+        assert os.path.basename(file3.path) == file2.fileNameOverride
     finally:
         try:
             os.remove(filepath)

--- a/tests/unit/unit_test_Entity.py
+++ b/tests/unit/unit_test_Entity.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from builtins import str
+
 import collections
 import os
 from synapseclient.entity import Entity, Project, Folder, File, split_entity_namespaces
@@ -81,6 +86,13 @@ def test_Entity():
         assert e.annotations.foo == 456
         assert e.properties['annotations'] == '/repo/v1/entity/syn1234/annotations'
         assert e.properties.annotations == '/repo/v1/entity/syn1234/annotations'
+
+        ## test unicode properties
+        e.train = '時刻表には記載されない　月への列車が来ると聞いて'
+        e.band = "Motörhead"
+        e.lunch = "すし"
+
+        print(e)
 
 
 def test_subclassing():

--- a/tests/unit/unit_tests.py
+++ b/tests/unit/unit_tests.py
@@ -276,8 +276,8 @@ def test_is_json():
     assert not utils._is_json('')
 
 def test_unicode_output():
-    a = "ȧƈƈḗƞŧḗḓ uʍop-ǝpısdn ŧḗẋŧ ƒǿř ŧḗşŧīƞɠ"
-    print(a.encode('utf-8'))
+    print("\n")
+    print("ȧƈƈḗƞŧḗḓ uʍop-ǝpısdn ŧḗẋŧ ƒǿř ŧḗşŧīƞɠ")
 
 def test_normalize_whitespace():
     assert "zip tang pow a = 2" == utils.normalize_whitespace("   zip\ttang   pow   \n    a = 2   ")


### PR DESCRIPTION
Partial solution for SYNPY-298 file name override for external files and sftp files and fixes for a couple of unicode issues.