### PR TITLE
Name integration test project for TestCopyFileHandles uniquely per run

### DIFF
--- a/tests/integration/synapseutils/test_synapseutils_copy.py
+++ b/tests/integration/synapseutils/test_synapseutils_copy.py
@@ -1,7 +1,5 @@
 import uuid
 import time
-import string
-import random
 import re
 import json
 
@@ -318,7 +316,7 @@ class TestCopyFileHandles:
         self.syn = syn
 
         # create external file handles for https://www.synapse.org/images/logo.svg,
-        project = Project(f"My uniquely named project {''.join(random.choice(string.digits) for i in range(10))}")
+        project = Project(str(uuid.uuid4()))
         project = self.syn.store(project)
         schedule_for_cleanup(project)
 

--- a/tests/integration/synapseutils/test_synapseutils_copy.py
+++ b/tests/integration/synapseutils/test_synapseutils_copy.py
@@ -1,5 +1,7 @@
 import uuid
 import time
+import string
+import random
 import re
 import json
 
@@ -312,12 +314,13 @@ class TestCopyWiki:
 class TestCopyFileHandles:
 
     @pytest.fixture(autouse=True)
-    def init(self, syn):
+    def init(self, syn, schedule_for_cleanup):
         self.syn = syn
 
         # create external file handles for https://www.synapse.org/images/logo.svg,
-        project = Project('My uniquely named project 121416')
+        project = Project(f"My uniquely named project {''.join(random.choice(string.digits) for i in range(10))}")
         project = self.syn.store(project)
+        schedule_for_cleanup(project)
 
         # create file entity from externalFileHandle
         external_file_handle_request_1 = {


### PR DESCRIPTION
Integration test used a fixed project name that could cause issues if multiple integration tests were running concurrently. This showed more obviously under GitHub Actions testing since the whole 3x3 test matrix is run concurrently, whereas before the tests happened to be staggered a bit more due to being split across Travis and AppVeyor and since the Travis Mac tests took a lot of time to boostrap brew dependencies.

e.g.
```
>           raise SynapseHTTPError(message, response=response)
E           synapseclient.core.exceptions.SynapseHTTPError: 412 Client Error: 
E           Object: syn11174160 was updated since you last fetched it, retrieve it again and re-apply the update

/Users/runner/work/synapsePythonClient/synapsePythonClient/synapseclient/core/exceptions.py:160: SynapseHTTPError
=========================== short test summary info ============================
ERROR tests/integration/synapseutils/test_synapseutils_copy.py::TestCopyFileHandles::test_copy_file_handles
```