### PR TITLE
SYNPY-1090 Allow use of api key with command line client

### DIFF
--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -818,7 +818,7 @@ def build_parser():
     parser_login.add_argument('-u', '--username', dest='synapseUser',
                               help='Username used to connect to Synapse')
     parser_login.add_argument('-p', '--password', dest='synapsePassword',
-                              help='Password used to connect to Synapse')
+                              help='Password or api key used to connect to Synapse')
     parser_login.add_argument('--rememberMe', '--remember-me', dest='rememberMe', action='store_true', default=False,
                               help='Cache credentials for automatic authentication on future interactions with Synapse')
     parser_login.set_defaults(func=login)

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -6,25 +6,26 @@ Utility Functions
 Utility functions useful in the implementation and testing of the Synapse client.
 
 """
-import collections.abc
-import os
-import sys
-import hashlib
-import re
+import base64
 import cgi
+import collections.abc
 import datetime
 import errno
-import inspect
-import random
-import requests
-import tempfile
-import platform
 import functools
-import threading
-import uuid
+import hashlib
 import importlib
+import inspect
 import numbers
+import os
+import platform
+import random
+import re
+import requests
+import sys
+import tempfile
+import threading
 import urllib.parse as urllib_parse
+import uuid
 import warnings
 
 
@@ -889,6 +890,19 @@ def snake_case(string):
     """Convert the given string from CamelCase to snake_case"""
     # https://stackoverflow.com/a/1176023
     return re.sub(r'(?<!^)(?=[A-Z])', '_', string).lower()
+
+
+def is_base64_encoded(input_string):
+    """Return whether the given input string appears to be base64 encoded"""
+    if not input_string:
+        # None, empty string are not considered encoded
+        return False
+    try:
+        # see if we can decode it and then reencode it back to the input
+        byte_string = input_string if isinstance(input_string, bytes) else str.encode(input_string)
+        return base64.b64encode(base64.b64decode(byte_string)) == byte_string
+    except Exception:
+        return False
 
 
 class deprecated_keyword_param:

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -1,12 +1,13 @@
 # unit tests for utils.py
 
+import base64
 import os
 import re
-from unittest.mock import patch, mock_open
-import tempfile
 from shutil import rmtree
+import tempfile
 
 import pytest
+from unittest.mock import patch, mock_open
 
 from synapseclient.core import utils
 
@@ -315,6 +316,24 @@ def test_snake_case():
         ('camel123Abc', 'camel123_abc'),
     ]:
         assert expected_output == utils.snake_case(input_word)
+
+
+@pytest.mark.parametrize(
+    "string,expected",
+    [
+        (None, False),
+        ('', False),
+
+        ('foo', False),
+        ('foo江', False),
+
+        # should be able to handle both byte strings and unicode strings
+        (base64.b64encode(b'foo'), True),
+        (base64.b64encode(b'foo').decode('utf-8'), True),
+     ]
+)
+def test_is_base_64_encoded(string, expected):
+    assert utils.is_base64_encoded(string) == expected
 
 
 def test_deprecated_keyword_param():

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -330,7 +330,7 @@ def test_snake_case():
         # should be able to handle both byte strings and unicode strings
         (base64.b64encode(b'foo'), True),
         (base64.b64encode(b'foo').decode('utf-8'), True),
-     ]
+    ]
 )
 def test_is_base_64_encoded(string, expected):
     assert utils.is_base64_encoded(string) == expected


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/SYNPY-1090

Allows an api key to be used where the password is in the command line client. It is used in place of a password instead of as a separate command line argument in order to simplify things for the user, in particular when inputting the password from the console input prompt  (don't want them to have to specify which they are using or enter an empty password followed by an api key for example).