### PR TITLE
SYNPY-1087 update installation instructions

### DIFF
--- a/synapseclient/__init__.py
+++ b/synapseclient/__init__.py
@@ -24,9 +24,12 @@ Installation
 ============
 
 The `synapseclient <https://pypi.python.org/pypi/synapseclient/>`_ package is available from PyPI. It can be installed
-or upgraded with pip::
+or upgraded with pip. Note that synapseclient requires Python 3, and if you have both Python 2 and Python 3
+installations your system, the pip command associated with Python 3 may be named pip3 to distinguish it from a
+Python 2 associated command. Prefixing the pip installation with sudo may be necessary if you are installing Python
+into a shared system installation of Python.
 
-    (sudo) pip install (--upgrade) synapseclient[pandas, pysftp]
+    (sudo) pip3 install (--upgrade) synapseclient[pandas, pysftp]
 
 The dependencies on pandas and pysftp are optional. The Synapse :py:mod:`synapseclient.table` feature integrates with
 Pandas. Support for sftp is required for users of SFTP file storage. Both require native libraries to be compiled or
@@ -53,11 +56,7 @@ Next, either install the package in the site-packages directory ``python setup.p
 Python 2 Support
 ----------------
 
-The sun is setting on Python 2. Many major open source Python packages are moving to require Python 3.
-
-The Synapse engineering team will step down Python 2.7 support to only bug fixes, and require Python 3
-on new feature releases. **Starting with Synapse Python client version 2.0 (will be released in Q1 2019),
-Synapse Python client will require Python 3.**
+synapseclient versions 2.0 and above require Python 3.6 or greater. Python 2.7 is no longer supported.
 
 Connecting to Synapse
 =====================

--- a/synapseclient/__init__.py
+++ b/synapseclient/__init__.py
@@ -29,6 +29,8 @@ installations your system, the pip command associated with Python 3 may be named
 Python 2 associated command. Prefixing the pip installation with sudo may be necessary if you are installing Python
 into a shared system installation of Python.
 
+::
+
     (sudo) pip3 install (--upgrade) synapseclient[pandas, pysftp]
 
 The dependencies on pandas and pysftp are optional. The Synapse :py:mod:`synapseclient.table` feature integrates with


### PR DESCRIPTION
The instructions say to use pip, which can commonly point to a Python 2 installation on systems when both Python 2 and 3 are installed and when not using a virtual environment. In most cases where Python 3 is on the path, pip3 will be on the path even in cases where the plain pip command also points to Python 3 (for example in a virtual env).


<img width="826" alt="Screen Shot 2020-07-28 at 14 34 20" src="https://user-images.githubusercontent.com/2145855/88724445-57f24100-d0df-11ea-9720-62d21e7124a8.png">

