### PR TITLE
SYNPY-1073 Parellelize syncToSynapse uploads

### DIFF
--- a/synapseclient/core/cumulative_transfer_progress.py
+++ b/synapseclient/core/cumulative_transfer_progress.py
@@ -24,10 +24,14 @@ def printTransferProgress(*args, **kwargs):
     be imported instead of utils.printTransferProgress in locations that may be part of a cumulative
     transfer (i.e. a Synapse sync)."""
 
-    if hasattr(_thread_local, 'cumulative_transfer_progress'):
+    if is_active():
         _thread_local.cumulative_transfer_progress.printTransferProgress(*args, **kwargs)
     else:
         utils.printTransferProgress(*args, **kwargs)
+
+
+def is_active():
+    return hasattr(_thread_local, 'cumulative_transfer_progress')
 
 
 class CumulativeTransferProgress:

--- a/synapseclient/core/cumulative_transfer_progress.py
+++ b/synapseclient/core/cumulative_transfer_progress.py
@@ -31,6 +31,7 @@ def printTransferProgress(*args, **kwargs):
 
 
 def is_active():
+    """Return whether the current thread is accumulating progress data."""
     return hasattr(_thread_local, 'cumulative_transfer_progress')
 
 

--- a/synapseclient/core/pool_provider.py
+++ b/synapseclient/core/pool_provider.py
@@ -12,6 +12,7 @@ To use these wrappers for single thread environment, set the following:
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
 import multiprocessing
 import multiprocessing.dummy
+import threading
 
 from . import config
 
@@ -96,3 +97,26 @@ def get_value(type, value):
         return SingleValue(type, value)
     else:
         return multiprocessing.Value(type, value)
+
+
+class BlockingExecutor(Executor):
+
+    def __init__(self, executor: Executor, max_concurrency: int):
+        self._executor = executor
+        self._semaphore = threading.BoundedSemaphore(max_concurrency)
+
+    def submit(self, fn, *args, **kwargs):
+        # wrap the function with acquisition/release of the semaphore
+        # this ensure that any submit call will block if the max concurrency
+        # is reached
+        def fn_wrapper():
+            self._semaphore.acquire()
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                self._semaphore.release()
+
+        return self._executor.submit(fn_wrapper)
+
+    def shutdown(self, wait=True):
+        return self._executor.shutdown(wait=wait)

--- a/synapseclient/core/upload/multipart_upload.py
+++ b/synapseclient/core/upload/multipart_upload.py
@@ -25,13 +25,14 @@ import time
 from typing import List, Mapping
 
 from synapseclient.core import pool_provider
+from synapseclient.core.cumulative_transfer_progress import printTransferProgress
 from synapseclient.core.exceptions import (
     _raise_for_status,  # why is is this a single underscore
     SynapseHTTPError,
     SynapseUploadAbortedException,
     SynapseUploadFailedException,
 )
-from synapseclient.core.utils import printTransferProgress, md5_for_file, MB
+from synapseclient.core.utils import md5_for_file, MB
 
 # AWS limits
 MAX_NUMBER_OF_PARTS = 10000

--- a/synapseclient/core/upload/upload_functions.py
+++ b/synapseclient/core/upload/upload_functions.py
@@ -3,11 +3,20 @@ import urllib.parse as urllib_parse
 import uuid
 
 from synapseclient.core.utils import is_url, md5_for_file, as_url, file_url_to_path, id_of
+from synapseclient.core import cumulative_transfer_progress
 from synapseclient.core.constants import concrete_types
 from synapseclient.core.remote_file_storage_wrappers import S3ClientWrapper, SFTPWrapper
 from synapseclient.core import sts_transfer
 from synapseclient.core.upload.multipart_upload import multipart_upload_file
 from synapseclient.core.exceptions import SynapseMd5MismatchError
+
+
+def log_upload_message(syn, message):
+    # if this upload is in the context of a larger, mulit threaded sync upload as indicated by a cumulative progress
+    # then we don't print the individual upload messages to the console since they wouldn't be properly
+    # interleaved properly
+    if not cumulative_transfer_progress.is_active():
+        syn.logger.info(message)
 
 
 def upload_file_handle(
@@ -56,7 +65,10 @@ def upload_file_handle(
     if sts_transfer.is_boto_sts_transfer_enabled(syn) and \
        sts_transfer.is_storage_location_sts_enabled(syn, entity_parent_id, location) and \
        upload_destination_type == concrete_types.EXTERNAL_S3_UPLOAD_DESTINATION:
-        syn.logger.info('\n' + '#' * 50 + '\n Uploading file to external S3 storage using boto3 \n' + '#' * 50 + '\n')
+        log_upload_message(
+            syn,
+            '\n' + '#' * 50 + '\n Uploading file to external S3 storage using boto3 \n' + '#' * 50 + '\n'
+        )
 
         return upload_synapse_sts_boto_s3(
             syn,
@@ -73,7 +85,10 @@ def upload_file_handle(
         storageString = 'Synapse' \
             if upload_destination_type == concrete_types.SYNAPSE_S3_UPLOAD_DESTINATION \
             else 'your external S3'
-        syn.logger.info('\n' + '#' * 50 + '\n Uploading file to ' + storageString + ' storage \n' + '#' * 50 + '\n')
+        log_upload_message(
+            syn,
+            '\n' + '#' * 50 + '\n Uploading file to ' + storageString + ' storage \n' + '#' * 50 + '\n'
+        )
 
         return upload_synapse_s3(
             syn,
@@ -85,22 +100,35 @@ def upload_file_handle(
     # external file handle (sftp)
     elif upload_destination_type == concrete_types.EXTERNAL_UPLOAD_DESTINATION:
         if location['uploadType'] == 'SFTP':
-            syn.logger.info('\n%s\n%s\nUploading to: %s\n%s\n' % ('#' * 50, location.get('banner', ''),
-                                                                  urllib_parse.urlparse(location['url']).netloc,
-                                                                  '#' * 50))
+            log_upload_message(
+                syn,
+                '\n%s\n%s\nUploading to: %s\n%s\n' % ('#' * 50, location.get('banner', ''),
+                                                      urllib_parse.urlparse(location['url']).netloc,
+                                                      '#' * 50)
+            )
             return upload_external_file_handle_sftp(syn, expanded_upload_path, location['url'], mimetype=mimetype)
         else:
             raise NotImplementedError('Can only handle SFTP upload locations.')
     # client authenticated S3
     elif upload_destination_type == concrete_types.EXTERNAL_OBJECT_STORE_UPLOAD_DESTINATION:
-        syn.logger.info('\n%s\n%s\nUploading to endpoint: [%s] bucket: [%s]\n%s\n'
-                        % ('#' * 50, location.get('banner', ''), location.get('endpointUrl'), location.get('bucket'),
-                           '#' * 50))
+        log_upload_message(
+            syn,
+            '\n%s\n%s\nUploading to endpoint: [%s] bucket: [%s]\n%s\n' % (
+                '#' * 50, location.get('banner', ''),
+                location.get('endpointUrl'),
+                location.get('bucket'),
+                '#' * 50,
+            )
+        )
         return upload_client_auth_s3(syn, expanded_upload_path, location['bucket'], location['endpointUrl'],
                                      location['keyPrefixUUID'], location['storageLocationId'], mimetype=mimetype)
     else:  # unknown storage location
-        syn.logger.info('\n%s\n%s\nUNKNOWN STORAGE LOCATION. Defaulting upload to Synapse.\n%s\n'
-                        % ('!' * 50, location.get('banner', ''), '!' * 50))
+        log_upload_message(
+            syn,
+            '\n%s\n%s\nUNKNOWN STORAGE LOCATION. Defaulting upload to Synapse.\n%s\n' % (
+                '!' * 50, location.get('banner', ''), '!' * 50
+            )
+        )
         return upload_synapse_s3(syn, expanded_upload_path, None, mimetype=mimetype, max_threads=max_threads)
 
 

--- a/synapseclient/core/upload/upload_functions.py
+++ b/synapseclient/core/upload/upload_functions.py
@@ -12,9 +12,8 @@ from synapseclient.core.exceptions import SynapseMd5MismatchError
 
 
 def log_upload_message(syn, message):
-    # if this upload is in the context of a larger, mulit threaded sync upload as indicated by a cumulative progress
-    # then we don't print the individual upload messages to the console since they wouldn't be properly
-    # interleaved properly
+    # if this upload is in the context of a larger, multi threaded sync upload as indicated by a cumulative progress
+    # then we don't print the individual upload messages to the console since they wouldn't be properly interleaved.
     if not cumulative_transfer_progress.is_active():
         syn.logger.info(message)
 

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -380,7 +380,8 @@ class _SyncUploader:
         self._executor = executor
         self._file_semaphore = threading.BoundedSemaphore(max_concurrent_file_transfers)
 
-    def _order_items(self, items):
+    @staticmethod
+    def _order_items(items):
 
         upload_paths = {i.entity.path for i in items}
         ordered_items = OrderedDict()
@@ -407,15 +408,17 @@ class _SyncUploader:
                 raise ValueError(
                     "Cannot upload these items due to a cyclic provenance dependency "
                     "within the following items: {}".format(
-                        [i.path for i in items]
+                        [i.entity.path for i in items]
                     )
                 )
 
             items = remaining_items
+            remaining_items = []
 
         return ordered_items.values()
 
-    def _convert_provenance(self, provenance, finished_items):
+    @staticmethod
+    def _convert_provenance(provenance, finished_items):
         converted_provenance = []
         pending_provenance = set()
         for p in provenance:
@@ -430,7 +433,8 @@ class _SyncUploader:
 
         return converted_provenance, pending_provenance
 
-    def _check_errors(self, futures):
+    @staticmethod
+    def _check_errors(futures):
         for future in futures:
             if future.done() and not future.cancelled():
                 # result will raise the error raised in the executed thread if any.
@@ -439,7 +443,8 @@ class _SyncUploader:
         # return value used in the Condition wait predicate
         return True
 
-    def _abort(self, futures):
+    @staticmethod
+    def _abort(futures):
         exception = None
         for future in futures:
             if future.done():
@@ -465,7 +470,6 @@ class _SyncUploader:
         # so that provenance dependent files can be uploaded
         condition = threading.Condition()
 
-        #
         pending_provenance = set()
         pending_provenance_count = 0
 

--- a/tests/integration/synapseutils/test_synapseutils_sync.py
+++ b/tests/integration/synapseutils/test_synapseutils_sync.py
@@ -115,7 +115,7 @@ def test_syncToSynapse(test_state):
 
     # Validate that annotations were set
     cols = synapseutils.sync.REQUIRED_FIELDS + synapseutils.sync.FILE_CONSTRUCTOR_FIELDS\
-        + synapseutils.sync.STORE_FUNCTION_FIELDS
+        + synapseutils.sync.STORE_FUNCTION_FIELDS + synapseutils.sync.PROVENANCE_FIELDS
     orig_anots = orig_df.drop(cols, axis=1, errors='ignore')
     new_anots = new_df.drop(cols, axis=1, errors='ignore')
     assert orig_anots.shape[1] == new_anots.shape[1]  # Verify that we have the same number of cols

--- a/tests/unit/synapseclient/core/unit_test_pool_provider.py
+++ b/tests/unit/synapseclient/core/unit_test_pool_provider.py
@@ -1,5 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
-from unittest.mock import call, MagicMock, patch
+from unittest.mock import call, MagicMock, patch, PropertyMock
 from multiprocessing.sharedctypes import Synchronized
 from multiprocessing.pool import ThreadPool
 
@@ -69,9 +69,8 @@ class TestPoolProvider:
 
 
 class TestGetValue:
-    def setup(self):
-        pass
 
+    @patch.object(synapseclient.core.config, 'single_threaded', PropertyMock(return_value=False))
     def test_get_value_for_multiple_thread(self):
         synapseclient.core.config.single_threaded = False
         test_value = get_value('d', 500)
@@ -83,6 +82,7 @@ class TestGetValue:
         test_value.value = 900
         assert test_value.value == 900
 
+    @patch.object(synapseclient.core.config, 'single_threaded', PropertyMock(return_value=True))
     def test_get_value_for_single_thread(self):
         synapseclient.core.config.single_threaded = True
         test_value = get_value('d', 500)

--- a/tests/unit/synapseutils/unit_test_synapseutils_sync.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_sync.py
@@ -458,8 +458,9 @@ class TestSyncUploader:
             ),
         ]
 
-        with pytest.raises(ValueError):
+        with pytest.raises(RuntimeError) as cm_ex:
             _SyncUploader._order_items(items)
+        assert 'cyclic' in str(cm_ex.value)
 
     @patch('os.path.isfile')
     def test_order_items__provenance_file_not_uploaded(self, isfile):

--- a/tests/unit/synapseutils/unit_test_synapseutils_sync.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_sync.py
@@ -690,7 +690,7 @@ class TestSyncUploader:
             if entity.path == item_1.entity.path:
                 with convert_provenance_condition:
                     if convert_provenance_calls > 0:
-                        convert_provenance_condition.wait_for(lambda: convert_provenance_calls == 0, timeout=5)
+                        convert_provenance_condition.wait_for(lambda: convert_provenance_calls == 0)
 
             return mock_stored_entities[entity.path]
 

--- a/tests/unit/synapseutils/unit_test_synapseutils_sync.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_sync.py
@@ -632,7 +632,6 @@ class TestSyncUploader:
     def test_upload(self, mock_os_isfile, syn):
         """Ensure that an upload including multiple items which depend on each other through
         provenance are all uploaded and in the expected order."""
-
         mock_os_isfile.return_value = True
 
         item_1 = _SyncUploadItem(
@@ -690,7 +689,8 @@ class TestSyncUploader:
         def syn_store_side_effect(entity, *args, **kwargs):
             if entity.path == item_1.entity.path:
                 with convert_provenance_condition:
-                    convert_provenance_condition.wait_for(lambda: convert_provenance_calls == 0)
+                    if convert_provenance_calls > 0:
+                        convert_provenance_condition.wait_for(lambda: convert_provenance_calls == 0, timeout=5)
 
             return mock_stored_entities[entity.path]
 

--- a/tests/unit/synapseutils/unit_test_synapseutils_sync.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_sync.py
@@ -471,8 +471,9 @@ class TestSyncUploader:
             ),
         ]
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as cm_ex:
             _SyncUploader._order_items(items)
+        assert 'not being uploaded' in cm_ex.value
 
     def test_upload_item_success(self, syn):
         """Test successfully uploading an item"""

--- a/tests/unit/synapseutils/unit_test_synapseutils_sync.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_sync.py
@@ -368,11 +368,14 @@ class TestSyncUploader:
         #                         |
         #                  _______|_______
         #                  |             |
+        #                  V             | 
         #  /tmp/4        /tmp/5          |
         #    |_____________|             |
         #           |                    |
+        #           V                    |
         #         /tmp/3                 |
         #           |                    |
+        #           V                    V
         #         /tmp/1               /tmp/2
 
         item_1 = _SyncUploadItem(


### PR DESCRIPTION
 [SYNPY-1073](https://sagebionetworks.jira.com/browse/SYNPY-1073)

Some performance numbers for this change are included in the JIRA issue.

Parallelizes syncToSynapse similar to how syncFromSynapse was parellelized with [SYNPY-1074](https://sagebionetworks.jira.com/browse/SYNPY-1073). Individual Synapse store calls are run in parallel using an Executor shared across all uploads and by the part uploads of the files themselves.

Files specified using provenance of other files in the manifest must have their uploads ordered since we need to be able to include the Synapse id of the uploaded file as provenance of the depending files.