### PR TITLE
Change internal version number to be comparable.

### DIFF
--- a/synapseclient/synapsePythonClient
+++ b/synapseclient/synapsePythonClient
@@ -1,6 +1,6 @@
 {
   "client":"synapsePythonClient",
-  "latestVersion":"1.9.4-develop",
+  "latestVersion":"1.9.4.dev0",
   "blacklist":["0.0.0", "0.4.1", "0.4.0", "0.3.0", "0.2.1", "0.2.0", "0.1.4"],
   "releaseNotes":"https://python-docs.synapse.org/build/html/news.html"
 }


### PR DESCRIPTION
When trying to include this package as a dependency by using a `requirements.txt` like this:

```
git+https://www.github.com/Sage-Bionetworks/synapsePythonClient.git@v1.9.4-develop
git+https://www.github.com/bsmn/ndasynapse.git@v0.4.3
```

with a version number of `v1.9.4-develop`, I get:

```
ERROR: ndasynapse 0.4.3 has requirement synapseclient>=1.7.2, but you'll have synapseclient 1.9.4-develop which is incompatible.
```

This indicates that the version number is not comparable and it bumps me back down to the latest release on PyPi (`v1.9.3`). The standard ([PEP-440](https://www.python.org/dev/peps/pep-0440/#developmental-releases)) indicates the format should be `v1.9.4.devN` where `N` is a non-negative integer.