### PR TITLE
DOCS-4 improve command line client docs

### DIFF
--- a/docs/CommandLineClient.rst
+++ b/docs/CommandLineClient.rst
@@ -1,1 +1,31 @@
-.. automodule:: synapseclient.__main__
+***************************
+Synapse command line client
+***************************
+
+The Synapse Python Client can be used from the command line via the **synapse** command.
+
+Installation
+============
+
+The command line client is installed along with `installation of the Synapse Python client \
+<http://python-docs.synapse.org/build/html/index.html#installation>`_.
+
+Help
+====
+
+For help, type::
+
+    synapse -h.
+
+For help on specific commands, type::
+
+    synapse [command] -h
+
+Usage
+=====
+
+.. argparse::
+    :module: synapseclient.__main__
+    :func: build_parser
+    :prog: synapse
+    :nodescription:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ sys.path.insert(0, os.path.abspath('..'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc']
+extensions = ['sphinx.ext.autodoc', 'sphinxarg.ext']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setuptools.setup(
         'pandas': ["pandas>=0.25.0,<2.0"],
         'pysftp': ["pysftp>=0.2.8,<0.3"],
         'boto3': ["boto3>=1.7.0,<2.0"],
+        'docs': ["sphinx>=3.0,<4.0", "sphinx-argparse>=0.2,<.3"],
         'tests': test_deps,
         ':sys_platform=="linux2" or sys_platform=="linux"': ['keyrings.alt==3.1'],
     },

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -1,68 +1,8 @@
 """
-***************************
-Synapse command line client
-***************************
+The Synapse command line client.
 
-The Synapse Python Client can be used from the command line via the **synapse** command.
-
-Installation
-============
-
-The command line client is installed along with `installation of the Synapse Python client \
-<http://python-docs.synapse.org/build/html/index.html#installation>`_.
-
-Help
-====
-
-For help, type::
-
-    synapse -h.
-
-For help on specific commands, type::
-
-    synapse [command] -h
-
-
-Optional arguments
-==================
-
-.. code-block:: shell
-
-    -h, --help            show this help message and exit
-    --version             show program's version number and exit
-    -u SYNAPSEUSER, --username SYNAPSEUSER
-                        Username used to connect to Synapse
-    -p SYNAPSEPASSWORD, --password SYNAPSEPASSWORD
-                        Password used to connect to Synapse
-
-Commands
-========
-  * **get**              - download an entity and associated data
-  * **sync**             - Synchronize files described in a manifest to Synapse
-  * **store**            - uploads and adds a file to Synapse
-  * **store-table**      - uploads a table to Syanpse given a csv
-  * **add**              - add or modify content to Synapse
-  * **mv**               - move a dataset in Synapse
-  * **cp**               - copy an entity/dataset in Synapse
-  * **associate**        - Associate local files with the files stored in Synapse so
-                           that calls to 'syntapse get' and 'synapse show' don't
-                           re-download the files, but use the already existing file.
-  * **delete**           - removes a dataset from Synapse
-  * **query**            - performs SQL like queries on Synapse
-  * **submit**           - submit an entity for evaluation
-  * **show**             - displays information about a Entity
-  * **cat**              - prints a dataset from Synapse
-  * **list**             - List Synapse entities contained by the given Project or
-                           Folder. Note: May not be supported in future versions of
-                           the client.
-  * **set-provenance**   - create provenance records
-  * **get-provenance**   - show provenance records
-  * **set-annotations**  - create annotations
-  * **get-annotations**  - show annotations
-  * **create**           - Creates folders or projects on Synapse
-  * **onweb**            - opens Synapse website for Entity
-  * **login**            - login to Synapse and (optionally) cache credentials
-  * **test-encoding**    - test character encoding to help diagnose problems
+For a description of its usage and parameters, see its documentation:
+https://python-docs.synapse.org/build/html/CommandLineClient.html
 """
 import argparse
 import collections.abc


### PR DESCRIPTION
The current command line client docs don't describe any of the arguments to any of the subcommands. This uses [sphinx-argparse](https://sphinx-argparse.readthedocs.io/en/stable/) to generate a more complete documentation leveraging the existing argparse meta data.

Old version:
https://python-docs.synapse.org/build/html/CommandLineClient.html

New version
https://jkiang13.github.io/synapsePythonClient/build/html/CommandLineClient.html