### PR TITLE
SYNPY-1096 - Update setup.py synapse url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setuptools.setup(
     description=description,
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url='http://synapse.sagebase.org/',
+    url='https://synapse.org',
     author='The Synapse Engineering Team',
     author_email='platform@sagebase.org',
     license='Apache',

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setuptools.setup(
     description=description,
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url='https://synapse.org',
+    url='https://www.synapse.org',
     author='The Synapse Engineering Team',
     author_email='platform@sagebase.org',
     license='Apache',


### PR DESCRIPTION
Current URL was deprecated and is no longer functioning.