### PR TITLE
Revert "Row and PartialRow now always cast values to string (SYNPY-615)" (SYNPY-616)

### DIFF
--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -856,7 +856,7 @@ class Row(DictObject):
     """
     def __init__(self, values, rowId=None, versionNumber=None, etag=None):
         super(Row, self).__init__()
-        self.values = [str(value) for value in values]
+        self.values = values
         if rowId is not None:
             self.rowId = rowId
         if versionNumber is not None:
@@ -906,8 +906,8 @@ class PartialRow(DictObject):
 
         rowId = int(rowId)
 
-        self.values = [{'key': str(nameToColumnId[x_key]) if nameToColumnId is not None else str(x_key),
-                        'value': str(x_value)} for x_key, x_value in six.iteritems(values)]
+        self.values = [{'key': nameToColumnId[x_key] if nameToColumnId is not None else x_key,
+                        'value': x_value} for x_key, x_value in six.iteritems(values)]
         self.rowId = rowId
         if etag is not None:
             self.etag = etag

--- a/tests/unit/unit_test_tables.py
+++ b/tests/unit/unit_test_tables.py
@@ -9,11 +9,10 @@ import io
 import math
 import os
 import sys
-import six
 import tempfile
 from builtins import zip
 from mock import MagicMock
-from nose.tools import assert_raises, assert_equals, assert_not_equals, raises, assert_false, assert_not_in, assert_sequence_equal, assert_in
+from nose.tools import assert_raises, assert_equals, assert_not_equals, raises, assert_false, assert_not_in, assert_sequence_equal
 from nose import SkipTest
 import unit
 
@@ -23,7 +22,7 @@ try:
 except ImportError:
     pandas_found = True
 
-from nose.tools import raises, assert_equals, assert_is_instance
+from nose.tools import raises, assert_equals, assert_set_equal
 import unit
 import synapseclient
 from synapseclient import Entity
@@ -314,15 +313,13 @@ def test_csv_table():
             # print(table_row, expected_row)
             assert table_row==expected_row
 
-        expected_rows = [[str(val) for val in row] for row in data]
-
         ## test asRowSet
         rowset = table.asRowSet()
-        for rowset_row, expected_row in zip(rowset.rows, expected_rows):
+        for rowset_row, expected_row in zip(rowset.rows, data):
             #print(rowset_row, expected_row)
-            assert_equals(rowset_row['values'], expected_row[2:])
-            assert_equals(rowset_row['rowId'], expected_row[0])
-            assert_equals(rowset_row['versionNumber'], expected_row[1])
+            assert rowset_row['values']==expected_row[2:]
+            assert rowset_row['rowId']==expected_row[0]
+            assert rowset_row['versionNumber']==expected_row[1]
 
         ## test asDataFrame
         try:
@@ -371,15 +368,12 @@ def test_list_of_rows_table():
     ## need columns to do cast_values w/o storing
     table = Table(schema1, data, headers=[SelectColumn.from_column(col) for col in cols])
 
-
     for table_row, expected_row in zip(table, data):
-        assert_equals(table_row, expected_row)
-
-    expected_rows = [[str(val) for val in row] for row in data]
+        assert table_row==expected_row
 
     rowset = table.asRowSet()
-    for rowset_row, expected_row in zip(rowset.rows, expected_rows):
-        assert_equals(rowset_row['values'], expected_row)
+    for rowset_row, expected_row in zip(rowset.rows, data):
+        assert rowset_row['values']==expected_row
 
     table.columns = cols
 
@@ -718,22 +712,6 @@ class TestPartialRow():
         assert_equals(711, partial_row.rowId)
 
 
-    def test_values_have_string_type(type):
-        values = {
-            '12three':321,
-            456:'65four'
-        }
-        partial_row = PartialRow(values, rowId=11111)
-        for key_val in partial_row.values:
-            assert_is_instance(key_val['key'], six.string_types)
-            assert_is_instance(key_val['value'], six.string_types)
-
-        expected_values = [{'key':'12three', 'value':'321'}, {'key':'456', 'value':'65four'}]
-        assert_equals(2, len(expected_values))
-        assert_in(expected_values[0], partial_row.values)
-        assert_in(expected_values[1], partial_row.values)
-
-
 class TestPartialRowSet():
     @raises(ValueError)
     def test_constructor__not_all_rows_of_type_PartialRow(self):
@@ -747,9 +725,3 @@ class TestPartialRowSet():
         assert_equals([partial_row], partial_rowset.rows)
 
 
-class TestRow():
-    def test_values_have_string_type(self):
-        row = Row([1,2,"three"])
-        for val in row.values:
-            assert_is_instance(val, six.string_types)
-        assert_equals(["1","2","three"], row.values)


### PR DESCRIPTION
Reverts Sage-Bionetworks/synapsePythonClient#497
The backend will be permissive with json Row values. So we should go back to using ints, floats, etc... in the `values` list. This also makes the using the retrieved data more intuitive for users.