### PR TITLE
SYNPY-1076 unpin specific dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,13 +38,13 @@ setuptools.setup(
     python_requires='>=3.6.*',
     install_requires=[
         'requests>=2.22.0',
-        'keyring==12.0.2',
-        'deprecated==1.2.4',
+        'keyring>=12.0.2',
+        'deprecated>=1.2.4',
     ],
     extras_require={
-        'pandas': ["pandas==0.25.0"],
+        'pandas': ["pandas>=0.25.0"],
         'pysftp': ["pysftp>=0.2.8"],
-        'boto3': ["boto3"],
+        'boto3': ["boto3>=1.7.0"],
         'tests': test_deps,
         ':sys_platform=="linux2" or sys_platform=="linux"': ['keyrings.alt==3.1'],
     },

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     python_requires='>=3.6.*',
     install_requires=[
         'requests>=2.22.0,<3.0',
-        'keyring>=12.0.2',
+        'keyring==12.0.2',
         'deprecated>=1.2.4,<2.0',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -37,14 +37,14 @@ setuptools.setup(
     # requirements
     python_requires='>=3.6.*',
     install_requires=[
-        'requests>=2.22.0',
+        'requests>=2.22.0,<3.0',
         'keyring>=12.0.2',
-        'deprecated>=1.2.4',
+        'deprecated>=1.2.4,<2.0',
     ],
     extras_require={
-        'pandas': ["pandas>=0.25.0"],
-        'pysftp': ["pysftp>=0.2.8"],
-        'boto3': ["boto3>=1.7.0"],
+        'pandas': ["pandas>=0.25.0,<2.0"],
+        'pysftp': ["pysftp>=0.2.8,<0.3"],
+        'boto3': ["boto3>=1.7.0,<2.0"],
         'tests': test_deps,
         ':sys_platform=="linux2" or sys_platform=="linux"': ['keyrings.alt==3.1'],
     },


### PR DESCRIPTION
This is to address [SYNPY-1076](https://sagebionetworks.jira.com/browse/SYNPY-1076) which results from a stale pandas dependency breaking when compiled against the latest released version of numpy.

But rather than just upgrade the pinned version this unpins specific package version dependencies instead and allows the installed version to float above a minimum.

My thoughts roughly mirror [these](https://stackoverflow.com/a/44938662). In a controlled deployment environment where all dependencies (including downstream dependencies) can be frozen by an environment manager such as pipenv, then it makes sense to pin all specific versions. But synapseclient is a library that is installed and used in other applications and environments and typically installed through a simple pip install. We cannot guarantee what dependencies might already exist or be needed in that environment, and being unnecessarily specific means we might overwrite a specific version that actually is needed in an environment.

Note that this is a different approach than that expressed in [SYNPY-791](https://sagebionetworks.jira.com/browse/SYNPY-791).

Furthermore since synapseclient is typically installed via pip install, the fact that we pin some versions can result in some unstable/untested combinations of downstream dependencies that we can't control unless we also define and pin the downstream dependencies of our dependencies, an immediate example of this being this issue. In these cases it's better to let contemporary versions be installed as they will have been tested with their own contemporary dependencies.

Without pinned versions we do become vulnerable to a breaking change in a new library release, but we are already vulnerable to that to some degree as illustrated above, and we don't foster the use of stale dependencies that may have bugs or security issues, or have stale versions of dependencies being installed alongside new versions of downstream dependencies as in this issue.