### PR TITLE
SYNPY-1084 allow anonymous calls

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1870,7 +1870,7 @@ class Synapse(object):
                     if os.path.exists(temp_destination) else {}
                 response = with_retry(
                     lambda: self._requests_session.get(url,
-                                                       headers=self._generateHeaders(url, range_header),
+                                                       headers=self._generate_headers(url, range_header),
                                                        stream=True, allow_redirects=False),
                     verbose=self.debug, **STANDARD_RETRY_PARAMS)
                 try:
@@ -3591,7 +3591,7 @@ class Synapse(object):
     #                   Low level Rest calls                   #
     ############################################################
 
-    def _generateHeaders(self, url, headers=None):
+    def _generate_headers(self, url, headers=None):
         """Generate headers signed with the API key."""
 
         if headers is None:
@@ -3706,7 +3706,7 @@ class Synapse(object):
             uri = endpoint + uri
 
         if headers is None:
-            headers = self._generateHeaders(uri)
+            headers = self._generate_headers(uri)
         return uri, headers
 
     def _build_retry_policy(self, retryPolicy={}):

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1870,7 +1870,7 @@ class Synapse(object):
                     if os.path.exists(temp_destination) else {}
                 response = with_retry(
                     lambda: self._requests_session.get(url,
-                                                       headers=self._generateSignedHeaders(url, range_header),
+                                                       headers=self._generateHeaders(url, range_header),
                                                        stream=True, allow_redirects=False),
                     verbose=self.debug, **STANDARD_RETRY_PARAMS)
                 try:
@@ -3591,18 +3591,16 @@ class Synapse(object):
     #                   Low level Rest calls                   #
     ############################################################
 
-    def _generateSignedHeaders(self, url, headers=None):
+    def _generateHeaders(self, url, headers=None):
         """Generate headers signed with the API key."""
-
-        if self.credentials is None:
-            raise SynapseAuthenticationError("Please login")
 
         if headers is None:
             headers = dict(self.default_headers)
 
         headers.update(synapseclient.USER_AGENT)
 
-        headers.update(self.credentials.get_signed_headers(url))
+        if self.credentials:
+            headers.update(self.credentials.get_signed_headers(url))
         return headers
 
     def restGET(self, uri, endpoint=None, headers=None, retryPolicy={}, requests_session=None, **kwargs):
@@ -3708,7 +3706,7 @@ class Synapse(object):
             uri = endpoint + uri
 
         if headers is None:
-            headers = self._generateSignedHeaders(uri)
+            headers = self._generateHeaders(uri)
         return uri, headers
 
     def _build_retry_policy(self, retryPolicy={}):

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -3621,7 +3621,7 @@ class Synapse(object):
             raise
 
     def _rest_call(self, method, uri, data, endpoint, headers, retryPolicy, requests_session, **kwargs):
-        uri, headers = self._build_uri_and_headers(uri, endpoint, headers)
+        uri, headers = self._build_uri_and_headers(uri, endpoint=endpoint, headers=headers)
         retryPolicy = self._build_retry_policy(retryPolicy)
         requests_session = requests_session or self._requests_session
 

--- a/tests/integration/synapseclient/test_evaluations.py
+++ b/tests/integration/synapseclient/test_evaluations.py
@@ -6,7 +6,7 @@ import random
 from nose.tools import assert_raises, assert_is_not_none, assert_true, assert_equals, assert_in
 
 
-from synapseclient import Evaluation, File, Team, SubmissionViewSchema
+from synapseclient import Evaluation, File, Synapse, SubmissionViewSchema, Team
 from synapseclient.core.exceptions import SynapseHTTPError
 from tests import integration
 from tests.integration import schedule_for_cleanup
@@ -188,12 +188,15 @@ def test_teams():
     team = syn.store(Team(name=name, description="A fake team for testing..."))
     schedule_for_cleanup(team)
 
-    found_team = syn.getTeam(team.id)
+    # not logged in, teams are public
+    anonymous_syn = Synapse()
+
+    found_team = anonymous_syn.getTeam(team.id)
     assert_equals(team, found_team)
 
     p = syn.getUserProfile()
     found = None
-    for m in syn.getTeamMembers(team):
+    for m in anonymous_syn.getTeamMembers(team):
         if m.member.ownerId == p.ownerId:
             found = m
             break
@@ -205,7 +208,7 @@ def test_teams():
     found_team = None
     while tries > 0:
         try:
-            found_team = syn.getTeam(name)
+            found_team = anonymous_syn.getTeam(name)
             break
         except ValueError:
             tries -= 1

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -114,7 +114,7 @@ def create_mock_response(url, response_type, **kwargs):
     return response
 
 
-def mock_generateSignedHeaders(self, url, headers=None):
+def mock_generateHeaders(self, url, headers=None):
     return {}
 
 
@@ -143,7 +143,7 @@ def test_mock_download():
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
     with patch.object(syn._requests_session, 'get', side_effect=mock_requests_get), \
-         patch.object(Synapse, '_generateSignedHeaders', side_effect=mock_generateSignedHeaders):
+         patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders):
         syn._download_from_URL(url, destination=temp_dir, fileHandleId=12345, expected_md5=contents_md5)
 
     # 2. Multiple redirects
@@ -156,7 +156,7 @@ def test_mock_download():
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
     with patch.object(syn._requests_session, 'get', side_effect=mock_requests_get), \
-         patch.object(Synapse, '_generateSignedHeaders', side_effect=mock_generateSignedHeaders):
+         patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders):
         syn._download_from_URL(url, destination=temp_dir, fileHandleId=12345, expected_md5=contents_md5)
 
     # 3. recover from partial download
@@ -176,7 +176,7 @@ def test_mock_download():
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
     with patch.object(syn._requests_session, 'get', side_effect=mock_requests_get), \
-            patch.object(Synapse, '_generateSignedHeaders', side_effect=mock_generateSignedHeaders), \
+            patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders), \
             patch.object(Synapse, '_getFileHandleDownload', return_value=_getFileHandleDownload_return_value), \
             patch.object(sts_transfer, "is_storage_location_sts_enabled", return_value=False):
         syn._downloadFileHandle(fileHandleId, objectId, objectType, destination=temp_dir)
@@ -197,7 +197,7 @@ def test_mock_download():
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
     with patch.object(syn._requests_session, 'get', side_effect=mock_requests_get), \
-            patch.object(Synapse, '_generateSignedHeaders', side_effect=mock_generateSignedHeaders), \
+            patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders), \
             patch.object(Synapse, '_getFileHandleDownload', return_value=_getFileHandleDownload_return_value), \
             patch.object(sts_transfer, "is_storage_location_sts_enabled", return_value=False):
 
@@ -219,7 +219,7 @@ def test_mock_download():
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
     with patch.object(syn._requests_session, 'get', side_effect=mock_requests_get), \
-            patch.object(Synapse, '_generateSignedHeaders', side_effect=mock_generateSignedHeaders), \
+            patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders), \
             patch.object(Synapse, '_getFileHandleDownload', return_value=_getFileHandleDownload_return_value):
 
         assert_raises(Exception,
@@ -236,7 +236,7 @@ def test_mock_download():
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
     with patch.object(syn._requests_session, 'get', side_effect=mock_requests_get), \
-            patch.object(Synapse, '_generateSignedHeaders', side_effect=mock_generateSignedHeaders), \
+            patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders), \
             patch.object(Synapse, '_getFileHandleDownload', return_value=_getFileHandleDownload_return_value), \
             patch.object(sts_transfer, "is_storage_location_sts_enabled", return_value=False):
         syn._downloadFileHandle(fileHandleId, objectId, objectType, destination=temp_dir)
@@ -248,7 +248,7 @@ def test_mock_download():
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
     with patch.object(syn._requests_session, 'get', side_effect=mock_requests_get), \
-            patch.object(Synapse, '_generateSignedHeaders', side_effect=mock_generateSignedHeaders), \
+            patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders), \
             patch.object(Synapse, '_getFileHandleDownload', return_value=_getFileHandleDownload_return_value), \
             patch.object(sts_transfer, "is_storage_location_sts_enabled", return_value=False):
         assert_raises(SynapseHTTPError, syn._downloadFileHandle, fileHandleId, objectId, objectType,
@@ -382,7 +382,7 @@ def test_download_end_early_retry():
     mock_requests_get.responses[1].headers['content-length'] = len(contents[partial_content_break:])
 
     with patch.object(syn._requests_session, 'get', side_effect=mock_requests_get), \
-         patch.object(Synapse, '_generateSignedHeaders', side_effect=mock_generateSignedHeaders), \
+         patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders), \
          patch.object(utils, 'temp_download_filename', return_value=temp_destination) as mocked_temp_dest, \
             patch.object(client, 'open', new_callable=mock_open(), create=True) as mocked_open, \
             patch.object(os.path, 'exists', side_effect=[False, True]) as mocked_exists, \
@@ -424,7 +424,7 @@ def test_download_md5_mismatch__not_local_file():
     ])
 
     with patch.object(syn._requests_session, 'get', side_effect=mock_requests_get), \
-         patch.object(Synapse, '_generateSignedHeaders', side_effect=mock_generateSignedHeaders), \
+         patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders), \
          patch.object(utils, 'temp_download_filename', return_value=temp_destination) as mocked_temp_dest, \
             patch.object(client, 'open', new_callable=mock_open(), create=True) as mocked_open, \
             patch.object(os.path, 'exists', side_effect=[False, True]) as mocked_exists, \
@@ -457,7 +457,7 @@ def test_download_md5_mismatch_local_file():
     url = "file:///some/file/path.txt"
     destination = os.path.normpath(os.path.expanduser("~/fake/path/filerino.txt"))
 
-    with patch.object(Synapse, '_generateSignedHeaders', side_effect=mock_generateSignedHeaders), \
+    with patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders), \
          patch.object(utils, 'file_url_to_path', return_value=destination) as mocked_file_url_to_path, \
             patch.object(utils, 'md5_for_file', return_value=hashlib.md5()) as mocked_md5_for_file, \
             patch('os.remove') as mocked_remove:

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -114,7 +114,7 @@ def create_mock_response(url, response_type, **kwargs):
     return response
 
 
-def mock_generateHeaders(self, url, headers=None):
+def mock_generate_headers(self, url, headers=None):
     return {}
 
 
@@ -143,7 +143,7 @@ def test_mock_download():
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
     with patch.object(syn._requests_session, 'get', side_effect=mock_requests_get), \
-         patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders):
+         patch.object(Synapse, '_generate_headers', side_effect=mock_generate_headers):
         syn._download_from_URL(url, destination=temp_dir, fileHandleId=12345, expected_md5=contents_md5)
 
     # 2. Multiple redirects
@@ -156,7 +156,7 @@ def test_mock_download():
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
     with patch.object(syn._requests_session, 'get', side_effect=mock_requests_get), \
-         patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders):
+         patch.object(Synapse, '_generate_headers', side_effect=mock_generate_headers):
         syn._download_from_URL(url, destination=temp_dir, fileHandleId=12345, expected_md5=contents_md5)
 
     # 3. recover from partial download
@@ -176,7 +176,7 @@ def test_mock_download():
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
     with patch.object(syn._requests_session, 'get', side_effect=mock_requests_get), \
-            patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders), \
+            patch.object(Synapse, '_generate_headers', side_effect=mock_generate_headers), \
             patch.object(Synapse, '_getFileHandleDownload', return_value=_getFileHandleDownload_return_value), \
             patch.object(sts_transfer, "is_storage_location_sts_enabled", return_value=False):
         syn._downloadFileHandle(fileHandleId, objectId, objectType, destination=temp_dir)
@@ -197,7 +197,7 @@ def test_mock_download():
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
     with patch.object(syn._requests_session, 'get', side_effect=mock_requests_get), \
-            patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders), \
+            patch.object(Synapse, '_generate_headers', side_effect=mock_generate_headers), \
             patch.object(Synapse, '_getFileHandleDownload', return_value=_getFileHandleDownload_return_value), \
             patch.object(sts_transfer, "is_storage_location_sts_enabled", return_value=False):
 
@@ -219,7 +219,7 @@ def test_mock_download():
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
     with patch.object(syn._requests_session, 'get', side_effect=mock_requests_get), \
-            patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders), \
+            patch.object(Synapse, '_generate_headers', side_effect=mock_generate_headers), \
             patch.object(Synapse, '_getFileHandleDownload', return_value=_getFileHandleDownload_return_value):
 
         assert_raises(Exception,
@@ -236,7 +236,7 @@ def test_mock_download():
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
     with patch.object(syn._requests_session, 'get', side_effect=mock_requests_get), \
-            patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders), \
+            patch.object(Synapse, '_generate_headers', side_effect=mock_generate_headers), \
             patch.object(Synapse, '_getFileHandleDownload', return_value=_getFileHandleDownload_return_value), \
             patch.object(sts_transfer, "is_storage_location_sts_enabled", return_value=False):
         syn._downloadFileHandle(fileHandleId, objectId, objectType, destination=temp_dir)
@@ -248,7 +248,7 @@ def test_mock_download():
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
     with patch.object(syn._requests_session, 'get', side_effect=mock_requests_get), \
-            patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders), \
+            patch.object(Synapse, '_generate_headers', side_effect=mock_generate_headers), \
             patch.object(Synapse, '_getFileHandleDownload', return_value=_getFileHandleDownload_return_value), \
             patch.object(sts_transfer, "is_storage_location_sts_enabled", return_value=False):
         assert_raises(SynapseHTTPError, syn._downloadFileHandle, fileHandleId, objectId, objectType,
@@ -382,7 +382,7 @@ def test_download_end_early_retry():
     mock_requests_get.responses[1].headers['content-length'] = len(contents[partial_content_break:])
 
     with patch.object(syn._requests_session, 'get', side_effect=mock_requests_get), \
-         patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders), \
+         patch.object(Synapse, '_generate_headers', side_effect=mock_generate_headers), \
          patch.object(utils, 'temp_download_filename', return_value=temp_destination) as mocked_temp_dest, \
             patch.object(client, 'open', new_callable=mock_open(), create=True) as mocked_open, \
             patch.object(os.path, 'exists', side_effect=[False, True]) as mocked_exists, \
@@ -424,7 +424,7 @@ def test_download_md5_mismatch__not_local_file():
     ])
 
     with patch.object(syn._requests_session, 'get', side_effect=mock_requests_get), \
-         patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders), \
+         patch.object(Synapse, '_generate_headers', side_effect=mock_generate_headers), \
          patch.object(utils, 'temp_download_filename', return_value=temp_destination) as mocked_temp_dest, \
             patch.object(client, 'open', new_callable=mock_open(), create=True) as mocked_open, \
             patch.object(os.path, 'exists', side_effect=[False, True]) as mocked_exists, \
@@ -457,7 +457,7 @@ def test_download_md5_mismatch_local_file():
     url = "file:///some/file/path.txt"
     destination = os.path.normpath(os.path.expanduser("~/fake/path/filerino.txt"))
 
-    with patch.object(Synapse, '_generateHeaders', side_effect=mock_generateHeaders), \
+    with patch.object(Synapse, '_generate_headers', side_effect=mock_generate_headers), \
          patch.object(utils, 'file_url_to_path', return_value=destination) as mocked_file_url_to_path, \
             patch.object(utils, 'md5_for_file', return_value=hashlib.md5()) as mocked_md5_for_file, \
             patch('os.remove') as mocked_remove:

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -2027,7 +2027,7 @@ class TestGenerateHeaders:
             get_signed_headers=Mock(return_value=signed_headers)
         )
 
-        headers = syn._generateHeaders(url)
+        headers = syn._generate_headers(url)
         expected = {}
         expected.update(signed_headers)
         expected.update(syn.default_headers)
@@ -2043,7 +2043,7 @@ class TestGenerateHeaders:
         syn = Synapse()
         syn.credentials = None
 
-        headers = syn._generateHeaders(url)
+        headers = syn._generate_headers(url)
         expected = {}
         expected.update(syn.default_headers)
         expected.update(synapseclient.USER_AGENT)
@@ -2061,7 +2061,7 @@ class TestGenerateHeaders:
         syn = Synapse()
         syn.credentials = None
 
-        headers = syn._generateHeaders(url, headers=custom_headers)
+        headers = syn._generate_headers(url, headers=custom_headers)
         expected = {}
         expected.update(custom_headers)
         expected.update(synapseclient.USER_AGENT)

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -1572,67 +1572,6 @@ class TestRestCalls:
         self._rest_call_test(session)
 
 
-class TestRequestsSession:
-    """Verify we can optionally pass in a requests.Session in kwargs
-    to have the client use that session instead of the instance session."""
-
-    def setup(self):
-        self._path = '/foo'
-        self._headers = {}
-
-    def test_init(self):
-        """Verify that an external requests session supplied at
-        instantiation is used for calls via a Synapse object."""
-        requests_session = Mock()
-        requests_session.get.return_value = Mock(status_code=200)
-
-        syn = Synapse(debug=False, skip_checks=True, requests_session=requests_session)
-        syn.restGET(self._path, headers=self._headers)
-        requests_session.get.assert_called_once()
-
-    def _http_method_test(self, method):
-        status_ok = Mock(status_code=200)
-        with patch.object(syn._requests_session, method) as requests_call:
-            requests_call.return_value = status_ok
-
-            # make call, check that it flowed through to the instance session
-            rest_call = getattr(syn, "rest{}".format(method.upper()))
-            rest_call(
-                self._path,
-                headers=self._headers
-            )
-            requests_call.assert_called_once()
-            requests_call.reset_mock()
-
-            # make call, check that it flowed through to the passed session
-            # (and not to the instance session)
-            external_session = Mock()
-            getattr(external_session, method).return_value = status_ok
-            rest_call(
-                self._path,
-                headers=self._headers,
-                requests_session=external_session
-            )
-            getattr(external_session, method).assert_called_once()
-            requests_call.assert_not_called()
-
-    def test_get(self):
-        """Test restGET session handling"""
-        self._http_method_test('get')
-
-    def test_put(self):
-        """Test restPUT session handling"""
-        self._http_method_test('put')
-
-    def test_post(self):
-        """Test restPOST session handling"""
-        self._http_method_test('put')
-
-    def test_delete(self):
-        """Test restDELETE session handling"""
-        self._http_method_test('put')
-
-
 class TestSetAnnotations:
 
     def test_not_annotation(self):


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/SYNPY-1084

Per SYNPY-1084 we always enforce that calls made to Synapse are from a logged in client, even for endpoints that don't require auth. This removes the client preemptively raising a SynapseAuthenticationError with a logged out client and instead allows the call to go through. If the call returns a 401 or 403 status code then the client will then raise a SynapseAuthenticationError chained from the error raised as a result of the call.

Also unifies the implementation of the various Synapse#rest methods which were largely duplicative so that they could be more easily tested.