### PR TITLE
SYNPY-1110-fix the console log on Windows

### DIFF
--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -968,11 +968,8 @@ def perform_main(args, syn):
                 sys.stderr.write(utils._synapse_error_msg(ex))
     else:
         # if no command provided print out help and quit
-        # if we require python 3.7 or above, we can use required argument add_subparsers
+        # if we require python 3.7 or above, we can use required argument tp add_subparsers instead
         build_parser().print_help()
-
-
-# print help
 
 
 def login_with_prompt(syn, user, password, rememberMe=False, silent=False, forced=False):

--- a/tests/unit/synapseclient/unit_test_commandline.py
+++ b/tests/unit/synapseclient/unit_test_commandline.py
@@ -254,7 +254,7 @@ def test_login_with_prompt__getpass(mock_authenticate_login, mock_input, mock_ge
 def test_login_with_prompt_no_tty(mock_input, mock_sys, syn):
     """
     Verify login_with_prompt when the terminal is not a tty,
-    we are unable to read from standard input and throwing the SynapseAuthenticationError.
+    we are unable to read from standard input and throw a SynapseAuthenticationError
     """
 
     user = 'test_user'
@@ -274,7 +274,7 @@ def test_login_with_prompt_no_tty(mock_input, mock_sys, syn):
 def test_no_command_print_help(mock_build_parser, syn):
     """
     Verify command without any function,
-    we are automatically print out the help instruction.
+    we are automatically print out help instructions.
     """
 
     args = cmdline.build_parser().parse_args(['-u', 'test_user'])

--- a/tests/unit/synapseclient/unit_test_commandline.py
+++ b/tests/unit/synapseclient/unit_test_commandline.py
@@ -210,10 +210,11 @@ def test_login_with_prompt(mock_authenticate_login, syn):
     mock_authenticate_login.assert_called_once_with(syn, user, password, **login_kwargs)
 
 
+@patch.object(cmdline, 'sys')
 @patch.object(cmdline, 'getpass')
 @patch.object(cmdline, 'input')
 @patch.object(cmdline, '_authenticate_login')
-def test_login_with_prompt__getpass(mock_authenticate_login, mock_input, mock_getpass, syn):
+def test_login_with_prompt__getpass(mock_authenticate_login, mock_input, mock_getpass, mock_sys, syn):
     """Verify logging in when entering username/pass from the console."""
 
     user = 'foo'
@@ -229,6 +230,8 @@ def test_login_with_prompt__getpass(mock_authenticate_login, mock_input, mock_ge
             raise SynapseNoCredentialsError()
         return
 
+    mock_sys.stdin.isatty.return_value = True
+
     mock_authenticate_login.side_effect = authenticate_side_effect
     mock_input.return_value = user
     mock_getpass.getpass.return_value = password
@@ -236,7 +239,7 @@ def test_login_with_prompt__getpass(mock_authenticate_login, mock_input, mock_ge
     cmdline.login_with_prompt(syn, None, None, **login_kwargs)
 
     mock_input.assert_called_once_with("Synapse username: ")
-    mock_getpass.getpass.assert_called_once_with(("Password or api key for " + user + ": ").encode('utf-8'))
+    mock_getpass.getpass.assert_called_once_with(("Password or api key for " + user + ": "))
 
     expected_authenticate_calls = [
         call(syn, None, None, **login_kwargs),
@@ -244,3 +247,55 @@ def test_login_with_prompt__getpass(mock_authenticate_login, mock_input, mock_ge
     ]
 
     assert expected_authenticate_calls == mock_authenticate_login.call_args_list
+
+
+@patch.object(cmdline, 'sys')
+@patch.object(cmdline, 'input')
+def test_login_with_prompt_no_tty(mock_input, mock_sys, syn):
+    """
+    Verify login_with_prompt when the terminal is not a tty,
+    we are unable to read from standard input and throwing the SynapseAuthenticationError.
+    """
+
+    user = 'test_user'
+    login_kwargs = {
+        'rememberMe': False,
+        'silent': True,
+        'forced': True,
+    }
+
+    mock_sys.stdin.isatty.return_value = False
+    mock_input.return_value = user
+    with pytest.raises(SynapseAuthenticationError):
+        cmdline.login_with_prompt(syn, None, None, **login_kwargs)
+
+
+@patch.object(cmdline, 'build_parser')
+def test_no_command_print_help(mock_build_parser, syn):
+    """
+    Verify command without any function,
+    we are automatically print out the help instruction.
+    """
+
+    args = cmdline.build_parser().parse_args(['-u', 'test_user'])
+    mock_build_parser.assert_called_once_with()
+
+    cmdline.perform_main(args, syn)
+    mock_build_parser.call_count == 2
+
+    mock_build_parser.return_value.print_help.assert_called_once_with()
+
+
+@patch.object(cmdline, 'login_with_prompt')
+def test_command_auto_login(mock_login_with_prompt, syn):
+    """
+    Verify command with the function but without login function,
+    we are calling login_with_prompt automatically.
+    """
+
+    mock_login_with_prompt.assert_not_called()
+
+    args = cmdline.build_parser().parse_args(['-u', 'test_user', 'get'])
+    cmdline.perform_main(args, syn)
+
+    mock_login_with_prompt.assert_called_once_with(syn, 'test_user', None, silent=True)


### PR DESCRIPTION
Fix the odd behavior when console login on Windows.
Check the terminal is tty or not, if False, throw the exception for the user
If the ommand line user typed in with no function argument, print out the help instruction. 
Create three unit tests for commandline.py
- command_auto_login
- no_command_print_help
- login_with_prompt_no_tty