### PR TITLE
maxThreads configurable

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -8,12 +8,18 @@ Release Notes
 Highlights:
 ----------------
 
-- The Synapse client object's :code:`store` and :code:`get` methods have been enhanced with an optional
-  :code:`maxThreads` keyword parameter that allows explicit specification of the number of concurrent threads
-  and connections that will be used to perform uploads and downloads. Currently these parameters only apply
-  to files whose underlying storage is AWS S3, and will be ignored if passed for other operations. If no parameter
-  is passed reasonable defaults will be chosen. If local resources allow adjusting these values higher can reduce
-  transfer times.
+- A :code:`max_threads` property of the Synapse object has been added to customize the number of concurrent threads
+  that will be used to transfer files.
+
+  .. code-block:: python
+
+    import synapseclient
+    syn = synapseclient.login()
+    syn.max_threads = 20
+
+  If not customized the default value is (cpu count + 4). Adjusting this value
+  higher may speed up file transfers if the underlying system resources can take advantage of the higher setting.
+
 
   Alternately, a value can be stored in the synapseConfig configuration file that will automatically apply
   as the default.
@@ -21,7 +27,7 @@ Highlights:
   .. code-block::
 
      [transfer]
-     maxThreads=16
+     max_threads=16
 
 A full list of issues addressed in this release are below.
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -2,6 +2,36 @@
 Release Notes
 =============
 
+2.1.0 (2020-04-0X)
+==================
+
+Highlights:
+----------------
+
+- The Synapse client object's :code:`store` and :code:`get` methods have been enhanced with an optional
+  :code:`maxThreads` keyword parameter that allows explicit specification of the number of concurrent threads
+  and connections that will be used to perform uploads and downloads. Currently these parameters only apply
+  to files whose underlying storage is AWS S3, and will be ignored if passed for other operations. If no parameter
+  is passed reasonable defaults will be chosen. If local resources allow adjusting these values higher can reduce
+  transfer times.
+
+  Alternately, a value can be stored in the synapseConfig configuration file that will automatically apply
+  as the default.
+
+  .. code-block::
+
+     [transfer]
+     maxThreads=16
+
+A full list of issues addressed in this release are below.
+
+Bug
+---
+
+-  [`SYNPY-1036 <https://sagebionetworks.jira.com/browse/SYNPY-1036>`__] -
+   different users storing same file to same folder results in 403
+
+
 2.0.0 (2020-03-23)
 ==================
 **Python 2 is no longer supported as of this release.** This release requires Python 3.6+.

--- a/synapseclient/.synapseConfig
+++ b/synapseclient/.synapseConfig
@@ -51,3 +51,11 @@
 #authEndpoint=<authEndpoint>
 #fileHandleEndpoint=<fileHandleEndpoint>
 #portalEndpoint=<portalEndpoint>
+
+## Settings to configure how Synapse uploads/downloads data
+#[transfer]
+
+# use this to confiurable how many threads/connections Synapse will use to perform file transfers
+# currently this applies to files whose underlying storage is AWS S3.
+# max_threads=16
+#

--- a/synapseclient/.synapseConfig
+++ b/synapseclient/.synapseConfig
@@ -55,7 +55,6 @@
 ## Settings to configure how Synapse uploads/downloads data
 #[transfer]
 
-# use this to confiurable how many threads/connections Synapse will use to perform file transfers
-# currently this applies to files whose underlying storage is AWS S3.
-# max_threads=16
-#
+# use this to configure the default for how many threads/connections Synapse will use to perform file transfers.
+# Currently this applies to files whose underlying storage is AWS S3.
+# maxThreads=16

--- a/synapseclient/.synapseConfig
+++ b/synapseclient/.synapseConfig
@@ -56,5 +56,5 @@
 #[transfer]
 
 # use this to configure the default for how many threads/connections Synapse will use to perform file transfers.
-# Currently this applies to files whose underlying storage is AWS S3.
-# maxThreads=16
+# Currently this applies only to files whose underlying storage is AWS S3.
+# max_threads=16

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -144,7 +144,8 @@ def get(args, syn):
         else:
             entity = syn.get(args.id, version=args.version,  # limitSearch=args.limitSearch,
                              followLink=args.followLink,
-                             downloadLocation=args.downloadLocation)
+                             downloadLocation=args.downloadLocation,
+                             max_threads=args.maxThreads)
             if "path" in entity and entity.path is not None and os.path.exists(entity.path):
                 print("Downloaded file: %s" % os.path.basename(entity.path))
             else:
@@ -533,6 +534,10 @@ def build_parser():
                             default=False, help='Download file using a multiple threaded implementation. '
                                                 'This flag will be removed in the future when multi-threaded download '
                                                 'is deemed fully stable and becomes the default implementation.')
+    parser_get.add_argument('--maxThreads', type=int, default=None,
+                            help='The maximum number of threads to use to speed up a file download. '
+                                  'Currently only applies to files stored in S3. If this is set multiThreaded '
+                                 'is implicitly assumed.')
     parser_get.add_argument('id', metavar='syn123', nargs='?', type=str,
                             help='Synapse ID of form syn123 of desired data object.')
     parser_get.set_defaults(func=get)
@@ -589,7 +594,8 @@ def build_parser():
     parser_store.add_argument('FILE', nargs='?', type=str,
                               help='file to be added to synapse.')
     parser_store.add_argument('--maxThreads', type=int, default=None,
-                              help='The maximum number of threads to use for concurrent uploads.')
+                              help='The maximum number of threads to use to speed up a file upload. '
+                                   'Currently only applies to files stored in S3.')
     parser_store.set_defaults(func=store)
 
     parser_add = subparsers.add_parser('add',  # Python 3.2+ would support alias=['store']

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -144,8 +144,7 @@ def get(args, syn):
         else:
             entity = syn.get(args.id, version=args.version,  # limitSearch=args.limitSearch,
                              followLink=args.followLink,
-                             downloadLocation=args.downloadLocation,
-                             maxThreads=args.maxThreads)
+                             downloadLocation=args.downloadLocation)
             if "path" in entity and entity.path is not None and os.path.exists(entity.path):
                 print("Downloaded file: %s" % os.path.basename(entity.path))
             else:
@@ -193,8 +192,7 @@ def store(args, syn):
     used = syn._convertProvenanceList(args.used, args.limitSearch)
     executed = syn._convertProvenanceList(args.executed, args.limitSearch)
     entity = syn.store(entity, used=used, executed=executed,
-                       forceVersion=force_version,
-                       maxThreads=args.maxThreads)
+                       forceVersion=force_version)
 
     _create_wiki_description_if_necessary(args, entity, syn)
 
@@ -534,10 +532,6 @@ def build_parser():
                             default=False, help='Download file using a multiple threaded implementation. '
                                                 'This flag will be removed in the future when multi-threaded download '
                                                 'is deemed fully stable and becomes the default implementation.')
-    parser_get.add_argument('--maxThreads', type=int, default=None,
-                            help='The maximum number of threads to use to speed up a file download. '
-                                 'Currently only applies to files stored in S3. If this is set multiThreaded '
-                                 'is implicitly assumed.')
     parser_get.add_argument('id', metavar='syn123', nargs='?', type=str,
                             help='Synapse ID of form syn123 of desired data object.')
     parser_get.set_defaults(func=get)
@@ -593,9 +587,6 @@ def build_parser():
     parser_store.add_argument('--file', type=str, help=argparse.SUPPRESS)
     parser_store.add_argument('FILE', nargs='?', type=str,
                               help='file to be added to synapse.')
-    parser_store.add_argument('--maxThreads', type=int, default=None,
-                              help='The maximum number of threads to use to speed up a file upload. '
-                                   'Currently only applies to files stored in S3.')
     parser_store.set_defaults(func=store)
 
     parser_add = subparsers.add_parser('add',  # Python 3.2+ would support alias=['store']

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -145,7 +145,7 @@ def get(args, syn):
             entity = syn.get(args.id, version=args.version,  # limitSearch=args.limitSearch,
                              followLink=args.followLink,
                              downloadLocation=args.downloadLocation,
-                             max_threads=args.maxThreads)
+                             maxThreads=args.maxThreads)
             if "path" in entity and entity.path is not None and os.path.exists(entity.path):
                 print("Downloaded file: %s" % os.path.basename(entity.path))
             else:
@@ -194,7 +194,7 @@ def store(args, syn):
     executed = syn._convertProvenanceList(args.executed, args.limitSearch)
     entity = syn.store(entity, used=used, executed=executed,
                        forceVersion=force_version,
-                       max_threads=args.maxThreads)
+                       maxThreads=args.maxThreads)
 
     _create_wiki_description_if_necessary(args, entity, syn)
 

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -536,7 +536,7 @@ def build_parser():
                                                 'is deemed fully stable and becomes the default implementation.')
     parser_get.add_argument('--maxThreads', type=int, default=None,
                             help='The maximum number of threads to use to speed up a file download. '
-                                  'Currently only applies to files stored in S3. If this is set multiThreaded '
+                                 'Currently only applies to files stored in S3. If this is set multiThreaded '
                                  'is implicitly assumed.')
     parser_get.add_argument('id', metavar='syn123', nargs='?', type=str,
                             help='Synapse ID of form syn123 of desired data object.')

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -396,7 +396,7 @@ class Synapse(object):
 
     def _get_transfer_config_max_threads(self):
         # note RawConfigParser lowercases so maxThreads -> maxthreads
-        max_threads =  self._get_config_section_dict('transfer').get('maxthreads')
+        max_threads = self._get_config_section_dict('transfer').get('maxthreads')
         if max_threads:
             try:
                 return int(max_threads)

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -205,7 +205,7 @@ class Synapse(object):
         self.table_query_max_sleep = 20
         self.table_query_timeout = 600  # in seconds
         self.multi_threaded = False  # if set to True, multi threaded download will be used for http and https URLs
-        self._max_threads = self._get_transfer_config_max_threads() or DEFAULT_NUM_THREADS
+        self.max_threads = self._get_transfer_config_max_threads() or DEFAULT_NUM_THREADS
 
         # TODO: remove once most clients are no longer on versions <= 1.7.5
         cached_sessions.migrate_old_session_file_credentials_if_necessary(self)

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -395,12 +395,13 @@ class Synapse(object):
         return self._get_config_section_dict(config_section).get("profile_name", "default")
 
     def _get_transfer_config_max_threads(self):
-        max_threads =  self._get_config_section_dict('transfer').get('max_threads')
+        # note RawConfigParser lowercases so maxThreads -> maxthreads
+        max_threads =  self._get_config_section_dict('transfer').get('maxthreads')
         if max_threads:
             try:
                 return int(max_threads)
             except ValueError:
-                self.logger.warning("Invalid transfer.max_threads config setting (%s), igoring.", max_threads)
+                self.logger.warning("Invalid transfer.maxThreads config setting (%s), igoring.", max_threads)
         return None
 
     def _getSessionToken(self, email, password):
@@ -574,7 +575,7 @@ class Synapse(object):
         :param limitSearch:      a Synanpse ID used to limit the search in Synapse if entity is specified as a local
                                  file.  That is, if the file is stored in multiple locations in Synapse only the ones
                                  in the specified folder/project will be returned.
-        :param max_threads:      The maximum number of threads to use when downloading the file (currently only
+        :param maxThreads:      The maximum number of threads to use when downloading the file (currently only
                                  applies to S3 uploads)
 
         :returns: A new Synapse Entity object of the appropriate type
@@ -700,7 +701,7 @@ class Synapse(object):
         submission = kwargs.pop('submission', None)
         followLink = kwargs.pop('followLink', False)
         path = kwargs.pop('path', None)
-        max_threads = kwargs.pop('max_threads', None) or self._get_transfer_config_max_threads()
+        max_threads = kwargs.pop('maxThreads', None) or self._get_transfer_config_max_threads()
 
         # make sure user didn't accidentlaly pass a kwarg that we don't handle
         if kwargs:  # if there are remaining items in the kwargs
@@ -830,7 +831,7 @@ class Synapse(object):
         return downloadPath
 
     def store(self, obj, *, createOrUpdate=True, forceVersion=True, versionLabel=None, isRestricted=False,
-              activity=None, used=None, executed=None, activityName=None, activityDescription=None, max_threads=None):
+              activity=None, used=None, executed=None, activityName=None, activityDescription=None, maxThreads=None):
         """
         Creates a new Entity or updates an existing Entity, uploading any files in the process.
 
@@ -851,7 +852,7 @@ class Synapse(object):
                                     the process of adding terms-of-use or review board approval for this entity.
                                     You will be contacted with regards to the specific data being restricted and the
                                     requirements of access.
-        :param max_threads:         The maximum number of threads to use when uploading the file (currently only
+        :param maxThreads:         The maximum number of threads to use when uploading the file (currently only
                                     applies to S3 uploads)
 
         :returns: A Synapse Entity, Evaluation, or Wiki
@@ -945,8 +946,6 @@ class Synapse(object):
                 needs_upload = True
 
             if needs_upload:
-                max_threads = max_threads or self._get_transfer_config_max_threads()
-
                 local_state_fh = local_state.get('_file_handle', {})
                 synapseStore = local_state.get('synapseStore', True)
                 fileHandle = upload_file_handle(self,
@@ -958,7 +957,7 @@ class Synapse(object):
                                                 md5=local_state_fh.get('contentMd5'),
                                                 file_size=local_state_fh.get('contentSize'),
                                                 mimetype=local_state_fh.get('contentType'),
-                                                max_threads=max_threads)
+                                                max_threads=maxThreads or self._get_transfer_config_max_threads())
                 properties['dataFileHandleId'] = fileHandle['id']
                 local_state['_file_handle'] = fileHandle
 

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -178,7 +178,7 @@ class Synapse(object):
 
         # cache reading the config file at an instance level (i.e.
         # the config will be read once per instantiated Synapse object).
-        self.getConfigFile = functools.lru_cache(self._getConfigFile)
+        self.getConfigFile = functools.lru_cache()(self._getConfigFile)
 
         config_debug = None
         # Check for a config file

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -177,10 +177,6 @@ class Synapse(object):
 
         cache_root_dir = cache.CACHE_ROOT_DIR
 
-        # cache reading the config file at an instance level (i.e.
-        # the config will be read once per instantiated Synapse object).
-        self.getConfigFile = functools.lru_cache()(self._getConfigFile)
-
         config_debug = None
         # Check for a config file
         self.configPath = configPath
@@ -240,9 +236,8 @@ class Synapse(object):
         # for backwards compatability when username was a part of the Synapse object and not in credentials
         return self.credentials.username if self.credentials is not None else None
 
-    # we wrap this with an instance decorator in the constructor so it
-    # is only read once per instance
-    def _getConfigFile(self, configPath):
+    @functools.lru_cache()
+    def getConfigFile(self, configPath):
         """
         Retrieves the client configuration information.
 

--- a/synapseclient/core/multithread_download/download_threads.py
+++ b/synapseclient/core/multithread_download/download_threads.py
@@ -286,10 +286,13 @@ def download_file(client,
 
     file_size = _get_file_size(pre_signed_url_provider.get_info().url)
 
+    # threads should be a positive integer
+    num_threads = max(num_threads, 1)
+
     # use a single worker to write to the file
     write_to_file_thread = DataChunkWriteToFileThread(data_queue, download_request.path, file_size)
     data_chunk_download_threads = [DataChunkDownloadThread(pre_signed_url_provider, range_queue, data_queue)
-                                   for _ in range(num_threads)]
+                                   for _ in range(max(num_threads, 1))]
 
     chunk_range_generator = _generate_chunk_ranges(file_size)
 

--- a/synapseclient/core/multithread_download/download_threads.py
+++ b/synapseclient/core/multithread_download/download_threads.py
@@ -286,9 +286,6 @@ def download_file(client,
 
     file_size = _get_file_size(pre_signed_url_provider.get_info().url)
 
-    # threads should be a positive integer
-    num_threads = max(num_threads, 1)
-
     # use a single worker to write to the file
     write_to_file_thread = DataChunkWriteToFileThread(data_queue, download_request.path, file_size)
     data_chunk_download_threads = [DataChunkDownloadThread(pre_signed_url_provider, range_queue, data_queue)

--- a/synapseclient/core/upload/multipart_upload.py
+++ b/synapseclient/core/upload/multipart_upload.py
@@ -252,93 +252,79 @@ class UploadAttempt:
 
         return part_number, part_size
 
-    def __call__(self):
-        upload_status_response = self._create_synapse_upload()
-        upload_state = upload_status_response.get('state')
-        if upload_state == 'COMPLETED':
-            # didn't force restart and already done
-            return upload_status_response
+    def _upload_parts(self, part_count, remaining_part_numbers):
+        time_upload_started = time.time()
+        completed_part_count = part_count - len(remaining_part_numbers)
 
-        self._upload_id = upload_status_response['uploadId']
-        part_count, remaining_part_numbers = self._get_remaining_part_numbers(
-            upload_status_response
+        # note this is an estimate, may not be exact since the final part
+        # may be smaller and might be included in the completed parts.
+        # it's good enough though.
+        progress = previously_transferred = min(
+            completed_part_count * self._part_size,
+            self._file_size
+        )
+        printTransferProgress(
+            progress,
+            self._file_size,
+            prefix='Uploading',
+            postfix=self._dest_file_name,
+            previouslyTransferred=previously_transferred,
         )
 
-        # if no remaining part numbers then all the parts have been
-        # uploaded but the upload has not been marked complete.
-        if remaining_part_numbers:
+        self._pre_signed_part_urls = self._fetch_pre_signed_part_urls(
+            self._upload_id,
+            remaining_part_numbers,
+        )
 
-            time_upload_started = time.time()
-            completed_part_count = part_count - len(remaining_part_numbers)
-
-            # note this is an estimate, may not be exact since the final part
-            # may be smaller and might be included in the completed parts.
-            # it's good enough though.
-            progress = previously_transferred = min(
-                completed_part_count * self._part_size,
-                self._file_size
-            )
-            printTransferProgress(
-                progress,
-                self._file_size,
-                prefix='Uploading',
-                postfix=self._dest_file_name,
-                previouslyTransferred=previously_transferred,
-            )
-
-            self._pre_signed_part_urls = self._fetch_pre_signed_part_urls(
-                self._upload_id,
-                remaining_part_numbers,
-            )
-
-            futures = []
-            executor = pool_provider.get_executor(thread_count=self._max_threads)
-            for part_number in remaining_part_numbers:
-                futures.append(
-                    executor.submit(
-                        self._handle_part,
-                        part_number,
-                    )
+        futures = []
+        executor = pool_provider.get_executor(thread_count=self._max_threads)
+        for part_number in remaining_part_numbers:
+            futures.append(
+                executor.submit(
+                    self._handle_part,
+                    part_number,
                 )
-            executor.shutdown(wait=False)
+            )
+        executor.shutdown(wait=False)
 
-            for result in concurrent.futures.as_completed(futures):
-                try:
-                    _, part_size = result.result()
-                    progress += part_size
-                    printTransferProgress(
-                        min(progress, self._file_size),
-                        self._file_size,
-                        prefix='Uploading',
-                        postfix=self._dest_file_name,
-                        dt=time.time() - time_upload_started,
-                        previouslyTransferred=previously_transferred,
+        for result in concurrent.futures.as_completed(futures):
+            try:
+                _, part_size = result.result()
+                progress += part_size
+                printTransferProgress(
+                    min(progress, self._file_size),
+                    self._file_size,
+                    prefix='Uploading',
+                    postfix=self._dest_file_name,
+                    dt=time.time() - time_upload_started,
+                    previouslyTransferred=previously_transferred,
+                )
+            except (Exception, KeyboardInterrupt) as cause:
+                with self._lock:
+                    self._aborted = True
+
+                # wait for all threads to complete before
+                # raising the exception, we don't want to return
+                # control while there are still threads from this
+                # upload attempt running
+                concurrent.futures.wait(futures)
+
+                if isinstance(cause, KeyboardInterrupt):
+                    raise SynapseUploadAbortedException(
+                        "User interrupted upload"
                     )
-                except (Exception, KeyboardInterrupt) as cause:
-                    with self._lock:
-                        self._aborted = True
 
-                    # wait for all threads to complete before
-                    # raising the exception, we don't want to return
-                    # control while there are still threads from this
-                    # upload attempt running
-                    concurrent.futures.wait(futures)
+                raise SynapseUploadFailedException(
+                    "Part upload failed"
+                ) from cause
 
-                    if isinstance(cause, KeyboardInterrupt):
-                        raise SynapseUploadAbortedException(
-                            "User interrupted upload"
-                        )
-
-                    raise SynapseUploadFailedException(
-                        "Part upload failed"
-                    ) from cause
-
+    def _complete_upload(self):
         upload_status_response = self._syn.restPUT(
             "/file/multipart/{upload_id}/complete".format(
                 upload_id=self._upload_id,
             ),
             requests_session=self._get_thread_session(),
-            endpoint=self._syn.fileHandleEndpoint
+            endpoint=self._syn.fileHandleEndpoint,
         )
 
         upload_state = upload_status_response.get('state')
@@ -349,6 +335,26 @@ class UploadAttempt:
             raise SynapseUploadFailedException(
                 "Upload status has an unexpected state {}".format(upload_state)
             )
+
+        return upload_status_response
+
+    def __call__(self):
+        upload_status_response = self._create_synapse_upload()
+        upload_state = upload_status_response.get('state')
+
+        if upload_state != 'COMPLETED':
+            self._upload_id = upload_status_response['uploadId']
+            part_count, remaining_part_numbers =\
+                self._get_remaining_part_numbers(
+                    upload_status_response
+                )
+
+            # if no remaining part numbers then all the parts have been
+            # uploaded but the upload has not been marked complete.
+            if remaining_part_numbers:
+                self._upload_parts(part_count, remaining_part_numbers)
+
+            upload_status_response = self._complete_upload()
 
         return upload_status_response
 

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -880,3 +880,4 @@ def attempt_import(module_name, fail_message):
 def require_param(param, name):
     if param is None:
         raise ValueError("%s parameter is required." %name)
+

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -879,5 +879,5 @@ def attempt_import(module_name, fail_message):
 
 def require_param(param, name):
     if param is None:
-        raise ValueError("%s parameter is required." %name)
+        raise ValueError("%s parameter is required." % name)
 

--- a/tests/integration/synapseclient/core/upload/test_multipart_upload.py
+++ b/tests/integration/synapseclient/core/upload/test_multipart_upload.py
@@ -62,6 +62,7 @@ def test_randomly_failing_parts():
     while uploading parts."""
 
     fail_every = 3  # fail every nth request
+    fail_cycle = random.randint(0, fail_every - 1)  # randomly vary which n of the request cycle we fail
     fhid = None
 
     filepath = utils.make_bogus_binary_file(MIN_PART_SIZE * 2 + (MIN_PART_SIZE / 2))
@@ -77,7 +78,7 @@ def test_randomly_failing_parts():
         nonlocal put_count
         put_count += 1
 
-        if put_count % fail_every == 0:
+        if (put_count + fail_cycle) % fail_every == 0:
             raise IOError("Ooops! Artificial upload failure for testing.")
 
         return normal_put(self, url, *args, **kwargs)

--- a/tests/integration/synapseclient/core/upload/test_multipart_upload.py
+++ b/tests/integration/synapseclient/core/upload/test_multipart_upload.py
@@ -71,7 +71,7 @@ def test_randomly_failing_parts():
 
     def _put_chunk_or_fail_randomly(self, url, *args, **kwargs):
         # fail every nth put to aws s3
-        if not 's3.amazonaws.com' in url:
+        if 's3.amazonaws.com' not in url:
             return normal_put(self, url, *args, **kwargs)
 
         nonlocal put_count

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -274,10 +274,11 @@ class Test__downloadFileHandle(unittest.TestCase):
             }
 
             syn.multi_threaded = True
-            syn._downloadFileHandle(fileHandleId=123, objectId=456, objectType="FileEntity", destination="/myfakepath")
+            syn._downloadFileHandle(fileHandleId=123, objectId=456, objectType="FileEntity", destination="/myfakepath",
+                                    max_threads=5)
 
             mock_multi_thread_download.assert_called_once_with(123, 456, "FileEntity", "/myfakepath",
-                                                               expected_md5="someMD5")
+                                                               expected_md5="someMD5", max_threads=5)
 
     def test_multithread_True__other_file_handle_type(self):
         with patch.object(os, "makedirs") as mock_makedirs, \
@@ -293,8 +294,10 @@ class Test__downloadFileHandle(unittest.TestCase):
                 'preSignedURL': 'asdf.com'
             }
 
+            # multi_threaded/max_threads will have efffect
             syn.multi_threaded = True
-            syn._downloadFileHandle(fileHandleId=123, objectId=456, objectType="FileEntity", destination="/myfakepath")
+            syn._downloadFileHandle(fileHandleId=123, objectId=456, objectType="FileEntity", destination="/myfakepath",
+                                    max_threads=7)
 
             mock_download_from_URL.assert_called_once_with("asdf.com", "/myfakepath", "123", expected_md5="someMD5")
 

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -274,11 +274,10 @@ class Test__downloadFileHandle(unittest.TestCase):
             }
 
             syn.multi_threaded = True
-            syn._downloadFileHandle(fileHandleId=123, objectId=456, objectType="FileEntity", destination="/myfakepath",
-                                    max_threads=5)
+            syn._downloadFileHandle(fileHandleId=123, objectId=456, objectType="FileEntity", destination="/myfakepath")
 
             mock_multi_thread_download.assert_called_once_with(123, 456, "FileEntity", "/myfakepath",
-                                                               expected_md5="someMD5", max_threads=5)
+                                                               expected_md5="someMD5")
 
     def test_multithread_True__other_file_handle_type(self):
         with patch.object(os, "makedirs") as mock_makedirs, \
@@ -294,10 +293,9 @@ class Test__downloadFileHandle(unittest.TestCase):
                 'preSignedURL': 'asdf.com'
             }
 
-            # multi_threaded/max_threads will have efffect
+            # multi_threaded/max_threads will have effect
             syn.multi_threaded = True
-            syn._downloadFileHandle(fileHandleId=123, objectId=456, objectType="FileEntity", destination="/myfakepath",
-                                    max_threads=7)
+            syn._downloadFileHandle(fileHandleId=123, objectId=456, objectType="FileEntity", destination="/myfakepath")
 
             mock_download_from_URL.assert_called_once_with("asdf.com", "/myfakepath", "123", expected_md5="someMD5")
 

--- a/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
+++ b/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
@@ -541,8 +541,8 @@ class TestUploadAttempt:
             mock.patch.object(upload, '_fetch_pre_signed_part_urls')\
             as fetch_pre_signed_urls,\
             mock.patch.object(pool_provider, 'get_executor')\
-                as get_executor,\
-            mock.patch.object(upload._syn, 'restPUT') as restPUT:
+            as get_executor,\
+                mock.patch.object(upload._syn, 'restPUT') as restPUT:
 
             create_synapse_upload.return_value = create_status_response
             restPUT.return_value = complete_status_response

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -1255,6 +1255,15 @@ def test_get_config_file_caching():
         assert_equal(2, get_config_file.call_count)
 
 
+def test_max_threads_bounded():
+    """Verify we disallow setting max threads higher than our cap."""
+    syn.max_threads = client.MAX_THREADS_CAP + 1
+    assert_equal(syn.max_threads, client.MAX_THREADS_CAP)
+
+    syn.max_threads = 0
+    assert_equal(syn.max_threads, 1)
+
+
 def test_get_transfer_config_max_threads():
     """Verify reading transfer.maxThreads from synapseConfig"""
 

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -1272,7 +1272,7 @@ def test_get_transfer_config_max_threads():
             mock_config_dict.return_value = {'max_threads': str(max_threads)}
             assert_equal(max_threads, syn._get_transfer_config_max_threads())
 
-        with assert_raises(ValueError) :
+        with assert_raises(ValueError):
             for invalid_value in ('not a number', '12.2', 'true'):
                 mock_config_dict.return_value = {'max_threads': invalid_value}
                 syn._get_transfer_config_max_threads()

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -1230,6 +1230,7 @@ class TestSetAnnotations:
                                                        ' "annotations": {"foo": {"type": "STRING", '
                                                        '"value": ["bar"]}}}')
 
+
 def test_get_transfer_config_max_threads():
     """Verify reading transfer.maxThreads from synapseConfig"""
 
@@ -1253,4 +1254,3 @@ def test_get_transfer_config_max_threads():
                 assert_is_none(syn._get_transfer_config_max_threads())
                 logger.warning.assert_called_once()
                 logger.reset_mock()
-

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -1236,8 +1236,8 @@ def test_get_config_file_caching():
     """Verify we read a config file once per Synapse and are not
     parsing the file multiple times just on init."""
 
-    with patch.object(Synapse, '_getConfigFile') as get_config_file:
-        get_config_file.return_value = configparser.ConfigParser()
+    with patch('configparser.RawConfigParser.read') as read_config:
+        read_config.return_value = configparser.ConfigParser()
 
         syn1 = Synapse(debug=False, skip_checks=True, configPath='/foo')
 
@@ -1245,14 +1245,14 @@ def test_get_config_file_caching():
         config1a = syn1.getConfigFile('/foo')
         config1b = syn1.getConfigFile('/foo')
         assert_equal(config1a, config1b)
-        assert_equal(1, get_config_file.call_count)
+        assert_equal(1, read_config.call_count)
 
         # however a new instance should not be cached
         syn2 = Synapse(debug=False, skip_checks=True, configPath='/foo')
-        assert_equal(2, get_config_file.call_count)
+        assert_equal(2, read_config.call_count)
 
         # but an additional call on that instance should be
-        assert_equal(2, get_config_file.call_count)
+        assert_equal(2, read_config.call_count)
 
 
 def test_max_threads_bounded():

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -117,7 +117,7 @@ class TestPrivateGetWithEntityBundle:
         }
 
         with patch.object(syn.logger, "warning") as mocked_warn:
-            entity_no_download = syn._getWithEntityBundle(entityBundle=bundle, max_threads=5)
+            entity_no_download = syn._getWithEntityBundle(entityBundle=bundle, maxThreads=5)
             mocked_warn.assert_called_once()
             assert_is_none(entity_no_download.path)
 
@@ -1231,22 +1231,25 @@ class TestSetAnnotations:
                                                        '"value": ["bar"]}}}')
 
 def test_get_transfer_config_max_threads():
-    """Verify reading transfer.max_threads from synapseConfig"""
+    """Verify reading transfer.maxThreads from synapseConfig"""
+
+    # note that RawConfigParser lower cases its option values so we
+    # simulate that behavior in our mocked values here
 
     with patch.object(syn, "_get_config_section_dict") as mock_config_dict:
         empty_value_dicts = [{}]
-        empty_value_dicts.extend([{'max_threads': v} for v in ('', None)])
+        empty_value_dicts.extend([{'maxthreads': v} for v in ('', None)])
         for empty_value_dict in empty_value_dicts:
             mock_config_dict.return_value = empty_value_dict
             assert_is_none(syn._get_transfer_config_max_threads())
 
         for max_threads in (1, 7, 100):
-            mock_config_dict.return_value = {'max_threads': str(max_threads)}
+            mock_config_dict.return_value = {'maxthreads': str(max_threads)}
             assert_equal(max_threads, syn._get_transfer_config_max_threads())
 
         with patch.object(syn, 'logger') as logger:
             for invalid_value in ('not a number', '12.2', 'true'):
-                mock_config_dict.return_value = {'max_threads': invalid_value}
+                mock_config_dict.return_value = {'maxthreads': invalid_value}
                 assert_is_none(syn._get_transfer_config_max_threads())
                 logger.warning.assert_called_once()
                 logger.reset_mock()

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -155,7 +155,7 @@ class TestPrivateGetWithEntityBundle:
         if os.path.exists(cacheMap):
             os.remove(cacheMap)
 
-        def _downloadFileHandle(fileHandleId,  objectId, objectType, path, retries=5):
+        def _downloadFileHandle(fileHandleId,  objectId, objectType, path, retries=5, max_threads=None):
             # touch file at path
             with open(path, 'a'):
                 os.utime(path, None)


### PR DESCRIPTION
1. Extends the threading configurability to allow you to specify a value for S3 downloads as well as uploads since it seems nicely symmetrical that way.
2. Adds a [transfer] section to the synapseConfig with a maxThreads option for specifying the setting so you don't have to always specify it on each call. 
3. Makes the public facing API param for maxThreads mixed case since that matches the existing convention on those calls. Internal function params may still be snake_cased per PEP8.
4. Adds some doc for this to the release notes.