### PR TITLE
remove outdated code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ notes.md
 notes/
 examples/
 jenkins/
+.idea/*

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -1397,20 +1397,6 @@ class CsvFileTable(TableAbstractBaseClass):
             header=header,
             includeRowIdAndRowVersion=includeRowIdAndRowVersion)
 
-        ## A dirty hack to find out if we got back row ID and Version
-        ## in particular, we don't get these back from aggregate queries
-        with io.open(path, 'r', encoding='utf-8') as f:
-            reader = csv.reader(f,
-                delimiter=separator,
-                escapechar=escapeCharacter,
-                lineterminator=lineEnd,
-                quotechar=quoteCharacter)
-            first_line = next(reader)
-        if len(download_from_table_result['headers']) + 2 == len(first_line):
-            includeRowIdAndRowVersion = True
-        else:
-            includeRowIdAndRowVersion = False
-
         self = cls(
             filepath=path,
             schema=download_from_table_result.get('tableId', None),


### PR DESCRIPTION
I believe that @zimingd recent work was about exposing the ability to set whether or not a user wants RowId and RowVersion in their query results. (Default TRUE.) This variable is used in the request to tell PLFM whether or not to return RowId and RowVersion. We no longer need to check the returned data.