### PR TITLE
SYNPY-1078 syncFromSynapse manifest performance

### DIFF
--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -25,6 +25,7 @@ import uuid
 import importlib
 import numbers
 import urllib.parse as urllib_parse
+import warnings
 
 
 UNIX_EPOCH = datetime.datetime(1970, 1, 1, 0, 0)
@@ -888,3 +889,29 @@ def snake_case(string):
     """Convert the given string from CamelCase to snake_case"""
     # https://stackoverflow.com/a/1176023
     return re.sub(r'(?<!^)(?=[A-Z])', '_', string).lower()
+
+
+class deprecated_keyword_param:
+    """A decorator to use to warn when a keyword parameter from a function has been deprecated
+    and is intended for future removal. Will emit a warning such a keyword is passed."""
+
+    def __init__(self, keywords, version, reason):
+        self.keywords = set(keywords)
+        self.version = version
+        self.reason = reason
+
+    def __call__(self, fn):
+        def wrapper(*args, **kwargs):
+            found = self.keywords.intersection(kwargs)
+            if found:
+                warnings.warn(
+                    "Parameter(s) {} deprecated since version {}; {}".format(
+                        list(found), self.version, self.reason
+                    ),
+                    category=DeprecationWarning,
+                    stacklevel=2
+                )
+
+            return fn(*args, **kwargs)
+
+        return wrapper

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -906,7 +906,7 @@ class deprecated_keyword_param:
             if found:
                 warnings.warn(
                     "Parameter(s) {} deprecated since version {}; {}".format(
-                        list(found), self.version, self.reason
+                        sorted(list(found)), self.version, self.reason
                     ),
                     category=DeprecationWarning,
                     stacklevel=2

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -154,7 +154,7 @@ def _extract_file_entity_metadata(syn, allFiles, *, provenance_cache=None):
 
         entity_id = entity['id']
         row_provenance = provenance_cache.get(entity_id) if provenance_cache is not None else None
-        if not row_provenance:
+        if row_provenance is None:
             row_provenance = _get_file_entity_provenance_dict(syn, entity)
 
             if provenance_cache is not None:

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -19,6 +19,7 @@ DEFAULT_GENERATED_MANIFEST_KEYS = ['path', 'parent', 'name', 'synapseStore', 'co
                                    'activityName', 'activityDescription']
 
 
+@utils.deprecated_keyword_param(['allFiles'], version="2.1.1", reason="Keyword parameter no longer needed")
 def syncFromSynapse(syn, entity, path=None, ifcollision='overwrite.local', allFiles=None, followLink=False):
     """Synchronizes all the files in a folder (including subfolders) from Synapse and adds a readme manifest with file
     metadata.
@@ -64,13 +65,13 @@ def syncFromSynapse(syn, entity, path=None, ifcollision='overwrite.local', allFi
         allFiles = list()
 
     provenance_cache = {}
-    synced_files = _syncFromHelper(syn, entity, path, ifcollision, followLink, provenance_cache)
+    synced_files = _sync_from(syn, entity, path, ifcollision, followLink, provenance_cache)
     allFiles.extend(synced_files)
 
     return allFiles
 
 
-def _syncFromHelper(syn, entity, path, ifcollision, followLink, provenance_cache):
+def _sync_from(syn, entity, path, ifcollision, followLink, provenance_cache):
     """
     Recursive helper for syncFromSynapse.
     See its documentation for repeated parameters.
@@ -107,7 +108,7 @@ def _syncFromHelper(syn, entity, path, ifcollision, followLink, provenance_cache
             else:
                 new_path = None
             # recursively explore this container's children
-            child_files = _syncFromHelper(syn, child['id'], new_path, ifcollision, followLink, provenance_cache)
+            child_files = _sync_from(syn, child['id'], new_path, ifcollision, followLink, provenance_cache)
             files.extend(child_files)
         else:
             # getting the child

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -57,17 +57,34 @@ def syncFromSynapse(syn, entity, path=None, ifcollision='overwrite.local', allFi
             print(f.path)
 
     """
-    # initialize the result list
+    # the allFiles parameter used to be passed in as part of the recursive implementation of this function
+    # with the public signature invoking itself. now that a private helper exists allFiles has no real utility
+    # but is retained for backwards compatibility in case an external user of this function is passing one in.
     if allFiles is None:
         allFiles = list()
+
+    provenance_cache = {}
+    synced_files = _syncFromHelper(syn, entity, path, ifcollision, followLink, provenance_cache)
+    allFiles.extend(synced_files)
+
+    return allFiles
+
+
+def _syncFromHelper(syn, entity, path, ifcollision, followLink, provenance_cache):
+    """
+    Recursive helper for syncFromSynapse.
+    See its documentation for repeated parameters.
+    :param provenance_cache: an dict of known provenance dicts keyed by entity ids
+    """
+    files = []
 
     # perform validation check on user input
     if is_synapse_id(entity):
         entity = syn.get(entity, downloadLocation=path, ifcollision=ifcollision, followLink=followLink)
 
     if isinstance(entity, File):
-        allFiles.append(entity)
-        return allFiles
+        files.append(entity)
+        return files
 
     entity_id = id_of(entity)
     if not is_container(entity):
@@ -90,37 +107,39 @@ def syncFromSynapse(syn, entity, path=None, ifcollision='overwrite.local', allFi
             else:
                 new_path = None
             # recursively explore this container's children
-            syncFromSynapse(syn, child['id'], new_path, ifcollision, allFiles, followLink=followLink)
+            child_files = _syncFromHelper(syn, child['id'], new_path, ifcollision, followLink, provenance_cache)
+            files.extend(child_files)
         else:
             # getting the child
             ent = syn.get(child['id'], downloadLocation=path, ifcollision=ifcollision, followLink=followLink)
             if isinstance(ent, File):
-                allFiles.append(ent)
+                files.append(ent)
 
     if path is not None:  # If path is None files are stored in cache.
         filename = os.path.join(path, MANIFEST_FILENAME)
         filename = os.path.expanduser(os.path.normcase(filename))
-        generateManifest(syn, allFiles, filename)
+        generateManifest(syn, files, filename, provenance_cache=provenance_cache)
 
-    return allFiles
+    return files
 
 
-def generateManifest(syn, allFiles, filename):
+def generateManifest(syn, allFiles, filename, *, provenance_cache=None):
     """Generates a manifest file based on a list of entities objects.
 
     :param allFiles:   A list of File Entities
-
     :param filename: file where manifest will be written
+    :param provenance_cache: an optional dict of known provenance dicts keyed by entity ids
     """
-    keys, data = _extract_file_entity_metadata(syn, allFiles)
+    keys, data = _extract_file_entity_metadata(syn, allFiles, provenance_cache=provenance_cache)
     _write_manifest_data(filename, keys, data)
 
 
-def _extract_file_entity_metadata(syn, allFiles):
+def _extract_file_entity_metadata(syn, allFiles, *, provenance_cache=None):
     """
     Extracts metadata from the list of File Entities and returns them in a form usable by csv.DictWriter
     :param syn:         instance of the Synapse client
     :param allFiles:    an iterable that provides File entities
+    :param provenance_cache: an optional dict of known provenance dicts keyed by entity ids
 
     :return: (keys: a list column headers, data: a list of dicts containing data from each row)
     """
@@ -132,7 +151,15 @@ def _extract_file_entity_metadata(syn, allFiles):
                'synapseStore': entity.synapseStore, 'contentType': entity['contentType']}
         row.update({key: (val[0] if len(val) > 0 else "") for key, val in entity.annotations.items()})
 
-        row.update(_get_file_entity_provenance_dict(syn, entity))
+        entity_id = entity['id']
+        row_provenance = provenance_cache.get(entity_id) if provenance_cache is not None else None
+        if not row_provenance:
+            row_provenance = _get_file_entity_provenance_dict(syn, entity)
+
+            if provenance_cache is not None:
+                provenance_cache[entity_id] = row_provenance
+
+        row.update(row_provenance)
 
         annotKeys.update(set(entity.annotations.keys()))
 

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -315,3 +315,26 @@ def test_snake_case():
         ('camel123Abc', 'camel123_abc'),
     ]:
         assert_equals(expected_output, utils.snake_case(input_word))
+
+
+def test_deprecated_keyword_param():
+
+    keywords = ['foo', 'baz']
+    version = '2.1.1'
+    reason = "keyword is no longer used"
+
+    fn_return_val = 'expected return'
+
+    @utils.deprecated_keyword_param(keywords, version, reason)
+    def test_fn(positional, foo=None, bar=None, baz=None):
+        return fn_return_val
+
+    with patch('warnings.warn') as mock_warn:
+        return_val = test_fn('positional', foo='foo', bar='bar', baz='baz')
+
+    assert_equals(fn_return_val, return_val)
+    mock_warn.assert_called_once_with(
+        "Parameter(s) ['baz', 'foo'] deprecated since version 2.1.1; keyword is no longer used",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )


### PR DESCRIPTION
syncFromSynapse when synced to an external location outside the cache generates manifest file(s) in the synced folder structure. For a deep folder structure there are performance issues related to interaction with the recursion and the manifest generation that are more completely described here:
https://sagebionetworks.jira.com/browse/SYNPY-1078

This speeds things up by changing the following:
1. A manifest file that is written to each subdirectory now only includes the files that are rooted in that subdirectory, rather than all files synced so far. The previous behavior of writing those files that happen to have been synced so far doesn't make much sense and seems to be a byproduct of the recursive implementation of the function rather than intentional behavior. It's not clear to me that we actually even want a manifest at anything other than the root of the sync, although this preserves that for now (with the more sensible set of files).
2. Caching the provenance fetches for each file.  When we write each manifest row we fetch the provenance via a call to Synapse. Because we include each file in potentially multiple manifests depending on how deeply it is located in the directory structure, this meant multiple provenance fetches for each file. This caches the provenance data so the provenance for each entity is only fetched once per sync.

The above two issues previously interacted with each other to result in severe slowdowns with all of the repeated provenance fetches.

Also adds a utility decorator that can be used when a keyword parameter is deprecated from a remaining public signature.