### PR TITLE
SYNPY-1075 handle Submission entityBundleJSON w/ v2 annotations

### DIFF
--- a/synapseclient/annotations.py
+++ b/synapseclient/annotations.py
@@ -339,17 +339,28 @@ def convert_old_annotation_json(annotations):
     """Transforms a parsed JSON dictionary of old style annotations
     into a new style consistent with the entity bundle v2 format."""
 
-    converted = {k: v for k, v in annotations.items() if k in ('id', 'etag')}
-    converted_annos = converted['annotations'] = {}
+    meta_keys = ('id', 'etag')
 
     type_mapping = {
         'doubleAnnotations': 'DOUBLE',
         'stringAnnotations': 'STRING',
         'longAnnotations': "LONG",
         'dateAnnotations': 'TIMESTAMP_MS',
-
-        # TODO what to do with blobAnnotations
     }
+
+    annos_v1_keys = set(meta_keys) | set(type_mapping.keys())
+
+    # blobAnnotations appear to be little/unused and there is no mapping defined here but if they
+    # are present on the annos we should treat it as an old style annos dict
+    annos_v1_keys.add('blobAnnotations')
+
+    # if any keys in the annos dict are not consistent with an old style annotations then we treat
+    # it as an annotations2 style dictionary that is not in need of any conversion
+    if any(k not in annos_v1_keys for k in annotations.keys()):
+        return annotations
+
+    converted = {k: v for k, v in annotations.items() if k in meta_keys}
+    converted_annos = converted['annotations'] = {}
 
     for old_type_key, converted_type in type_mapping.items():
         values = annotations.get(old_type_key)

--- a/synapseclient/annotations.py
+++ b/synapseclient/annotations.py
@@ -339,7 +339,7 @@ def convert_old_annotation_json(annotations):
     """Transforms a parsed JSON dictionary of old style annotations
     into a new style consistent with the entity bundle v2 format."""
 
-    meta_keys = ('id', 'etag')
+    meta_keys = ('id', 'etag', 'creationDate', 'uri')
 
     type_mapping = {
         'doubleAnnotations': 'DOUBLE',

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -2827,6 +2827,7 @@ class Synapse(object):
             # getWithEntityBundle expects a bundle services v2 style
             # annotations dict, but the evaluations API may return
             # an older format annotations object in the encoded JSON
+            # depending on when the original submission was made.
             annotations = entityBundleJSON.get('annotations')
             if annotations:
                 entityBundleJSON['annotations'] = convert_old_annotation_json(annotations)

--- a/tests/unit/synapseclient/unit_test_annotations.py
+++ b/tests/unit/synapseclient/unit_test_annotations.py
@@ -271,7 +271,6 @@ def test_convert_old_annotation_json():
         'dateAnnotations': {'now': [now, now + 1]},
 
         'blobAnnotations': {'blobs': ['are ignored']},
-        'anything else': 'is ignored',
     }
 
     converted = convert_old_annotation_json(old_json)
@@ -301,3 +300,28 @@ def test_convert_old_annotation_json():
     }
 
     assert_equals(converted, expected)
+
+
+def test_convert_old_annotations_json__already_v2():
+    """Test that the presence of any loose annotations key not consistent
+    with v1 annotations causes annotations conversion to v2 to be short
+    circuited and the dictionary passed through as-is."""
+
+    annos_dict = {
+        'id': 'foo',
+        'etag': str(uuid.uuid4()),
+    }
+
+    # these keys are consistent with old style v1 annos
+    v1_keys = {
+        'stringAnnotations': ['foo'],
+        'longAnnotations': [1, 2, 3],
+    }
+    annos_dict.update(v1_keys)
+
+    # however this key is not so its presence reveals this to be to a v2 dict
+    # (and the above keys just happen to be v1 looking keys in a v2 annotations dict
+    annos_dict['v2_key'] = ['these are actually v2 annotations']
+
+    converted = convert_old_annotation_json(annos_dict)
+    assert_equals(annos_dict, converted)

--- a/tests/unit/synapseclient/unit_test_annotations.py
+++ b/tests/unit/synapseclient/unit_test_annotations.py
@@ -310,6 +310,8 @@ def test_convert_old_annotations_json__already_v2():
     annos_dict = {
         'id': 'foo',
         'etag': str(uuid.uuid4()),
+        'creationDate': '1444559717946',
+        'uri': '/entity/syn123/annotations',
     }
 
     # these keys are consistent with old style v1 annos


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/SYNPY-1075

In stack 316 archived entityBundleJSON on a Submission is saved/returned using v2 annotations. This allows the client to handle either form, as either form might be returned depending on when the submission was made and the entity JSON was serialized. 