### PR TITLE
SYNPY-1109 handle cacheMap files not parseable as JSON

### DIFF
--- a/synapseclient/core/cache.py
+++ b/synapseclient/core/cache.py
@@ -103,7 +103,13 @@ class Cache:
             return {}
 
         with open(cache_map_file, 'r') as f:
-            cache_map = json.load(f)
+            try:
+                cache_map = json.load(f)
+            except json.decoder.JSONDecodeError:
+                # a corrupt cache map file that is not parseable as JSON is treated
+                # as if it does not exist at all (will be overwritten).
+                return {}
+
         return cache_map
 
     def _write_cache_map(self, cache_dir, cache_map):


### PR DESCRIPTION
Currently a .cacheMap file in the synapseCache that is not parseable as JSON will raise an error whenever a download is attempted of the associated file. For robustness this treats an unparseable cacheMap entry as if it does not exist, a new cacheMap entry will be written on a download rather than an error raised.

https://sagebionetworks.jira.com/browse/SYNPY-1109