### PR TITLE
SYNPY-1103 multipart copy support

### DIFF
--- a/synapseclient/core/constants/concrete_types.py
+++ b/synapseclient/core/constants/concrete_types.py
@@ -27,3 +27,14 @@ PARTIAL_ROW_SET = 'org.sagebionetworks.repo.model.table.PartialRowSet'
 APPENDABLE_ROWSET_REQUEST = 'org.sagebionetworks.repo.model.table.AppendableRowSetRequest'
 
 COLUMN_MODEL = 'org.sagebionetworks.repo.model.table.ColumnModel'
+
+# EntityTypes
+FILE_ENTITY = 'org.sagebionetworks.repo.model.FileEntity'
+FOLDER_ENTITY = 'org.sagebionetworks.repo.model.Folder'
+LINK_ENTITY = 'org.sagebionetworks.repo.model.Link'
+PROJECT_ENTITY = 'org.sagebionetworks.repo.model.Project'
+TABLE_ENTITY = 'org.sagebionetworks.repo.model.table.TableEntity'
+
+# upload requests
+MULTIPART_UPLOAD_REQUEST = 'org.sagebionetworks.repo.model.file.MultipartUploadRequest'
+MULTIPART_UPLOAD_COPY_REQUEST = 'org.sagebionetworks.repo.model.file.MultipartUploadCopyRequest'

--- a/synapseclient/core/upload/multipart_upload.py
+++ b/synapseclient/core/upload/multipart_upload.py
@@ -427,10 +427,10 @@ def _get_part_size(part_size, file_size):
 def multipart_upload_file(
     syn,
     file_path: str,
-    storage_location_id: str,
     dest_file_name: str = None,
     content_type: str = None,
     part_size: int = None,
+    storage_location_id: str = None,
     preview: bool = True,
     force_restart: bool = False,
     max_threads: int = None,
@@ -514,10 +514,10 @@ def multipart_upload_file(
 def multipart_upload_string(
     syn,
     text: str,
-    storage_location_id: str,
     dest_file_name: str = None,
     part_size: int = None,
     content_type: str = None,
+    storage_location_id: str = None,
     preview: bool = True,
     force_restart: bool = False,
     max_threads: int = None,

--- a/synapseclient/core/upload/multipart_upload.py
+++ b/synapseclient/core/upload/multipart_upload.py
@@ -481,7 +481,7 @@ def multipart_upload_file(
 
     upload_request = {
         'concreteType': 'org.sagebionetworks.repo.model.file.MultipartUploadRequest',
-        'contentType':  content_type,
+        'contentType': content_type,
         'contentMD5Hex': md5_hex,
         'fileName': dest_file_name,
         'fileSizeBytes': file_size,
@@ -562,7 +562,7 @@ def multipart_upload_string(
 
     upload_request = {
         'concreteType': 'org.sagebionetworks.repo.model.file.MultipartUploadRequest',
-        'contentType':  content_type,
+        'contentType': content_type,
         'contentMD5Hex': md5_hex,
         'fileName': dest_file_name,
         'fileSizeBytes': file_size,

--- a/synapseclient/core/upload/multipart_upload.py
+++ b/synapseclient/core/upload/multipart_upload.py
@@ -86,7 +86,6 @@ class UploadAttempt:
         self,
         syn,
         dest_file_name,
-        part_size,
 
         upload_request_payload,
         part_fn,
@@ -97,9 +96,8 @@ class UploadAttempt:
     ):
         self._syn = syn
         self._dest_file_name = dest_file_name
-        self._part_size = part_size
+        self._part_size = upload_request_payload['partSizeBytes']
 
-        upload_request_payload['partSizeBytes'] = part_size
         self._upload_request_payload = upload_request_payload
 
         self._part_fn = part_fn
@@ -489,6 +487,7 @@ def multipart_upload_file(
         'fileName': dest_file_name,
         'fileSizeBytes': file_size,
         'generatePreview': preview,
+        'partSizeBytes': part_size,
         'storageLocationId': storage_location_id,
     }
 
@@ -503,7 +502,6 @@ def multipart_upload_file(
     return _multipart_upload(
         syn,
         dest_file_name,
-        part_size,
 
         upload_request,
         part_fn,
@@ -570,6 +568,7 @@ def multipart_upload_string(
         'fileName': dest_file_name,
         'fileSizeBytes': file_size,
         'generatePreview': preview,
+        'partSizeBytes': part_size,
         'storageLocationId': storage_location_id,
     }
 
@@ -585,7 +584,6 @@ def multipart_upload_string(
     return _multipart_upload(
         syn,
         dest_file_name,
-        part_size,
 
         upload_request,
         part_fn,
@@ -627,7 +625,6 @@ def multipart_copy(
     return _multipart_upload(
         syn,
         dest_file_name,
-        part_size,
 
         upload_request,
         None,  # part_fn
@@ -641,7 +638,6 @@ def multipart_copy(
 def _multipart_upload(
     syn,
     dest_file_name,
-    part_size,
 
     upload_request,
     part_fn,
@@ -662,7 +658,6 @@ def _multipart_upload(
             upload_status_response = UploadAttempt(
                 syn,
                 dest_file_name,
-                part_size,
 
                 upload_request,
                 part_fn,

--- a/synapseclient/core/upload/multipart_upload.py
+++ b/synapseclient/core/upload/multipart_upload.py
@@ -610,6 +610,7 @@ def multipart_copy(
         'concreteType': 'org.sagebionetworks.repo.model.file.MultipartUploadCopyRequest',
         'fileName': dest_file_name,
         'generatePreview': preview,
+        'partSizeBytes': part_size,
         'sourceFileHandleAssociation': source_file_handle_association,
         'storageLocationId': storage_location_id,
     }

--- a/tests/integration/synapseclient/core/upload/test_multipart_upload.py
+++ b/tests/integration/synapseclient/core/upload/test_multipart_upload.py
@@ -201,10 +201,9 @@ def test_multipart_copy(syn, project, schedule_for_cleanup):
     copied_fhid = multipart_copy(
         syn,
         source_file_handle_assocation,
-        part_size=part_size,
-        dest_file_name=dest_file_name,
-        storage_location_id=dest_storage_location,
-        part_md5_hexes=part_md5_hexes,
+        dest_file_name,
+        part_size,
+        dest_storage_location,
     )
 
     copied_file_handle = syn._get_file_handle_as_creator(copied_fhid)

--- a/tests/integration/synapseclient/core/upload/test_multipart_upload.py
+++ b/tests/integration/synapseclient/core/upload/test_multipart_upload.py
@@ -9,7 +9,7 @@ import traceback
 import uuid
 from io import open
 
-from unittest import mock
+from unittest import mock, skip
 
 from synapseclient import File
 import synapseclient.core.config
@@ -140,7 +140,7 @@ def test_multipart_upload_big_string(syn, project, schedule_for_cleanup):
     assert retrieved_text == text
 
 
-def test_multipart_copy(syn, project, schedule_for_cleanup):
+def _multipart_copy_test(syn, project, schedule_for_cleanup, part_size):
     import logging
     logging.basicConfig()
     logging.getLogger(synapseclient.client.DEFAULT_LOGGER_NAME).setLevel(logging.DEBUG)
@@ -153,8 +153,8 @@ def test_multipart_copy(syn, project, schedule_for_cleanup):
         folder_name=dest_folder_name
     )
 
-    part_size = MIN_PART_SIZE
-    file_size = int(MIN_PART_SIZE * 1.1)
+    part_size = part_size
+    file_size = int(part_size * 1.1)
 
     base_string = ''.join(random.choices(string.ascii_lowercase, k=1024))
 
@@ -187,7 +187,7 @@ def test_multipart_copy(syn, project, schedule_for_cleanup):
 
     fhid = entity['dataFileHandleId']
 
-#    source_file_handle = syn._get_file_handle_as_creator(fhid)
+    #    source_file_handle = syn._get_file_handle_as_creator(fhid)
 
     dest_file_name = "{}_copy".format(entity.name)
     source_file_handle_assocation = {
@@ -221,3 +221,13 @@ def test_multipart_copy(syn, project, schedule_for_cleanup):
         dest_file_content = dest_file_in.read()
 
     assert file_content == dest_file_content
+
+
+def test_multipart_copy(syn, project, schedule_for_cleanup):
+    """Test multi part copy using the minimum part size."""
+    _multipart_copy_test(syn, project, schedule_for_cleanup, MIN_PART_SIZE)
+
+
+@skip("Skip in normal testing because the large size makes it slow")
+def test_multipart_copy__big_parts(syn, project, schedule_for_cleanup):
+    _multipart_copy_test(syn, project, schedule_for_cleanup, 100 * utils.MB)

--- a/tests/integration/synapseclient/core/upload/test_multipart_upload.py
+++ b/tests/integration/synapseclient/core/upload/test_multipart_upload.py
@@ -1,9 +1,12 @@
 import filecmp
+import hashlib
 import os
 import random
 import requests
+import string
 import tempfile
 import traceback
+import uuid
 from io import open
 
 from unittest import mock
@@ -14,7 +17,8 @@ import synapseclient.core.utils as utils
 from synapseclient.core.upload.multipart_upload import (
     MIN_PART_SIZE,
     multipart_upload_file,
-    multipart_upload_string
+    multipart_upload_string,
+    multipart_copy,
 )
 
 
@@ -134,3 +138,87 @@ def test_multipart_upload_big_string(syn, project, schedule_for_cleanup):
         retrieved_text = f.read()
 
     assert retrieved_text == text
+
+
+def test_multipart_copy(syn, project, schedule_for_cleanup):
+    import logging
+    logging.basicConfig()
+    logging.getLogger(synapseclient.client.DEFAULT_LOGGER_NAME).setLevel(logging.DEBUG)
+
+    dest_folder_name = "test_multipart_copy_{}".format(uuid.uuid4())
+
+    # create a new folder with a storage location we own that we can copy to
+    dest_folder, storage_location_setting, _ = syn.create_s3_storage_location(
+        parent=project,
+        folder_name=dest_folder_name
+    )
+
+    part_size = MIN_PART_SIZE
+    file_size = int(MIN_PART_SIZE * 1.1)
+
+    base_string = ''.join(random.choices(string.ascii_lowercase, k=1024))
+
+    file_content = base_string
+    while len(file_content) < file_size:
+        file_content += base_string
+
+    part_md5_hexes = []
+    part_count = file_size // part_size
+    if file_size % part_size > 0:
+        part_count += 1
+
+    content_pos = 0
+    for _ in range(part_count):
+        next_pos = content_pos + part_size
+        part_content = file_content[content_pos:next_pos]
+        content_pos = next_pos
+
+        md5 = hashlib.md5(part_content.encode('utf-8'))
+        part_md5_hexes.append(md5.hexdigest())
+
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    schedule_for_cleanup(tmp.name)
+
+    with open(tmp.name, 'w') as tmp_out:
+        tmp_out.write(file_content)
+
+    file = File(tmp.name, parent=project)
+    entity = syn.store(file)
+
+    fhid = entity['dataFileHandleId']
+
+#    source_file_handle = syn._get_file_handle_as_creator(fhid)
+
+    dest_file_name = "{}_copy".format(entity.name)
+    source_file_handle_assocation = {
+        'fileHandleId': fhid,
+        'associateObjectId': entity.id,
+        'associateObjectType': 'FileEntity',
+    }
+
+    dest_storage_location = storage_location_setting['storageLocationId']
+
+    copied_fhid = multipart_copy(
+        syn,
+        source_file_handle_assocation,
+        part_size=part_size,
+        dest_file_name=dest_file_name,
+        storage_location_id=dest_storage_location,
+        part_md5_hexes=part_md5_hexes,
+    )
+
+    copied_file_handle = syn._get_file_handle_as_creator(copied_fhid)
+
+    dest_file = File(
+        name=dest_file_name,
+        parent=dest_folder,
+    )
+    dest_file['dataFileHandleId'] = copied_fhid
+    dest_file['_file_handle'] = copied_file_handle
+    dest_file_entity = syn.store(dest_file)
+
+    dest_file_local = syn.get(dest_file_entity.id)
+    with open(dest_file_local.path, 'r') as dest_file_in:
+        dest_file_content = dest_file_in.read()
+
+    assert file_content == dest_file_content

--- a/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
+++ b/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
@@ -706,8 +706,8 @@ class TestMultipartUpload:
         storage_location_id = 5432
 
         with mock.patch.object(
-               multipart_upload,
-               '_multipart_upload',
+                multipart_upload,
+                '_multipart_upload',
            ) as mock_multipart_upload:
 
             encoded = upload_text.encode('utf-8')
@@ -798,7 +798,7 @@ class TestMultipartUpload:
                 'concreteType': 'org.sagebionetworks.repo.model.file.MultipartUploadCopyRequest',
                 'fileName': None,
                 'generatePreview': True,
-                'partSizeBytes':  DEFAULT_PART_SIZE,
+                'partSizeBytes': DEFAULT_PART_SIZE,
                 'sourceFileHandleAssociation': source_file_handle_association,
                 'storageLocationId': None
             }

--- a/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
+++ b/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
@@ -618,13 +618,13 @@ class TestMultipartUpload:
 
             # bad file
             with pytest.raises(IOError):
-                multipart_upload_file(syn, file_path, storage_location_id)
+                multipart_upload_file(syn, file_path, storage_location_id=storage_location_id)
 
             os_path_exists.return_value = True
             os_path_is_dir.return_value = True
 
             with pytest.raises(IOError):
-                multipart_upload_file(syn, file_path, storage_location_id)
+                multipart_upload_file(syn, file_path, storage_location_id=storage_location_id)
 
             os_path_is_dir.return_value = False
 
@@ -642,7 +642,7 @@ class TestMultipartUpload:
             multipart_upload_file(
                 syn,
                 file_path,
-                storage_location_id,
+                storage_location_id=storage_location_id,
             )
             mock_multipart_upload.assert_called_once_with(
                 syn,
@@ -680,7 +680,7 @@ class TestMultipartUpload:
             multipart_upload_file(
                 syn,
                 file_path,
-                storage_location_id,
+                storage_location_id=storage_location_id,
                 **kwargs
             )
             mock_multipart_upload.assert_called_once_with(
@@ -713,7 +713,7 @@ class TestMultipartUpload:
             md5_hex = hashlib.md5(encoded).hexdigest()
 
             # call w/ default args
-            multipart_upload_string(syn, upload_text, storage_location_id)
+            multipart_upload_string(syn, upload_text, storage_location_id=storage_location_id)
 
             expected_upload_request = {
                 'concreteType': 'org.sagebionetworks.repo.model.file.MultipartUploadRequest',

--- a/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
+++ b/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
@@ -793,7 +793,8 @@ class TestMultipartUpload:
 
         storage_location_id = 5432
 
-        with mock.patch.object(multipart_upload, '_multipart_upload') as mock_multipart_upload:
+        with mock.patch.object(multipart_upload, '_multipart_upload') as mock_multipart_upload, \
+                mock.patch.object(multipart_upload, 'printTransferProgress') as mock_print_progress:
             expected_upload_request = {
                 'concreteType': 'org.sagebionetworks.repo.model.file.MultipartUploadCopyRequest',
                 'fileName': None,
@@ -858,6 +859,8 @@ class TestMultipartUpload:
                 force_restart=kwargs['force_restart'],
                 max_threads=kwargs['max_threads'],
             )
+
+            assert not mock_print_progress.called
 
     def _multipart_upload_test(self, upload_side_effect, syn, *args, **kwargs):
         with mock.patch.object(

--- a/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
+++ b/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
@@ -11,7 +11,7 @@ from synapseclient.core.exceptions import (
     SynapseUploadAbortedException,
     SynapseUploadFailedException,
 )
-import synapseclient.core.upload.multipart_upload
+import synapseclient.core.upload.multipart_upload as multipart_upload
 from synapseclient.core.upload.multipart_upload import (
     DEFAULT_PART_SIZE,
     MAX_NUMBER_OF_PARTS,
@@ -26,62 +26,78 @@ from synapseclient.core.upload.multipart_upload import (
 
 class TestUploadAttempt:
 
-    def _init_upload_attempt(self):
-        syn = mock.Mock()
-        file_path = "/foo/bar/baz"
-        dest_file_name = "target.txt"
-        file_size = 1024
-        part_size = 256
-        md5_hex = "abc"
-        content_type = "application/text"
-        preview = False
-        storage_location_id = "1234"
+    dest_file_name = 'target.txt'
+    content_type = 'application/text'
+    part_size = 256
+    file_size = 1024
+    md5_hex = 'abc'
+    preview = False
+    storage_location_id = '1234'
+
+    def _init_upload_attempt(self, syn):
+        upload_request_payload = {
+            'concreteType': 'org.sagebionetworks.repo.model.file.MultipartUploadRequest',
+            'contentMD5Hex': self.md5_hex,
+            'contentType': self.content_type,
+            'fileName': self.dest_file_name,
+            'fileSizeBytes': self.file_size,
+            'generatePreview': self.preview,
+            'storageLocationId': self.storage_location_id,
+        }
+
+        def part_fn(part_number):
+            return (f"{part_number}" * self.part_size).encode('utf-8')
+
+        def md5_fn(part, _):
+            md5 = hashlib.md5()
+            md5.update(part)
+            return md5.hexdigest()
+
         max_threads = 8
         force_restart = True
 
         return UploadAttempt(
             syn,
-            file_path,
-            dest_file_name,
-            file_size,
-            part_size,
-            md5_hex,
-            content_type,
-            preview,
-            storage_location_id,
+            self.dest_file_name,
+            self.part_size,
+            upload_request_payload,
+            part_fn,
+            md5_fn,
             max_threads,
             force_restart=force_restart,
         )
 
-    def test_create_synapse_upload(self):
-        upload = self._init_upload_attempt()
+    def test_create_synapse_upload(self, syn):
+        upload = self._init_upload_attempt(syn)
 
         expected_upload_request = {
-            'contentMD5Hex': upload._md5_hex,
-            'fileName': upload._dest_file_name,
-            'generatePreview': upload._preview,
-            'contentType': upload._content_type,
-            'partSizeBytes': upload._part_size,
-            'fileSizeBytes': upload._file_size,
-            'storageLocationId': upload._storage_location_id,
+            'concreteType': 'org.sagebionetworks.repo.model.file.MultipartUploadRequest',
+            'contentMD5Hex': self.md5_hex,
+            'contentType': self.content_type,
+            'fileName': self.dest_file_name,
+            'fileSizeBytes': self.file_size,
+            'generatePreview': self.preview,
+            'storageLocationId': self.storage_location_id,
+            'partSizeBytes': self.part_size,
         }
         expected_uri = "/file/multipart?forceRestart={}".format(
             str(upload._force_restart).lower()
         )
 
         response = mock.Mock()
-        upload._syn.restPOST.return_value = response
+        with mock.patch.object(syn, 'restPOST') as restPOST:
+            restPOST.return_value = response
 
-        assert upload._create_synapse_upload() == response
+            assert upload._create_synapse_upload() == response
 
-        upload._syn.restPOST.assert_called_once_with(
+        restPOST.assert_called_once_with(
             expected_uri,
             json.dumps(expected_upload_request),
             endpoint=upload._syn.fileHandleEndpoint,
         )
 
-    def test_fetch_presigned_urls(self):
-        upload = self._init_upload_attempt()
+    def test_fetch_presigned_urls(self, syn):
+        upload = self._init_upload_attempt(syn)
 
         upload_id = '1234'
         part_numbers = [1, 3]
@@ -92,26 +108,30 @@ class TestUploadAttempt:
                 {
                     'partNumber': 1,
                     'uploadPresignedUrl': 'https://foo.com/1',
+                    'signedHeaders': {'a': 'b'},
                 },
                 {
                     'partNumber': 3,
                     'uploadPresignedUrl': 'https://foo.com/3',
+                    'signedHeaders': {'c': 'd'},
                 }
             ]
 
         }
-        upload._syn.restPOST.return_value = response
 
-        expected_return = {
-            i['partNumber']: i['uploadPresignedUrl']
-            for i in response['partPresignedUrls']
-        }
+        with mock.patch.object(syn, 'restPOST') as restPOST:
+            restPOST.return_value = response
 
-        pre_signed_urls = upload._fetch_pre_signed_part_urls(
-            upload_id,
-            part_numbers,
-            requests_session=session,
-        )
+            expected_return = {
+                i['partNumber']: (i['uploadPresignedUrl'], i['signedHeaders'])
+                for i in response['partPresignedUrls']
+            }
+
+            pre_signed_urls = upload._fetch_pre_signed_part_urls(
+                upload_id,
+                part_numbers,
+                requests_session=session,
+            )
 
         assert pre_signed_urls == expected_return
 
@@ -124,20 +144,20 @@ class TestUploadAttempt:
             'partNumbers': part_numbers,
         }
 
-        upload._syn.restPOST.assert_called_once_with(
+        restPOST.assert_called_once_with(
             expected_uri,
             json.dumps(expected_body),
             requests_session=session,
             endpoint=upload._syn.fileHandleEndpoint,
         )
 
-    def test_refresh_presigned_part_url__fetch_required(self):
+    def test_refresh_presigned_part_url__fetch_required(self, syn):
         """Verify that when calling the refresh function that if the
         url that was passed as expired is that last known available
         url for the given part number then we know that no other
         thread has already refreshed and this thread needs to do so."""
 
-        upload = self._init_upload_attempt()
+        upload = self._init_upload_attempt(syn)
 
         part_number = 2
         current_url = "http://bar.com{}".format(part_number)
@@ -169,12 +189,12 @@ class TestUploadAttempt:
                 list(original_presigned_urls.keys())
             )
 
-    def test_refresh_presigned_part_url__no_fetch_required(self):
+    def test_refresh_presigned_part_url__no_fetch_required(self, syn):
         """Test that if another thread already refreshed all the
         signed urls after this thread's url was detected as expired
         then we don't need to fetch new urls from synapse."""
 
-        upload = self._init_upload_attempt()
+        upload = self._init_upload_attempt(syn)
 
         part_number = 2
 
@@ -201,11 +221,11 @@ class TestUploadAttempt:
             assert refreshed_url == current_url
             fetch_urls.assert_not_called()
 
-    def test_handle_part_aborted(self):
+    def test_handle_part_aborted(self, syn):
         """Verify that handle part processing short circuits when
         the upload attempt has already been aborted."""
 
-        upload = self._init_upload_attempt()
+        upload = self._init_upload_attempt(syn)
         upload._aborted = True
 
         with pytest.raises(SynapseUploadAbortedException):
@@ -213,6 +233,7 @@ class TestUploadAttempt:
 
     def _handle_part_success_test(
         self,
+        syn,
         upload,
         part_number,
         expired_url,
@@ -225,12 +246,13 @@ class TestUploadAttempt:
 
         md5_hex = hashlib.md5(chunk).hexdigest()
 
-        with mock.patch.object(upload, '_chunk_fn')\
-                as chunk_fn,\
-                mock.patch.object(upload, '_get_thread_session')\
-                as get_session,\
-                mock.patch.object(upload, '_refresh_pre_signed_part_urls')\
-                as refresh_urls:
+        with mock.patch.object(multipart_upload, '_get_file_chunk') \
+                as chunk_fn, \
+                mock.patch.object(upload, '_get_thread_session') \
+                as get_session, \
+                mock.patch.object(upload, '_refresh_pre_signed_part_urls') \
+                as refresh_urls, \
+                mock.patch.object(syn, 'restPUT'):
 
             get_session.return_value = mock_session
             chunk_fn.return_value = chunk
@@ -242,75 +264,78 @@ class TestUploadAttempt:
 
             result = upload._handle_part(1)
 
-        expected_put_calls = [
-            aws_call[0] for aws_call in aws_calls
-        ]
-        assert (
-            mock_session.put.call_args_list ==
-            expected_put_calls)
+            expected_put_calls = [
+                aws_call[0] for aws_call in aws_calls
+            ]
+            assert (
+                mock_session.put.call_args_list ==
+                expected_put_calls)
 
-        assert (
-            result ==
-            (part_number, len(chunk)))
+            assert result == part_number
 
-        if refresh_url_response:
-            refresh_urls.assert_called_once_with(
-                part_number,
-                expired_url,
+            if refresh_url_response:
+                refresh_urls.assert_called_once_with(
+                    part_number,
+                    expired_url,
+                )
+            else:
+                assert not refresh_urls.called
+
+            syn.restPUT.assert_called_once_with(
+                "/file/multipart/{upload_id}/add/{part_number}?partMD5Hex={md5}"
+                .format(
+                    upload_id=upload._upload_id,
+                    part_number=part_number,
+                    md5=md5_hex,
+                ),
+                requests_session=mock_session,
+                endpoint=upload._syn.fileHandleEndpoint
             )
-        else:
-            assert not refresh_urls.called
 
-        upload._syn.restPUT.assert_called_once_with(
-            "/file/multipart/{upload_id}/add/{part_number}?partMD5Hex={md5}"
-            .format(
-                upload_id=upload._upload_id,
-                part_number=part_number,
-                md5=md5_hex,
-            ),
-            requests_session=mock_session,
-            endpoint=upload._syn.fileHandleEndpoint
-        )
+            assert part_number not in upload._pre_signed_part_urls
 
-        assert part_number not in upload._pre_signed_part_urls
-
-    def test_handle_part_success(self):
+    def test_handle_part_success(self, syn):
         """Verify behavior of a successful processing of a part.
         Part bytes should be uploaded to aws, and """
 
-        upload = self._init_upload_attempt()
+        upload = self._init_upload_attempt(syn)
         upload._upload_id = '123'
         part_number = 1
-        chunk = b'1234'
+        chunk = b'1' * TestUploadAttempt.part_size
         pre_signed_url_1 = 'https://foo.com/1'
+        signed_headers_1 = {'a': 'b'}
 
-        upload._pre_signed_part_urls = {part_number: pre_signed_url_1}
+        upload._pre_signed_part_urls = {part_number: (pre_signed_url_1, signed_headers_1)}
 
         self._handle_part_success_test(
+            syn,
             upload,
             part_number,
             pre_signed_url_1,
-            [(mock.call(pre_signed_url_1, chunk), mock.Mock(status_code=200))],
+            [(mock.call(pre_signed_url_1, chunk, headers=signed_headers_1), mock.Mock(status_code=200))],
             chunk,
             None,
         )
 
-    def test_handle_part_expired_url(self):
+    def test_handle_part_expired_url(self, syn):
         """An initial 403 when invoking a presigned url indicates its
         expired, verify that we recovery by refreshing the urls and
         invoking the refreshed url."""
 
-        upload = self._init_upload_attempt()
+        upload = self._init_upload_attempt(syn)
         upload._upload_id = '123'
         part_number = 1
-        chunk = b'1234'
+        chunk = b'1' * TestUploadAttempt.part_size
 
         pre_signed_url_1 = 'https://foo.com/1'
+        signed_headers_1 = {'a': 1}
         pre_signed_url_2 = 'https://bar.com/1'
+        signed_headers_2 = {'a': 2}
 
-        upload._pre_signed_part_urls = {part_number: pre_signed_url_1}
+        upload._pre_signed_part_urls = {part_number: (pre_signed_url_1, signed_headers_1)}
 
         self._handle_part_success_test(
+            syn,
             upload,
             part_number,
             pre_signed_url_1,
@@ -319,7 +344,7 @@ class TestUploadAttempt:
             # second call is successful
             [
                 (
-                    mock.call(pre_signed_url_1, chunk),
+                    mock.call(pre_signed_url_1, chunk, headers=signed_headers_1),
                     mock.Mock(
                         status_code=403,
                         headers={},
@@ -327,30 +352,31 @@ class TestUploadAttempt:
                     )
                 ),
                 (
-                    mock.call(pre_signed_url_2, chunk),
+                    mock.call(pre_signed_url_2, chunk, headers=signed_headers_2),
                     mock.Mock(status_code=200)
                 ),
             ],
             chunk,
-            pre_signed_url_2,
+            (pre_signed_url_2, signed_headers_2)
         )
 
-    def test_handle_part__url_expired_twice(self):
+    def test_handle_part__url_expired_twice(self, syn):
         """Verify that consecutive attempts to upload a part resulting
         in a 403 from AWS results in the expected error."""
 
-        upload = self._init_upload_attempt()
+        upload = self._init_upload_attempt(syn)
         upload._upload_id = '123'
         part_number = 1
-        chunk = b'1234'
+        chunk = b'1' * TestUploadAttempt.part_size
 
         pre_signed_url_1 = 'https://foo.com/1'
         pre_signed_url_2 = 'https://bar.com/1'
+        signed_headers = {'a': 1}
 
-        upload._pre_signed_part_urls = {part_number: pre_signed_url_1}
+        upload._pre_signed_part_urls = {part_number: (pre_signed_url_1, signed_headers)}
         mock_session = mock.Mock()
 
-        with mock.patch.object(upload, '_chunk_fn')\
+        with mock.patch.object(multipart_upload, '_get_file_chunk')\
                 as chunk_fn,\
                 mock.patch.object(upload, '_get_thread_session')\
                 as get_session,\
@@ -360,12 +386,10 @@ class TestUploadAttempt:
             get_session.return_value = mock_session
             chunk_fn.return_value = chunk
             refresh_urls.side_effect = [
-                {
-                    part_number: url for url in [
-                        pre_signed_url_1,
-                        pre_signed_url_2,
-                    ]
-                }
+                (url, signed_headers) for url in [
+                    pre_signed_url_1,
+                    pre_signed_url_2,
+                ]
             ]
 
             mock_session.put.return_value = mock.Mock(
@@ -377,12 +401,12 @@ class TestUploadAttempt:
             with pytest.raises(SynapseHTTPError):
                 upload._handle_part(1)
 
-    def test_call_upload(self):
+    def test_call_upload(self, syn):
         """Verify the behavior of an upload call, it should trigger
         calls to handle each of the individual outstanding parts
         and then call Synapse indicating that the upload is complete"""
 
-        upload = self._init_upload_attempt()
+        upload = self._init_upload_attempt(syn)
 
         upload_id = '1234'
         parts_state = '010'
@@ -408,7 +432,9 @@ class TestUploadAttempt:
             mock.patch.object(pool_provider, 'get_executor')\
             as get_executor,\
             mock.patch.object(upload, '_get_thread_session')\
-                as get_session:
+            as get_session,\
+            mock.patch.object(syn, 'restPUT')\
+                as restPUT:
 
             mock_session = mock.Mock()
             get_session.return_value = mock_session
@@ -422,11 +448,11 @@ class TestUploadAttempt:
                 'state': 'COMPLETED'
             }
 
-            upload._syn.restPUT.return_value = upload_response
+            restPUT.return_value = upload_response
             result = upload()
             assert result == upload_response
 
-            upload._syn.restPUT.assert_called_once_with(
+            restPUT.assert_called_once_with(
                 "/file/multipart/{upload_id}/complete".format(
                     upload_id=upload_id
                 ),
@@ -436,10 +462,11 @@ class TestUploadAttempt:
 
     def _test_call_upload__part_exception(
             self,
+            syn,
             part_exception,
             expected_raised_exception
     ):
-        upload = self._init_upload_attempt()
+        upload = self._init_upload_attempt(syn)
 
         upload_id = '1234'
         parts_state = '0'
@@ -469,26 +496,28 @@ class TestUploadAttempt:
             with pytest.raises(expected_raised_exception):
                 upload()
 
-    def test_call_upload__part_failure(self):
+    def test_call_upload__part_failure(self, syn):
         """Verify that an error raised while processing one part
         results in an error on the upload."""
         self._test_call_upload__part_exception(
+            syn,
             Exception,
             SynapseUploadFailedException,
         )
 
-    def test_call_upload__interrupt(self):
+    def test_call_upload__interrupt(self, syn):
         """Verify that a KeyboardInterrupt raises an abort exception"""
         self._test_call_upload__part_exception(
+            syn,
             KeyboardInterrupt,
             SynapseUploadAbortedException,
         )
 
-    def test_already_completed(self):
+    def test_already_completed(self, syn):
         """Verify that uploading a file that is already complete
         but that wasn't force restarted returns without attempting
         to reupload the file."""
-        upload = self._init_upload_attempt()
+        upload = self._init_upload_attempt(syn)
 
         upload_id = '1234'
         parts_state = '0'
@@ -514,12 +543,12 @@ class TestUploadAttempt:
             assert not fetch_pre_signed_urls.called
             assert not get_executor.called
 
-    def test_all_parts_completed(self):
+    def test_all_parts_completed(self, syn):
         """Verify that if all the parts are already complete but
         the upload itself hasn't been marked as complete then
         we mark it as such without re-uploading any of the parts."""
 
-        upload = self._init_upload_attempt()
+        upload = self._init_upload_attempt(syn)
 
         upload_id = '1234'
         parts_state = '11'
@@ -568,16 +597,17 @@ class TestMultipartUpload:
         file_path = '/foo/bar/baz'
         file_size = 1234
         md5_hex = 'abc123'
+        storage_location_id = 5432
 
         with mock.patch('os.path.exists') as os_path_exists,\
                 mock.patch('os.path.isdir') as os_path_is_dir,\
                 mock.patch('os.path.getsize') as os_path_getsize,\
                 mock.patch.object(
-                    synapseclient.core.upload.multipart_upload,
+                    multipart_upload,
                     'md5_for_file',
                 ) as md5_for_file,\
                 mock.patch.object(
-                    synapseclient.core.upload.multipart_upload,
+                    multipart_upload,
                     '_multipart_upload',
                 ) as mock_multipart_upload:
 
@@ -588,30 +618,43 @@ class TestMultipartUpload:
 
             # bad file
             with pytest.raises(IOError):
-                multipart_upload_file(syn, file_path)
+                multipart_upload_file(syn, file_path, storage_location_id)
 
             os_path_exists.return_value = True
             os_path_is_dir.return_value = True
 
             with pytest.raises(IOError):
-                multipart_upload_file(syn, file_path)
+                multipart_upload_file(syn, file_path, storage_location_id)
 
             os_path_is_dir.return_value = False
 
+            expected_upload_request = {
+                'concreteType': 'org.sagebionetworks.repo.model.file.MultipartUploadRequest',
+                'contentType': 'application/octet-stream',
+                'contentMD5Hex': md5_hex,
+                'fileName': 'baz',
+                'fileSizeBytes': file_size,
+                'generatePreview': True,
+                'storageLocationId': storage_location_id,
+            }
+
             # call w/ defaults
-            multipart_upload_file(syn, file_path)
+            multipart_upload_file(
+                syn,
+                file_path,
+                storage_location_id,
+            )
             mock_multipart_upload.assert_called_once_with(
                 syn,
-                mock.ANY,  # lambda chunk function
-                file_size,
-                None,  # part_size
                 'baz',
-                md5_hex,
-                'application/octet-stream',  # content_type
-                None,  # storage_location_id
-                True,  # preview
-                False,  # force_restart
-                None,  # max_threads
+                DEFAULT_PART_SIZE,
+
+                expected_upload_request,
+                mock.ANY,  # part_fn
+                mock.ANY,  # md5_fn,
+
+                force_restart=False,
+                max_threads=None,
             )
 
             mock_multipart_upload.reset_mock()
@@ -620,29 +663,37 @@ class TestMultipartUpload:
             kwargs = {
                 'dest_file_name': 'blort',
                 'content_type': 'text/plain',
-                'part_size': 9876,
-                'storage_location_id': 5432,
+                'part_size': MIN_PART_SIZE * 2,
                 'preview': False,
                 'force_restart': True,
                 'max_threads': 8,
             }
+            expected_upload_request = {
+                'concreteType': 'org.sagebionetworks.repo.model.file.MultipartUploadRequest',
+                'contentType': kwargs['content_type'],
+                'contentMD5Hex': md5_hex,
+                'fileName': kwargs['dest_file_name'],
+                'fileSizeBytes': file_size,
+                'generatePreview': kwargs['preview'],
+                'storageLocationId': storage_location_id,
+            }
             multipart_upload_file(
                 syn,
                 file_path,
+                storage_location_id,
                 **kwargs
             )
             mock_multipart_upload.assert_called_once_with(
                 syn,
-                mock.ANY,  # lambda chunk function
-                file_size,
-                kwargs['part_size'],
                 kwargs['dest_file_name'],
-                md5_hex,
-                kwargs['content_type'],
-                kwargs['storage_location_id'],
-                kwargs['preview'],
-                kwargs['force_restart'],
-                kwargs['max_threads'],
+                kwargs['part_size'],
+
+                expected_upload_request,
+                mock.ANY,  # part_fn
+                mock.ANY,  # md5_fn,
+
+                force_restart=kwargs['force_restart'],
+                max_threads=kwargs['max_threads'],
             )
 
     def test_multipart_upload_string(self):
@@ -651,9 +702,10 @@ class TestMultipartUpload:
 
         syn = mock.Mock()
         upload_text = 'foobarbaz'
+        storage_location_id = 5432
 
         with mock.patch.object(
-               synapseclient.core.upload.multipart_upload,
+               multipart_upload,
                '_multipart_upload',
            ) as mock_multipart_upload:
 
@@ -661,19 +713,28 @@ class TestMultipartUpload:
             md5_hex = hashlib.md5(encoded).hexdigest()
 
             # call w/ default args
-            multipart_upload_string(syn, upload_text)
+            multipart_upload_string(syn, upload_text, storage_location_id)
+
+            expected_upload_request = {
+                'concreteType': 'org.sagebionetworks.repo.model.file.MultipartUploadRequest',
+                'contentType': 'text/plain; charset=utf-8',
+                'contentMD5Hex': md5_hex,
+                'fileName': 'message.txt',
+                'fileSizeBytes': len(upload_text),
+                'generatePreview': True,
+                'storageLocationId': storage_location_id,
+            }
             mock_multipart_upload.assert_called_once_with(
                 syn,
-                mock.ANY,  # lambda chunk function
-                len(encoded),
-                None,  # part_size
                 'message.txt',
-                md5_hex,
-                'text/plain; charset=utf-8',
-                None,  # storage_location_id
-                True,  # preview
-                False,  # force_restart
-                None,  # max_threads
+                DEFAULT_PART_SIZE,
+
+                expected_upload_request,
+                mock.ANY,  # part_fn
+                mock.ANY,  # md5_fn,
+
+                force_restart=False,
+                max_threads=None,
             )
 
             mock_multipart_upload.reset_mock()
@@ -682,30 +743,39 @@ class TestMultipartUpload:
             kwargs = {
                 'dest_file_name': 'blort',
                 'content_type': 'text/csv',
-                'part_size': 9876,
-                'storage_location_id': 5432,
+                'part_size': MIN_PART_SIZE * 2,
+                'storage_location_id': storage_location_id,
                 'preview': False,
                 'force_restart': True,
                 'max_threads': 8,
             }
             multipart_upload_string(syn, upload_text, **kwargs)
+
+            expected_upload_request = {
+                'concreteType': 'org.sagebionetworks.repo.model.file.MultipartUploadRequest',
+                'contentType': kwargs['content_type'],
+                'contentMD5Hex': md5_hex,
+                'fileName': kwargs['dest_file_name'],
+                'fileSizeBytes': len(upload_text),
+                'generatePreview': kwargs['preview'],
+                'storageLocationId': storage_location_id,
+            }
             mock_multipart_upload.assert_called_once_with(
                 syn,
-                mock.ANY,  # lambda chunk function
-                len(encoded),
-                kwargs['part_size'],
                 kwargs['dest_file_name'],
-                md5_hex,
-                kwargs['content_type'],
-                kwargs['storage_location_id'],
-                kwargs['preview'],
-                kwargs['force_restart'],
-                kwargs['max_threads'],
+                kwargs['part_size'],
+
+                expected_upload_request,
+                mock.ANY,  # part_fn
+                mock.ANY,  # md5_fn,
+
+                force_restart=kwargs['force_restart'],
+                max_threads=kwargs['max_threads'],
             )
 
     def _multipart_upload_test(self, upload_side_effect, syn, *args, **kwargs):
         with mock.patch.object(
-            synapseclient.core.upload.multipart_upload,
+            multipart_upload,
             'UploadAttempt'
         ) as mock_upload_attempt:
             mock_upload_attempt.side_effect = upload_side_effect
@@ -718,7 +788,6 @@ class TestMultipartUpload:
         are validated/adjusted as expected."""
 
         syn = mock.Mock()
-        chunk_fn = mock.Mock()
         md5_hex = 'ab123'
         dest_file_name = 'foo'
         content_type = 'text/plain'
@@ -734,27 +803,19 @@ class TestMultipartUpload:
         # (out_part_size, out_max_threads, out_force_restart)
         tests = [
 
-            # part_size exceeds file size, so only 1 part expect 1 worker
+            # non-positive max threads corrected
             (
-                (1234, None, None, False),
+                (1234, None, 0, False),
                 (DEFAULT_PART_SIZE, 1, False)
             ),
 
-            # multiple parts, but less parts than specified max workers
-            # so we expect max workers to be num of parts
-            (
-               (pow(2, 24), pow(2, 23) - 1000, None, False),
-               (pow(2, 23) - 1000, 3, False),
-            ),
-
-            # parts exceeds specified max_threads, so specified max_threads
-            # passes through unchanged, also specify force_restart
+            # specify force_restart
             (
                (pow(2, 28), None, 8, True),
                (DEFAULT_PART_SIZE, 8, True),
             ),
 
-            # many parts, no max_threads, specified, should use default
+            # no max_threads, specified, should use default
             (
                 (pow(2, 28), None, None, False),
                 (DEFAULT_PART_SIZE, pool_provider.DEFAULT_NUM_THREADS, False),
@@ -762,15 +823,15 @@ class TestMultipartUpload:
 
             # part size specified below min, should be raised
             (
-                (1000, 1, None, False),
-                (MIN_PART_SIZE, 1, False),
+                (1000, 1, 5, False),
+                (MIN_PART_SIZE, 5, False),
             ),
 
             # part size would exceed max number of parts,
             # should be adjusted accordingly
             (
-                (pow(2, 36), MIN_PART_SIZE + 1, 32, True),
-                (int(math.ceil(pow(2, 36) / MAX_NUMBER_OF_PARTS)), 32, True),
+                (pow(2, 36), MIN_PART_SIZE + 1, 8, True),
+                (int(math.ceil(pow(2, 36) / MAX_NUMBER_OF_PARTS)), 8, True),
             )
         ]
 
@@ -778,32 +839,52 @@ class TestMultipartUpload:
             (out_part_size, out_max_threads, out_force_restart)\
                 in tests:
 
+            expected_upload_request = {
+                'concreteType': 'org.sagebionetworks.repo.model.file.MultipartUploadRequest',
+                'contentType': content_type,
+                'contentMD5Hex': md5_hex,
+                'fileName': dest_file_name,
+                'fileSizeBytes': file_size,
+                'generatePreview': True,
+                'storageLocationId': storage_location_id,
+            }
+
             result, upload_mock = self._multipart_upload_test(
                 upload_side_effect,
                 syn,
-                chunk_fn,
-                file_size,
-                in_part_size,
                 dest_file_name,
-                md5_hex,
-                content_type,
-                storage_location_id,
+                in_part_size,
+
+                expected_upload_request,
+                mock.ANY,
+                mock.ANY,
+
                 max_threads=in_max_threads,
                 force_restart=in_force_restart,
             )
 
+            expected_upload_request = {
+                'concreteType': 'org.sagebionetworks.repo.model.file.MultipartUploadRequest',
+                'contentType': content_type,
+                'contentMD5Hex': md5_hex,
+                'fileName': dest_file_name,
+                'fileSizeBytes': file_size,
+                'generatePreview': True,
+                'storageLocationId': storage_location_id,
+            }
+
             upload_mock.assert_called_once_with(
                 syn,
-                chunk_fn,
                 dest_file_name,
-                file_size,
-                out_part_size,
-                md5_hex,
-                content_type,
-                True,
-                storage_location_id,
+                in_part_size,
+
+                expected_upload_request,
+
+                mock.ANY,  # part_fn
+                mock.ANY,  # md5_fn,
+
                 out_max_threads,
-                force_restart=out_force_restart,
+                out_force_restart,
             )
 
     def test_multipart_upload__retry_success(self):
@@ -811,13 +892,14 @@ class TestMultipartUpload:
         retry succeeds."""
 
         syn = mock.Mock()
-        chunk_fn = mock.Mock()
         md5_hex = 'ab123'
         file_size = 1234
+        part_size = 567
         dest_file_name = 'foo'
         content_type = 'text/plain'
         storage_location_id = 3210
         result_file_handle_id = 'foo'
+        max_threads = 5
         upload_side_effect = [
             SynapseUploadFailedException(),
             SynapseUploadFailedException(),
@@ -826,17 +908,30 @@ class TestMultipartUpload:
             )
         ]
 
+        expected_upload_request = {
+            'concreteType': 'org.sagebionetworks.repo.model.file.MultipartUploadRequest',
+            'contentType': content_type,
+            'contentMD5Hex': md5_hex,
+            'fileName': dest_file_name,
+            'fileSizeBytes': file_size,
+            'generatePreview': True,
+            'storageLocationId': storage_location_id,
+        }
+
         result, upload_mock = self._multipart_upload_test(
             upload_side_effect,
+
             syn,
-            chunk_fn,
-            file_size,
-            None,  # part_size
             dest_file_name,
-            md5_hex,
-            content_type,
-            storage_location_id,
-            None,  # max_threads
+            part_size,
+
+            expected_upload_request,
+
+            mock.ANY,  # part_fn
+            mock.ANY,  # md5_fn,
+
+            max_threads,
+            False,
         )
 
         # should have been called multiple times but returned
@@ -849,24 +944,38 @@ class TestMultipartUpload:
         and raise the failure."""
 
         syn = mock.Mock()
-        chunk_fn = mock.Mock()
         md5_hex = 'ab123'
         file_size = 1234
+        part_size = 567
         dest_file_name = 'foo'
         content_type = 'text/plain'
         storage_location_id = 3210
+        max_threads = 5
         upload_side_effect = SynapseUploadFailedException()
+
+        expected_upload_request = {
+            'concreteType': 'org.sagebionetworks.repo.model.file.MultipartUploadRequest',
+            'contentType': content_type,
+            'contentMD5Hex': md5_hex,
+            'fileName': dest_file_name,
+            'fileSizeBytes': file_size,
+            'generatePreview': True,
+            'storageLocationId': storage_location_id,
+        }
 
         with pytest.raises(SynapseUploadFailedException):
             self._multipart_upload_test(
                 upload_side_effect,
+
                 syn,
-                chunk_fn,
-                file_size,
-                None,  # part_size
                 dest_file_name,
-                md5_hex,
-                content_type,
-                storage_location_id,
-                None,  # max_threads
+                part_size,
+
+                expected_upload_request,
+
+                mock.ANY,  # part_fn
+                mock.ANY,  # md5_fn,
+
+                max_threads,
+                False,
             )

--- a/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
+++ b/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
@@ -915,8 +915,8 @@ class TestMultipartUpload:
 
             # specify force_restart
             (
-               (pow(2, 28), DEFAULT_PART_SIZE, 8, True),
-               (8, True),
+                (pow(2, 28), DEFAULT_PART_SIZE, 8, True),
+                (8, True),
             ),
 
             # no max_threads, specified, should use default


### PR DESCRIPTION
Part 1 of 2 PRs for [SYNPY-1103](https://sagebionetworks.jira.com/browse/SYNPY-1103)

This PR refactors the existing multipart upload code to also support [multipart copies](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/MultipartUploadCopyRequest.html).