### PR TITLE
flake8 F821 ignore

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,8 +9,9 @@ exclude =
     docs
     dist
 
-# allow F821 undefined name in tests for now due to how we dynamically
+# allow F821 undefined name for now due to how we dynamically
 # assign 'syn' and 'project' module variables as part of our test setups
-per-file-ignores =
-    tests/*: F821
+# note that pep8speaks doesn't support per-file-ignores or we could
+# restrict this exclusion to tests only.
+extend-ignore = F821
 


### PR DESCRIPTION
https://github.com/Sage-Bionetworks/synapsePythonClient/pull/751 introduced flake8 as its linter and switched pep8speaks to use it as well. It used the flake8 per-file-ignores option to ignore F821 (undefined name) in tests only to how e.g. syn and project are set as module variables in tests, but pep8speaks [doesn't support](https://github.com/OrkoHunter/pep8speaks/pull/151) that option, so it would flag these as issues (but only when part of a diff since that's how we configure pep8speaks). This just extends the ignore to all files, not just tests, for pep8speaks compatibility.
