### PR TITLE
SYNPY-851 invite user/email to team

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -2177,7 +2177,8 @@ class Synapse(object):
         https://docs.synapse.org/rest/GET/team/id/member/principalId/membershipStatus.html
 
         :param user: Synapse userid
-        :param team: A :py:class:`synapseclient.team.Team` object or a team's ID.
+        :param team: A :py:class:`synapseclient.team.Team` object or a
+                     team's ID.
 
         :returns: dict of TeamMembershipStatus"""
         teamid = id_of(team)

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -2209,8 +2209,9 @@ class Synapse(object):
         """
         self.restDELETE("/membershipInvitation/{id}".format(id=invitationid))
 
-    def membership_invitation(self, teamId, inviteeId=None, inviteeEmail=None,
-                              message=None):
+    def send_membership_invitation(self, teamId, inviteeId=None,
+                                   inviteeEmail=None,
+                                   message=None):
         """Create a membership invitation and send an email notification
         to the invitee.
 
@@ -2275,7 +2276,7 @@ class Synapse(object):
             # Delete all old invitations
             for invite in open_invites:
                 self._delete_membership_invitation(invite['id'])
-            return self.membership_invitation(teamid, **kwargs)
+            return self.send_membership_invitation(teamid, **kwargs)
         # Return None if no invite is sent.  Should an error should be thrown?
         return None
 

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -2190,7 +2190,7 @@ class Synapse(object):
         """Retrieve a user's Team Membership Status bundle.
         https://docs.synapse.org/rest/GET/team/id/member/principalId/membershipStatus.html
 
-        :param user: Synapse userid
+        :param user: Synapse user ID
         :param team: A :py:class:`synapseclient.team.Team` object or a
                      team's ID.
 

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -2252,26 +2252,28 @@ class Synapse(object):
 
         :returns: MembershipInvitation or None if user is already a member
         """
-        user = kwargs.get("inviteeId")
-        email = kwargs.get("inviteeEmail")
-        if email is not None and user is not None:
-            raise ValueError("Must only specify one of 'inviteeId' or 'inviteeEmail'")
+        # Throw error if both user and email is specified and if both not
+        # specified
+        id_email_specified = inviteeEmail is not None and inviteeId is not None
+        id_email_notspecified = inviteeEmail is None and inviteeId is None
+        if id_email_specified or id_email_notspecified:
+            raise ValueError("Must specify either 'inviteeId' or 'inviteeEmail'")
 
         teamid = id_of(team)
         is_member = False
         open_invitations = self.get_team_open_invitations(teamid)
 
-        if user is not None:
-            userid = self.getUserProfile(user)['ownerId']
+        if inviteeId is not None:
+            userid = self.getUserProfile(inviteeId)['ownerId']
             membership_status = self.get_membership_status(userid, teamid)
             is_member = membership_status['isMember']
             open_invites_to_user = [invitation
                                     for invitation in open_invitations
-                                    if invitation.get('inviteeId') == user]
+                                    if invitation.get('inviteeId') == inviteeId]
         else:
             open_invites_to_user = [invitation
                                     for invitation in open_invitations
-                                    if invitation.get('inviteeEmail') == email]
+                                    if invitation.get('inviteeEmail') == inviteeEmail]
         # Only invite if the invitee is not a member and
         # if invitee doesn't have an open invitation unless force=True
         if not is_member and (not open_invites_to_user or force):

--- a/tests/integration/integration_test_Entity.py
+++ b/tests/integration/integration_test_Entity.py
@@ -241,10 +241,10 @@ def test_store_with_flags():
     # This should be ignored because contents (and md5) are different
     different_filepath = utils.make_bogus_binary_file()
     schedule_for_cleanup(different_filepath)
-    differentBogus = File(different_filepath, name='Bogus Test File',
+    mutaBogus = File(different_filepath, name='Bogus Test File',
                           parent=project)
-    differentBogus = syn.store(differentBogus, forceVersion=False)
-    assert_equals(differentBogus.versionNumber, 3)
+    mutaBogus = syn.store(mutaBogus, forceVersion=False)
+    assert_equals(mutaBogus.versionNumber, 3)
 
     # -- CreateOrUpdate flag for files --
     # Store a different file with the same name and parent
@@ -254,13 +254,13 @@ def test_store_with_flags():
     mutaBogus.path = new_filepath
     mutaBogus = syn.store(mutaBogus, createOrUpdate=True)
     assert_equals(mutaBogus.id, origBogus.id)
-    assert_equals(mutaBogus.versionNumber, 3)
+    assert_equals(mutaBogus.versionNumber, 4)
     assert_false(filecmp.cmp(mutaBogus.path, filepath))
 
     # Make doubly sure the File was uploaded
     checkBogus = syn.get(mutaBogus.id)
     assert_equals(checkBogus.id, origBogus.id)
-    assert_equals(checkBogus.versionNumber, 3)
+    assert_equals(checkBogus.versionNumber, 4)
     assert_true(filecmp.cmp(mutaBogus.path, checkBogus.path))
 
     # Create yet another file with the same name and parent

--- a/tests/unit/unit_test_client.py
+++ b/tests/unit/unit_test_client.py
@@ -831,6 +831,7 @@ class MembershipInvitation:
         self.member_status = {'isMember': True}
         self.response = {'inviteeId': self.userid}
         self.message = "custom message"
+        self.profile = {'ownerId': self.userid}
 
     def test_teamid_get_membership_status(self):
         """Get membership status when team id is passed in"""
@@ -861,7 +862,7 @@ class MembershipInvitation:
                        'message': self.message,
                        'inviteeEmail': self.email}
         with patch.object(syn, "getUserProfile",
-                          return_value={'ownerId': self.userid}) as patch_getprofile,\
+                          return_value=self.profile) as patch_getprofile,\
              patch.object(syn, "restPOST",
                           return_value=self.response) as patch_restpost:
             invite = syn.invite_member_to_team(self.team, email=self.email,
@@ -880,7 +881,7 @@ class MembershipInvitation:
         with patch.object(syn, "get_membership_status",
                           return_value=self.member_status) as patch_getmem,\
              patch.object(syn, "getUserProfile",
-                          return_value={'ownerId': self.userid}) as patch_getprofile,\
+                          return_value=self.profile) as patch_getprofile,\
              patch.object(syn, "restPOST",
                           return_value=self.response) as patch_restpost:
             invite = syn.invite_member_to_team(self.team, user=self.userid)
@@ -896,7 +897,7 @@ class MembershipInvitation:
         with patch.object(syn, "get_membership_status",
                           return_value=self.member_status) as patch_getmem,\
              patch.object(syn, "getUserProfile",
-                          return_value={'ownerId': self.userid}) as patch_getprofile,\
+                          return_value=self.profile) as patch_getprofile,\
              patch.object(syn, "restPOST") as patch_restpost:
             invite = syn.invite_member_to_team(self.team, user=self.userid,
                                                message=None)

--- a/tests/unit/unit_test_client.py
+++ b/tests/unit/unit_test_client.py
@@ -907,7 +907,7 @@ class TestMembershipInvitation:
         """Invite user to team via their email"""
         invite_body = {'message': self.message,
                        'inviteeEmail': self.email,
-                       'inviteeId':None}
+                       'inviteeId': None}
         with patch.object(syn, "get_team_open_invitations",
                           return_value=[]) as patch_get_invites,\
              patch.object(syn, "getUserProfile",

--- a/tests/unit/unit_test_client.py
+++ b/tests/unit/unit_test_client.py
@@ -879,7 +879,7 @@ class TestMembershipInvitation:
                 user=self.userid)
             patch_restget.assert_called_once_with(request)
 
-    def test_membership_invitation(self):
+    def test_send_membership_invitation(self):
         """Test membership invitation post"""
         invite_body = {'teamId': self.team.id,
                        'message': self.message,
@@ -887,9 +887,9 @@ class TestMembershipInvitation:
                        'inviteeId': self.userid}
         with patch.object(syn, "restPOST",
                           return_value=self.response) as patch_rest_post:
-            syn.membership_invitation(self.team.id, inviteeId=self.userid,
-                                      inviteeEmail=self.email,
-                                      message=self.message)
+            syn.send_membership_invitation(self.team.id, inviteeId=self.userid,
+                                           inviteeEmail=self.email,
+                                           message=self.message)
             patch_rest_post.assert_called_once_with("/membershipInvitation",
                                                     body=json.dumps(invite_body))
 
@@ -906,7 +906,7 @@ class TestMembershipInvitation:
                           return_value=[]) as patch_get_invites,\
              patch.object(syn, "getUserProfile",
                           return_value=self.profile) as patch_get_profile,\
-             patch.object(syn, "membership_invitation",
+             patch.object(syn, "send_membership_invitation",
                           return_value=self.response) as patch_invitation:
             invite = syn.invite_to_team(self.team, inviteeEmail=self.email,
                                         message=self.message)
@@ -926,7 +926,7 @@ class TestMembershipInvitation:
                           return_value=[]) as patch_get_invites,\
              patch.object(syn, "getUserProfile",
                           return_value=self.profile) as patch_get_profile,\
-             patch.object(syn, "membership_invitation",
+             patch.object(syn, "send_membership_invitation",
                           return_value=self.response) as patch_invitation:
             invite = syn.invite_to_team(self.team, inviteeId=self.userid)
             patch_getmem.assert_called_once_with(self.userid,
@@ -946,7 +946,7 @@ class TestMembershipInvitation:
                           return_value=[]) as patch_get_invites,\
              patch.object(syn, "getUserProfile",
                           return_value=self.profile) as patch_get_profile,\
-             patch.object(syn, "membership_invitation",
+             patch.object(syn, "send_membership_invitation",
                           return_value=self.response) as patch_invitation:
             invite = syn.invite_to_team(self.team, inviteeId=self.userid)
             patch_getmem.assert_called_once_with(self.userid,

--- a/tests/unit/unit_test_client.py
+++ b/tests/unit/unit_test_client.py
@@ -833,6 +833,9 @@ class MembershipInvitation:
         self.message = "custom message"
         self.profile = {'ownerId': self.userid}
 
+    def test_get_team_open_invitations(self):
+        pass
+
     def test_teamid_get_membership_status(self):
         """Get membership status when team id is passed in"""
         with patch.object(syn, "restGET") as patch_restget:


### PR DESCRIPTION
This functionality includes 4 convenience functions that wrap rest calls
* get team open invitations (GET)
* get membership status of a user (GET)
* delete membership invitation (DELETE)
* membership invitation (POST)

It also has a helper function that allows users to invite a Synapse user or an email to a Synapse team.  If the user is already part of the team, it will not send an invitation.  If an open invitation exists, the user will not be sent an invitation unless `force=True`
