### PR TITLE
fix rest doc links

### DIFF
--- a/synapseclient/__init__.py
+++ b/synapseclient/__init__.py
@@ -264,7 +264,7 @@ Accessing the API directly
 
 These methods enable access to the Synapse REST(ish) API taking care of details
 like endpoints and authentication. See the
-`REST API documentation <http://rest.synapse.org/>`_.
+`REST API documentation <http://docs.synapse.org/rest/>`_.
 
 See:
 

--- a/synapseclient/activity.py
+++ b/synapseclient/activity.py
@@ -140,7 +140,7 @@ class Activity(dict):
     :param name:        name of the Activity
     :param description: a short text description of the Activity
     :param used:        Either a list of:
-                        - `reference objects <http://rest.synapse.org/org/sagebionetworks/repo/model/Reference.html>`_ (e.g. ``[{'targetId':'syn123456', 'targetVersionNumber':1}]``)
+                        - `reference objects <http://docs.synapse.org/rest/org/sagebionetworks/repo/model/Reference.html>`_ (e.g. ``[{'targetId':'syn123456', 'targetVersionNumber':1}]``)
                         - a list of Synapse Entities or Entity IDs
                         - a list of URL's
     :param executed:    A code resource that was executed to generate the Entity.

--- a/synapseclient/annotations.py
+++ b/synapseclient/annotations.py
@@ -175,7 +175,7 @@ def to_submission_status_annotations(annotations, is_private=True):
 
     Synapse categorizes these annotations by: stringAnnos, doubleAnnos,
     longAnnos. If date or blob annotations are supported, they are not
-    `documented <http://rest.synapse.org/org/sagebionetworks/repo/model/annotation/Annotations.html>`_
+    `documented <http://docs.synapse.org/rest/org/sagebionetworks/repo/model/annotation/Annotations.html>`_
     """
     if is_submission_status_annotations(annotations):
         return annotations
@@ -219,8 +219,8 @@ def from_submission_status_annotations(annotations):
 def set_privacy(annotations, key, is_private=True, value_types=['longAnnos', 'doubleAnnos', 'stringAnnos']):
     """
     Set privacy of individual annotations, where annotations are in the format used by Synapse
-    SubmissionStatus objects. See the `Annotations documentation <http://rest.synapse.org/org/sagebionetworks/repo/model/annotation/Annotations.html>`_
-    and the docs regarding `querying annotations <http://rest.synapse.org/GET/evaluation/submission/query.html>`_.
+    SubmissionStatus objects. See the `Annotations documentation <http://docs.synapse.org/rest/org/sagebionetworks/repo/model/annotation/Annotations.html>`_
+    and the docs regarding `querying annotations <http://docs.synapse.org/rest/GET/evaluation/submission/query.html>`_.
 
     :param annotations: Annotations that have already been converted to Synapse format using
                         :py:func:`to_submission_status_annotations`.

--- a/synapseclient/cache.py
+++ b/synapseclient/cache.py
@@ -6,7 +6,7 @@ File Caching
 ************
 
 Implements a cache on local disk for Synapse file entities and other objects
-with a `FileHandle <https://rest.synapse.org/org/sagebionetworks/repo/model/file/FileHandle.html>`_.
+with a `FileHandle <https://docs.synapse.org/rest/org/sagebionetworks/repo/model/file/FileHandle.html>`_.
 This is part of the internal implementation of the client and should not be
 accessed directly by users of the client.
 """

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1916,7 +1916,7 @@ class Synapse:
 
         :returns: a FileHandle_
 
-        .. FileHandle: http://rest.synapse.org/org/sagebionetworks/repo/model/file/FileHandle.html
+        .. FileHandle: http://docs.synapse.org/rest/org/sagebionetworks/repo/model/file/FileHandle.html
         """
 
         if filename is None:
@@ -2291,7 +2291,7 @@ class Synapse:
 
         ## if a team is found, build contributors list
         if team:
-            ## see http://rest.synapse.org/GET/evaluation/evalId/team/id/submissionEligibility.html
+            ## see http://docs.synapse.org/rest/GET/evaluation/evalId/team/id/submissionEligibility.html
             eligibility = self.restGET('/evaluation/{evalId}/team/{id}/submissionEligibility'.format(evalId=evaluation_id, id=team.id))
 
             # {'eligibilityStateHash': -100952509,
@@ -2685,7 +2685,7 @@ class Synapse:
 
         async_job_id = self.restPOST(uri+'/start', body=json.dumps(request), endpoint=endpoint)
 
-        # http://rest.synapse.org/org/sagebionetworks/repo/model/asynch/AsynchronousJobStatus.html
+        # http://docs.synapse.org/rest/org/sagebionetworks/repo/model/asynch/AsynchronousJobStatus.html
         sleep = self.table_query_sleep
         start_time = time.time()
         lastMessage, lastProgress, lastTotal, progressed = '', 0, 1, False
@@ -2774,7 +2774,7 @@ class Synapse:
         """
         Query a Synapse Table.
 
-        :param query: query string in a `SQL-like syntax <http://rest.synapse.org/org/sagebionetworks/repo/web/controller/TableExamples.html>`_::
+        :param query: query string in a `SQL-like syntax <http://docs.synapse.org/rest/org/sagebionetworks/repo/web/controller/TableExamples.html>`_::
 
             SELECT * from syn12345
 
@@ -2828,7 +2828,7 @@ class Synapse:
 
     def _queryTable(self, query, limit=None, offset=None, isConsistent=True, partMask=None):
         """
-        Query a table and return the first page of results as a `QueryResultBundle <http://rest.synapse.org/org/sagebionetworks/repo/model/table/QueryResultBundle.html>`_.
+        Query a table and return the first page of results as a `QueryResultBundle <http://docs.synapse.org/rest/org/sagebionetworks/repo/model/table/QueryResultBundle.html>`_.
         If the result contains a *nextPageToken*, following pages a retrieved
         by calling :py:meth:`~._queryTableNext`.
 
@@ -2840,7 +2840,7 @@ class Synapse:
                             Max Rows Per Page (maxRowsPerPage) = 0x8
         """
 
-        # See: http://rest.synapse.org/org/sagebionetworks/repo/model/table/QueryBundleRequest.html
+        # See: http://docs.synapse.org/rest/org/sagebionetworks/repo/model/table/QueryBundleRequest.html
         query_bundle_request = {
             "concreteType": "org.sagebionetworks.repo.model.table.QueryBundleRequest",
             "query": {
@@ -2869,13 +2869,13 @@ class Synapse:
 
     def _uploadCsv(self, filepath, schema, updateEtag=None, quoteCharacter='"', escapeCharacter="\\", lineEnd=os.linesep, separator=",", header=True, linesToSkip=0):
         """
-        Send an `UploadToTableRequest <http://rest.synapse.org/org/sagebionetworks/repo/model/table/UploadToTableRequest.html>`_ to Synapse.
+        Send an `UploadToTableRequest <http://docs.synapse.org/rest/org/sagebionetworks/repo/model/table/UploadToTableRequest.html>`_ to Synapse.
 
         :param filepath: Path of a `CSV <https://en.wikipedia.org/wiki/Comma-separated_values>`_ file.
         :param schema: A table entity or its Synapse ID.
         :param updateEtag: Any RowSet returned from Synapse will contain the current etag of the change set. To update any rows from a RowSet the etag must be provided with the POST.
 
-        :returns: `UploadToTableResult <http://rest.synapse.org/org/sagebionetworks/repo/model/table/UploadToTableResult.html>`_
+        :returns: `UploadToTableResult <http://docs.synapse.org/rest/org/sagebionetworks/repo/model/table/UploadToTableResult.html>`_
         """
 
         fileHandleId = multipart_upload(self, filepath, contentType="text/csv")
@@ -2904,9 +2904,9 @@ class Synapse:
         """
         Query a Synapse Table and download a CSV file containing the results.
 
-        Sends a `DownloadFromTableRequest <http://rest.synapse.org/org/sagebionetworks/repo/model/table/DownloadFromTableRequest.html>`_ to Synapse.
+        Sends a `DownloadFromTableRequest <http://docs.synapse.org/rest/org/sagebionetworks/repo/model/table/DownloadFromTableRequest.html>`_ to Synapse.
 
-        :return: a tuple containing a `DownloadFromTableResult <http://rest.synapse.org/org/sagebionetworks/repo/model/table/DownloadFromTableResult.html>`_
+        :return: a tuple containing a `DownloadFromTableResult <http://docs.synapse.org/rest/org/sagebionetworks/repo/model/table/DownloadFromTableResult.html>`_
 
         The DownloadFromTableResult object contains these fields:
          * headers: ARRAY<STRING>, The list of ColumnModel IDs that describes the rows of this set.
@@ -3026,7 +3026,7 @@ class Synapse:
             'headers':[{'id':column_id}],
             'rows':[{'rowId':rowId,'versionNumber':versionNumber}]
         }
-        # result is a http://rest.synapse.org/org/sagebionetworks/repo/model/table/TableFileHandleResults.html
+        # result is a http://docs.synapse.org/rest/org/sagebionetworks/repo/model/table/TableFileHandleResults.html
         result = self.restPOST("/entity/%s/table/filehandles" % table_id, body=json.dumps(row_reference_set))
         if len(result['rows'])==0 or len(result['rows'][0]['list']) != 1:
             raise SynapseError('Couldn\'t get file handle for tableId={id}, column={columnId}, row={rowId}, version={versionNumber}'.format(
@@ -3111,7 +3111,7 @@ class Synapse:
             raise ValueError("Columns not found: " + ", ".join('"'+col+'"' for col in cols_not_found))
         col_indices = [i for i,h in enumerate(table.headers) if h.name in columns]
 
-        ## see: http://rest.synapse.org/org/sagebionetworks/repo/model/file/BulkFileDownloadRequest.html
+        ## see: http://docs.synapse.org/rest/org/sagebionetworks/repo/model/file/BulkFileDownloadRequest.html
         file_handle_associations = []
         file_handle_to_path_map = OrderedDict()
         for row in table:
@@ -3144,7 +3144,7 @@ class Synapse:
             ##------------------------------------------------------------
 
             ## returns a BulkFileDownloadResponse:
-            ##   http://rest.synapse.org/org/sagebionetworks/repo/model/file/BulkFileDownloadResponse.html
+            ##   http://docs.synapse.org/rest/org/sagebionetworks/repo/model/file/BulkFileDownloadResponse.html
             request = dict(
                 concreteType="org.sagebionetworks.repo.model.file.BulkFileDownloadRequest",
                 requestedFiles=file_handle_associations_batch)

--- a/synapseclient/evaluation.py
+++ b/synapseclient/evaluation.py
@@ -99,7 +99,7 @@ class Evaluation(DictObject):
     :param submissionReceiptMessage: Message to display to users upon submission
     :param submissionInstructionsMessage: Message to display to users detailing acceptable formatting for submissions
 
-    `To create an Evaluation <http://rest.synapse.org/org/sagebionetworks/evaluation/model/Evaluation.html>`_
+    `To create an Evaluation <http://docs.synapse.org/rest/org/sagebionetworks/evaluation/model/Evaluation.html>`_
     and store it in Synapse::
 
         evaluation = syn.store(Evaluation(
@@ -110,7 +110,7 @@ class Evaluation(DictObject):
     The contentSource field links the evaluation to its :py:class:`synapseclient.entity.Project`.
     (Or, really, any synapse ID, but sticking to projects is a good idea.)
 
-    `Evaluations <http://rest.synapse.org/org/sagebionetworks/evaluation/model/Evaluation.html>`_
+    `Evaluations <http://docs.synapse.org/rest/org/sagebionetworks/evaluation/model/Evaluation.html>`_
     can be retrieved from Synapse by ID::
 
         evaluation = syn.getEvaluation(1901877)

--- a/synapseclient/multipart_upload.py
+++ b/synapseclient/multipart_upload.py
@@ -7,7 +7,7 @@ Implements the client side of `Synapse multipart upload`_, which provides
 a robust means of uploading large files (into the 10s of GB). End users
 should not need to call any of these functions directly.
 
-.. _Synapse multipart upload: http://rest.synapse.org/index.html#org.sagebionetworks.file.controller.UploadController
+.. _Synapse multipart upload: http://docs.synapse.org/rest/index.html#org.sagebionetworks.file.controller.UploadController
 
 """
 from __future__ import absolute_import
@@ -97,7 +97,7 @@ def _start_multipart_upload(syn, filename, md5, fileSize, partSize, contentType,
     """
     :returns: A `MultipartUploadStatus`_
 
-    .. _MultipartUploadStatus: http://rest.synapse.org/org/sagebionetworks/repo/model/file/MultipartUploadStatus.html
+    .. _MultipartUploadStatus: http://docs.synapse.org/rest/org/sagebionetworks/repo/model/file/MultipartUploadStatus.html
     """
     upload_request = {
         'contentMD5Hex': md5,
@@ -123,7 +123,7 @@ def _get_presigned_urls(syn, uploadId, parts_to_upload):
 
 
     :returns: A BatchPresignedUploadUrlResponse_.
-    .. BatchPresignedUploadUrlResponse: http://rest.synapse.org/POST/file/multipart/uploadId/presigned/url/batch.html
+    .. BatchPresignedUploadUrlResponse: http://docs.synapse.org/rest/POST/file/multipart/uploadId/presigned/url/batch.html
     """
     if len(parts_to_upload)==0:
         return 
@@ -142,7 +142,7 @@ def _add_part(syn, uploadId, partNumber, partMD5Hex):
     :returns: An AddPartResponse_ with fields for an errorMessage and addPartState containing
               either 'ADD_SUCCESS' or 'ADD_FAILED'.
 
-    .. AddPartResponse: http://rest.synapse.org/org/sagebionetworks/repo/model/file/AddPartResponse.html
+    .. AddPartResponse: http://docs.synapse.org/rest/org/sagebionetworks/repo/model/file/AddPartResponse.html
     """
     uri = '/file/multipart/{uploadId}/add/{partNumber}?partMD5Hex={partMD5Hex}'.format(**locals())
     return DictObject(**syn.restPUT(uri, endpoint=syn.fileHandleEndpoint))
@@ -152,7 +152,7 @@ def _complete_multipart_upload(syn, uploadId):
     """
     :returns: A MultipartUploadStatus_.
 
-    .. MultipartUploadStatus: http://rest.synapse.org/org/sagebionetworks/repo/model/file/MultipartUploadStatus.html
+    .. MultipartUploadStatus: http://docs.synapse.org/rest/org/sagebionetworks/repo/model/file/MultipartUploadStatus.html
     """
     uri = '/file/multipart/{uploadId}/complete'.format(uploadId=uploadId)
     return DictObject(**syn.restPUT(uri, endpoint=syn.fileHandleEndpoint))
@@ -300,7 +300,7 @@ def _multipart_upload(syn, filename, contentType, get_chunk_function, md5, fileS
 
     Keyword arguments are passed down to :py:func:`_start_multipart_upload`.
 
-    .. MultipartUploadStatus: http://rest.synapse.org/org/sagebionetworks/repo/model/file/MultipartUploadStatus.html
+    .. MultipartUploadStatus: http://docs.synapse.org/rest/org/sagebionetworks/repo/model/file/MultipartUploadStatus.html
     .. contentType: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17
     """
     partSize = calculate_part_size(fileSize, partSize, MIN_PART_SIZE, MAX_NUMBER_OF_PARTS)

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -214,7 +214,7 @@ Queries
 
 The query language is quite similar to SQL select statements, except that joins
 are not supported. The documentation for the Synapse API has lots of
-`query examples <http://rest.synapse.org/org/sagebionetworks/repo/web/controller/TableExamples.html>`_.
+`query examples <http://docs.synapse.org/rest/org/sagebionetworks/repo/web/controller/TableExamples.html>`_.
 
 ~~~~~~
 Schema
@@ -419,7 +419,7 @@ def cast_values(values, headers):
     """
     Convert a row of table query results from strings to the correct column type.
 
-    See: http://rest.synapse.org/org/sagebionetworks/repo/model/table/ColumnType.html
+    See: http://docs.synapse.org/rest/org/sagebionetworks/repo/model/table/ColumnType.html
     """
     if len(values) != len(headers):
         raise ValueError('Each field in the row must have a matching column header. %d fields, %d headers' % (len(values), len(headers)))
@@ -610,7 +610,7 @@ class Column(DictObject):
 
 class RowSet(DictObject):
     """
-    A Synapse object of type `org.sagebionetworks.repo.model.table.RowSet <http://rest.synapse.org/org/sagebionetworks/repo/model/table/RowSet.html>`_.
+    A Synapse object of type `org.sagebionetworks.repo.model.table.RowSet <http://docs.synapse.org/rest/org/sagebionetworks/repo/model/table/RowSet.html>`_.
 
     :param schema:   A :py:class:`synapseclient.table.Schema` object that will be used to set the tableId
     :param headers:  The list of SelectColumn objects that describe the fields in each row.
@@ -651,7 +651,7 @@ class RowSet(DictObject):
         """
         Creates and POSTs an AppendableRowSetRequest_
 
-        .. AppendableRowSetRequest: http://rest.synapse.org/org/sagebionetworks/repo/model/table/AppendableRowSetRequest.html
+        .. AppendableRowSetRequest: http://docs.synapse.org/rest/org/sagebionetworks/repo/model/table/AppendableRowSetRequest.html
         """
         arsr = dict(
             concreteType='org.sagebionetworks.repo.model.table.AppendableRowSetRequest',
@@ -677,7 +677,7 @@ class RowSet(DictObject):
 
 class Row(DictObject):
     """
-    A `row <http://rest.synapse.org/org/sagebionetworks/repo/model/table/Row.html>`_ in a Table.
+    A `row <http://docs.synapse.org/rest/org/sagebionetworks/repo/model/table/Row.html>`_ in a Table.
 
     :param values:         A list of values
     :param rowId:          The immutable ID issued to a new row
@@ -694,7 +694,7 @@ class Row(DictObject):
 
 class RowSelection(DictObject):
     """
-    A set of rows to be `deleted <http://rest.synapse.org/POST/entity/id/table/deleteRows.html>`_.
+    A set of rows to be `deleted <http://docs.synapse.org/rest/POST/entity/id/table/deleteRows.html>`_.
 
     :param rowIds: list of row ids
     :param etag: etag of latest change set
@@ -1302,4 +1302,3 @@ class CsvFileTable(TableAbstractBaseClass):
 
     def __len__(self):
         return sum(1 for row in self)
-

--- a/synapseclient/team.py
+++ b/synapseclient/team.py
@@ -16,7 +16,7 @@ class UserGroupHeader(DictObject):
 
 class Team(DictObject):
     """
-    Represent a `Synapse Team <http://rest.synapse.org/org/sagebionetworks/repo/model/Team.html>`_. User definable fields are:
+    Represent a `Synapse Team <http://docs.synapse.org/rest/org/sagebionetworks/repo/model/Team.html>`_. User definable fields are:
     :param icon:          fileHandleId for icon image of the Team
     :param description:   A short description of this Team.
     :param name:          The name of the Team.

--- a/tests/unit/unit_test_tables.py
+++ b/tests/unit/unit_test_tables.py
@@ -426,7 +426,7 @@ def test_waitForAsync():
     syn.table_query_max_sleep = 0.001
     syn.restPOST = MagicMock(return_value={"token":"1234567"})
 
-    # return a mocked http://rest.synapse.org/org/sagebionetworks/repo/model/asynch/AsynchronousJobStatus.html
+    # return a mocked http://docs.synapse.org/rest/org/sagebionetworks/repo/model/asynch/AsynchronousJobStatus.html
     syn.restGET  = MagicMock(return_value={
         "jobState": "PROCESSING",
         "progressMessage": "Test progress message",


### PR DESCRIPTION
Many outdated links to rest.synapse.org changed to docs.synapse.org/rest