### PR TITLE
Fix invalid version constraint on sphinx-argparse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
         'pandas': ["pandas>=0.25.0,<2.0"],
         'pysftp': ["pysftp>=0.2.8,<0.3"],
         'boto3': ["boto3>=1.7.0,<2.0"],
-        'docs': ["sphinx>=3.0,<4.0", "sphinx-argparse>=0.2,<.3"],
+        'docs': ["sphinx>=3.0,<4.0", "sphinx-argparse>=0.2,<0.3"],
         'tests': test_deps,
         ':sys_platform=="linux2" or sys_platform=="linux"': ['keyrings.alt==3.1'],
     },


### PR DESCRIPTION
I get the following warning when installing `synapseclient` using Poetry. I think the one-line change in this PR addresses the issue. 

```
PackageInfo: Invalid constraint (sphinx-argparse<.3,>=0.2 ; extra == "docs") found in synapseclient-2.2.2 dependencies, skipping
```