### PR TITLE
Support parallelized integration tests from Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ script:
 - nosetests --traverse-namespace -s tests/unit
 - |
   if [ "${TRAVIS_PULL_REQUEST}" = "false" ];then
-    nosetests --traverse-namespace -s -v tests/integration
+    nosetests --processes=-1 --process-timeout=180 --traverse-namespace -s -v tests/integration
   else
     echo "Skipping integration tests";
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+_linux_env: &linux_env
+  env:
+  - 'PYTHON_LIBS="-L$(python-config --prefix)/lib $(python-config --libs)"'
+  - PY_ENABLE_SHARD=0
+  - MULTI_PROCESS_PARAMS="--processes=-1 --process-timeout=180"
+
 sudo: required
 language: python
 
@@ -5,23 +11,15 @@ matrix:
   include:
     - os: linux
       python: 3.6
-      env:
-      - 'PYTHON_LIBS="-L$(python-config --prefix)/lib $(python-config --libs)"'
-      - PY_ENABLE_SHARD=0
+      <<: *linux_env
     - os: linux
       python: 3.7
-      env:
-      - 'PYTHON_LIBS="-L$(python-config --prefix)/lib $(python-config --libs)"'
-      - PY_ENABLE_SHARD=0
+      <<: *linux_env
     - os: linux
       python: 3.8
       dist: bionic
       sudo: required
-      env:
-      - 'PYTHON_LIBS="-L$(python-config --prefix)/lib $(python-config --libs)"'
-      - PY_ENABLE_SHARD=0
-
-
+      <<: *linux_env
     - os: osx
       language: generic
       env: PY_VERSION=3.6.10
@@ -72,10 +70,7 @@ script:
 - nosetests --traverse-namespace -s tests/unit
 - |
   if [ "${TRAVIS_PULL_REQUEST}" = "false" ];then
-    nosetests --processes=-1 --process-timeout=180 --traverse-namespace -s -v tests/integration
+    nosetests $MULTI_PROCESS_PARAMS --traverse-namespace -s -v tests/integration
   else
     echo "Skipping integration tests";
   fi
-
-
-

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -21,6 +21,11 @@ from synapseclient.core.logging_setup import SILENT_LOGGER_NAME
 
 QUERY_TIMEOUT_SEC = 25
 
+# when running integration tests using the nose multiprocess plugin
+# the fixtures in this module should be invoked once in the parent process
+# prior to the fork.
+_multiprocess_shared_ = True
+
 
 def setup_module(module):
     print("Python version:", sys.version)

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -26,22 +26,40 @@ QUERY_TIMEOUT_SEC = 25
 # prior to the fork.
 _multiprocess_shared_ = True
 
+_parent_pid = os.getpid()
+_child_syn = None
+
+
+def _get_syn():
+    # return a Synapse instance for safely running tests.
+    # if we're in the parent process we can use the instance
+    # initialized during shared Setup, otherwise in a child
+    # process we lazily initialize a new Synapse.
+    # we need separate Synapse instances otherwise we may
+    # have http session issues using forked copies of the same
+    # Synapse instance and its underlying http connection pool.
+
+    if os.getpid() == _parent_pid:
+        return syn
+
+    global _child_syn
+    if not _child_syn:
+        _child_syn = _init_syn()
+    return _child_syn
+
 
 def setup_module(module):
     print("Python version:", sys.version)
 
-    syn = Synapse(debug=False, skip_checks=True)
-    syn.logger = logging.getLogger(SILENT_LOGGER_NAME)
-
+    syn = _init_syn()
     print("Testing against endpoints:")
     print("  " + syn.repoEndpoint)
     print("  " + syn.authEndpoint)
     print("  " + syn.fileHandleEndpoint)
     print("  " + syn.portalEndpoint + "\n")
 
-    syn.login()
     module.syn = syn
-    module._to_cleanup = []
+    _init_cleanup(module)
 
     # Make one project for all the tests to use
     project = syn.store(Project(name="integration_test_project"+str(uuid.uuid4())))
@@ -55,6 +73,19 @@ def setup_module(module):
     os.chdir(working_directory)
 
 
+def _init_syn():
+    syn = Synapse(debug=False, skip_checks=True)
+    syn.logger = logging.getLogger(SILENT_LOGGER_NAME)
+    syn.login()
+    return syn
+
+
+def _init_cleanup(module):
+    to_cleanup = []
+    module._to_cleanup = to_cleanup
+    module.schedule_for_cleanup = lambda item: to_cleanup.append(item)
+
+
 def init_module(module, teardown=None):
     """Instrument the given module with integration test facilities.
     Adds a logged in Synapse object, a project that can be used for
@@ -66,33 +97,28 @@ def init_module(module, teardown=None):
     :param teardown: a teardown function if there is additional behavior
         that needs to be invoked on module teardown
     """
-    module.syn = syn
+
+    module.syn = _get_syn()
     module.project = project
 
-    to_cleanup = []
-    module._to_cleanup = to_cleanup
-    module.schedule_for_cleanup = lambda item: to_cleanup.append(item)
+    _init_cleanup(module)
 
     def _teardown(module):
         if teardown:
             teardown(module)
-        cleanup(to_cleanup)
+        cleanup(module._to_cleanup, module.syn)
 
     module.teardown = _teardown
 
 
 def teardown_module(module):
     os.chdir(module._old_working_directory)
-    cleanup(module._to_cleanup)
+    cleanup(module._to_cleanup, module.syn)
 
 
-def schedule_for_cleanup(item):
-    """schedule a file of Synapse Entity to be deleted during teardown"""
-    globals()['_to_cleanup'].append(item)
-
-
-def cleanup(items):
+def cleanup(items, syn):
     """cleanup junk created during testing"""
+
     for item in reversed(items):
         if isinstance(item, Entity) or utils.is_synapse_id(item) or hasattr(item, 'deleteURI'):
             try:

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -5,6 +5,9 @@ To run all the tests      : nosetests -vs tests
 To run a single test suite: nosetests -vs tests/integration
 To run a single test set  : nosetests -vs tests/integration/integration_test_Entity.py
 To run a single test      : nosetests -vs tests/integration/integration_test_Entity.py:test_Entity
+
+On linux supports the nost multiprocess plugin to parallize test runs, e.g.:
+nosetests -vs --processes=-1 --process-timeout=180 tests/integration
 """
 
 import logging
@@ -22,8 +25,7 @@ from synapseclient.core.logging_setup import SILENT_LOGGER_NAME
 QUERY_TIMEOUT_SEC = 25
 
 # when running integration tests using the nose multiprocess plugin
-# the fixtures in this module should be invoked once in the parent process
-# prior to the fork.
+# the fixtures in this module should be invoked once in the parent process.
 _multiprocess_shared_ = True
 
 _parent_pid = os.getpid()
@@ -89,8 +91,8 @@ def _init_cleanup(module):
 def init_module(module, teardown=None):
     """Instrument the given module with integration test facilities.
     Adds a logged in Synapse object, a project that can be used for
-    with testing, a schedule_for_cleanup function, and a teardown
-    that will automatically invoke the cleanup in when the module
+    testing, a schedule_for_cleanup function, and a teardown
+    that will automatically invoke the cleanup when the module
     is torn down.
 
     :param module: the module being instrumented

--- a/tests/integration/synapseclient/core/test_caching.py
+++ b/tests/integration/synapseclient/core/test_caching.py
@@ -13,27 +13,25 @@ from queue import Queue
 
 from synapseclient.core.exceptions import *
 from synapseclient import *
-from tests import integration
-from tests.integration import schedule_for_cleanup
+from tests.integration import init_module
 
 
 def setup(module):
-    module.syn = integration.syn
-    module.project = integration.project
-    
+    init_module(module, teardown=_teardown)
+
     # Use the module-level syn object to communicate between main and child threads
     # - Read-only objects (for the children)
     module.syn.test_parent = module.syn.store(Project(name=str(uuid.uuid4())))
     schedule_for_cleanup(module.syn.test_parent)
     module.syn.test_keepRunning = True
-    
+
     # - Child writeable objects
     module.syn.test_errors = Queue()
     module.syn.test_runCountMutex = Lock()
     module.syn.test_threadsRunning = 0
-    
 
-def teardown(module):
+
+def _teardown(module):
     del module.syn.test_parent
     del module.syn.test_keepRunning
     del module.syn.test_errors
@@ -45,13 +43,13 @@ def test_threaded_access():
     """Starts multiple threads to perform store and get calls randomly."""
     # Doesn't this test look like a DOS attack on Synapse?
     # Maybe it should be called explicity...
-    
+
     # Suppress most of the output from the many REST calls
     #   Otherwise, it flood the screen with irrelevant data upon error
     requests_log = logging.getLogger("requests")
     requests_originalLevel = requests_log.getEffectiveLevel()
     requests_log.setLevel(logging.WARNING)
-    
+
     store_thread = wrap_function_as_child_thread(thread_keep_storing_one_File)
     get_thread = wrap_function_as_child_thread(thread_get_files_from_Project)
     update_thread = wrap_function_as_child_thread(thread_get_and_update_file_from_Project)
@@ -65,19 +63,19 @@ def test_threaded_access():
     thread.start_new_thread(update_thread, ())
     thread.start_new_thread(update_thread, ())
     thread.start_new_thread(update_thread, ())
-    
+
     # Give the threads some time to wreak havoc on the cache
     time.sleep(20)
-    
+
     syn.test_keepRunning = False
     while syn.test_threadsRunning > 0:
         time.sleep(1)
 
     # Reset the requests logging level
     requests_log.setLevel(requests_originalLevel)
-        
+
     collect_errors_and_fail()
-  
+
 #############
 #  Helpers  #
 #############
@@ -85,23 +83,23 @@ def test_threaded_access():
 
 def wrap_function_as_child_thread(function):
     """Wraps the given function so that it ties into the main thread."""
-    
+
     def child_thread():
         syn.test_runCountMutex.acquire()
         syn.test_threadsRunning += 1
         syn.test_runCountMutex.release()
-        
+
         try:
             function()
         except Exception:
             syn.test_errors.put(traceback.format_exc())
-            
+
         syn.test_runCountMutex.acquire()
         syn.test_threadsRunning -= 1
         syn.test_runCountMutex.release()
-        
+
     return child_thread
-    
+
 
 def collect_errors_and_fail():
     """Pulls error traces from the error queue and fails if the queue is not empty."""
@@ -110,7 +108,7 @@ def collect_errors_and_fail():
         failures.append(syn.test_errors.get())
     if len(failures) > 0:
         raise SynapseError('\n' + '\n'.join(failures))
-    
+
 ######################
 #  Thread Behaviors  #
 ######################
@@ -118,12 +116,12 @@ def collect_errors_and_fail():
 
 def thread_keep_storing_one_File():
     """Makes one file and stores it over and over again."""
-    
+
     # Make a local file to continuously store
     path = utils.make_bogus_data_file()
     schedule_for_cleanup(path)
     myPrecious = File(path, parent=syn.test_parent, description='This bogus file is MINE', mwa="hahahah")
-    
+
     while syn.test_keepRunning:
         stored = store_catch_412_HTTPError(myPrecious)
         if stored is not None:
@@ -133,28 +131,28 @@ def thread_keep_storing_one_File():
 
         sleep_for_a_bit()
 
-        
+
 def thread_get_files_from_Project():
     """Continually polls and fetches items from the Project."""
-    
+
     while syn.test_keepRunning:
         for id in get_all_ids_from_Project():
             pass
-            
+
         sleep_for_a_bit()
-        
+
 
 def thread_get_and_update_file_from_Project():
     """Fetches one item from the Project and updates it with a new file."""
-    
+
     while syn.test_keepRunning:
         id = get_all_ids_from_Project()
         if len(id) <= 0:
             continue
-            
+
         id = id[random.randrange(len(id))]
         entity = syn.get(id)
-        
+
         # Replace the file and re-store
         path = utils.make_bogus_data_file()
         schedule_for_cleanup(path)
@@ -162,24 +160,24 @@ def thread_get_and_update_file_from_Project():
         entity = store_catch_412_HTTPError(entity)
         if entity is not None:
             assert_equals(os.stat(entity.path), os.stat(path))
-            
+
         sleep_for_a_bit()
-    
+
 ####################
 #  Thread Helpers  #
 ####################
-    
+
 
 def sleep_for_a_bit():
     """Sleeps for a random amount of seconds between 1 and 5 inclusive."""
-    
+
     time.sleep(random.randint(1, 5))
 
 
 def get_all_ids_from_Project():
     """Fetches all currently available Synapse IDs from the parent Project."""
     return [result['id'] for result in syn.getChildren(syn.test_parent.id)]
-    
+
 
 def store_catch_412_HTTPError(entity):
     """Returns the stored Entity if the function succeeds or None if the 412 is caught."""
@@ -190,4 +188,3 @@ def store_catch_412_HTTPError(entity):
         if err.response.status_code == 412:
             return None
         raise
-

--- a/tests/integration/synapseclient/core/test_download.py
+++ b/tests/integration/synapseclient/core/test_download.py
@@ -9,14 +9,11 @@ import time
 
 from synapseclient.core.exceptions import *
 from synapseclient import *
-from tests import integration
-from tests.integration import schedule_for_cleanup
+from tests.integration import init_module
 
 
 def setup(module):
-
-    module.syn = integration.syn
-    module.project = integration.project
+    init_module(module)
 
 
 def test_download_check_md5():
@@ -38,7 +35,6 @@ def test_download_check_md5():
 
 def test_resume_partial_download():
     original_file = utils.make_bogus_data_file(40000)
-    original_md5 = utils.md5_for_file(original_file).hexdigest()
 
     entity = File(original_file, parent=project['id'])
     entity = syn.store(entity)

--- a/tests/integration/synapseclient/core/upload/test_multipart_upload.py
+++ b/tests/integration/synapseclient/core/upload/test_multipart_upload.py
@@ -10,15 +10,12 @@ import synapseclient.core.config
 from synapseclient.core.utils import *
 from synapseclient.core.exceptions import *
 from synapseclient import *
-from synapseclient.core.upload import multipart_upload
 from synapseclient.core.upload.multipart_upload import *
-from tests import integration
-from tests.integration import schedule_for_cleanup
+from tests.integration import init_module
 
 
 def setup(module):
-    module.syn = integration.syn
-    module.project = integration.project
+    init_module(module)
 
 
 def test_round_trip():
@@ -137,4 +134,3 @@ def test_multipart_upload_big_string():
         retrieved_text = f.read()
 
     assert_equals(retrieved_text, text)
-

--- a/tests/integration/synapseclient/core/upload/test_sftp_upload.py
+++ b/tests/integration/synapseclient/core/upload/test_sftp_upload.py
@@ -3,7 +3,7 @@ from urllib.parse import urlparse
 import filecmp
 import os
 import traceback
-import uuid 
+import uuid
 from nose.tools import assert_is_not_none, assert_equals
 import tempfile
 import shutil
@@ -12,8 +12,7 @@ from synapseclient.core.utils import MB
 from synapseclient.core.exceptions import *
 from synapseclient import *
 from synapseclient.core.remote_file_storage_wrappers import SFTPWrapper
-from tests import integration
-from tests.integration import schedule_for_cleanup
+from tests.integration import init_module
 
 SFTP_SERVER_PREFIX = "sftp://ec2-18-209-45-78.compute-1.amazonaws.com"
 SFTP_USER_HOME_PATH = "/home/sftpuser"
@@ -32,9 +31,8 @@ DESTINATIONS = [{"uploadType": "SFTP",
 
 
 def setup(module):
+    init_module(module, teardown=teardown)
 
-    module.syn = integration.syn
-    module.project = integration.project
     # Create the upload destinations
     destinations = [syn.createStorageLocationSetting('ExternalStorage', **x)['storageLocationId'] for x in DESTINATIONS]
     module._sftp_project_setting_id = syn.setStorageLocation(project, destinations)['id']

--- a/tests/integration/synapseclient/integration_test.py
+++ b/tests/integration/synapseclient/integration_test.py
@@ -15,13 +15,11 @@ from synapseclient import client
 from synapseclient import *
 from synapseclient.core.exceptions import *
 from synapseclient.core.version_check import version_check
-from tests import integration
-from tests.integration import schedule_for_cleanup
+from tests.integration import init_module
 
 
 def setup(module):
-    module.syn = integration.syn
-    module.project = integration.project
+    init_module(module)
 
 
 def test_login():
@@ -58,7 +56,7 @@ def test_login():
         # mock to make the config file empty
         with patch.object(syn, "_get_config_authentication", return_value={}):
 
-            # Login with no credentials 
+            # Login with no credentials
             assert_raises(SynapseNoCredentialsError, syn.login)
 
             # remember login info in cache
@@ -135,8 +133,8 @@ def test_entity_version():
     assert_equals(returnEntity.versionNumber, 1)
     assert_equals(returnEntity['fizzbuzz'][0], 111222)
     assert_not_in('foo', returnEntity)
-    
-    # Delete version 2 
+
+    # Delete version 2
     syn.delete(entity, version=2)
     returnEntity = syn.get(entity)
     assert_equals(returnEntity.versionNumber, 1)
@@ -147,14 +145,14 @@ def test_md5_query():
     path = utils.make_bogus_data_file()
     schedule_for_cleanup(path)
     repeated = File(path, parent=project['id'], description='Same data over and over again')
-    
+
     # Retrieve the data via MD5
     num = 5
     stored = []
     for i in range(num):
         repeated.name = 'Repeated data %d.dat' % i
         stored.append(syn.store(repeated).id)
-    
+
     # Although we expect num results, it is possible for the MD5 to be non-unique
     results = syn.md5Query(utils.md5_for_file(path).hexdigest())
     assert_equals(str(sorted(stored)), str(sorted([res['id'] for res in results])))
@@ -163,12 +161,12 @@ def test_md5_query():
 
 def test_uploadFile_given_dictionary():
     # Make a Folder Entity the old fashioned way
-    folder = {'concreteType': Folder._synapse_entity_type, 
+    folder = {'concreteType': Folder._synapse_entity_type,
               'parentId': project['id'],
               'name': 'fooDictionary',
               'foo': 334455}
     entity = syn.store(folder)
-    
+
     # Download and verify that it is the same file
     entity = syn.get(entity)
     assert_equals(entity.parentId, project.id)
@@ -238,6 +236,7 @@ def test_download_multithreaded():
     assert_true(filecmp.cmp(fname, entity['path']))
     syn.multi_threaded = False
 
+
 def test_downloadFile():
     # See if the a "wget" works
     filename = utils.download_file("http://dev-versions.synapse.sagebase.org/sage_bionetworks_logo_274x128.png")
@@ -284,13 +283,13 @@ def test_provenance():
             """))
     schedule_for_cleanup(path)
     code_entity = syn.store(File(path, parent=project['id']))
-    
+
     # Create a new Activity asserting that the Code Entity was 'used'
     activity = Activity(name='random.gauss', description='Generate some random numbers')
     activity.used(code_entity, wasExecuted=True)
     activity.used({'name': 'Superhack', 'url': 'https://github.com/joe_coder/Superhack'}, wasExecuted=True)
     activity = syn.setProvenance(data_entity, activity)
-    
+
     # Retrieve and verify the saved Provenance record
     retrieved_activity = syn.getProvenance(data_entity)
     assert_equals(retrieved_activity, activity)
@@ -333,13 +332,13 @@ def test_annotations():
     annote['goobers'] = ['chris', 'jen', 'jane']
     annote['present_time'] = datetime.now()
     syn.set_annotations(annote)
-    
+
     # Check it again
     annotation = syn.get_annotations(entity)
     assert_equals(annotation['primes'], [2, 3, 5, 7, 11, 13, 17, 19, 23, 29])
     assert_equals(annotation['phat_numbers'], [1234.5678, 8888.3333, 1212.3434, 6677.8899])
     assert_equals(annotation['goobers'], ['chris', 'jen', 'jane'])
-    assert_equals(annotation['present_time'][0].strftime('%Y-%m-%d %H:%M:%S'), \
+    assert_equals(annotation['present_time'][0].strftime('%Y-%m-%d %H:%M:%S'),
                   annote['present_time'].strftime('%Y-%m-%d %H:%M:%S'))
 
 

--- a/tests/integration/synapseclient/integration_test_Entity.py
+++ b/tests/integration/synapseclient/integration_test_Entity.py
@@ -11,13 +11,11 @@ from synapseclient.core.upload.upload_functions import create_external_file_hand
 
 from synapseclient import *
 from synapseclient.core.exceptions import *
-from tests import integration
-from tests.integration import schedule_for_cleanup
+from tests.integration import init_module
 
 
 def setup(module):
-    module.syn = integration.syn
-    module.project = integration.project
+    init_module(module)
 
 
 def test_Entity():
@@ -28,7 +26,7 @@ def test_Entity():
     schedule_for_cleanup(project)
     project = syn.get(project)
     assert_equals(project.name, project_name)
-    
+
     # Create and get a Folder
     folder = Folder('Test Folder', parent=project, description='A place to put my junk', foo=1000)
     folder = syn.store(folder)
@@ -37,7 +35,7 @@ def test_Entity():
     assert_equals(folder.parentId, project.id)
     assert_equals(folder.description, 'A place to put my junk')
     assert_equals(folder.foo[0], 1000)
-    
+
     # Update and get the Folder
     folder.pi = 3.14159265359
     folder.description = 'The rejects from the other folder'
@@ -71,7 +69,7 @@ def test_Entity():
     assert_equals(a_file.contentType, 'text/flapdoodle', u'contentType= %s' % a_file.contentType)
     assert_equals(a_file['band'][0], u"Motörhead", u'band= %s' % a_file['band'][0])
     assert_equals(a_file['lunch'][0], u"すし", u'lunch= %s' % a_file['lunch'][0])
-    
+
     a_file = syn.get(a_file)
     assert_true(filecmp.cmp(path, a_file.path))
 
@@ -93,21 +91,21 @@ def test_Entity():
 
     # Test create, store, get Links
     # If version isn't specified, targetVersionNumber should not be set
-    link = Link(a_file['id'], 
+    link = Link(a_file['id'],
                 parent=project)
     link = syn.store(link)
     assert_equals(link['linksTo']['targetId'], a_file['id'])
     assert_is_none(link['linksTo'].get('targetVersionNumber'))
     assert_equals(link['linksToClassName'], a_file['concreteType'])
 
-    link = Link(a_file['id'], 
+    link = Link(a_file['id'],
                 targetVersion=a_file.versionNumber,
                 parent=project)
     link = syn.store(link)
     assert_equals(link['linksTo']['targetId'], a_file['id'])
     assert_equals(link['linksTo']['targetVersionNumber'], a_file.versionNumber)
     assert_equals(link['linksToClassName'], a_file['concreteType'])
-    
+
     testLink = syn.get(link)
     assert_equals(testLink, link)
 
@@ -217,16 +215,16 @@ def test_store_with_flags():
     projUpdate = syn.store(projUpdate, createOrUpdate=True)
     assert_equals(project.id, projUpdate.id)
     assert_equals(projUpdate.updatedThing, ['Updated again'])
-    
+
     # -- ForceVersion flag --
     # Re-store the same thing and don't up the version
     mutaBogus = syn.store(origBogus, forceVersion=False)
     assert_equals(mutaBogus.versionNumber, 1)
-    
+
     # Re-store again, essentially the same condition
     mutaBogus = syn.store(mutaBogus, createOrUpdate=True, forceVersion=False)
     assert_equals(mutaBogus.versionNumber, 1, "expected version 1 but got version %s" % mutaBogus.versionNumber)
-    
+
     # And again, but up the version this time
     mutaBogus = syn.store(mutaBogus, forceVersion=True)
     assert_equals(mutaBogus.versionNumber, 2)
@@ -236,7 +234,7 @@ def test_store_with_flags():
     different_filepath = utils.make_bogus_binary_file()
     schedule_for_cleanup(different_filepath)
     mutaBogus = File(different_filepath, name='Bogus Test File',
-                          parent=project)
+                     parent=project)
     mutaBogus = syn.store(mutaBogus, forceVersion=False)
     assert_equals(mutaBogus.versionNumber, 3)
 
@@ -263,7 +261,7 @@ def test_store_with_flags():
     schedule_for_cleanup(newer_filepath)
     badBogus = File(newer_filepath, name='Bogus Test File', parent=project)
     assert_raises(SynapseHTTPError, syn.store, badBogus, createOrUpdate=False)
-    
+
     # -- Storing after syn.get(..., downloadFile=False) --
     ephemeralBogus = syn.get(mutaBogus, downloadFile=False)
     ephemeralBogus.description = 'Snorklewacker'
@@ -284,21 +282,21 @@ def test_get_with_downloadLocation_and_ifcollision():
 
     # Compare stuff to this one
     normalBogus = syn.get(bogus)
-    
+
     # Download to the temp folder, should be the same
     otherBogus = syn.get(bogus, downloadLocation=os.path.dirname(filepath))
     assert_equals(otherBogus.id, normalBogus.id)
     assert_true(filecmp.cmp(otherBogus.path, normalBogus.path))
-    
+
     # Invalidate the downloaded file's timestamps
     os.utime(otherBogus.path, (0, 0))
     badtimestamps = os.path.getmtime(otherBogus.path)
-    
+
     # Download again, should change the modification time
     overwriteBogus = syn.get(bogus, downloadLocation=os.path.dirname(filepath), ifcollision="overwrite.local")
     overwriteModTime = os.path.getmtime(overwriteBogus.path)
     assert_not_equal(badtimestamps, overwriteModTime)
-    
+
     # Download again, should not change the modification time
     otherBogus = syn.get(bogus, downloadLocation=os.path.dirname(filepath), ifcollision="keep.local")
     assert_equal(overwriteModTime, os.path.getmtime(overwriteBogus.path))
@@ -310,12 +308,12 @@ def test_get_with_downloadLocation_and_ifcollision():
     # Invalidate the timestamps again
     os.utime(overwriteBogus.path, (0, 0))
     badtimestamps = os.path.getmtime(overwriteBogus.path)
-    
+
     # Download once more, but rename
     renamedBogus = syn.get(bogus, downloadLocation=os.path.dirname(filepath), ifcollision="keep.both")
     assert_not_equal(overwriteBogus.path, renamedBogus.path)
     assert_true(filecmp.cmp(overwriteBogus.path, renamedBogus.path))
-    
+
     # Clean up
     os.remove(overwriteBogus.path)
     os.remove(renamedBogus.path)
@@ -347,7 +345,7 @@ def test_store_activity():
     assert_false(honking['used'][1]['wasExecuted'])
 
     # Store another Entity with the same Activity
-    entity = File('http://en.wikipedia.org/wiki/File:Nettlebed_cave.jpg', 
+    entity = File('http://en.wikipedia.org/wiki/File:Nettlebed_cave.jpg',
                   name='Nettlebed Cave', parent=project, synapseStore=False)
     entity = syn.store(entity, activity=honking)
 
@@ -361,7 +359,7 @@ def test_store_isRestricted_flag():
     path = utils.make_bogus_binary_file()
     schedule_for_cleanup(path)
     entity = File(path, name='Secret human data', parent=project)
-    
+
     # We don't want to spam ACT with test emails
     with patch('synapseclient.client.Synapse._createAccessRequirementIfNone') as intercepted:
         entity = syn.store(entity, isRestricted=True)
@@ -454,23 +452,23 @@ def test_create_or_update_project():
 
 def test_download_file_false():
     RENAME_SUFFIX = 'blah'
-    
+
     # Upload a file
     filepath = utils.make_bogus_binary_file()
     schedule_for_cleanup(filepath)
     schedule_for_cleanup(filepath + RENAME_SUFFIX)
     file = File(filepath, name='SYNR 619', parent=project)
     file = syn.store(file)
-    
+
     # Now hide the file from the cache and download with downloadFile=False
     os.rename(filepath, filepath + RENAME_SUFFIX)
     file = syn.get(file.id, downloadFile=False)
-    
+
     # Change something and reupload the file's metadata
     file.name = "Only change the name, not the file"
     reupload = syn.store(file)
     assert_is_none(reupload.path, "Path field should be null: %s" % reupload.path)
-    
+
     # This should still get the correct file
     reupload = syn.get(reupload.id)
     assert_true(filecmp.cmp(filepath + RENAME_SUFFIX, reupload.path))
@@ -484,7 +482,7 @@ def test_download_file_URL_false():
     reupload = syn.store(reupload)
     reupload = syn.get(reupload, downloadFile=False)
     originalVersion = reupload.versionNumber
-    
+
     # Reupload and check that the URL and version does not get mangled
     reupload = syn.store(reupload, forceVersion=False)
     assert_equals(reupload.path, fileThatExists, "Entity should still be pointing at a URL")
@@ -497,7 +495,7 @@ def test_download_file_URL_false():
     reupload = syn.store(reupload)
     reupload = syn.get(reupload, downloadFile=False)
     originalVersion = reupload.versionNumber
-    
+
     reupload = syn.store(reupload, forceVersion=False)
     assert_equals(reupload.path, fileThatDoesntExist, "Entity should still be pointing at a URL")
     assert_equals(originalVersion, reupload.versionNumber)
@@ -601,6 +599,3 @@ def test_store__changing_from_Synapse_to_externalURL_by_changing_path():
     assert_equal("org.sagebionetworks.repo.model.file.S3FileHandle", ext._file_handle.concreteType)
     assert_equal(None, ext.externalURL)
     assert_equal(True, ext.synapseStore)
-
-
-

--- a/tests/integration/synapseclient/test_command_line_client.py
+++ b/tests/integration/synapseclient/test_command_line_client.py
@@ -16,16 +16,13 @@ from synapseclient import client
 from synapseclient.core.exceptions import *
 from synapseclient import *
 import synapseclient.__main__ as cmdline
-from tests import integration
-from tests.integration import schedule_for_cleanup
+from tests.integration import init_module
 
 from io import StringIO
 
 
 def setup_module(module):
-
-    module.syn = integration.syn
-    module.project = integration.project
+    init_module(module)
 
     module.parser = cmdline.build_parser()
 
@@ -496,11 +493,11 @@ def test_command_line_store_and_submit():
     schedule_for_cleanup(filename)
     repo_url = 'https://github.com/Sage-Bionetworks/synapsePythonClient'
     run('synapse', '--skip-checks', 'submit',
-         '--evalID', eval.id,
-         '--file', filename,
-         '--parent', project_id,
-         '--used', exteral_entity_id,
-         '--executed', repo_url)
+        '--evalID', eval.id,
+        '--file', filename,
+        '--parent', project_id,
+        '--used', exteral_entity_id,
+        '--executed', repo_url)
 
     # Delete project
     run('synapse', '--skip-checks', 'delete', project_id)
@@ -513,10 +510,10 @@ def test_command_get_recursive_and_query():
 
     # Create Folders in Project
     folder_entity = syn.store(Folder(name=str(uuid.uuid4()),
-                                                   parent=project_entity))
+                                     parent=project_entity))
 
     folder_entity2 = syn.store(Folder(name=str(uuid.uuid4()),
-                                                    parent=folder_entity))
+                                      parent=folder_entity))
 
     # Create and upload two files in sub-Folder
     uploaded_paths = []
@@ -589,7 +586,7 @@ def test_command_copy():
 
     # Create a Folder in Project
     folder_entity = syn.store(Folder(name=str(uuid.uuid4()),
-                                                   parent=project_entity))
+                                     parent=project_entity))
     schedule_for_cleanup(folder_entity.id)
     # Create and upload a file in Folder
     repo_url = 'https://github.com/Sage-Bionetworks/synapsePythonClient'
@@ -754,7 +751,7 @@ def test_login():
     password = "password"
     with patch.object(alt_syn, "login") as mock_login, \
             patch.object(alt_syn, "getUserProfile", return_value={"userName": "test_user", "ownerId": "ownerId"})\
-                    as mock_get_user_profile:
+            as mock_get_user_profile:
         run('synapse', '--skip-checks', 'login',
             '-u', username,
             '-p', password,

--- a/tests/integration/synapseclient/test_evaluations.py
+++ b/tests/integration/synapseclient/test_evaluations.py
@@ -7,25 +7,23 @@ from nose.tools import assert_raises, assert_false, assert_is_not_none, assert_t
 
 from synapseclient.core.exceptions import *
 from synapseclient import *
-from tests import integration
-from tests.integration import schedule_for_cleanup
+from tests.integration import init_module
 from synapseclient.annotations import to_submission_status_annotations, from_submission_status_annotations, set_privacy
 
 
 def setup(module):
-    module.syn = integration.syn
-    module.project = integration.project
+    init_module(module)
 
 
 def test_evaluations():
     # Create an Evaluation
     name = 'Test Evaluation %s' % str(uuid.uuid4())
-    ev = Evaluation(name=name, description='Evaluation for testing', 
+    ev = Evaluation(name=name, description='Evaluation for testing',
                     contentSource=project['id'], status='CLOSED')
     ev = syn.store(ev)
 
     try:
-        
+
         # -- Get the Evaluation by name
         evalNamed = syn.getEvaluationByName(name)
         assert_equals(ev['contentSource'], evalNamed['contentSource'])
@@ -36,7 +34,7 @@ def test_evaluations():
         assert_equals(ev['name'], evalNamed['name'])
         assert_equals(ev['ownerId'], evalNamed['ownerId'])
         assert_equals(ev['status'], evalNamed['status'])
-        
+
         # -- Get the Evaluation by project
         evalProj = syn.getEvaluationByContentSource(project)
         evalProj = next(evalProj)
@@ -48,7 +46,7 @@ def test_evaluations():
         assert_equals(ev['name'], evalProj['name'])
         assert_equals(ev['ownerId'], evalProj['ownerId'])
         assert_equals(ev['status'], evalProj['status'])
-        
+
         # Update the Evaluation
         ev['status'] = 'OPEN'
         ev = syn.store(ev, createOrUpdate=True)
@@ -194,5 +192,3 @@ def test_teams():
             if tries > 0:
                 time.sleep(1)
     assert_equals(team, found_team)
-
-

--- a/tests/integration/synapseclient/test_tables.py
+++ b/tests/integration/synapseclient/test_tables.py
@@ -1,15 +1,13 @@
 import csv
 import io
-import filecmp
 import os
 import random
 import tempfile
 import time
 import uuid
-from nose.tools import assert_equals, assert_less, assert_not_equal, assert_false, assert_true, assert_is_not_none
+from nose.tools import assert_equals, assert_less, assert_not_equal, assert_true, assert_is_not_none
 from pandas.util.testing import assert_frame_equal
 from datetime import datetime
-from mock import patch
 
 import pandas as pd
 import numpy as np
@@ -17,13 +15,11 @@ import numpy as np
 from synapseclient.core.utils import id_of
 from synapseclient.core.exceptions import *
 from synapseclient import *
-from tests import integration
-from tests.integration import schedule_for_cleanup, QUERY_TIMEOUT_SEC
+from tests.integration import init_module, QUERY_TIMEOUT_SEC
 
 
 def setup(module):
-    module.syn = integration.syn
-    module.project = integration.project
+    init_module(module)
 
     module.syn.table_query_timeout = 423
 
@@ -136,7 +132,8 @@ def test_entity_view_add_annotation_columns():
     syn.store(entity_view)
 
     entity_view = EntityViewSchema(name=str(uuid.uuid4()), scopeIds=scopeIds, addDefaultViewColumns=False,
-                                   addAnnotationColumns=True, includeEntityTypes=[EntityViewType.PROJECT], parent=project)
+                                   addAnnotationColumns=True, includeEntityTypes=[EntityViewType.PROJECT],
+                                   parent=project)
     syn.store(entity_view)
 
 
@@ -310,6 +307,7 @@ def test_synapse_integer_columns_with_missing_values_from_dataframe():
     df2 = table_from_dataframe.asDataFrame()
     assert_frame_equal(df, df2)
 
+
 def test_store_table_datetime():
     current_datetime = datetime.fromtimestamp(round(time.time(), 3))
     schema = syn.store(Schema("testTable", [Column(name="testerino", columnType='DATE')], project))
@@ -423,4 +421,3 @@ class TestPartialRowSet(object):
         return syn.store(
             EntityViewSchema(name='PartialRowTestViews' + str(uuid.uuid4()), columns=cols, addDefaultViewColumns=False,
                              parent=project, scopes=[folder]))
-

--- a/tests/integration/synapseclient/test_wikis.py
+++ b/tests/integration/synapseclient/test_wikis.py
@@ -5,14 +5,11 @@ from nose.tools import assert_raises, assert_equal, assert_in, assert_equals, as
 from synapseclient.core.exceptions import *
 from synapseclient import *
 from synapseclient.core.upload.upload_functions import upload_synapse_s3
-from tests import integration
-from tests.integration import schedule_for_cleanup
+from tests.integration import init_module
 
 
 def setup(module):
-
-    module.syn = integration.syn
-    module.project = integration.project
+    init_module(module)
 
 
 def test_wikiAttachment():
@@ -23,7 +20,7 @@ def test_wikiAttachment():
     schedule_for_cleanup(attachname)
     fileHandle = upload_synapse_s3(syn, filename)
 
-    # Create and store a Wiki 
+    # Create and store a Wiki
     # The constructor should accept both file handles and file paths
     md = """
     This is a test wiki
@@ -31,16 +28,16 @@ def test_wikiAttachment():
 
     Blabber jabber blah blah boo.
     """
-    wiki = Wiki(owner=project, title='A Test Wiki', markdown=md, 
-                fileHandles=[fileHandle['id']], 
+    wiki = Wiki(owner=project, title='A Test Wiki', markdown=md,
+                fileHandles=[fileHandle['id']],
                 attachments=[attachname])
     wiki = syn.store(wiki)
-    
+
     # Create a Wiki sub-page
-    subwiki = Wiki(owner=project, title='A sub-wiki', 
+    subwiki = Wiki(owner=project, title='A sub-wiki',
                    markdown='nothing', parentWikiId=wiki.id)
     subwiki = syn.store(subwiki)
-    
+
     # Retrieve the root Wiki from Synapse
     wiki2 = syn.getWiki(project)
     # due to the new wiki api, we'll get back some new properties,

--- a/tests/integration/synapseutils/test_synapseutils_copy.py
+++ b/tests/integration/synapseutils/test_synapseutils_copy.py
@@ -1,19 +1,17 @@
 import uuid
 import time
 
-from nose.tools import assert_raises, assert_equals, assert_is_none, assert_is_not_none
+from nose.tools import assert_raises, assert_equals
 import re
 import json
 from synapseclient.core.exceptions import *
 from synapseclient import *
-from tests import integration
-from tests.integration import schedule_for_cleanup
+from tests.integration import init_module
 import synapseutils
-import synapseclient
+
 
 def setup(module):
-    module.syn = integration.syn
-    module.project = integration.project
+    init_module(module)
 
 
 # Add Test for UPDATE
@@ -209,7 +207,7 @@ class TestCopyWiki:
         md = """
         This is a test wiki
         =======================
-    
+
         Blabber jabber blah blah boo.
         syn123
         syn456
@@ -227,9 +225,9 @@ class TestCopyWiki:
         second_md = """
         Testing internal links
         ======================
-    
+
         [test](#!Synapse:%s/wiki/%s)
-    
+
         %s)
         """ % (self.project_entity.id, self.subwiki.id, file_entity.id)
 
@@ -278,7 +276,7 @@ class TestCopyWiki:
             orig_file = [i['fileName'] for i in orig_attach
                          if not i['isPreview']]
             new_file = [i['fileName'] for i in new_attach
-                        if  not i['isPreview']]
+                        if not i['isPreview']]
 
             # check that attachment file names are the same
             assert_equals(orig_file, new_file)
@@ -296,9 +294,9 @@ class TestCopyWiki:
 
         # Test: destinationSubPageId
         third_header = synapseutils.copyWiki(syn, self.project_entity.id, self.second_project.id,
-                                              entitySubPageId=self.subwiki.id,
-                                              destinationSubPageId=test_ent_subpage.id, updateLinks=False,
-                                              updateSynIds=False, entityMap=None)
+                                             entitySubPageId=self.subwiki.id,
+                                             destinationSubPageId=test_ent_subpage.id, updateLinks=False,
+                                             updateSynIds=False, entityMap=None)
         temp = syn.getWiki(self.second_project.id, third_header[0]['id'])
         # There are issues where some title pages are blank.  This is an issue that needs to be addressed
         assert_equals(temp.title, self.subwiki.title)
@@ -339,4 +337,3 @@ class TestCopyFileHandles:
         copy_results = synapseutils.copyFileHandles(syn, file_handles, associate_object_types, associate_object_ids)
         # assert copy result contains one copy result
         assert_equals(len(copy_results), 1)
-

--- a/tests/integration/synapseutils/test_synapseutils_walk.py
+++ b/tests/integration/synapseutils/test_synapseutils_walk.py
@@ -5,14 +5,12 @@ from nose.tools import assert_equals, assert_in
 
 from synapseclient.core.exceptions import *
 from synapseclient import *
-from tests import integration
-from tests.integration import schedule_for_cleanup
+from tests.integration import init_module
 import synapseutils
 
 
 def setup(module):
-    module.syn = integration.syn
-    module.project = integration.project
+    init_module(module)
 
 
 def test_walk():
@@ -66,4 +64,3 @@ def test_walk():
 
     temp = synapseutils.walk(syn, second_file.id)
     assert_equals(list(temp), [])
-


### PR DESCRIPTION
Includes changes to the integration tests to support the nose multiprocessing plugin to support faster integration test runs via parallelization. https://nose.readthedocs.io/en/latest/plugins/multiprocess.html

The ```test/integration/__init__.py``` fixtures are changed to support being a shared fixture across processes. This necessitates creating separate Synapse objects after the fork for child processes (to avoid SSL issues arising from multiple connections from forked identical Synapse object's http connection pools) as well as moving the scheduled cleanups for resources associated with individual modules into the teardowns of those modules specifically, since the parent process cleanup can no longer be responsible. This is better anyway since it more tightly couples test module cleanup with their associated tests and leaves less cruft behind if a build should be aborted early for any reason.

On my own machine this drops an integration test run from ~6.5 minutes to ~2.5 minutes, and on Travis the Linux tests go from about 10 minutes to about 5 minutes, which makes it quicker to verify changes. This isn't supported on OSX unfortunately (outside of a VM or container) but the tests can continue to run as before there without use of the multi processsing params.

