### PR TITLE
SYNPY-1102 - filter out empty string annotations on syncToSynapse

### DIFF
--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -896,10 +896,15 @@ def _manifest_upload(syn, df):
             parent=row['parent'],
             **{key: row[key] for key in FILE_CONSTRUCTOR_FIELDS if key in row},
         )
-        file.annotations = dict(row.drop(
+
+        annotations = dict(row.drop(
             FILE_CONSTRUCTOR_FIELDS + STORE_FUNCTION_FIELDS + REQUIRED_FIELDS + PROVENANCE_FIELDS,
             errors='ignore'
         ))
+
+        # if a item in the manifest upload is an empty string we do not want to upload that
+        # as an empty string annotation
+        file.annotations = {k: v for k, v in annotations.items() if v != ''}
 
         item = _SyncUploadItem(
             file,

--- a/tests/unit/synapseutils/unit_test_synapseutils_sync.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_sync.py
@@ -364,6 +364,14 @@ def test_manifest_upload(syn):
         'anno_2': ['v3', 'v4', ''],
     }
 
+    # any empty annotations that result from any empty csv column should not
+    # be included in the upload
+    expected_anno_data = [
+        {'anno_2': 'v3'},
+        {'anno_1': 'v1', 'anno_2': 'v4'},
+        {'anno_1': 'v2'}
+    ]
+
     df = pd.DataFrame(data=data)
 
     with patch.object(synapseutils.sync, '_SyncUploadItem') as upload_item_init, \
@@ -377,13 +385,7 @@ def test_manifest_upload(syn):
         expected_name = data['name'][i]
         expected_used = data['used'][i]
         expected_executed = data['executed'][i]
-
-        expected_annos = {}
-        expected_annos.update({'anno_1': data['anno_1'][i]})
-        expected_annos.update({'anno_2': data['anno_2'][i]})
-
-        # empty strings values should not be uploaded as annotations
-        expected_annos = {k: v for k, v in expected_annos.items() if v != ''}
+        expected_annos = expected_anno_data[i]
 
         upload_items.append(upload_item_init.return_value)
         upload_item_init_args = upload_item_init.call_args_list[i]

--- a/tests/unit/synapseutils/unit_test_synapseutils_sync.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_sync.py
@@ -351,6 +351,53 @@ def test_extract_file_entity_metadata__ensure_correct_row_metadata(syn):
                 assert file_entity.get(key) == file_row_data.get(key)
 
 
+def test_manifest_upload(syn):
+    """Verify behavior of synapseutils.sync._manifest_upload"""
+
+    data = {
+        'path': ['/tmp/foo', '/tmp/bar', '/tmp/baz'],
+        'parent': ['syn123', 'syn456', 'syn789'],
+        'name': ['foo', 'bar', 'baz'],
+        'used': [None, '/tmp/foo', '/tmp/bar'],
+        'executed': [None, None, '/tmp/foo'],
+        'anno_1': ['', 'v1', 'v2'],
+        'anno_2': ['v3', 'v4', ''],
+    }
+
+    df = pd.DataFrame(data=data)
+
+    with patch.object(synapseutils.sync, '_SyncUploadItem') as upload_item_init, \
+            patch.object(synapseutils.sync, '_SyncUploader') as uploader_init:
+        synapseutils.sync._manifest_upload(syn, df)
+
+    upload_items = []
+    for i in range(3):
+        expected_path = data['path'][i]
+        expected_parent = data['parent'][i]
+        expected_name = data['name'][i]
+        expected_used = data['used'][i]
+        expected_executed = data['executed'][i]
+
+        expected_annos = {}
+        expected_annos.update({'anno_1': data['anno_1'][i]})
+        expected_annos.update({'anno_2': data['anno_2'][i]})
+
+        # empty strings values should not be uploaded as annotations
+        expected_annos = {k: v for k, v in expected_annos.items() if v != ''}
+
+        upload_items.append(upload_item_init.return_value)
+        upload_item_init_args = upload_item_init.call_args_list[i]
+        file, used, executed, store_fields = upload_item_init_args[0]
+        assert file.path == expected_path
+        assert file.parentId == expected_parent
+        assert file.name == expected_name
+        assert file.annotations == expected_annos
+        assert used == expected_used
+        assert executed == expected_executed
+
+    uploader_init.return_value.upload.assert_called_once_with(upload_items)
+
+
 class TestSyncUploader:
 
     @patch('os.path.isfile')


### PR DESCRIPTION
syncToSynapse will parse and set an empty string as an annotation value from a manifest TSV file if an upload row doesn't contain a value for that annotation. We'd prefer that on a manifest sync it set no annotation for that key if there is no value rather than an empty string.

https://sagebionetworks.jira.com/browse/SYNPY-1102