### PR TITLE
SYNPY-1059: Change collections to collections.abc where appropriate

### DIFF
--- a/synapseclient/activity.py
+++ b/synapseclient/activity.py
@@ -69,7 +69,7 @@ Activity
 
 """
 
-import collections
+import collections.abc
 
 from synapseclient.core.utils import is_url, is_synapse_id
 from synapseclient.entity import is_synapse_entity
@@ -80,7 +80,7 @@ def is_used_entity(x):
     """Returns True if the given object represents a UsedEntity."""
 
     # A UsedEntity must be a dictionary with a 'reference' field, with a 'targetId' field
-    if not isinstance(x, collections.Mapping) \
+    if not isinstance(x, collections.abc.Mapping) \
             or 'reference' not in x \
             or 'targetId' not in x['reference']:
         return False
@@ -100,7 +100,7 @@ def is_used_url(x):
     """Returns True if the given object represents a UsedURL."""
 
     # A UsedURL must be a dictionary with a 'url' field
-    if not isinstance(x, collections.Mapping) or 'url' not in x:
+    if not isinstance(x, collections.abc.Mapping) or 'url' not in x:
         return False
 
     # Must only have four keys

--- a/synapseclient/annotations.py
+++ b/synapseclient/annotations.py
@@ -111,7 +111,7 @@ def _annotation_value_list_element_type(annotation_values: typing.List):
 def is_submission_status_annotations(annotations):
     """Tests if the given dictionary is in the form of annotations to submission status"""
     keys = ['objectId', 'scopeId', 'stringAnnos', 'longAnnos', 'doubleAnnos']
-    if not isinstance(annotations, collections.Mapping):
+    if not isinstance(annotations, collections.abc.Mapping):
         return False
     return all([key in keys for key in annotations.keys()])
 

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -28,6 +28,7 @@ See also the `Synapse API documentation <https://docs.synapse.org/rest/>`_.
 
 """
 import collections
+import collections.abc
 import configparser
 import deprecated
 import functools
@@ -490,7 +491,7 @@ class Synapse(object):
             # if id is unset or a userID, this will succeed
             id = '' if id is None else int(id)
         except (TypeError, ValueError):
-            if isinstance(id, collections.Mapping) and 'ownerId' in id:
+            if isinstance(id, collections.abc.Mapping) and 'ownerId' in id:
                 id = id.ownerId
             elif isinstance(id, TeamMember):
                 id = id.member.ownerId
@@ -1122,7 +1123,7 @@ class Synapse(object):
                                 'includeAnnotations': True,
                                 'includeFileHandles': True,
                                 'includeRestrictionInformation': True}
-        if isinstance(entity, collections.Mapping) and 'id' not in entity and 'name' in entity:
+        if isinstance(entity, collections.abc.Mapping) and 'id' not in entity and 'name' in entity:
             entity = self.findEntityId(entity['name'], entity.get('parentId', None))
 
         # Avoid an exception from finding an ID from a NoneType
@@ -3158,7 +3159,7 @@ class Synapse(object):
             raise ValueError("downloadTableColumn doesn't work with rowsets. Please use default tableQuery settings.")
         if isinstance(columns, str):
             columns = [columns]
-        if not isinstance(columns, collections.Iterable):
+        if not isinstance(columns, collections.abc.Iterable):
             raise TypeError('Columns parameter requires a list of column names')
 
         file_handle_associations, file_handle_to_path_map = self._build_table_download_file_handle_list(table, columns)
@@ -3237,7 +3238,7 @@ class Synapse(object):
         col_indices = [i for i, h in enumerate(table.headers) if h.name in columns]
         # see: http://docs.synapse.org/rest/org/sagebionetworks/repo/model/file/BulkFileDownloadRequest.html
         file_handle_associations = []
-        file_handle_to_path_map = collections.OrderedDict()
+        file_handle_to_path_map = collections.abc.OrderedDict()
         seen_file_handle_ids = set()  # ensure not sending duplicate requests for the same FileHandle IDs
         for row in table:
             for col_index in col_indices:

--- a/synapseclient/core/cache.py
+++ b/synapseclient/core/cache.py
@@ -10,7 +10,7 @@ Implements a cache on local disk for Synapse file entities and other objects wit
 This is part of the internal implementation of the client and should not be accessed directly by users of the client.
 """
 
-import collections
+import collections.abc
 import datetime
 import json
 import operator
@@ -87,7 +87,7 @@ class Cache:
         self.cache_map_file_name = ".cacheMap"
 
     def get_cache_dir(self, file_handle_id):
-        if isinstance(file_handle_id, collections.Mapping):
+        if isinstance(file_handle_id, collections.abc.Mapping):
             if 'dataFileHandleId' in file_handle_id:
                 file_handle_id = file_handle_id['dataFileHandleId']
             elif 'concreteType' in file_handle_id \
@@ -238,7 +238,7 @@ class Cache:
         cache_dir = self.get_cache_dir(file_handle_id)
 
         # if we've passed an entity and not a path, get path from entity
-        if path is None and isinstance(file_handle_id, collections.Mapping) and 'path' in file_handle_id:
+        if path is None and isinstance(file_handle_id, collections.abc.Mapping) and 'path' in file_handle_id:
             path = file_handle_id['path']
 
         with Lock(self.cache_map_file_name, dir=cache_dir):

--- a/synapseclient/core/models/dict_object.py
+++ b/synapseclient/core/models/dict_object.py
@@ -3,7 +3,7 @@
 # chris.bare@sagebase.org
 ############################################################
 
-import collections
+import collections.abc
 import json
 
 
@@ -17,7 +17,7 @@ class DictObject(dict):
     def __init__(self, *args, **kwargs):
         self.__dict__ = self
         for arg in args:
-            if isinstance(arg, collections.Mapping):
+            if isinstance(arg, collections.abc.Mapping):
                 self.__dict__.update(arg)
         self.__dict__.update(kwargs)
 

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -6,7 +6,7 @@ Utility Functions
 Utility functions useful in the implementation and testing of the Synapse client.
 
 """
-
+import collections.abc
 import os
 import sys
 import hashlib
@@ -17,7 +17,6 @@ import errno
 import inspect
 import random
 import requests
-import collections
 import tempfile
 import platform
 import functools
@@ -292,7 +291,7 @@ def is_date(dt):
 
 def to_list(value):
     """Convert the value (an iterable or a scalar value) to a list."""
-    if isinstance(value, collections.Iterable) and not isinstance(value, str):
+    if isinstance(value, collections.abc.Iterable) and not isinstance(value, str):
         return list(value)
     else:
         return [value]
@@ -300,7 +299,7 @@ def to_list(value):
 
 def _to_iterable(value):
     """Convert the value (an iterable or a scalar value) to an iterable."""
-    if isinstance(value, collections.Iterable):
+    if isinstance(value, collections.abc.Iterable):
         return value
     return value,
 

--- a/synapseclient/entity.py
+++ b/synapseclient/entity.py
@@ -138,7 +138,7 @@ See also:
 
 """
 
-import collections
+import collections.abc
 import itertools
 import io
 import os
@@ -167,7 +167,7 @@ class Versionable(object):
 # entity_object branch)
 # - giving up on hiding the difference between properties and annotations
 
-class Entity(collections.MutableMapping):
+class Entity(collections.abc.MutableMapping):
     """
     A Synapse entity is an object that has metadata, access control, and potentially a file. It can represent data,
     source code, or a folder that contains other entities.
@@ -235,8 +235,8 @@ class Entity(collections.MutableMapping):
     def __init__(self, properties=None, annotations=None, local_state=None, parent=None, **kwargs):
 
         if properties:
-            if isinstance(properties, collections.Mapping):
-                if 'annotations' in properties and isinstance(properties['annotations'], collections.Mapping):
+            if isinstance(properties, collections.abc.Mapping):
+                if 'annotations' in properties and isinstance(properties['annotations'], collections.abc.Mapping):
                     annotations.update(properties['annotations'])
                     del properties['annotations']
                 self.__dict__['properties'].update(properties)
@@ -244,7 +244,7 @@ class Entity(collections.MutableMapping):
                 raise SynapseMalformedEntityError('Unknown argument type: properties is a %s' % str(type(properties)))
 
         if annotations:
-            if isinstance(annotations, collections.Mapping):
+            if isinstance(annotations, collections.abc.Mapping):
                 self.__dict__['annotations'].update(annotations)
             elif isinstance(annotations, str):
                 self.properties['annotations'] = annotations
@@ -252,7 +252,7 @@ class Entity(collections.MutableMapping):
                 raise SynapseMalformedEntityError('Unknown argument type: annotations is a %s' % str(type(annotations)))
 
         if local_state:
-            if isinstance(local_state, collections.Mapping):
+            if isinstance(local_state, collections.abc.Mapping):
                 self.local_state(local_state)
             else:
                 raise SynapseMalformedEntityError('Unknown argument type: local_state is a %s' % str(type(local_state)))
@@ -690,7 +690,7 @@ def split_entity_namespaces(entity):
         # Defensive programming: return copies
         return entity.properties.copy(), entity.annotations.copy(), entity.local_state()
 
-    if not isinstance(entity, collections.Mapping):
+    if not isinstance(entity, collections.abc.Mapping):
         raise SynapseMalformedEntityError("Can't split a %s object." % entity.__class__.__name__)
 
     if 'concreteType' in entity and entity['concreteType'] in entity_type_to_class:
@@ -727,7 +727,7 @@ ENTITY_TYPES = [
 def is_synapse_entity(entity):
     if isinstance(entity, Entity):
         return True
-    if isinstance(entity, collections.Mapping):
+    if isinstance(entity, collections.abc.Mapping):
         return entity.get('concreteType', None) in ENTITY_TYPES
     return False
 
@@ -752,7 +752,7 @@ def is_container(entity):
         concreteType = entity['concreteType']
     elif 'type' in entity:
         concreteType = entity['type']
-    elif isinstance(entity, collections.Mapping):
+    elif isinstance(entity, collections.abc.Mapping):
         prefix = utils.extract_prefix(entity.keys())
         if prefix+'concreteType' in entity:
             concreteType = entity[prefix+'concreteType'][0]

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -286,6 +286,7 @@ See also:
  - :py:meth:`synapseclient.Synapse.store`
  - :py:meth:`synapseclient.Synapse.delete`
 """
+import collections.abc
 import csv
 import io
 import os
@@ -1003,7 +1004,7 @@ class PartialRowset(AppendableRowset):
         :param originalQueryResult:
         :return: a PartialRowSet that can be syn.store()-ed to apply the changes
         """
-        if not isinstance(mapping, collections.Mapping):
+        if not isinstance(mapping, collections.abc.Mapping):
             raise ValueError("mapping must be a supported Mapping type such as 'dict'")
 
         try:
@@ -1157,7 +1158,7 @@ class PartialRow(DictObject):
 
     def __init__(self, values, rowId, etag=None, nameToColumnId=None):
         super(PartialRow, self).__init__()
-        if not isinstance(values, collections.Mapping):
+        if not isinstance(values, collections.abc.Mapping):
             raise ValueError("values must be a Mapping")
 
         rowId = int(rowId)
@@ -1268,7 +1269,7 @@ def Table(schema, values, **kwargs):
         raise ValueError("Don't know how to make tables from values of type %s." % type(values))
 
 
-class TableAbstractBaseClass(collections.Iterable, collections.Sized):
+class TableAbstractBaseClass(collections.abc.Iterable, collections.abc.Sized):
     """
     Abstract base class for Tables based on different data containers.
     """


### PR DESCRIPTION
My understanding is the `collections.namedtuple()` and `collections.OrderedDict()` will be obsolete as well in Python 3.10, but there is still some time for that.

