### PR TITLE
SYNPY-881 Don't copy entities that don't have DOWNLOAD permission

### DIFF
--- a/synapseutils/copy.py
+++ b/synapseutils/copy.py
@@ -206,7 +206,7 @@ def _copyRecursive(syn, entity, destinationId, mapping=None, skipCopyAnnotations
         print("{} not copied".format(ent.id))
         return mapping
     copiedId = None
-    
+
     if isinstance(ent, Project):
         if not isinstance(syn.get(destinationId), Project):
             raise ValueError("You must give a destinationId of a new project to copy projects")

--- a/synapseutils/copy.py
+++ b/synapseutils/copy.py
@@ -194,6 +194,13 @@ def _copyRecursive(syn, entity, destinationId, mapping=None, skipCopyAnnotations
     if not isinstance(ent, (Project, Folder, File, Link, Schema, Entity)):
         raise ValueError("Not able to copy this type of file")
 
+    profile_username = syn.username
+    permissions = syn.getPermissions(ent, profile_username)
+    # Don't copy entities without DOWNLOAD permissions
+    if "DOWNLOAD" not in permissions:
+        print("%s not copied" % ent.id)
+        return mapping
+
     if isinstance(ent, Project):
         if not isinstance(syn.get(destinationId), Project):
             raise ValueError("You must give a destinationId of a new project to copy projects")

--- a/tests/unit/unit_test_synapseutils_copy.py
+++ b/tests/unit/unit_test_synapseutils_copy.py
@@ -50,6 +50,7 @@ def test_copyWiki_input_validation():
         assert_raises(ValueError, synapseutils.copyWiki, syn, "syn123", "syn456", entitySubPageId="some_string",
                       updateLinks=False)
 
+
 class TestCopyPermissions:
     """Test copy entities with different permissions"""
     def setup(self):
@@ -59,21 +60,22 @@ class TestCopyPermissions:
                              id="syn3456")
 
     def test_dont_copy_read_permissions(self):
-        #TEST: Entities with READ permissions not copied
+        """Entities with READ permissions not copied"""
         permissions = ["READ"]
         with patch.object(syn, "get",
                          return_value=self.file_ent) as patch_syn_get,\
              patch.object(syn, "getPermissions",
                           return_value=permissions) as patch_syn_permissions:
             copied_file = synapseutils.copy(syn, self.file_ent,
-                                  destinationId=self.second_project.id,
-                                  skipCopyWikiPage=True)
+                                            destinationId=self.second_project.id,
+                                            skipCopyWikiPage=True)
             assert_equals(copied_file, dict())
             patch_syn_get.assert_called_once_with(self.file_ent,
                                                   downloadFile=False)
             patch_syn_permissions.assert_called_once_with(self.file_ent,
                                                           syn.username)
-          
+
+
 class TestCopyAccessRestriction:
     """Test that entities with access restrictions aren't copied"""
     def setup(self):

--- a/tests/unit/unit_test_synapseutils_copy.py
+++ b/tests/unit/unit_test_synapseutils_copy.py
@@ -85,8 +85,11 @@ class TestCopyAccessRestriction:
     def test_copy_entity_access_requirements(self):
         # TEST: Entity with access requirement not copied
         access_requirements = {'results': ["fee", "fi"]}
+        permissions = ["DOWNLOAD"]
         with patch.object(syn, "get",
                           return_value=self.file_ent) as patch_syn_get,\
+             patch.object(syn, "getPermissions",
+                          return_value=permissions) as patch_syn_permissions,\
              patch.object(syn, "restGET",
                           return_value=access_requirements) as patch_restget:
             copied_file = synapseutils.copy(syn, self.file_ent,

--- a/tests/unit/unit_test_synapseutils_copy.py
+++ b/tests/unit/unit_test_synapseutils_copy.py
@@ -4,10 +4,12 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import unit
-from nose.tools import assert_raises
 from mock import patch, call
+from nose.tools import assert_raises, assert_equals
+import unit
+import uuid
 
+from synapseclient import Project, File
 import synapseutils
 
 
@@ -47,4 +49,28 @@ def test_copyWiki_input_validation():
         mock_getWiki.assert_has_calls(expected_calls)
 
         assert_raises(ValueError, synapseutils.copyWiki, syn, "syn123", "syn456", entitySubPageId="some_string",
-                              updateLinks=False)
+                      updateLinks=False)
+
+class TestCopyPermissions:
+    """Test copy entities with different permissions"""
+    def setup(self):
+        self.project_entity = Project(name=str(uuid.uuid4()), id="syn1234")
+        self.second_project = Project(name=str(uuid.uuid4()), id="syn2345")
+        self.file_ent = File(name='File', parent=self.project_entity.id,
+                             id="syn3456")
+
+    def test_dont_copy_read_permissions(self):
+        #TEST: Entities with READ permissions not copied
+        permissions = ["READ"]
+        with patch.object(syn, "get",
+                         return_value=self.file_ent) as patch_syn_get,\
+             patch.object(syn, "getPermissions",
+                          return_value=permissions) as patch_syn_permissions:
+            copied_file = synapseutils.copy(syn, self.file_ent,
+                                            destinationId=self.second_project.id,
+                                            skipCopyWikiPage=True)
+            assert_equals(copied_file, dict())
+            patch_syn_get.assert_called_once_with(self.file_ent,
+                                                  downloadFile=False)
+            patch_syn_permissions.assert_called_once_with(self.file_ent,
+                                                          syn.username)


### PR DESCRIPTION
Currently the permissions of entities aren't checked, so copy function attempts to copy entities with VIEW permissions and fails.