### PR TITLE
SYNPY-1104 Python 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,12 @@ jobs:
       - name: install-py-dependencies
         shell: bash
         run: |
+          if [ "${{startsWith(runner.os, 'MacOS')}}" == "true" ] && [ "${{matrix.python}}" == "3.9" ]; then
+            # no wheels yet for numpy on 3.9 and numpy 1.19 has issues with accelerate vs openblas
+            # https://github.com/numpy/numpy/issues/15947
+            pip install numpy==1.18.5
+          fi
+
           pip install -e ".[boto3,pandas,pysftp,tests]"
 
           # ensure that numpy c extensions are installed on windows
@@ -56,6 +62,7 @@ jobs:
             pip install setuptools
             pip install numpy
           fi
+
 
       - name: lint
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,12 +46,6 @@ jobs:
       - name: install-py-dependencies
         shell: bash
         run: |
-          if [ "${{startsWith(runner.os, 'MacOS')}}" == "true" ] && [ "${{matrix.python}}" == "3.9" ]; then
-            # no wheels yet for numpy on 3.9 and numpy 1.19 has issues with accelerate vs openblas
-            # https://github.com/numpy/numpy/issues/15947
-            pip install numpy==1.18.5
-          fi
-
           pip install -e ".[boto3,pandas,pysftp,tests]"
 
           # ensure that numpy c extensions are installed on windows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
-        python: [3.6, 3.7, 3.8]
+        python: [3.6, 3.7, 3.8, 3.9]
 
     runs-on: ${{ matrix.os }}
 
@@ -69,8 +69,12 @@ jobs:
 
       # run integration tests iff the decryption keys for the test configuration are available.
       # they will not be available in pull requests from forks.
+      # run integration tests on the oldest and newest supported versions of python.
+      # we don't run on the entire matrix to avoid a 3xN set of concurrent tests against
+      # the target server where N is the number of supported python versions.
       - name: run-integration-tests
         shell: bash
+        if: ${{ contains(fromJSON('[3.6, 3.9]'), matrix.python) }}
         run: |
           if [ -z "${{ secrets.encrypted_d17283647768_key }}" ]  || [ -z "${{ secrets.encrypted_d17283647768_key }}" ]; then
             echo "No test configuration decryption keys available, skipping integration tests"

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ setuptools.setup(
     zip_safe=False,
 
     # test
-    test_suite='nose.collector',
     tests_require=test_deps,
 
     # metadata to display on PyPI

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Operating System :: MacOS',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: Unix',


### PR DESCRIPTION
Adds Python 3.9 as a classifier and to the build matrix.

Currently there are no wheels available for numpy or pandas for 3.9 so it makes sense to wait for those to become available to include the support classifier in a synapseclient since installs would then have to compile these dependencies which is slow and error prone.

This also changes it so that we only run integration tests and the lowest and highest supported python versions (3.6 and 3.9 as of this PR) rather than all supported versions, otherwise running 3x4 integration test runs is overkill and can cause slower builds due to build runner limits and lead to some spurious build failures (especially our SFTP tests which can hit connection errors communicating with the EC2 host used for tests if too many tests hit it at once).