### PR TITLE
SYNPY-1036 Handle id-less entity updates without a failed create

### DIFF
--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -1608,19 +1608,22 @@ def test_store__needsUploadFalse__fileHandleId_not_in_local_state():
     returned_file_handle = {
         'id': '1234'
     }
+    synapse_id = 'syn123'
+    etag = 'db9bc70b-1eb6-4a21-b3e8-9bf51d964031'
     returned_bundle = {'entity': {'name': 'fake_file.txt',
-                                  'id': 'syn123',
-                                  'etag': 'db9bc70b-1eb6-4a21-b3e8-9bf51d964031',
+                                  'id': synapse_id,
+                                  'etag': etag,
                                   'concreteType': 'org.sagebionetworks.repo.model.FileEntity',
                                   'dataFileHandleId': '123412341234'},
                        'entityType': 'file',
                        'fileHandles': [{'id': '123412341234',
-                                        'concreteType': 'org.sagebionetworks.repo.model.file.S3FileHandle'}]
+                                        'concreteType': 'org.sagebionetworks.repo.model.file.S3FileHandle'}],
+                       'annotations': {'id': synapse_id, 'etag': etag, 'annotations': {}},
                        }
     with patch.object(syn, '_getEntityBundle', return_value=returned_bundle), \
          patch.object(synapseclient.client, 'upload_file_handle', return_value=returned_file_handle), \
          patch.object(syn.cache, 'contains', return_value=True), \
-         patch.object(syn, '_createEntity'), \
+         patch.object(syn, '_updateEntity'), \
          patch.object(syn, 'set_annotations'), \
          patch.object(Entity, 'create'), \
          patch.object(syn, 'get'):


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/SYNPY-1036

https://github.com/Sage-Bionetworks/synapsePythonClient/pull/723 prevented a 403 that occurred while attempting to retrieve the file handle during a store, but another 403 is raised when "creating" the entity later in the store operation if the user is different from the original file handle creator.

Currently we seem to handle every store that doesn't include the entity id as a create (POST /entity) only switching to handling it as an update (PUT /entity/[id]) after the back end returns a 409 conflict error for the create. This mostly works when the user invoking the store is the creator of the file handle, but returns an uncaught 403 for other users.

This change is so that if the the bundle fetch earlier in the store operation returns an entity bundle, we process the store as an update (merging the passed properties and annotations with those of found bundle) rather than as a failed create followed by an update. Doing it this way succeeds for any user that has permission to update the File, and avoids the extra failed create call.
