### PR TITLE
Link class should not auto set targetVersionNumber

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1030,9 +1030,9 @@ class Synapse:
         else:
             #If Link, get the target name, version number and concrete type and store in link properties
             if properties['concreteType']=="org.sagebionetworks.repo.model.Link":
-                target_properties = self._getEntity(properties['linksTo']['targetId'], version=properties['linksTo']['targetVersionNumber'])
+                target_properties = self._getEntity(properties['linksTo']['targetId'], version=properties['linksTo'].get('targetVersionNumber'))
                 properties['linksToClassName'] = target_properties['concreteType']
-                if target_properties.get('versionNumber') is not None:
+                if target_properties.get('versionNumber') is not None and properties['linksTo'].get('targetVersionNumber') is not None:
                     properties['linksTo']['targetVersionNumber'] = target_properties['versionNumber']
                 properties['name'] = target_properties['name']
             try:

--- a/synapseclient/entity.py
+++ b/synapseclient/entity.py
@@ -507,8 +507,10 @@ class Link(Entity):
     _synapse_entity_type = 'org.sagebionetworks.repo.model.Link'
 
     def __init__(self, targetId=None, targetVersion=None, parent=None, properties=None, annotations=None, local_state=None, **kwargs):
-        if targetId is not None:
+        if targetId is not None and targetVersion is not None:
             kwargs['linksTo'] = dict(targetId=utils.id_of(targetId), targetVersionNumber=targetVersion)
+        elif targetId is not None and targetVersion is None:
+            kwargs['linksTo'] = dict(targetId=utils.id_of(targetId))
         elif properties is not None and 'linksTo' in properties:
             pass
         else:

--- a/tests/integration/integration_test_Entity.py
+++ b/tests/integration/integration_test_Entity.py
@@ -120,6 +120,14 @@ def test_Entity():
     assert a_file.versionNumber == 1, "unexpected version number: " +  str(a_file.versionNumber)
 
     #Test create, store, get Links
+    #If version isn't specified, targetVersionNumber should not be set
+    link = Link(a_file['id'], 
+                parent=project)
+    link = syn.store(link)
+    assert link['linksTo']['targetId'] == a_file['id']
+    assert link['linksTo'].get('targetVersionNumber') is None
+    assert link['linksToClassName'] == a_file['concreteType']
+
     link = Link(a_file['id'], 
                 targetVersion=a_file.versionNumber,
                 parent=project)


### PR DESCRIPTION
A Link should always point to the latest version if the version Number isn't set by users.