### PR TITLE
SYNPY-1074 parallelize syncFromSynapse file downloads

### DIFF
--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -546,8 +546,8 @@ def build_parser():
                             help='Directory to download file to [default: %(default)s].')
     parser_get.add_argument('--multiThreaded', action='store_true',
                             default=True, help='Download file using a multiple threaded implementation. '
-                                                'This flag will be removed in the future when multi-threaded download '
-                                                'is deemed fully stable and becomes the default implementation.')
+                            'This flag will be removed in the future when multi-threaded download '
+                            'is deemed fully stable and becomes the default implementation.')
     parser_get.add_argument('id', metavar='syn123', nargs='?', type=str,
                             help='Synapse ID of form syn123 of desired data object.')
     parser_get.set_defaults(func=get)

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -545,7 +545,7 @@ def build_parser():
     parser_get.add_argument('--downloadLocation', metavar='path', type=str, default="./",
                             help='Directory to download file to [default: %(default)s].')
     parser_get.add_argument('--multiThreaded', action='store_true',
-                            default=False, help='Download file using a multiple threaded implementation. '
+                            default=True, help='Download file using a multiple threaded implementation. '
                                                 'This flag will be removed in the future when multi-threaded download '
                                                 'is deemed fully stable and becomes the default implementation.')
     parser_get.add_argument('id', metavar='syn123', nargs='?', type=str,

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1725,7 +1725,6 @@ class Synapse(object):
                 "You are not authorized to access fileHandleId %s associated with the Synapse"
                 " %s: %s" % (fileHandleId, objectType, objectId)
             )
-
         return result
 
     def _downloadFileHandle(self, fileHandleId, objectId, objectType, destination, *,

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1778,7 +1778,13 @@ class Synapse(object):
                         'read_only',
                     )
 
-                elif self.multi_threaded and concreteType == concrete_types.S3_FILE_HANDLE:
+                elif self.multi_threaded and \
+                        concreteType == concrete_types.S3_FILE_HANDLE and \
+                        fileHandle.get('contentSize', 0) > multithread_download.SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE:
+                    # run the download multi threaded if the file supports it, we're configured to do so,
+                    # and the file is large enough that it would be broken into parts to take advantage of
+                    # multiple downloading threads. otherwise it's more efficient to run the download as a simple
+                    # single threaded URL download.
                     downloaded_path = self._download_from_url_multi_threaded(fileHandleId,
                                                                              objectId,
                                                                              objectType,

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1688,7 +1688,7 @@ class Synapse(object):
     #                File handle service calls                 #
     ############################################################
 
-    def _getFileHandleDownload(self, fileHandleId,  objectId, objectType=None):
+    def _getFileHandleDownload(self, fileHandleId, objectId, objectType=None):
         """
         Gets the URL and the metadata as filehandle object for a filehandle or fileHandleId
 
@@ -1942,7 +1942,7 @@ class Synapse(object):
                                     toBeTransferred,
                                     'Downloading ',
                                     os.path.basename(destination),
-                                    dt=time.time()-t0
+                                    dt=time.time() - t0
                                 )
                     except Exception as ex:  # We will add a progress parameter then push it back to retry.
                         ex.progress = transferred-previouslyTransferred

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1700,7 +1700,7 @@ class Synapse(object):
     #                File handle service calls                 #
     ############################################################
 
-    def _getFileHandleDownload(self, fileHandleId,  objectId, objectType='FileEntity'):
+    def _getFileHandleDownload(self, fileHandleId,  objectId, objectType=None):
         """
         Gets the URL and the metadata as filehandle object for a filehandle or fileHandleId
 
@@ -1713,7 +1713,7 @@ class Synapse(object):
         body = {'includeFileHandles': True, 'includePreSignedURLs': True,
                 'requestedFiles': [{'fileHandleId': fileHandleId,
                                     'associateObjectId': objectId,
-                                    'associateObjectType': objectType}]}
+                                    'associateObjectType': objectType or 'FileEntity'}]}
         response = self.restPOST('/fileHandle/batch', body=json.dumps(body),
                                  endpoint=self.fileHandleEndpoint)
         result = response['requestedFiles'][0]

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -795,7 +795,8 @@ class Synapse(object):
                                         + '!'*len(warning_message)+'\n')
         return entity
 
-    def _download_file_entity(self, downloadLocation, entity, ifcollision, submission, *, executor=None, maxThreads=None):
+    def _download_file_entity(self, downloadLocation, entity, ifcollision, submission, *,
+                              executor=None, maxThreads=None):
         # set the initial local state
         entity.path = None
         entity.files = []
@@ -1727,7 +1728,8 @@ class Synapse(object):
 
         return result
 
-    def _downloadFileHandle(self, fileHandleId, objectId, objectType, destination, *, retries=5, executor=None, maxThreads=None):
+    def _downloadFileHandle(self, fileHandleId, objectId, objectType, destination, *,
+                            retries=5, executor=None, maxThreads=None):
         """
         Download a file from the given URL to the local file system.
 
@@ -1777,7 +1779,7 @@ class Synapse(object):
                         'read_only',
                     )
 
-                elif self.multi_threaded and concreteType == concrete_types.S3_FILE_HANDLE :
+                elif self.multi_threaded and concreteType == concrete_types.S3_FILE_HANDLE:
                     downloaded_path = self._download_from_url_multi_threaded(fileHandleId,
                                                                              objectId,
                                                                              objectType,

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -638,10 +638,6 @@ class Synapse(object):
            print(syn.getProvenance(entity))
 
         """
-        return self._get(entity, **kwargs)
-
-    def _get(self, entity, **kwargs):
-
         # If entity is a local file determine the corresponding synapse entity
         if isinstance(entity, str) and os.path.isfile(entity):
             bundle = self._getFromFile(entity, kwargs.pop('limitSearch', None))

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -777,12 +777,7 @@ class Synapse(object):
 
             if downloadFile:
                 if file_handle:
-                    self._download_file_entity(
-                        downloadLocation,
-                        entity,
-                        ifcollision,
-                        submission,
-                    )
+                    self._download_file_entity(downloadLocation, entity, ifcollision, submission)
                 else:  # no filehandle means that we do not have DOWNLOAD permission
                     warning_message = "WARNING: You have READ permission on this file entity but not DOWNLOAD " \
                                       "permission. The file has NOT been downloaded."

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -747,6 +747,7 @@ class Synapse(object):
         submission = kwargs.pop('submission', None)
         followLink = kwargs.pop('followLink', False)
         path = kwargs.pop('path', None)
+        executor = kwargs.pop('executor', None)
 
         # make sure user didn't accidentlaly pass a kwarg that we don't handle
         if kwargs:  # if there are remaining items in the kwargs
@@ -778,7 +779,7 @@ class Synapse(object):
 
             if downloadFile:
                 if file_handle:
-                    self._download_file_entity(downloadLocation, entity, ifcollision, submission)
+                    self._download_file_entity(downloadLocation, entity, ifcollision, submission, executor=executor)
                 else:  # no filehandle means that we do not have DOWNLOAD permission
                     warning_message = "WARNING: You have READ permission on this file entity but not DOWNLOAD " \
                                       "permission. The file has NOT been downloaded."
@@ -786,7 +787,7 @@ class Synapse(object):
                                         + '!'*len(warning_message)+'\n')
         return entity
 
-    def _download_file_entity(self, downloadLocation, entity, ifcollision, submission):
+    def _download_file_entity(self, downloadLocation, entity, ifcollision, submission, *, executor=None):
         # set the initial local state
         entity.path = None
         entity.files = []

--- a/synapseclient/core/cumulative_transfer_progress.py
+++ b/synapseclient/core/cumulative_transfer_progress.py
@@ -1,0 +1,102 @@
+from contextlib import contextmanager
+import threading
+import time
+import sys
+
+from synapseclient.core import utils
+
+# Defines a mechanism for printing file transfer progress that includes potentially multiple file transfers to the
+# console in a possibly multi threaded manner. Normally each individual file download will write its own output
+# to the console, overwriting each other if multiple file downloads are concurrently running.
+# This will print a running total of transferred bytes with each finished file printed as it is completed.
+
+# we use a thread local to configure this because we are potentially running file transfers in multiple threads,
+# and we don't want individual download implementations to have to know about the details or track the track
+# any other concurrent downloads. instead it is up to a master coordinator that is launching the threads (e.g.
+# a Synapse sync) to configure the thread state. individual download implementations don't have to do anything
+# but import and use this instead of the underlying utils function.
+_thread_local = threading.local()
+
+
+def printTransferProgress(*args, **kwargs):
+    """Prints transfer progress using the cumulative format if that has been configured on the running
+    thread, otherwise prints transfer directly to standard out as normal. This function should
+    be imported instead of utils.printTransferProgress in locations that may be part of a cumulative
+    transfer (i.e. a Synapse sync)."""
+
+    if hasattr(_thread_local, 'cumulative_transfer_progress'):
+        _thread_local.cumulative_transfer_progress.printTransferProgress(*args, **kwargs)
+    else:
+        utils.printTransferProgress(*args, **kwargs)
+
+
+class CumulativeTransferProgress:
+
+    def __init__(self, label, start=None):
+        self._lock = threading.Lock()
+        self._label = label
+
+        self._tick = 0
+        self._start = start if start is not None else time.time()
+
+        self._total_transferred = 0
+        self._thread_totals = {}
+
+    @contextmanager
+    def accumulate_progress(self):
+        """Threads should enter this context while they are running their transfers."""
+
+        _thread_local.cumulative_transfer_progress = self
+        try:
+            yield
+        finally:
+            self._thread_totals.pop(threading.get_ident(), None)
+            del _thread_local.cumulative_transfer_progress
+
+    def printTransferProgress(self, transferred, toBeTransferred, prefix='', postfix='', isBytes=True, dt=None,
+                              previouslyTransferred=0):
+        """
+        Parameters match those of synapseclient.core.utils.printTransferProgress.
+        """
+
+        if not sys.stdout.isatty():
+            return
+
+        cumulative_dt = time.time() - self._start
+        rate = (transferred - previouslyTransferred) / float(cumulative_dt)
+        rate = '(%s/s)' % utils.humanizeBytes(rate) if isBytes else rate
+
+        with self._lock:
+            if toBeTransferred == 0 or float(transferred) / toBeTransferred >= 1:
+                # if the individual transfer is complete then we pass through the print
+                # to the underlying utility method which will print a complete 100%
+                # progress bar on a newline.
+                utils.printTransferProgress(
+                    transferred,
+                    toBeTransferred,
+                    prefix=prefix,
+                    postfix=postfix,
+                    isBytes=isBytes,
+                    dt=dt,
+                    previouslyTransferred=previouslyTransferred
+                )
+
+            # in order to know how much of the transferred data is newly transferred
+            # we subtract the previously reported amount. this assumes that the printing
+            # of the progress for any particular transfer is always conducted by the same
+            # thread, which is true for all current transfer implementations.
+            thread_id = threading.get_ident()
+            already_transferred_by_thread = self._thread_totals.get(thread_id, 0)
+            self._total_transferred += (transferred - already_transferred_by_thread)
+            self._thread_totals[thread_id] = transferred
+
+            cumulative_dt = time.time() - self._start
+            rate = self._total_transferred / float(cumulative_dt)
+            rate = '(%s/s)' % utils.humanizeBytes(rate) if isBytes else rate
+
+            # we print a rotating tick with each update
+            self._tick += 1
+            spinner = ['|', '/', '-', '\\'][self._tick % 4]
+
+            sys.stdout.write(f"\r {spinner} {self._label} {utils.humanizeBytes(self._total_transferred)} {rate}")
+            sys.stdout.flush()

--- a/synapseclient/core/cumulative_transfer_progress.py
+++ b/synapseclient/core/cumulative_transfer_progress.py
@@ -11,7 +11,7 @@ from synapseclient.core import utils
 # This will print a running total of transferred bytes with each finished file printed as it is completed.
 
 # we use a thread local to configure this because we are potentially running file transfers in multiple threads,
-# and we don't want individual download implementations to have to know about the details or track the track
+# and we don't want individual download implementations to have to know about the details or track
 # any other concurrent downloads. instead it is up to a master coordinator that is launching the threads (e.g.
 # a Synapse sync) to configure the thread state. individual download implementations don't have to do anything
 # but import and use this instead of the underlying utils function.

--- a/synapseclient/core/cumulative_transfer_progress.py
+++ b/synapseclient/core/cumulative_transfer_progress.py
@@ -62,10 +62,6 @@ class CumulativeTransferProgress:
         if not sys.stdout.isatty():
             return
 
-        cumulative_dt = time.time() - self._start
-        rate = (transferred - previouslyTransferred) / float(cumulative_dt)
-        rate = '(%s/s)' % utils.humanizeBytes(rate) if isBytes else rate
-
         with self._lock:
             if toBeTransferred == 0 or float(transferred) / toBeTransferred >= 1:
                 # if the individual transfer is complete then we pass through the print

--- a/synapseclient/core/multithread_download/__init__.py
+++ b/synapseclient/core/multithread_download/__init__.py
@@ -1,3 +1,8 @@
-from .download_threads import DownloadRequest, download_file, SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE
+from .download_threads import (
+    DownloadRequest,
+    download_file,
+    shared_executor,
+    SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE,
+)
 
-__all__ = ['DownloadRequest', 'download_file', 'SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE']
+__all__ = ['DownloadRequest', 'download_file', 'shared_executor', 'SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE']

--- a/synapseclient/core/multithread_download/__init__.py
+++ b/synapseclient/core/multithread_download/__init__.py
@@ -1,3 +1,3 @@
-from .download_threads import DownloadRequest, download_file
+from .download_threads import DownloadRequest, download_file, SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE
 
-__all__ = ['DownloadRequest', 'download_file']
+__all__ = ['DownloadRequest', 'download_file', 'SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE']

--- a/synapseclient/core/multithread_download/download_threads.py
+++ b/synapseclient/core/multithread_download/download_threads.py
@@ -16,7 +16,7 @@ import time
 
 from synapseclient.core.exceptions import SynapseError
 from synapseclient.core.pool_provider import get_executor
-from synapseclient.core.utils import printTransferProgress
+from synapseclient.core.cumulative_transfer_progress import printTransferProgress
 
 # constants
 MAX_QUEUE_SIZE: int = 20

--- a/synapseclient/core/multithread_download/download_threads.py
+++ b/synapseclient/core/multithread_download/download_threads.py
@@ -125,7 +125,11 @@ class PresignedUrlProvider(object):
         :return: PresignedUrlInfo
         """
         # noinspection PyProtectedMember
-        response = self.client._getFileHandleDownload(self.request.file_handle_id, self.request.object_id)
+        response = self.client._getFileHandleDownload(
+            self.request.file_handle_id,
+            self.request.object_id,
+            objectType=self.request.object_type,
+        )
         file_name = response["fileHandle"]["fileName"]
         pre_signed_url = response["preSignedURL"]
         return PresignedUrlInfo(file_name, pre_signed_url, _pre_signed_url_expiration_time(pre_signed_url))

--- a/synapseclient/core/multithread_download/download_threads.py
+++ b/synapseclient/core/multithread_download/download_threads.py
@@ -203,8 +203,10 @@ def download_file(
     :param max_concurrent_parts: The maximum concurrent number parts to download at once when downloading this file
     """
 
-    shutdown_after = False
+    # we obtain an executor from a thread local if we are in the context of a Synapse sync
+    # and wan't to re-use the same threadpool as was created for that
     executor = getattr(thread_local, 'executor', None)
+    shutdown_after = False
     if not executor:
         shutdown_after = True
         executor = get_executor(client.max_threads)

--- a/synapseclient/core/multithread_download/download_threads.py
+++ b/synapseclient/core/multithread_download/download_threads.py
@@ -1,14 +1,12 @@
-import time
-
 try:
     import threading as _threading
 except ImportError:
     import dummy_threading as _threading
 import datetime
-import os
-import queue
 
-from typing import Generator, Sequence, NamedTuple, Tuple, Iterable
+import concurrent.futures
+
+from typing import Generator, NamedTuple
 from urllib.parse import urlparse, parse_qs
 from urllib3.util.retry import Retry
 from synapseclient.core.utils import printTransferProgress
@@ -16,6 +14,8 @@ from synapseclient.core.exceptions import SynapseError
 from requests import Session, Response
 from requests.adapters import HTTPAdapter
 from http import HTTPStatus
+
+from synapseclient.core.pool_provider import get_executor
 
 # constants
 MAX_QUEUE_SIZE: int = 20
@@ -40,7 +40,7 @@ class DownloadRequest(NamedTuple):
         The file handle ID to download.
     object_id : str
         The Synapse object this file associated to.
-    object_type : str
+    object_type : str/
         the type of the associated Synapse object.
     path : str
         The local path to download the file to.
@@ -75,66 +75,6 @@ class TransferStatus(object):
         return time.time() - self._t0
 
 
-class CloseableQueue(queue.Queue):
-    """
-    A closeable queue used to signal when producers are finished producing so consumer threads know when to terminate.
-    Adopted from Effective Python Item 39.
-
-    !!!!!This SHOULD NOT be used as a drop in replacement for queue.Queue as some operations are not supported!!!
-    """
-    # Sentinel object to signal producer is done producing
-    SENTINEL = object()
-
-    def __init__(self, maxsize=0):
-        self._closed_lock = _threading.Lock()
-        self._closed = False
-        super().__init__(maxsize=maxsize)
-
-    def send_sentinel(self, num_sentinels=1):
-        try:
-            for _ in range(num_sentinels):
-                self.put(CloseableQueue.SENTINEL)
-        except QueueClosedException:
-            pass
-
-    def __iter__(self):
-        while True:
-            item = self.get()
-            if item is CloseableQueue.SENTINEL:
-                return  # stop iteration
-            yield item
-
-    def close(self):
-        with self._closed_lock:
-            self._closed = True
-
-    def put(self, item, block=True, timeout=None):
-        with self._closed_lock:
-            if self._closed:
-                raise QueueClosedException("queue is closed")
-        super().put(item, block=block, timeout=timeout)
-
-    def get(self, block=True, timeout=None):
-        with self._closed_lock:
-            if self._closed:
-                return CloseableQueue.SENTINEL
-        return super().get(block=block, timeout=timeout)
-
-    """
-        Once closed, the queue will always return the sentinel, even though nothing else was added to the queue.
-        Therefore, calling task_done() can not be relied upon
-        for tracking progress for a join() once the queue is closed.
-    """
-
-    def join(self):
-        raise NotImplementedError("join() is not supported")
-
-    def task_done(self):
-        raise NotImplementedError("task_done() is not supported")
-
-
-class QueueClosedException(Exception):
-    pass
 
 
 class PresignedUrlInfo(NamedTuple):
@@ -193,156 +133,6 @@ class PresignedUrlProvider(object):
         return PresignedUrlInfo(file_name, pre_signed_url, _pre_signed_url_expiration_time(pre_signed_url))
 
 
-class DataChunkDownloadThread(_threading.Thread):
-    """
-    The producer threads that make the GET request and obtain the data for a download chunk
-    """
-
-    def __init__(self, presigned_url_provider: PresignedUrlProvider, range_queue: CloseableQueue,
-                 data_queue: CloseableQueue):
-        super().__init__()
-        self.daemon = True
-        self.presigned_url_provider = presigned_url_provider
-        self.range_queue = range_queue
-        self.data_queue = data_queue
-        self.session = _get_new_session()
-
-    def run(self):
-        for byte_range in self.range_queue:
-            start, end = byte_range
-
-            response = self._get_response_with_retry(start, end)
-
-            try:
-                for data_chunk in response.iter_content(MAX_CHUNK_WRITE_SIZE):
-                    self.data_queue.put((start, data_chunk))
-                    start += len(data_chunk)
-            except QueueClosedException:
-                # the data_queue was closed so stop retrieving data chunks
-                response.close()
-                break
-
-    def _get_response_with_retry(self, start: int, end: int) -> Response:
-        range_header = {'Range': f'bytes={start}-{end}'}
-        response = self.session.get(self.presigned_url_provider.get_info().url, headers=range_header, stream=True)
-        # try request until successful or out of retries
-        try_counter = 1
-        while response.status_code != HTTPStatus.PARTIAL_CONTENT:
-            if try_counter >= MAX_RETRIES:
-                raise SynapseError(
-                    f'Could not download the file: {self.presigned_url_provider.get_info().file_name},'
-                    f' please try again.')
-            response = self.session.get(self.presigned_url_provider.get_info().url, headers=range_header, stream=True)
-            try_counter += 1
-        return response
-
-
-class DataChunkWriteToFileThread(_threading.Thread):
-    """
-    The worker threads that write download chunks to file
-    """
-    path: str
-
-    def __init__(self, data_queue: CloseableQueue, path: str, expected_file_size: int):
-        super().__init__()
-        self.daemon = True
-        self.data_queue = data_queue
-        self.transfer_status = TransferStatus(expected_file_size)
-        self.path = path
-
-    def run(self):
-        try:
-            # write data to file
-            with open(self.path, 'wb') as file_write:
-                for start, data in self.data_queue:
-                    file_write.seek(start)
-                    file_write.write(data)
-                    self.transfer_status.transferred += len(data)
-                    printTransferProgress(self.transfer_status.transferred,
-                                          self.transfer_status.total_bytes_to_be_transferred,
-                                          'Downloading ', os.path.basename(self.path),
-                                          dt=self.transfer_status.elapsed_time())
-        except OSError:
-            self.data_queue.close()
-            raise
-
-
-def download_file(client,
-                  download_request: DownloadRequest,
-                  num_threads: int):
-    """
-    Main driver for the multi-threaded download. Uses the producer-consumer with Queue design pattern as described
-    in Effective Python Item 39.
-
-    :param client: A synapseclient
-    :param download_request: A batch of DownloadRequest objects specifying what Synapse files to download
-    :param num_threads: The number of download threads
-    :return: Map between each DownloadRequest in download_requests object and the corresponding DownloadResponse object
-    """
-    data_queue = CloseableQueue(MAX_QUEUE_SIZE)
-    range_queue = CloseableQueue(MAX_QUEUE_SIZE)
-
-    pre_signed_url_provider = PresignedUrlProvider(client, download_request)
-
-    file_size = _get_file_size(pre_signed_url_provider.get_info().url)
-
-    # use a single worker to write to the file
-    write_to_file_thread = DataChunkWriteToFileThread(data_queue, download_request.path, file_size)
-    data_chunk_download_threads = [DataChunkDownloadThread(pre_signed_url_provider, range_queue, data_queue)
-                                   for _ in range(max(num_threads, 1))]
-
-    chunk_range_generator = _generate_chunk_ranges(file_size)
-
-    return _download_file(data_queue, range_queue,
-                          write_to_file_thread, data_chunk_download_threads,
-                          chunk_range_generator)
-
-
-def _download_file(data_queue: CloseableQueue,
-                   range_queue: CloseableQueue,
-                   write_to_file_thread: DataChunkWriteToFileThread,
-                   data_chunk_download_threads: Sequence[DataChunkDownloadThread],
-                   chunk_ranges: Iterable[Tuple[int, int]]):
-    """
-    helper for download_file() to make testing the thread management logic easier
-    """
-    try:
-        write_to_file_thread.start()
-
-        for data_chunk_download_worker in data_chunk_download_threads:
-            data_chunk_download_worker.start()
-
-        for chunk_range in chunk_ranges:
-            # code in this main thread will usually block in this loop while download is progressing
-            range_queue.put(chunk_range)
-
-        # send signal for download threads to stop
-        range_queue.send_sentinel(len(data_chunk_download_threads))
-        # wait for download threads to complete
-        for data_chunk_download_thread in data_chunk_download_threads:
-            data_chunk_download_thread.join()
-
-        # once download threads are done, send sentinel to the data queue to tell the file worker to stop
-        data_queue.send_sentinel()
-        # wait for the writer workers to shutdown
-        write_to_file_thread.join()
-    except BaseException:
-        # on any exception (e.g. KeyboardInterrupt), ensure the started threads are killed
-
-        # stop other threads early by closing the queues upon which they rely
-        range_queue.close()
-        data_queue.close()
-
-        # release file lock and delete the partially downloaded file
-        write_to_file_thread.join()
-        try:
-            os.remove(write_to_file_thread.path)
-        except FileNotFoundError:
-            pass
-
-        raise
-
-
 def _generate_chunk_ranges(file_size: int,
                            ) -> Generator:
     """
@@ -394,3 +184,164 @@ def _get_file_size(url: str) -> int:
     session = _get_new_session()
     res_get = session.get(url, stream=True)
     return int(res_get.headers['Content-Length'])
+
+
+def download_file(
+    client,
+    download_request: DownloadRequest,
+    *,
+    max_concurrent_parts: int = None,
+    executor=None
+):
+    """
+    Main driver for the multi-threaded download. Uses the producer-consumer with Queue design pattern as described
+    in Effective Python Item 39.
+
+    :param client: A synapseclient
+    :param download_request: A batch of DownloadRequest objects specifying what Synapse files to download
+    :param max_concurrent_parts: The maximum concurrent number parts to download at once when downloading this file
+    :param executor: An ExecutorService instance to use to process this download, if None a ThreadPoolExcecutor
+                        will be created
+    """
+
+    #start = time.time()
+
+    shutdown_after = False
+    if not executor:
+        shutdown_after = True
+        executor = get_executor(client.max_threads)
+
+    max_concurrent_parts = max_concurrent_parts or client.max_threads
+    try:
+        downloader = _MultithreadedDownloader(client, executor, max_concurrent_parts)
+        downloader.download_file(download_request)
+    finally:
+        # if we created the Executor for the purposes of processing this download we also
+        # shut it down. if it was passed in from the outside then it's managed by the caller
+        if shutdown_after:
+            executor.shutdown()
+
+    #elapsed = time.time() - start
+    #print(elapsed)
+
+
+thread_local = _threading.local()
+
+
+class _MultithreadedDownloader:
+
+    def __init__(self, syn, executor, max_concurrent_parts):
+        self._syn = syn
+        self._executor = executor
+        self._max_concurrent_parts = max_concurrent_parts
+
+    @classmethod
+    def _get_thread_session(cls):
+        # get a lazily initialized requests.Session from the thread.
+        # we want to share a requests.Session over the course of a thread
+        # to take advantage of persistent http connection. we put it on a
+        # thread local rather that in the task closure since a connection can
+        # be reused across separate part uploads so no reason to restrict it
+        # per worker task.
+        session = getattr(thread_local, 'session', None)
+        if not session:
+            session = _get_new_session()
+        return session
+
+    def _get_response_with_retry(self, presigned_url_provider, start: int, end: int) -> Response:
+        session = self._get_thread_session()
+        range_header = {'Range': f'bytes={start}-{end}'}
+        response = session.get(presigned_url_provider.get_info().url, headers=range_header)
+        # try request until successful or out of retries
+        try_counter = 1
+        while response.status_code != HTTPStatus.PARTIAL_CONTENT:
+            if try_counter >= MAX_RETRIES:
+                raise SynapseError(
+                    f'Could not download the file: {presigned_url_provider.get_info().file_name},'
+                    f' please try again.')
+            response = session.get(presigned_url_provider.get_info().url, headers=range_header)
+            try_counter += 1
+        return start, response
+
+    def download_file(self, request):
+        url_provider = PresignedUrlProvider(self._syn, request)
+
+        file_size = _get_file_size(url_provider.get_info().url)
+        chunk_range_generator = _generate_chunk_ranges(file_size)
+
+        self._prep_file(request)
+
+        # the entrant thread runs in a loop doing the following:
+        # 1. scheduling any additional part downloads as previous parts are completed
+        # 2. writing any completed parts out to the local disk
+        # 3. waiting for additional parts to complete
+        pending_futures = set()
+        completed_futures = set()
+        while True:
+            submitted_futures = self._submit_chunks(
+                url_provider,
+                chunk_range_generator,
+                pending_futures,
+            )
+
+            self._write_chunks(request.path, completed_futures)
+
+            # once there is nothing else pending we are done with the file download
+            pending_futures = pending_futures.union(submitted_futures)
+            if not pending_futures:
+                break
+
+            completed_futures, pending_futures = concurrent.futures.wait(
+                pending_futures,
+                return_when=concurrent.futures.FIRST_COMPLETED
+            )
+
+            self._check_for_errors(request, completed_futures, pending_futures)
+
+    def _prep_file(self, request):
+        # upon receiving the parts of the file we'll open the file
+        # and write the specific byte ranges, but to open it in
+        # r+ mode we need to to exist and be empty
+        open(request.path, 'wb').close()
+
+    def _submit_chunks(self, url_provider, chunk_range_generator, pending_futures):
+        submit_count = self._max_concurrent_parts - len(pending_futures)
+        submitted_futures = set()
+
+        for chunk_range in chunk_range_generator:
+            start, end = chunk_range
+            chunk_future = self._executor.submit(
+                self._get_response_with_retry,
+                url_provider,
+                start,
+                end,
+            )
+            submitted_futures.add(chunk_future)
+
+            if len(submitted_futures) == submit_count:
+                break
+
+        return submitted_futures
+
+    def _write_chunks(self, path, completed_futures):
+        if completed_futures:
+            with open(path, 'rb+') as file_write:
+                for chunk_future in completed_futures:
+                    start, chunk_response = chunk_future.result()
+                    print(start)
+                    print(len(chunk_response.content))
+                    print("***")
+                    file_write.seek(start)
+                    file_write.write(chunk_response.content)
+
+    def _check_for_errors(self, request, completed_futures, pending_futures):
+        # if any submitted part download failed we abort the download.
+        # any retry/recovery should be attempted within the download method
+        # submitted to the Executor, if an Exception was flagged on the Future
+        # we consider it unrecoverable
+        for completed_future in completed_futures:
+            exception = completed_future.exception()
+            if exception:
+                for pending_future in pending_futures:
+                    pending_future.cancel()
+                raise ValueError(f"Failed downloading {request.object_id} to {request.path}") from exception

--- a/synapseclient/core/remote_file_storage_wrappers.py
+++ b/synapseclient/core/remote_file_storage_wrappers.py
@@ -3,7 +3,8 @@ import time
 import multiprocessing
 import urllib.parse as urllib_parse
 
-from synapseclient.core.utils import printTransferProgress, attempt_import
+from synapseclient.core.cumulative_transfer_progress import printTransferProgress
+from synapseclient.core.utils import attempt_import
 
 
 class S3ClientWrapper:

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -217,7 +217,8 @@ class _SyncDownloader:
                     entity_id,
                     downloadLocation=path,
                     ifcollision=ifcollision,
-                    followLink=followLink
+                    followLink=followLink,
+                    executor=self._executor,
                 )
 
             if isinstance(entity, File):

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -330,18 +330,17 @@ class _SyncDownloader:
                 folder_sync.update()
 
             else:
-                if child_file_ids:
-                    for child_file_id in child_file_ids:
-                        self._file_semaphore.acquire()
-                        self._executor.submit(
-                            self._sync_file,
-                            child_file_id,
-                            folder_sync,
-                            folder_path,
-                            ifcollision,
-                            followLink,
-                            progress,
-                        )
+                for child_file_id in child_file_ids:
+                    self._file_semaphore.acquire()
+                    self._executor.submit(
+                        self._sync_file,
+                        child_file_id,
+                        folder_sync,
+                        folder_path,
+                        ifcollision,
+                        followLink,
+                        progress,
+                    )
 
                 for child_folder in child_folders:
                     folder_stack.append((child_folder, folder_path, folder_sync))

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -274,7 +274,6 @@ class _SyncDownloader:
 
         finally:
             self._file_semaphore.release()
-            del downloads_thread_local.executor
 
     def _sync_root(self, root, root_path, ifcollision, followLink, progress):
         # stack elements are a 3-tuple of:

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -246,12 +246,12 @@ class _SyncDownloader:
             # download, reasonable recovery should be handled within the file download code.
             parent_progress.set_exception(ex)
 
-    def _sync_root(self, root, path, ifcollision, followLink):
+    def _sync_root(self, root, root_path, ifcollision, followLink):
         # stack elements are a 3-tuple of:
         # 1. the folder entity/dict
         # 2. the local path to the folder to download to
         # 3. the FolderProgress of the parent to the folder (None at the root)
-        folder_stack = [(root, path, None)]
+        folder_stack = [(root, root_path, None)]
 
         root_progress = None
         while folder_stack:
@@ -267,7 +267,12 @@ class _SyncDownloader:
             entity_id = id_of(folder)
             folder_path = None
             if parent_path is not None:
-                folder_path = os.path.join(parent_path, folder['name'])
+                folder_path = parent_path
+                if root_progress:
+                    # syncFromSynapse behavior is that we do NOT create a folder for the root folder of the sync.
+                    # we treat the download local path folder as the root and write the children of the sync
+                    # directly into that local folder
+                    folder_path = os.path.join(folder_path, folder['name'])
                 os.makedirs(folder_path, exist_ok=True)
 
             child_ids = []

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -227,21 +227,23 @@ class _SyncDownloader:
                 executor=self._executor,
             )
 
+            files = []
+            provenance = None
             if isinstance(entity, File):
-                provenance = None
                 if path:
                     entity_provenance = _get_file_entity_provenance_dict(self._syn, entity)
                     provenance = {entity_id: entity_provenance}
 
-                parent_progress.update(
-                    finished_id=entity_id,
-                    files=[entity],
-                    provenance=provenance,
-                )
+                files.append(entity)
 
-            else:
-                # not sure this is actually possible, what else can there be in a File hierarchy
-                raise ValueError(f"The provided id: {entity_id} is neither a Project/Folder nor a File")
+            # else if the entity is not a File (and wasn't a container)
+            # then we ignore it for the purposes of this sync
+
+            parent_progress.update(
+                finished_id=entity_id,
+                files=files,
+                provenance=provenance,
+            )
 
         except Exception as ex:
             # this could be anything raised by any type of download, and so by nature is a broad catch.

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -221,8 +221,6 @@ class _SyncDownloader:
             )
 
             if isinstance(entity, File):
-                print(entity['path'])
-
                 provenance = None
                 if path:
                     entity_provenance = _get_file_entity_provenance_dict(self._syn, entity)

--- a/tests/integration/synapseclient/core/test_download.py
+++ b/tests/integration/synapseclient/core/test_download.py
@@ -23,15 +23,7 @@ def setup(module):
 def test_download_check_md5():
     tempfile_path = utils.make_bogus_data_file()
     schedule_for_cleanup(tempfile_path)
-    entity = File(parent=project['id'])
-    entity['path'] = tempfile_path
-    entity = syn.store(entity)
-
-    syn._downloadFileHandle(entity['dataFileHandleId'], entity['id'], 'FileEntity', tempfile.gettempdir())
-
-    tempfile_path2 = utils.make_bogus_data_file()
-    schedule_for_cleanup(tempfile_path2)
-    entity_bad_md5 = syn.store(File(path=tempfile_path2, parent=project['id'], synapseStore=False))
+    entity_bad_md5 = syn.store(File(path=tempfile_path, parent=project['id'], synapseStore=False))
 
     assert_raises(SynapseMd5MismatchError, syn._download_from_URL, entity_bad_md5['externalURL'], tempfile.gettempdir(),
                   entity_bad_md5['dataFileHandleId'], expected_md5="2345a")

--- a/tests/unit/synapseclient/core/multithread_download/unit_test_download_threads.py
+++ b/tests/unit/synapseclient/core/multithread_download/unit_test_download_threads.py
@@ -89,6 +89,11 @@ class TestPresignedUrlProvider(object):
             assert_equals(expected, presigned_url_provider._get_pre_signed_info())
 
             mock_pre_signed_url_expiration_time.assert_called_with(fake_url)
+            self.mock_synapse_client._getFileHandleDownload.assert_called_with(
+                self.download_request.file_handle_id,
+                self.download_request.object_id,
+                objectType=self.download_request.object_type,
+            )
 
 
 def test_generate_chunk_ranges():

--- a/tests/unit/synapseclient/core/multithread_download/unit_test_download_threads.py
+++ b/tests/unit/synapseclient/core/multithread_download/unit_test_download_threads.py
@@ -142,7 +142,11 @@ def test_download_file(mock_multithreaded_downloader_init):
     mock_multithreaded_downloader_init.return_value = mock_downloader
 
     max_concurrent_parts = 5
-    download_file(syn, request, executor=mock_executor, max_concurrent_parts=max_concurrent_parts)
+
+    download_threads.thread_local.executor = mock_executor
+    download_file(syn, request, max_concurrent_parts=max_concurrent_parts)
+    del download_threads.thread_local.executor
+
     mock_multithreaded_downloader_init.assert_called_once_with(syn, mock_executor, max_concurrent_parts)
     mock_downloader.download_file.assert_called_once_with(request)
 

--- a/tests/unit/synapseclient/core/multithread_download/unit_test_download_threads.py
+++ b/tests/unit/synapseclient/core/multithread_download/unit_test_download_threads.py
@@ -407,9 +407,8 @@ class MultithreadedDownloaderTests(TestCase):
             expected_writes.append(mock.call(chunk))
 
             byte_start += len(chunk)
-            expected_print_transfer_progresses.append(mock.call(
-                byte_start, file_size, 'Downloading ', os.path.basename(request.path), dt=mock.ANY
-               )
+            expected_print_transfer_progresses.append(
+                mock.call(byte_start, file_size, 'Downloading ', os.path.basename(request.path), dt=mock.ANY)
             )
 
         downloader = _MultithreadedDownloader(mock.Mock(), mock.Mock(), 5)

--- a/tests/unit/synapseclient/core/multithread_download/unit_test_download_threads.py
+++ b/tests/unit/synapseclient/core/multithread_download/unit_test_download_threads.py
@@ -1,87 +1,44 @@
+import concurrent.futures
 import datetime
-import queue
-import time
-import threading
-import unittest.mock as mock
+import os
 import requests
 
-from nose.tools import assert_equals, assert_raises, assert_greater, assert_in
+from unittest import TestCase
+import unittest.mock as mock
+from nose.tools import assert_equals, assert_false, assert_raises, assert_true
 
 import synapseclient.core.multithread_download.download_threads as download_threads
+from synapseclient.core.multithread_download.download_threads import (
+    _MultithreadedDownloader,
+    download_file,
+    DownloadRequest,
+    PresignedUrlProvider,
+    PresignedUrlInfo,
+    TransferStatus,
+)
 
 from synapseclient import Synapse
 from synapseclient.core.exceptions import SynapseError
 
 
-class TestCloseableQueue:
-    def setup(self):
-        self.queue = download_threads.CloseableQueue(maxsize=5)
-
-    def test_send_sentinel(self):
-        self.queue.send_sentinel(3)
-        for _ in range(3):
-            assert_equals(download_threads.CloseableQueue.SENTINEL, self.queue.get())
-
-        assert_raises(queue.Empty, self.queue.get_nowait)
-
-    def test_iter(self):
-        for i in range(3):
-            self.queue.put(i)
-
-        wait_for_sentinel_sec = 3
-
-        def delay_send_sentinel(closable_queue):
-            time.sleep(wait_for_sentinel_sec)
-            closable_queue.send_sentinel()
-            print("done")
-
-        # delay sending the sentinel on another thread
-        t = threading.Thread(target=delay_send_sentinel, args=(self.queue,), daemon=True)
-        t.start()
-        start_time = time.time()
-        for i, queue_val in enumerate(self.queue):
-            assert_equals(i, queue_val)
-        elapsed_time = time.time() - start_time
-        # should have waited for some time before loop closed
-        assert_greater(elapsed_time, wait_for_sentinel_sec - 1)
-
-    def test_close(self):
-        for i in range(2):
-            self.queue.put(i)
-
-        self.queue.close()
-
-        # get() should always return the sentinel even past the actual capacity of the queue
-        for _ in range(8):
-            assert_equals(download_threads.CloseableQueue.SENTINEL, self.queue.get())
-
-        # put() should always throw a QueueClosed exception
-        for i in range(8):
-            assert_raises(download_threads.QueueClosedException, self.queue.put, i)
-
-    def test_unsupported_operations(self):
-        assert_raises(NotImplementedError, self.queue.join)
-        assert_raises(NotImplementedError, self.queue.task_done)
-
-
 class TestPresignedUrlProvider(object):
     def setup(self):
         self.mock_synapse_client = mock.create_autospec(Synapse)
-        self.download_request = download_threads.DownloadRequest(123, '456', 'FileEntity', '/myFakepath')
+        self.download_request = DownloadRequest(123, '456', 'FileEntity', '/myFakepath')
 
     def test_get_info_not_expired(self):
         utc_now = datetime.datetime.utcnow()
 
-        info = download_threads.PresignedUrlInfo("myFile.txt", "https://synapse.org/somefile.txt",
-                                                 expiration_utc=utc_now + datetime.timedelta(seconds=6))
+        info = PresignedUrlInfo("myFile.txt", "https://synapse.org/somefile.txt",
+                                expiration_utc=utc_now + datetime.timedelta(seconds=6))
 
-        with mock.patch.object(download_threads.PresignedUrlProvider, '_get_pre_signed_info',
+        with mock.patch.object(PresignedUrlProvider, '_get_pre_signed_info',
                                return_value=info) as mock_get_presigned_info, \
                 mock.patch.object(download_threads, "datetime", wraps=datetime) as mock_datetime:
             mock_datetime.datetime.utcnow.return_value = utc_now
 
-            presigned_url_provider = download_threads.PresignedUrlProvider(self.mock_synapse_client,
-                                                                           self.download_request)
+            presigned_url_provider = PresignedUrlProvider(self.mock_synapse_client,
+                                                          self.download_request)
             assert_equals(info, presigned_url_provider.get_info())
 
             # only caled once in init
@@ -92,20 +49,19 @@ class TestPresignedUrlProvider(object):
         utc_now = datetime.datetime.utcnow()
 
         # expires in the past
-        expired_info = download_threads.PresignedUrlInfo("myFile.txt", "https://synapse.org/somefile.txt",
-                                                         expiration_utc=utc_now - datetime.timedelta(seconds=5))
-        unexpired_info = download_threads.PresignedUrlInfo("myFile.txt",
-                                                           "https://synapse.org/somefile.txt",
-                                                           expiration_utc=utc_now + datetime.timedelta(
-                                                               seconds=6))
+        expired_info = PresignedUrlInfo("myFile.txt", "https://synapse.org/somefile.txt",
+                                        expiration_utc=utc_now - datetime.timedelta(seconds=5))
+        unexpired_info = PresignedUrlInfo("myFile.txt",
+                                          "https://synapse.org/somefile.txt",
+                                          expiration_utc=utc_now + datetime.timedelta(seconds=6))
 
-        with mock.patch.object(download_threads.PresignedUrlProvider, '_get_pre_signed_info',
+        with mock.patch.object(PresignedUrlProvider, '_get_pre_signed_info',
                                side_effect=[expired_info, unexpired_info]) as mock_get_presigned_info, \
                 mock.patch.object(download_threads, "datetime") as mock_datetime:
             mock_datetime.datetime.utcnow.return_value = utc_now
 
-            presigned_url_provider = download_threads.PresignedUrlProvider(self.mock_synapse_client,
-                                                                           self.download_request)
+            presigned_url_provider = PresignedUrlProvider(self.mock_synapse_client,
+                                                          self.download_request)
             assert_equals(unexpired_info, presigned_url_provider.get_info())
 
             # only caled once in init and again in get_info
@@ -126,195 +82,13 @@ class TestPresignedUrlProvider(object):
 
             self.mock_synapse_client._getFileHandleDownload.return_value = fake_file_handle_response
 
-            presigned_url_provider = download_threads.PresignedUrlProvider(self.mock_synapse_client,
-                                                                           self.download_request)
+            presigned_url_provider = PresignedUrlProvider(self.mock_synapse_client,
+                                                          self.download_request)
 
-            expected = download_threads.PresignedUrlInfo(fake_file_name, fake_url, fake_exp_time)
+            expected = PresignedUrlInfo(fake_file_name, fake_url, fake_exp_time)
             assert_equals(expected, presigned_url_provider._get_pre_signed_info())
 
             mock_pre_signed_url_expiration_time.assert_called_with(fake_url)
-
-
-class TestDataChunkDownloadThread:
-
-    def setup(self):
-        self.mock_data_queue = mock.create_autospec(download_threads.CloseableQueue)
-        self.mock_range_queue = mock.create_autospec(download_threads.CloseableQueue)
-        self.mock_presigned_url_provider = mock.create_autospec(download_threads.PresignedUrlProvider)
-        self.presigned_url_info = download_threads.PresignedUrlInfo("foo.txt", "synapse.org/foo.txt",
-                                                                    datetime.datetime.utcnow())
-        self.mock_presigned_url_provider.get_info.return_value = self.presigned_url_info
-        self.mock_requests_session = mock.create_autospec(requests.Session)
-        self.mock_requests_response = mock.create_autospec(requests.Response)
-        self.mock_requests_session.get.return_value = self.mock_requests_response
-        self.response_bytes = [b'some bytes', b'some more bytes']
-        self.mock_requests_response.iter_content.return_value = self.response_bytes
-
-        response_byte_len = sum(len(x) for x in self.response_bytes)
-        self.mock_range_queue.__iter__.return_value = [(0, response_byte_len - 1),
-                                                       (response_byte_len, response_byte_len * 2)]
-
-    def test_get_response_with_retry__exceed_max_retries(self):
-        self.mock_requests_response.status_code = 403
-        start = 5
-        end = 42
-
-        with mock.patch.object(download_threads, "_get_new_session",
-                               return_value=self.mock_requests_session):
-            download_thread = download_threads.DataChunkDownloadThread(self.mock_presigned_url_provider,
-                                                                       self.mock_range_queue,
-                                                                       self.mock_data_queue)
-
-            assert_raises(SynapseError, download_thread._get_response_with_retry, start, end)
-
-            expected_call_list = [mock.call(self.presigned_url_info.url, headers={"Range": "bytes=5-42"},
-                                            stream=True)] * download_threads.MAX_RETRIES
-            assert_equals(expected_call_list, self.mock_requests_session.get.call_args_list)
-
-    def test_get_response_with_retry__partial_content_reponse(self):
-        self.mock_requests_response.status_code = 206
-        start = 5
-        end = 42
-
-        with mock.patch.object(download_threads, "_get_new_session",
-                               return_value=self.mock_requests_session):
-            download_thread = download_threads.DataChunkDownloadThread(self.mock_presigned_url_provider,
-                                                                       self.mock_range_queue,
-                                                                       self.mock_data_queue)
-
-            assert_equals(self.mock_requests_response, download_thread._get_response_with_retry(start, end))
-
-            self.mock_requests_session.get \
-                .assert_called_once_with(self.presigned_url_info.url, headers={"Range": "bytes=5-42"}, stream=True)
-
-    def test_run(self):
-        with mock.patch.object(download_threads, "_get_new_session",
-                               return_value=self.mock_requests_session), \
-             mock.patch.object(download_threads.DataChunkDownloadThread, "_get_response_with_retry",
-                               return_value=self.mock_requests_response):
-            t = download_threads.DataChunkDownloadThread(self.mock_presigned_url_provider,
-                                                         self.mock_range_queue,
-                                                         self.mock_data_queue)
-
-            t.run()
-
-            # should terminate early since queue is closed
-            assert_equals(4, self.mock_data_queue.put.call_count)
-            expected_queue_put_calls = [mock.call((0, b'some bytes')), mock.call((10, b'some more bytes')),
-                                        mock.call((25, b'some bytes')), mock.call((35, b'some more bytes'))]
-            assert_equals(expected_queue_put_calls, self.mock_data_queue.put.call_args_list)
-            self.mock_requests_response.close.assert_not_called()
-
-    def test_run__queue_closed(self):
-        self.mock_data_queue.put.side_effect = download_threads.QueueClosedException('')
-
-        with mock.patch.object(download_threads, "_get_new_session", return_value=self.mock_requests_session), \
-            mock.patch.object(download_threads.DataChunkDownloadThread, "_get_response_with_retry",
-                              return_value=self.mock_requests_response):
-            t = download_threads.DataChunkDownloadThread(self.mock_presigned_url_provider,
-                                                         self.mock_range_queue,
-                                                         self.mock_data_queue)
-
-            t.run()
-
-            # should terminate early since queue is closed
-            assert_equals(1, self.mock_data_queue.put.call_count)
-            self.mock_requests_response.close.assert_called_once()
-
-
-class TestDataChunkWriteToFileThread:
-    def setup(self):
-        self.mock_data_queue = mock.create_autospec(download_threads.CloseableQueue)
-        self.path = "/myfakepath/foo.txt"
-        self.expected_file_size = 58
-        self.bytes_a = b'some bytes'
-        self.bytes_b = b'some more bytes'
-        self.bytes_c = b'another chunk of bytes'
-        self.offset_b = len(self.bytes_a)
-        self.offset_c = self.offset_b + len(self.bytes_b)
-        self.mock_data_queue.__iter__.return_value = [(0, self.bytes_a), (self.offset_b, self.bytes_b),
-                                                      (self.offset_c, self.bytes_c)]
-
-    def test_run(self):
-        with mock.patch.object(download_threads, 'open', mock.mock_open()) as mock_open:
-            t = download_threads.DataChunkWriteToFileThread(self.mock_data_queue, self.path, self.expected_file_size)
-
-            t.run()
-
-            self.mock_data_queue.close.assert_not_called()
-            assert_equals(3, mock_open().write.call_count)
-
-            # make sure seek/write was called in order
-            expected_calls = [mock.call.seek(0), mock.call.write(self.bytes_a),
-                              mock.call.seek(self.offset_b), mock.call.write(self.bytes_b),
-                              mock.call.seek(self.offset_c), mock.call.write(self.bytes_c)]
-            print(mock_open().mock_calls)
-            print(expected_calls)
-            assert_in(expected_calls, mock_open().mock_calls)
-
-    def test_run__write_error(self):
-        with mock.patch.object(download_threads, 'open', mock.mock_open()) as mock_open:
-            mock_open().write.side_effect = [len(self.bytes_a), OSError('fake error')]
-
-            t = download_threads.DataChunkWriteToFileThread(self.mock_data_queue, self.path, self.expected_file_size)
-
-            assert_raises(OSError, t.run)
-
-            self.mock_data_queue.close.assert_called_once()
-
-            assert_equals(2, mock_open().write.call_count)
-            # make sure seek/write was called in order
-            assert_in([mock.call.seek(0), mock.call.write(b'some bytes'),
-                       mock.call.seek(self.offset_b), mock.call.write(b'some more bytes')],
-                      mock_open().mock_calls)
-
-
-class TestDownloadThread:
-    def setup(self):
-        self.mock_data_queue = mock.create_autospec(download_threads.CloseableQueue)
-        self.mock_range_queue = mock.create_autospec(download_threads.CloseableQueue)
-        self.mock_write_file_thread = mock.create_autospec(download_threads.DataChunkWriteToFileThread)
-        self.mock_write_file_thread.path = "/fake_path/foo.txt"
-        self.mock_data_chunk_download_threads = [mock.create_autospec(download_threads.DataChunkDownloadThread)
-                                                 for _ in range(4)]
-        self.chunk_ranges = [(0, 7), (8, 15), (16, 18)]
-
-    def test_download_file__exception_thrown(self):
-        self.mock_range_queue.put.side_effect = KeyboardInterrupt("fake interrupt")
-
-        with mock.patch.object(download_threads.os, "remove") as mock_os_remove:
-            assert_raises(KeyboardInterrupt, download_threads._download_file, self.mock_data_queue,
-                          self.mock_range_queue,
-                          self.mock_write_file_thread, self.mock_data_chunk_download_threads,
-                          self.chunk_ranges)
-
-            self.mock_data_queue.close.assert_called_once()
-            self.mock_range_queue.close.assert_called_once()
-            self.mock_write_file_thread.join.assert_called_once()
-            mock_os_remove.assert_called_once()
-
-            self.mock_range_queue.send_sentinel.assert_not_called()
-            self.mock_data_queue.send_sentinel.assert_not_called()
-
-    def test_download_file__no_exception(self):
-        with mock.patch.object(download_threads.os, "remove") as mock_os_remove:
-            download_threads._download_file(self.mock_data_queue, self.mock_range_queue,
-                                            self.mock_write_file_thread, self.mock_data_chunk_download_threads,
-                                            self.chunk_ranges)
-
-            self.mock_data_queue.close.assert_not_called()
-            self.mock_range_queue.close.assert_not_called()
-            mock_os_remove.assert_not_called()
-
-            self.mock_range_queue.send_sentinel.assert_called_once_with(len(self.mock_data_chunk_download_threads))
-            self.mock_data_queue.send_sentinel.assert_called_once()
-
-            self.mock_write_file_thread.join.assert_called_once()
-            for mock_download_thread in self.mock_data_chunk_download_threads:
-                mock_download_thread.join.assert_called_once()
-
-            assert_equals([mock.call(chunk_range) for chunk_range in self.chunk_ranges],
-                          self.mock_range_queue.put.call_args_list)
 
 
 def test_generate_chunk_ranges():
@@ -340,3 +114,394 @@ def test_pre_signed_url_expiration_time():
     expected = datetime.datetime(year=2013, month=7, day=21, hour=20, minute=12, second=7) + datetime.timedelta(
         seconds=86400)
     assert_equals(expected, download_threads._pre_signed_url_expiration_time(url))
+
+
+@mock.patch.object(download_threads, '_MultithreadedDownloader')
+def test_download_file(mock_multithreaded_downloader_init):
+    """Verify that initiating a download instantiates a downloader and passes it the correct args"""
+
+    syn = mock.Mock()
+    file_handle_id = 1234
+    object_id = 'syn123'
+    object_type = None
+    path = '/tmp/foo'
+    request = DownloadRequest(
+        file_handle_id,
+        object_id,
+        object_type,
+        path,
+    )
+
+    mock_executor = mock.Mock()
+    mock_downloader = mock.Mock()
+    mock_multithreaded_downloader_init.return_value = mock_downloader
+
+    max_concurrent_parts = 5
+    download_file(syn, request, executor=mock_executor, max_concurrent_parts=max_concurrent_parts)
+    mock_multithreaded_downloader_init.assert_called_once_with(syn, mock_executor, max_concurrent_parts)
+    mock_downloader.download_file.assert_called_once_with(request)
+
+    # executor was passed in from the outside, so it should be managed from the outside
+    assert_false(mock_executor.shutdown.called)
+
+
+@mock.patch.object(download_threads, 'get_executor')
+@mock.patch.object(download_threads, '_MultithreadedDownloader')
+def test_download_file__executor_shutdown(mock_multithreaded_downloader_init, mock_get_executor):
+    """Verify that if no external executor is passed in the internally created one
+    is shutdown once the download is done"""
+
+    max_threads = 5
+    syn = mock.Mock(max_threads=max_threads)
+
+    file_handle_id = 1234
+    object_id = 'syn123'
+    object_type = None
+    path = '/tmp/foo'
+    request = DownloadRequest(
+        file_handle_id,
+        object_id,
+        object_type,
+        path,
+    )
+
+    mock_executor = mock.Mock()
+    mock_get_executor.return_value = mock_executor
+
+    mock_downloader = mock.Mock()
+    mock_multithreaded_downloader_init.return_value = mock_downloader
+
+    download_file(syn, request)
+
+    # no max_concurrent_parts passed, should default to the number of client configured threads
+    mock_multithreaded_downloader_init.assert_called_once_with(syn, mock_executor, max_threads)
+    mock_downloader.download_file.assert_called_once_with(request)
+
+    # internally created executor should be shutdown
+    assert_true(mock_executor.shutdown.called)
+
+
+class MultithreadedDownloaderTests(TestCase):
+
+    def test_download_file(self):
+        """Test downloading a file, succesfully, with multiple trips through the loop needed to complete the file"""
+
+        file_handle_id = 1234
+        object_id = 'syn123'
+        path = '/tmp/foo'
+        url = 'http://foo.com/bar'
+        file_size = int(1.5 * (2 ** 20))
+        request = DownloadRequest(file_handle_id, object_id, None, path)
+
+        with mock.patch.object(download_threads, 'PresignedUrlProvider') as mock_url_provider_init, \
+                mock.patch.object(download_threads, 'TransferStatus') as mock_transfer_status_init, \
+                mock.patch.object(download_threads, '_get_file_size') as mock_get_file_size, \
+                mock.patch.object(download_threads, '_generate_chunk_ranges') as mock_generate_chunk_ranges, \
+                mock.patch.object(_MultithreadedDownloader, '_prep_file') as mock_prep_file, \
+                mock.patch.object(_MultithreadedDownloader, '_submit_chunks') as mock_submit_chunks, \
+                mock.patch.object(_MultithreadedDownloader, '_write_chunks') as mock_write_chunks, \
+                mock.patch('concurrent.futures.wait') as mock_futures_wait, \
+                mock.patch.object(_MultithreadedDownloader, '_check_for_errors') as mock_check_for_errors:
+
+            url_info = mock.Mock(url=url)
+            mock_url_provider = mock.Mock(get_info=mock.Mock(return_value=url_info))
+            mock_url_provider_init.return_value = mock_url_provider
+            mock_get_file_size.return_value = file_size
+            chunk_generator = mock.Mock()
+            mock_generate_chunk_ranges.return_value = chunk_generator
+
+            transfer_status = TransferStatus(file_size)
+            mock_transfer_status_init.return_value = transfer_status
+
+            first_future = mock.Mock()
+            second_future = mock.Mock()
+            third_future = mock.Mock()
+
+            # 3 parts total, submit 2, then 1, then no more the third time through the loop
+            mock_submit_chunks.side_effect = [
+                set([first_future, second_future]),
+                set([third_future]),
+                set(),
+            ]
+
+            # on first wait 1 part is done, one is pending,
+            # on second wait last remaining part is completed
+
+            mock_futures_wait.side_effect = [
+                (set([first_future]), set([second_future])),
+                (set([second_future, third_future]), set()),
+            ]
+
+            syn = mock.Mock()
+            executor = mock.Mock()
+            max_concurrent_parts = 5
+            downloader = _MultithreadedDownloader(syn, executor, max_concurrent_parts)
+
+            downloader.download_file(request)
+
+            mock_prep_file.assert_called_once_with(request)
+
+            expected_submit_chunks_calls = [
+                mock.call(mock_url_provider, chunk_generator, set()),
+                mock.call(mock_url_provider, chunk_generator, set([second_future])),
+                mock.call(mock_url_provider, chunk_generator, set()),
+            ]
+            assert_equals(expected_submit_chunks_calls, mock_submit_chunks.call_args_list)
+
+            expected_write_chunk_calls = [
+                mock.call(request, set(), transfer_status),
+                mock.call(request, set([first_future]), transfer_status),
+                mock.call(request, set([second_future, third_future]), transfer_status),
+            ]
+            assert_equals(expected_write_chunk_calls, mock_write_chunks.call_args_list)
+
+            expected_futures_wait_calls = [
+                mock.call(set([first_future, second_future]), return_when=concurrent.futures.FIRST_COMPLETED),
+                mock.call(set([second_future, third_future]), return_when=concurrent.futures.FIRST_COMPLETED),
+            ]
+            assert_equals(expected_futures_wait_calls, mock_futures_wait.call_args_list)
+
+            expected_check_for_errors_calls = [
+                mock.call(request, set([first_future]), set([second_future])),
+                mock.call(request, set([second_future, third_future]), set()),
+            ]
+            assert_equals(expected_check_for_errors_calls, mock_check_for_errors.call_args_list)
+
+    def test_download_file__error(self):
+        """Test downloading a file when one of the file downloads generates an error.
+        It should be surfaced raised in the entrant thread.
+        """
+
+        file_handle_id = 1234
+        entity_id = 'syn123'
+        path = '/tmp/foo'
+        url = 'http://foo.com/bar'
+        file_size = int(1.5 * (2 ** 20))
+        request = DownloadRequest(file_handle_id, entity_id, None, path)
+
+        with mock.patch.object(download_threads, 'PresignedUrlProvider') as mock_url_provider_init, \
+                mock.patch.object(download_threads, 'TransferStatus') as mock_transfer_status_init, \
+                mock.patch.object(download_threads, '_get_file_size') as mock_get_file_size, \
+                mock.patch.object(download_threads, '_generate_chunk_ranges') as mock_generate_chunk_ranges, \
+                mock.patch.object(_MultithreadedDownloader, '_prep_file'), \
+                mock.patch.object(_MultithreadedDownloader, '_submit_chunks') as mock_submit_chunks, \
+                mock.patch.object(_MultithreadedDownloader, '_write_chunks'), \
+                mock.patch('concurrent.futures.wait') as mock_futures_wait:
+
+            url_info = mock.Mock(url=url)
+            mock_url_provider = mock.Mock(get_info=mock.Mock(return_value=url_info))
+            mock_url_provider_init.return_value = mock_url_provider
+            mock_get_file_size.return_value = file_size
+            chunk_generator = mock.Mock()
+            mock_generate_chunk_ranges.return_value = chunk_generator
+
+            transfer_status = TransferStatus(file_size)
+            mock_transfer_status_init.return_value = transfer_status
+
+            exception = ValueError('failed!')
+            part_future = mock.Mock(
+                exception=mock.Mock(
+                    return_value=exception
+                )
+            )
+
+            mock_submit_chunks.return_value = set([part_future])
+            mock_futures_wait.return_value = (set([part_future]), set([]))
+
+            syn = mock.Mock()
+            executor = mock.Mock()
+            max_concurrent_parts = 5
+            downloader = _MultithreadedDownloader(syn, executor, max_concurrent_parts)
+
+            with assert_raises(exception.__class__):
+                downloader.download_file(request)
+
+    @mock.patch.object(download_threads, 'open')
+    def test_prep_file(self, mock_open):
+        """Should open and close the file to create/truncate it"""
+        path = '/tmp/foo'
+        request = DownloadRequest(None, None, None, path)
+        download_threads._MultithreadedDownloader._prep_file(request)
+        mock_open.assert_called_once_with(path, 'wb')
+
+        mock_open.return_value.close.assert_called_once_with()
+
+    def test_submit_chunks(self):
+        """Verify chunks are submitted to the executor as expected, not exceeding the available
+        number of outstanding concurrent parts"""
+
+        syn = mock.Mock()
+        max_concurrent_parts = 3
+        pending_futures = [mock.Mock()] * 1
+
+        expected_submit_count = max_concurrent_parts - len(pending_futures)
+        executor_submit_side_effect = [mock.Mock() for _ in range(expected_submit_count)]
+        executor_submit = mock.Mock(side_effect=executor_submit_side_effect)
+        executor = mock.Mock(submit=executor_submit)
+        url_provider = mock.Mock()
+
+        file_size = int(2.5 * download_threads.SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE)
+        chunk_range_generator = download_threads._generate_chunk_ranges(file_size)
+
+        downloader = _MultithreadedDownloader(syn, executor, max_concurrent_parts)
+        submitted_futures = downloader._submit_chunks(url_provider, chunk_range_generator, pending_futures)
+
+        ranges = [r for r in download_threads._generate_chunk_ranges(file_size)][:expected_submit_count]
+        expected_submits = [
+            mock.call(
+                downloader._get_response_with_retry,
+                url_provider,
+                start,
+                end,
+            ) for start, end in ranges
+        ]
+        assert_equals(expected_submits, executor_submit.call_args_list)
+        assert_equals(set(executor_submit_side_effect), submitted_futures)
+
+    @mock.patch.object(download_threads, 'open')
+    def test_write_chunks__none_ready(self, mock_open):
+        """Verify that if there are no parts ready that nothing is written out"""
+        request = mock.Mock()
+        transfer_status = mock.Mock()
+        completed_futures = set()
+        downloader = _MultithreadedDownloader(mock.Mock(), mock.Mock(), 5)
+        downloader._write_chunks(request, completed_futures, transfer_status)
+        assert_false(mock_open.called)
+
+    @mock.patch.object(download_threads, 'printTransferProgress')
+    @mock.patch.object(download_threads, 'open')
+    def test_write_chunks(self, mock_open, mock_print_transfer_progress):
+        """Verify expected behavior writing out chunks to disk"""
+        request = mock.Mock(path='/tmp/foo')
+
+        chunks = [b'foo', b'bar', b'baz']
+        file_size = sum(len(d) for d in chunks)
+        transfer_status = TransferStatus(file_size)
+
+        completed_futures = []
+        expected_seeks = []
+        expected_writes = []
+        expected_print_transfer_progresses = []
+
+        byte_start = 0
+        for chunk in chunks:
+            future = mock.Mock(
+                result=mock.Mock(
+                    return_value=(
+                        byte_start,
+                        mock.Mock(content=chunk)
+                    )
+                )
+            )
+            completed_futures.append(future)
+            expected_seeks.append(mock.call(byte_start))
+            expected_writes.append(mock.call(chunk))
+
+            byte_start += len(chunk)
+            expected_print_transfer_progresses.append(mock.call(
+                byte_start, file_size, 'Downloading ', os.path.basename(request.path), dt=mock.ANY
+               )
+            )
+
+        downloader = _MultithreadedDownloader(mock.Mock(), mock.Mock(), 5)
+        downloader._write_chunks(request, completed_futures, transfer_status)
+
+        # with open (as a context manager)
+        mock_write = mock_open.return_value.__enter__.return_value
+        assert_equals(expected_seeks, mock_write.seek.call_args_list)
+        assert_equals(expected_writes, mock_write.write.call_args_list)
+
+        assert_equals(sum(len(c) for c in chunks), transfer_status.transferred)
+        assert_equals(expected_print_transfer_progresses, mock_print_transfer_progress.call_args_list)
+
+    def test_check_for_errors__no_errors(self):
+        """Verify check_for_errors when there were no errors"""
+        downloader = _MultithreadedDownloader(mock.Mock(), mock.Mock(), 5)
+
+        request = mock.Mock()
+        completed_futures = [mock.Mock(exception=mock.Mock(return_value=None))] * 3
+        pending_future = mock.Mock()
+        pending_futures = [pending_future]
+
+        # does not raise error
+        downloader._check_for_errors(request, completed_futures, pending_futures)
+
+        # pending not cancalled
+        assert_false(pending_future.cancel.called)
+
+    def test_check_for_errors(self):
+        """Verify check_for_errors when there were no errors"""
+        downloader = _MultithreadedDownloader(mock.Mock(), mock.Mock(), 5)
+
+        request = mock.Mock()
+        exception = ValueError('failed')
+
+        successful_future = mock.Mock(exception=mock.Mock(return_value=None))
+        failed_future = mock.Mock(exception=mock.Mock(return_value=exception))
+        completed_futures = ([successful_future] * 2) + [failed_future] + [successful_future]
+
+        pending_futures = [mock.Mock(), mock.Mock()]
+
+        with assert_raises(exception.__class__):
+            downloader._check_for_errors(request, completed_futures, pending_futures)
+
+        # pendings should have been cancelled
+        for future in pending_futures:
+            future.cancel.assert_called_once_with()
+
+    @mock.patch.object(download_threads, "_get_thread_session")
+    def test_get_response_with_retry__exceed_max_retries(self, mock_get_thread_session):
+        mock_requests_response = mock.Mock(status_code=403)
+        mock_requests_session = mock.create_autospec(requests.Session)
+        mock_requests_session.get.return_value = mock_requests_response
+        mock_get_thread_session.return_value = mock_requests_session
+
+        mock_presigned_url_provider = mock.create_autospec(download_threads.PresignedUrlProvider)
+        presigned_url_info = download_threads.PresignedUrlInfo(
+            "foo.txt", "synapse.org/foo.txt",
+            datetime.datetime.utcnow()
+        )
+        mock_presigned_url_provider.get_info.return_value = presigned_url_info
+
+        start = 5
+        end = 42
+
+        downloader = _MultithreadedDownloader(mock.Mock(), mock.Mock(), 5)
+        with assert_raises(SynapseError):
+            downloader._get_response_with_retry(mock_presigned_url_provider, start, end)
+
+        expected_call_list = [
+            mock.call(
+                presigned_url_info.url, headers={"Range": "bytes=5-42"}, stream=True
+            )
+        ] * download_threads.MAX_RETRIES
+        assert_equals(expected_call_list, mock_requests_session.get.call_args_list)
+
+    @mock.patch.object(download_threads, "_get_thread_session")
+    def test_get_response_with_retry__partial_content_reponse(self, mock_get_thread_session):
+        mock_requests_response = mock.Mock(status_code=206)
+        mock_requests_session = mock.create_autospec(requests.Session)
+        mock_requests_session.get.return_value = mock_requests_response
+        mock_get_thread_session.return_value = mock_requests_session
+
+        mock_presigned_url_provider = mock.create_autospec(download_threads.PresignedUrlProvider)
+        presigned_url_info = download_threads.PresignedUrlInfo(
+            "foo.txt", "synapse.org/foo.txt",
+            datetime.datetime.utcnow()
+        )
+
+        mock_presigned_url_provider.get_info.return_value = presigned_url_info
+        start = 5
+        end = 42
+
+        downloader = _MultithreadedDownloader(mock.Mock(), mock.Mock(), 5)
+        assert_equals(
+            (start, mock_requests_response),
+            downloader._get_response_with_retry(mock_presigned_url_provider, start, end)
+        )
+
+        mock_requests_session.get.assert_called_once_with(
+            presigned_url_info.url,
+            headers={"Range": "bytes=5-42"},
+            stream=True
+        )

--- a/tests/unit/synapseclient/core/unit_test_cumulative_transfer_progress.py
+++ b/tests/unit/synapseclient/core/unit_test_cumulative_transfer_progress.py
@@ -76,6 +76,7 @@ def test_progress(mock_utils_print_transfer_progress, mock_sys, mock_time):
     assert_false(threading.get_ident() in progress._thread_totals)
     assert_false(hasattr(cumulative_transfer_progress._thread_local, 'cumulative_transfer_progress'))
 
+
 @mock.patch.object(cumulative_transfer_progress, 'sys')
 @mock.patch.object(utils, 'printTransferProgress')
 def test_progress__not_tty(mock_utils_print_transfer_progress, mock_sys):

--- a/tests/unit/synapseclient/core/unit_test_cumulative_transfer_progress.py
+++ b/tests/unit/synapseclient/core/unit_test_cumulative_transfer_progress.py
@@ -1,0 +1,89 @@
+import threading
+
+from synapseclient.core import cumulative_transfer_progress
+from synapseclient.core import utils
+
+from unittest import mock
+from nose.tools import assert_equals, assert_false, assert_is
+
+
+@mock.patch.object(utils, 'printTransferProgress')
+def test_not_configured(mock_utils_print_transfer_progress):
+    """Verify that if no thread local state is configured that printTransferProgress falls through to utils"""
+
+    args = [5, 10]
+    kwargs = {
+        'prefix': 'prefix',
+        'postfix': 'postfix',
+        'isBytes': True,
+        'dt': 100,
+        'previouslyTransferred': 200,
+    }
+
+    cumulative_transfer_progress.printTransferProgress(*args, **kwargs)
+    mock_utils_print_transfer_progress.assert_called_once_with(*args, **kwargs)
+
+
+@mock.patch.object(cumulative_transfer_progress, 'time')
+@mock.patch.object(cumulative_transfer_progress, 'sys')
+@mock.patch.object(utils, 'printTransferProgress')
+def test_progress(mock_utils_print_transfer_progress, mock_sys, mock_time):
+    """Verify writing progress via a CumulativeProgress"""
+
+    # mock time for predictability
+    mock_time.time.return_value = 0
+    progress = cumulative_transfer_progress.CumulativeTransferProgress('Testing')
+
+    mock_time.time.return_value = 100
+    with progress.accumulate_progress():
+        assert_is(progress, getattr(cumulative_transfer_progress._thread_local, 'cumulative_transfer_progress'))
+
+        # a complete transfer (transferred >= toBeTransferred)
+        # should additionally trigger a fall through to utils to print the complete progress bar
+        args1 = [100, 100]
+        kwargs1 = {
+            'prefix': 'prefix1',
+            'postfix':  'postfix1',
+            'isBytes': True,
+            'dt': 300,
+            'previouslyTransferred': 0
+        }
+        cumulative_transfer_progress.printTransferProgress(*args1, **kwargs1)
+
+        cumulative_transfer_progress.printTransferProgress(
+            150,
+            200,
+            prefix='prefix2',
+            postfix='postfix2',
+            isBytes=True,
+            dt=300,
+            previouslyTransferred=0
+        )
+
+        assert_equals(150, progress._total_transferred)
+        assert_equals(150, progress._thread_totals[threading.get_ident()])
+
+        print(progress)
+
+    mock_utils_print_transfer_progress.assert_called_once_with(*args1, **kwargs1)
+
+    expected_stdout_writes = [
+        mock.call('\r / Testing 100.0bytes (1.0bytes/s)'),
+        mock.call('\r - Testing 150.0bytes (1.5bytes/s)'),
+    ]
+    assert_equals(expected_stdout_writes, mock_sys.stdout.write.call_args_list)
+
+    assert_false(threading.get_ident() in progress._thread_totals)
+    assert_false(hasattr(cumulative_transfer_progress._thread_local, 'cumulative_transfer_progress'))
+
+@mock.patch.object(cumulative_transfer_progress, 'sys')
+@mock.patch.object(utils, 'printTransferProgress')
+def test_progress__not_tty(mock_utils_print_transfer_progress, mock_sys):
+    """Verify nothing written if stdout is not a tty"""
+    mock_sys.stdout.isatty.return_value = False
+    progress = cumulative_transfer_progress.CumulativeTransferProgress('Testing')
+
+    with progress.accumulate_progress():
+        cumulative_transfer_progress.printTransferProgress(100, 100)
+        assert_false(mock_sys.stdout.write.called)
+        assert_false(mock_utils_print_transfer_progress.called)

--- a/tests/unit/synapseclient/core/unit_test_cumulative_transfer_progress.py
+++ b/tests/unit/synapseclient/core/unit_test_cumulative_transfer_progress.py
@@ -43,7 +43,7 @@ def test_progress(mock_utils_print_transfer_progress, mock_sys, mock_time):
         args1 = [100, 100]
         kwargs1 = {
             'prefix': 'prefix1',
-            'postfix':  'postfix1',
+            'postfix': 'postfix1',
             'isBytes': True,
             'dt': 300,
             'previouslyTransferred': 0

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -273,11 +273,19 @@ class Test__downloadFileHandle(unittest.TestCase):
                 }
             }
 
+            executor = MagicMock()
             syn.multi_threaded = True
-            syn._downloadFileHandle(fileHandleId=123, objectId=456, objectType="FileEntity", destination="/myfakepath")
+            syn._downloadFileHandle(
+                fileHandleId=123,
+                objectId=456,
+                objectType="FileEntity",
+                destination="/myfakepath",
+                executor=executor,
+            )
 
             mock_multi_thread_download.assert_called_once_with(123, 456, "FileEntity", "/myfakepath",
-                                                               expected_md5="someMD5")
+                                                               expected_md5="someMD5",
+                                                               executor=executor)
 
     def test_multithread_True__other_file_handle_type(self):
         with patch.object(os, "makedirs"), \

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -275,19 +275,16 @@ class Test__downloadFileHandle(unittest.TestCase):
                 }
             }
 
-            executor = MagicMock()
             syn.multi_threaded = True
             syn._downloadFileHandle(
                 fileHandleId=123,
                 objectId=456,
                 objectType="FileEntity",
                 destination="/myfakepath",
-                executor=executor,
             )
 
             mock_multi_thread_download.assert_called_once_with(123, 456, "FileEntity", "/myfakepath",
-                                                               expected_md5="someMD5",
-                                                               executor=executor)
+                                                               expected_md5="someMD5")
 
     def _multithread_not_applicable(self, file_handle):
         with patch.object(os, "makedirs"), \

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -317,7 +317,7 @@ class Test__downloadFileHandle(unittest.TestCase):
         download if the file is not large enough to make it worthwhile"""
         file_handle = {
             'id': '123',
-            'concreteType': "someFakeConcreteType",
+            'concreteType': concrete_types.S3_FILE_HANDLE,
             'contentMd5': 'someMD5',
             'contentSize': multithread_download.SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE - 1
         }

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -172,11 +172,10 @@ class TestPrivateGetWithEntityBundle:
         cacheDir = syn.cache.get_cache_dir(fileHandle)
         # Make sure the .cacheMap file does not already exist
         cacheMap = os.path.join(cacheDir, '.cacheMap')
-        executor = Mock()
         if os.path.exists(cacheMap):
             os.remove(cacheMap)
 
-        def _downloadFileHandle(fileHandleId,  objectId, objectType, path, retries=5, maxThreads=None, executor=None):
+        def _downloadFileHandle(fileHandleId,  objectId, objectType, path, retries=5):
             # touch file at path
             with open(path, 'a'):
                 os.utime(path, None)
@@ -198,8 +197,7 @@ class TestPrivateGetWithEntityBundle:
 
         e = syn._getWithEntityBundle(entityBundle=bundle,
                                      downloadLocation=temp_dir1,
-                                     ifcollision="overwrite.local",
-                                     executor=executor)
+                                     ifcollision="overwrite.local")
 
         assert_equal(e.name, bundle["entity"]["name"])
         assert_equal(e.parentId, bundle["entity"]["parentId"])

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -175,7 +175,7 @@ class TestPrivateGetWithEntityBundle:
         if os.path.exists(cacheMap):
             os.remove(cacheMap)
 
-        def _downloadFileHandle(fileHandleId,  objectId, objectType, path, retries=5):
+        def _downloadFileHandle(fileHandleId, objectId, objectType, path, retries=5):
             # touch file at path
             with open(path, 'a'):
                 os.utime(path, None)

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -172,10 +172,11 @@ class TestPrivateGetWithEntityBundle:
         cacheDir = syn.cache.get_cache_dir(fileHandle)
         # Make sure the .cacheMap file does not already exist
         cacheMap = os.path.join(cacheDir, '.cacheMap')
+        executor = Mock()
         if os.path.exists(cacheMap):
             os.remove(cacheMap)
 
-        def _downloadFileHandle(fileHandleId,  objectId, objectType, path, retries=5, max_threads=None):
+        def _downloadFileHandle(fileHandleId,  objectId, objectType, path, retries=5, maxThreads=None, executor=None):
             # touch file at path
             with open(path, 'a'):
                 os.utime(path, None)
@@ -197,7 +198,8 @@ class TestPrivateGetWithEntityBundle:
 
         e = syn._getWithEntityBundle(entityBundle=bundle,
                                      downloadLocation=temp_dir1,
-                                     ifcollision="overwrite.local")
+                                     ifcollision="overwrite.local",
+                                     executor=executor)
 
         assert_equal(e.name, bundle["entity"]["name"])
         assert_equal(e.parentId, bundle["entity"]["parentId"])

--- a/tests/unit/synapseclient/unit_test_commandline.py
+++ b/tests/unit/synapseclient/unit_test_commandline.py
@@ -2,7 +2,7 @@
 
 """
 
-from nose.tools import assert_equal, assert_true, assert_false
+from nose.tools import assert_equal, assert_true
 from unittest.mock import Mock, patch
 
 import synapseutils
@@ -41,21 +41,15 @@ def test_command_sync():
 
 
 def test_get_multi_threaded_flag():
-    """Test the sync function.
-
-    Since this function only passes argparse arguments for the sync subcommand
-    straight to `synapseutils.sync.syncToSynapse`, the only tests here are for
-    the command line arguments provided and that the function is called once.
-
-    """
-
+    """Test the multi threaded command line flag"""
     parser = cmdline.build_parser()
     args = parser.parse_args(['get', '--multiThreaded', 'syn123'])
 
     assert_true(args.multiThreaded)
 
+    # defaults to True
     args = parser.parse_args(['get', 'syn123'])
-    assert_false(args.multiThreaded)
+    assert_true(args.multiThreaded)
 
 
 @patch('builtins.print')

--- a/tests/unit/synapseutils/unit_test_synapseutils_sync.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_sync.py
@@ -1,6 +1,6 @@
 import os
 import csv
-from unittest.mock import patch, create_autospec, Mock, call
+from unittest.mock import patch, create_autospec, Mock, call, ANY
 from nose.tools import assert_dict_equal, assert_raises, assert_equals, assert_list_equal
 import pandas as pd
 import pandas.util.testing as pdt
@@ -10,6 +10,7 @@ import tempfile
 import synapseutils
 from synapseclient import Activity, File, Folder, Project, Schema
 from synapseclient.core.exceptions import SynapseHTTPError
+from synapseclient.core.utils import id_of
 from tests import unit
 
 
@@ -133,15 +134,27 @@ def test_syncFromSynapse__project_contains_empty_folder():
     project = Project(name="the project", parent="whatever", id="syn123")
     file = File(name="a file", parent=project, id="syn456")
     folder = Folder(name="a folder", parent=project, id="syn789")
+
+    entities = {
+        file.id: file,
+        folder.id: folder,
+    }
+
+    def syn_get_side_effect(entity, *args, **kwargs):
+        return entities[id_of(entity)]
+
     with patch.object(syn, "getChildren", side_effect=[[folder, file], []]) as patch_syn_get_children,\
-            patch.object(syn, "get", side_effect=[folder, file]) as patch_syn_get:
+            patch.object(syn, "get", side_effect=syn_get_side_effect) as patch_syn_get:
         assert_equals([file], synapseutils.syncFromSynapse(syn, project))
         expected_get_children_agrs = [call(project['id']), call(folder['id'])]
         assert_list_equal(expected_get_children_agrs, patch_syn_get_children.call_args_list)
-        expected_get_args = [
-            call(folder['id'], downloadLocation=None, ifcollision='overwrite.local', followLink=False),
-            call(file['id'], downloadLocation=None, ifcollision='overwrite.local', followLink=False)]
-        assert_list_equal(expected_get_args, patch_syn_get.call_args_list)
+        patch_syn_get.assert_called_once_with(
+            file['id'],
+            downloadLocation=None,
+            ifcollision='overwrite.local',
+            followLink=False,
+            executor=ANY,
+        )
 
 
 def _compareCsv(expected_csv_string, csv_path):
@@ -157,9 +170,19 @@ def test_syncFromSynase__manifest():
     """Verify that we generate manifest files when syncing to a location outside of the cache."""
 
     project = Project(name="the project", parent="whatever", id="syn123")
-    file1 = File(name="file1", parent=project, id="syn456")
-    file2 = File(name="file2", parent=project, id="syn789", parentId='syn098')
-    folder = Folder(name="a folder", parent=project, id="syn098")
+    path1 = '/tmp/foo'
+    file1 = File(name="file1", parent=project, id="syn456", path=path1)
+    path2 = '/tmp/afolder/bar'
+    file2 = File(name="file2", parent=project, id="syn789", parentId='syn098', path=path2)
+    folder = Folder(name="afolder", parent=project, id="syn098")
+    entities = {
+        file1.id: file1,
+        file2.id: file2,
+        folder.id: folder,
+    }
+
+    def syn_get_side_effect(entity, *args, **kwargs):
+        return entities[id_of(entity)]
 
     file_1_provenance = Activity(data={
         'used': '',
@@ -172,15 +195,23 @@ def test_syncFromSynase__manifest():
         'description': 'bar',
     })
 
+    provenance = {
+        file1.id: file_1_provenance,
+        file2.id: file_2_provenance,
+    }
+
+    def getProvenance_side_effect(entity, *args, **kwargs):
+        return provenance[id_of(entity)]
+
     expected_project_manifest = \
-        """path\tparent\tname\tsynapseStore\tcontentType\tused\texecuted\tactivityName\tactivityDescription
-\tsyn098\tfile2\tTrue\t\t\t\tfoo\tbar
-\tsyn123\tfile1\tTrue\t\t\t\t\t
+        f"""path\tparent\tname\tsynapseStore\tcontentType\tused\texecuted\tactivityName\tactivityDescription
+{path1}\tsyn123\tfile1\tTrue\t\t\t\t\t
+{path2}\tsyn098\tfile2\tTrue\t\t\t\tfoo\tbar
 """
 
     expected_folder_manifest = \
-        """path\tparent\tname\tsynapseStore\tcontentType\tused\texecuted\tactivityName\tactivityDescription
-\tsyn098\tfile2\tTrue\t\t\t\tfoo\tbar
+        f"""path\tparent\tname\tsynapseStore\tcontentType\tused\texecuted\tactivityName\tactivityDescription
+{path2}\tsyn098\tfile2\tTrue\t\t\t\tfoo\tbar
 """
 
     expected_synced_files = [file2, file1]
@@ -188,14 +219,17 @@ def test_syncFromSynase__manifest():
     with tempfile.TemporaryDirectory() as sync_dir:
 
         with patch.object(syn, "getChildren", side_effect=[[folder, file1], [file2]]),\
-            patch.object(syn, "get", side_effect=[folder, file2, file1]),\
+                patch.object(syn, "get", side_effect=syn_get_side_effect),\
                 patch.object(syn, "getProvenance") as patch_syn_get_provenance:
 
-            patch_syn_get_provenance.side_effect = [file_2_provenance, file_1_provenance]
+            patch_syn_get_provenance.side_effect = getProvenance_side_effect
 
             synced_files = synapseutils.syncFromSynapse(syn, project, path=sync_dir)
 
-            assert_equals(expected_synced_files, synced_files)
+            assert_equals(
+                sorted([id_of(e) for e in expected_synced_files]),
+                sorted([id_of(e) for e in synced_files])
+            )
 
             # we only expect two calls to provenance even though there are three rows of provenance data
             # in the manifests (two in the outer project, one in the folder)

--- a/tests/unit/synapseutils/unit_test_synapseutils_sync.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_sync.py
@@ -1,6 +1,6 @@
 import os
 import csv
-from unittest.mock import patch, create_autospec, Mock, call, ANY
+from unittest.mock import patch, create_autospec, Mock, call
 from nose.tools import assert_dict_equal, assert_raises, assert_true, assert_equals, assert_list_equal
 import pandas as pd
 import pandas.util.testing as pdt
@@ -154,7 +154,6 @@ def test_syncFromSynapse__project_contains_empty_folder():
             downloadLocation=None,
             ifcollision='overwrite.local',
             followLink=False,
-            executor=ANY,
         )
 
 


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/SYNPY-1074

Improves performance of syncFromSynapse (synapse get -r) by allowing multiple files from the sync to be dowloaded in parallel. The current implementation downloads files serially (if the existing client is configured in multiThreaded mode each individual S3 file is downloaded in parallel chunks, but the files themselves are still downloaded serially). Some performance stats are included in the linked bug.

In order to achieve this:
1. synapseclient.sync.syncFromSynapse is refactored to use a thread pool Executor service The folder hierarchy is walked in the main entrant thread but the individual files are submitted for asynchronous download in the thread pool. This also necessitates reimplementing syncFromSynapse in an iterative walk rather than recursive as it was before.
2. Multithreaded file downloads are refactored to also use a thread pool. Previously a multi threaded file download would spawn additional threads on demand to download the data and write the file. By refactoring it to use a thread pool the same thread pool from the sync can be passed through to the download (in this case by means of a thread local to avoid needing to pass the executor instance through the entire Synapse.get call hierarchy).
3. Support is added to print the transfer progress of the Sync as a whole. Previously the console would print transfer progress for each individual file which worked when the files were downloaded serially, but when they are downloaded in parallel the progress bars would otherwise interfere with each other. Instead progress is tracked through a central accumulator which prints the overall number of bytes transferred and prints individual files when they are completed.
4. With the above changes it should be ok to move downloads to multiThreaded by default which this PR does (previously it was an opt in). Some of these changes should iron out some of the unexpected performance characteristics enabling it before would have caused (see the bug performance numbers for some examples).