### PR TITLE
SYNPY-1097 handle out of disk space errors during downloads better

### DIFF
--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -511,7 +511,20 @@ def _synapse_error_msg(ex):
     if isinstance(ex, str):
         return ex
 
-    return '\n' + ex.__class__.__name__ + ': ' + str(ex) + '\n\n'
+    # one line for the root exception and then an additional line per chained cause
+    error_str = ""
+    depth = 0
+    while ex:
+        error_str += \
+            '\n' + ("  " * depth) + ("caused by " if depth > 0 else "") + ex.__class__.__name__ + ': ' + str(ex)
+
+        ex = ex.__cause__
+        if ex:
+            depth += 1
+        else:
+            break
+
+    return error_str + '\n\n'
 
 
 def _limit_and_offset(uri, limit=None, offset=None):

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -357,3 +357,30 @@ def test_deprecated_keyword_param():
         category=DeprecationWarning,
         stacklevel=2,
     )
+
+
+def test_synapse_error_msg():
+    """Test the output of utils._synapse_error_message"""
+
+    # single unchained exception
+    expected = "\nValueError: test error\n\n"
+    ex = ValueError("test error")
+    assert expected == utils._synapse_error_msg(ex)
+
+    # exception chain with multiple chained causes
+    try:
+        raise NotImplementedError('root error')
+    except NotImplementedError as ex0:
+        try:
+            raise NameError('error 1') from ex0
+        except NameError as ex1:
+            try:
+                raise ValueError('error 2') from ex1
+            except ValueError as ex2:
+                expected = """
+ValueError: error 2
+  caused by NameError: error 1
+    caused by NotImplementedError: root error
+
+"""
+                assert expected == utils._synapse_error_msg(ex2)

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -377,10 +377,11 @@ def test_synapse_error_msg():
             try:
                 raise ValueError('error 2') from ex1
             except ValueError as ex2:
-                expected = """
+                expected = \
+"""
 ValueError: error 2
   caused by NameError: error 1
     caused by NotImplementedError: root error
 
-"""
+"""  # noqa for outdenting
                 assert expected == utils._synapse_error_msg(ex2)


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/SYNPY-1097

File handle downloads via the client retry the specified number of times (currently defaults to 5) on any exception.

Some exceptions do not represent recoverable scenarios and shouldn't be retried, two that I've observed are MD5 mismatches and out of disk space errors.

The out of disk space errors in particular cause odd behavior in the context of a parallel syncFromSynapse since a file can fail, delete itself, which frees up space for another thread to attempt to continue downloading etc and the threads fight until all have exhausted their retry attempts.

This PR also changes the "human readable" output on an uncaught exception in the command line client to include chained exceptions if the uncaught exception has cause(s). This should better help diagnose errors in the command line client which can currently output unhelpful wrapping exceptions which are not useful in error submitted reports.