### PR TITLE
SYNPY-1056 - expectation new style annotations breaking getSubmission call

### DIFF
--- a/synapseclient/annotations.py
+++ b/synapseclient/annotations.py
@@ -333,3 +333,31 @@ def from_synapse_annotations(raw_annotations: typing.Dict[str, typing.Any]) -> A
         annos[key] = [conversion_func(v) for v in value_and_type['value']]
 
     return annos
+
+
+def convert_old_annotation_json(annotations):
+    """Transforms a parsed JSON dictionary of old style annotations
+    into a new style consistent with the entity bundle v2 format."""
+
+    converted = {k: v for k, v in annotations.items() if k in ('id', 'etag')}
+    converted_annos = converted['annotations'] = {}
+
+    type_mapping = {
+        'doubleAnnotations': 'DOUBLE',
+        'stringAnnotations': 'STRING',
+        'longAnnotations': "LONG",
+        'dateAnnotations': 'TIMESTAMP_MS',
+
+        # TODO what to do with blobAnnotations
+    }
+
+    for old_type_key, converted_type in type_mapping.items():
+        values = annotations.get(old_type_key)
+        if values:
+            for k, vs in values.items():
+                converted_annos[k] = {
+                    'type': converted_type,
+                    'value': vs,
+                }
+
+    return converted

--- a/tests/integration/synapseclient/test_evaluations.py
+++ b/tests/integration/synapseclient/test_evaluations.py
@@ -17,6 +17,7 @@ def setup(module):
     module.project = integration.project
 
 
+
 def test_evaluations():
     # Create an Evaluation
     name = 'Test Evaluation %s' % str(uuid.uuid4())
@@ -88,7 +89,21 @@ def test_evaluations():
             f = File(filename, parentId=project.id, name='entry-%02d' % i,
                      description='An entry for testing evaluation')
             entity = syn.store(f)
-            syn.submit(ev, entity, name='Submission %02d' % i, submitterAlias='My Team')
+
+            # annotate the submission entity in order to flex some extra
+            # code paths
+            annos = syn.get_annotations(entity)
+            annos['submissionCount'] = i
+            syn.set_annotations(annos)
+
+            entity = syn.get(entity.id)
+
+            last_submission = syn.submit(ev, entity, name='Submission %02d' % i, submitterAlias='My Team')
+
+        # retrieve the submission individually to exercise that call
+        submission = syn.getSubmission(last_submission.id)
+        assert_equals(submission.id, last_submission.id)
+        assert_equals(submission.entity.annotations['submissionCount'], [num_of_submissions - 1])
 
         # Score the submissions
         submissions = syn.getSubmissions(ev, limit=num_of_submissions-1)
@@ -109,6 +124,7 @@ def test_evaluations():
         submissions = syn.getSubmissions(ev)
         b = 123
         for submission, status in syn.getSubmissionBundles(ev):
+
             bogosity[submission.id] = b
             a = dict(foo='bar', bogosity=b)
             b += 123
@@ -194,5 +210,3 @@ def test_teams():
             if tries > 0:
                 time.sleep(1)
     assert_equals(team, found_team)
-
-

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -1346,7 +1346,7 @@ def test_get_submission_with_annotations():
     }
 
     with patch.object(syn, 'restGET') as restGET,\
-         patch.object(syn, '_getWithEntityBundle') as get_entity:
+            patch.object(syn, '_getWithEntityBundle') as get_entity:
 
         restGET.return_value = submission
         response = syn.getSubmission(submission_id)


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/SYNPY-1056

syn.getSubmission pre fetches the associated entity, and in doing so passes along annotations returned in its entityBundleJSON from the Evaluations api which are old style (stringAnnotations, dateAnnotations, etc.). With recent changes getWithEntityBundle expects new style annotations as used with Entity Bundle Services V2.

This attempts to translate between the two for the purposes of making the getWithEntityBundle call.
