### PR TITLE
SYNPY-999 Don't copy entities with access restrictions

### DIFF
--- a/tests/unit/unit_test_synapseutils_copy.py
+++ b/tests/unit/unit_test_synapseutils_copy.py
@@ -4,10 +4,12 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import unit
-from nose.tools import assert_raises
 from mock import patch, call
+from nose.tools import assert_raises, assert_equals
+import unit
+import uuid
 
+from synapseclient import Project, File
 import synapseutils
 
 
@@ -48,3 +50,27 @@ def test_copyWiki_input_validation():
 
         assert_raises(ValueError, synapseutils.copyWiki, syn, "syn123", "syn456", entitySubPageId="some_string",
                               updateLinks=False)
+
+
+class TestCopyAccessRestriction:
+    """Test that entities with access restrictions aren't copied"""
+    def setup(self):
+        self.project_entity = Project(name=str(uuid.uuid4()), id="syn1234")
+        self.second_project = Project(name=str(uuid.uuid4()), id="syn2345")
+        self.file_ent = File(name='File', parent=self.project_entity.id)
+        self.file_ent.id = "syn3456"
+
+    def test_copy_entity_access_requirements(self):
+        #TEST: Entity access requirement > 0 not copied
+        access_requirements = {'results': ["fee", "fi"]}
+        with patch.object(syn, "get",
+                          return_value=self.file_ent) as patch_syn_get, \
+             patch.object(syn, "restGET",
+                          return_value=access_requirements) as patch_restget:
+            copied_file = synapseutils.copy(syn, self.file_ent,
+                                            destinationId=self.second_project.id,
+                                            skipCopyWikiPage=True)
+            assert_equals(copied_file, dict())
+            patch_syn_get.assert_called_once_with(self.file_ent,
+                                                  downloadFile=False)
+            patch_restget.assert_called_once_with('/entity/{}/accessRequirement'.format(self.file_ent.id))

--- a/tests/unit/unit_test_synapseutils_copy.py
+++ b/tests/unit/unit_test_synapseutils_copy.py
@@ -48,7 +48,7 @@ def test_copyWiki_input_validation():
         mock_getWiki.assert_has_calls(expected_calls)
 
         assert_raises(ValueError, synapseutils.copyWiki, syn, "syn123", "syn456", entitySubPageId="some_string",
-                              updateLinks=False)
+                      updateLinks=False)
 
 
 class TestCopyAccessRestriction:
@@ -60,7 +60,7 @@ class TestCopyAccessRestriction:
         self.file_ent.id = "syn3456"
 
     def test_copy_entity_access_requirements(self):
-        #TEST: Entity with access requirement not copied
+        # TEST: Entity with access requirement not copied
         access_requirements = {'results': ["fee", "fi"]}
         with patch.object(syn, "get",
                           return_value=self.file_ent) as patch_syn_get,\

--- a/tests/unit/unit_test_synapseutils_copy.py
+++ b/tests/unit/unit_test_synapseutils_copy.py
@@ -12,7 +12,6 @@ import uuid
 from synapseclient import Project, File
 import synapseutils
 
-
 def setup(module):
     module.syn = unit.syn
 
@@ -61,10 +60,10 @@ class TestCopyAccessRestriction:
         self.file_ent.id = "syn3456"
 
     def test_copy_entity_access_requirements(self):
-        #TEST: Entity access requirement > 0 not copied
+        #TEST: Entity with access requirement not copied
         access_requirements = {'results': ["fee", "fi"]}
         with patch.object(syn, "get",
-                          return_value=self.file_ent) as patch_syn_get, \
+                          return_value=self.file_ent) as patch_syn_get,\
              patch.object(syn, "restGET",
                           return_value=access_requirements) as patch_restget:
             copied_file = synapseutils.copy(syn, self.file_ent,


### PR DESCRIPTION
PLFM-5305, SYNPY-1018
This should be a patch to master so that users can't copy files with access restrictions.