### PR TITLE
Recursive download of links should not cause an error

### DIFF
--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -7,7 +7,7 @@ import errno
 from .monitor import notifyMe
 from synapseclient.entity import is_container
 from synapseclient.utils import id_of, topolgical_sort, is_url
-from synapseclient import File, table
+from synapseclient import File, table, Link
 from synapseclient.exceptions import *
 import os
 from sys import stderr
@@ -85,7 +85,8 @@ def syncFromSynapse(syn, entity, path=None, ifcollision='overwrite.local', allFi
             syncFromSynapse(syn, result['id'], new_path, ifcollision, allFiles)
         else:
             ent = syn.get(result['id'], downloadLocation = path, ifcollision = ifcollision, followLink=followLink)
-            allFiles.append(ent)
+            if not isinstance(ent, Link):
+                allFiles.append(ent)
     if zero_results:
         #a http error would be raised if the synapse Id was not valid (404) or no permission (403) so at this point the entity should be get-able
         stderr.write("The synapse id provided is not a container, attempting to get the entity anyways")

--- a/tests/integration/test_synapseutils_sync.py
+++ b/tests/integration/test_synapseutils_sync.py
@@ -10,7 +10,7 @@ import uuid, filecmp, os, sys, time, tempfile
 from nose.tools import assert_raises, assert_equals, assert_is_none, assert_less
 
 import synapseclient
-from synapseclient import Project, Folder, File, Entity
+from synapseclient import Project, Folder, File, Entity, Link
 from synapseclient.exceptions import *
 import synapseutils
 import re
@@ -126,6 +126,9 @@ def test_syncFromSynapse():
     # Create a Project
     project_entity = syn.store(synapseclient.Project(name=str(uuid.uuid4())))
     schedule_for_cleanup(project_entity.id)
+    second_project_entity = syn.store(synapseclient.Project(name=str(uuid.uuid4())))
+    schedule_for_cleanup(second_project_entity.id)
+
 
     # Create a Folder in Project
     folder_entity = syn.store(Folder(name=str(uuid.uuid4()), parent=project_entity))
@@ -137,26 +140,41 @@ def test_syncFromSynapse():
         uploaded_paths.append(f)
         schedule_for_cleanup(f)
         file_entity = syn.store(File(f, parent=folder_entity))
+
     #Add a file in the project level as well
     f  = utils.make_bogus_data_file()
     uploaded_paths.append(f)
     schedule_for_cleanup(f)
+    uploaded_paths_without_links = list(uploaded_paths)
     file_entity = syn.store(File(f, parent=project_entity))
 
+    f  = utils.make_bogus_data_file()
+    uploaded_paths.append(f)
+    schedule_for_cleanup(f)
+    file_entity_2 = syn.store(File(f, parent=second_project_entity))
+    link_entity = syn.store(Link(file_entity_2.id, parent=project_entity))
+
+
     #syncFromSynapse() uses chunkedQuery() which will return results that are eventually consistent but not always right after the entity is created.
-    start_time = time.time()
-    while syn.query("select id from entity where id=='%s'" % file_entity.id).get('totalNumberOfResults') <= 0:
-        assert_less(time.time() - start_time, QUERY_TIMEOUT_SEC)
-        time.sleep(2)
+    #start_time = time.time()
+    # while syn.query("select id from entity where id=='%s'" % file_entity.id).get('totalNumberOfResults') <= 0:
+    #     assert_less(time.time() - start_time, QUERY_TIMEOUT_SEC)
+    #     time.sleep(2)
 
     ### Test recursive get
     output = synapseutils.syncFromSynapse(syn, project_entity)
+
+    assert len(output) == len(uploaded_paths_without_links)
+    for f in output:
+        assert f.path in uploaded_paths
+
+    ### Test recursive get with link
+    output = synapseutils.syncFromSynapse(syn, project_entity,followLink=True)
 
     assert len(output) == len(uploaded_paths)
     for f in output:
         assert f.path in uploaded_paths
 
 
-        
-    
+
 


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/SYNPY-543?filter=-8

Currently, recursive download of links will append link entities to a list, but links don't have `path`, so it will cause an error in generating the manifest.

Now, unless `followLink` is given as a parameter, Links will not be added to the manifest.