### PR TITLE
Synpy 929(834) silent parameter functions

### DIFF
--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -30,9 +30,6 @@ from synapseclient.core.exceptions import (
 )
 
 
-
-
-
 def _init_console_logging():
     # init a stdout logger for purposes of logging cli activity.
     # logging is preferred to writing directly to stdout since it can be configured/formatted/suppressed

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -30,7 +30,10 @@ from synapseclient.core.exceptions import (
 )
 
 
-def _init_console_Logging():
+
+
+
+def _init_console_logging():
     # init a stdout logger for purposes of logging cli activity.
     # logging is preferred to writing directly to stdout since it can be configured/formatted/suppressed
     # but this is not yet universal across the client so it is initialized here from cli commands that
@@ -104,19 +107,19 @@ def get(args, syn):
         if isinstance(args.id, str) and os.path.isfile(args.id):
             entity = syn.get(args.id, version=args.version, limitSearch=args.limitSearch, downloadFile=False)
             if "path" in entity and entity.path is not None and os.path.exists(entity.path):
-                print("Associated file: %s with synapse ID %s" % (entity.path, entity.id))
+                syn.logger.info("Associated file: %s with synapse ID %s", entity.path, entity.id)
         # normal syn.get operation
         else:
             entity = syn.get(args.id, version=args.version,  # limitSearch=args.limitSearch,
                              followLink=args.followLink,
                              downloadLocation=args.downloadLocation)
             if "path" in entity and entity.path is not None and os.path.exists(entity.path):
-                print("Downloaded file: %s" % os.path.basename(entity.path))
-            else:
-                print('WARNING: No files associated with entity %s\n' % entity.id)
-                print(entity)
 
-        print('Creating %s' % entity.path)
+                syn.logger.info("Downloaded file: %s", os.path.basename(entity.path))
+            else:
+                syn.logger.info('WARNING: No files associated with entity %s\n', entity.id)
+                syn.logger.info(entity)
+        syn.logger.info('Creating %s', entity.path)
 
 
 def sync(args, syn):
@@ -160,8 +163,7 @@ def store(args, syn):
                        forceVersion=force_version)
 
     _create_wiki_description_if_necessary(args, entity, syn)
-
-    print('Created/Updated entity: %s\t%s' % (entity['id'], entity['name']))
+    syn.logger.info('Created/Updated entity: %s\t%s', entity['id'], entity['name'])
 
     # After creating/updating, if there are annotations to add then
     # add them
@@ -191,7 +193,7 @@ def _descriptionFile_arg_check(args):
 def move(args, syn):
     """Moves an entity specified by args.id to args.parentId"""
     entity = syn.move(args.id, args.parentid)
-    print('Moved %s to %s' % (entity.id, entity.parentId))
+    syn.logger.info('Moved %s to %s', entity.id, entity.parentId)
 
 
 def associate(args, syn):
@@ -208,9 +210,9 @@ def associate(args, syn):
         try:
             ent = syn.get(fp, limitSearch=args.limitSearch)
         except SynapseFileNotFoundError:
-            print('WARNING: The file %s is not available in Synapse' % fp)
+            syn.logger.warning('WARNING: The file %s is not available in Synapse', fp)
         else:
-            print('%s.%i\t%s' % (ent.id, ent.versionNumber, fp))
+            syn.logger.info('%s.%i\t%s', ent.id, ent.versionNumber, fp)
 
 
 def copy(args, syn):
@@ -220,7 +222,7 @@ def copy(args, syn):
                                  excludeTypes=args.excludeTypes,
                                  version=args.version, updateExisting=args.updateExisting,
                                  setProvenance=args.setProvenance)
-    print(mappings)
+    syn.logger.info(mappings)
 
 
 def cat(args, syn):
@@ -253,18 +255,18 @@ def show(args, syn):
     sys.stdout.write('Provenance:\n')
     try:
         prov = syn.getProvenance(ent)
-        print(prov)
+        syn.logger.info(prov)
     except SynapseHTTPError:
-        print('  No Activity specified.\n')
+        syn.logger.error('  No Activity specified.\n')
 
 
 def delete(args, syn):
     if args.version:
         syn.delete(args.id, args.version)
-        print('Deleted entity %s, version %s' % (args.id, args.version))
+        syn.logger.info('Deleted entity %s, version %s', args.id, args.version)
     else:
         syn.delete(args.id)
-        print('Deleted entity: %s' % args.id)
+        syn.logger.info('Deleted entity: %s', args.id)
 
 
 def create(args, syn):
@@ -279,8 +281,7 @@ def create(args, syn):
     entity = syn.store(entity)
 
     _create_wiki_description_if_necessary(args, entity, syn)
-
-    print('Created entity: %s\t%s\n' % (entity['id'], entity['name']))
+    syn.logger.info('Created entity: %s\t%s\n', entity['id'], entity['name'])
 
 
 def onweb(args, syn):
@@ -310,14 +311,14 @@ def setProvenance(args, syn):
                 f.write(json.dumps(activity))
                 f.write('\n')
     else:
-        print('Set provenance record %s on entity %s\n' % (str(activity['id']), str(args.id)))
+        syn.logger.info('Set provenance record %s on entity %s\n', str(activity['id']), str(args.id))
 
 
 def getProvenance(args, syn):
     activity = syn.getProvenance(args.id, args.version)
 
     if args.output is None or args.output == 'STDOUT':
-        print(json.dumps(activity, sort_keys=True, indent=2))
+        syn.logger.info(json.dumps(activity, sort_keys=True, indent=2))
     else:
         with open(args.output, 'w') as f:
             f.write(json.dumps(activity))
@@ -364,7 +365,7 @@ def getAnnotations(args, syn):
     annotations = syn.get_annotations(args.id)
 
     if args.output is None or args.output == 'STDOUT':
-        print(json.dumps(annotations, sort_keys=True, indent=2))
+        syn.logger.info(json.dumps(annotations, sort_keys=True, indent=2))
     else:
         with open(args.output, 'w') as f:
             f.write(json.dumps(annotations))
@@ -377,7 +378,7 @@ def storeTable(args, syn):
                                             args.parentid,
                                             args.csv)
     table_ent = syn.store(table)
-    print('{"tableId": "%s"}' % table_ent.tableId)
+    syn.logger.info('{"tableId": "%s"}', table_ent.tableId)
 
 
 def submit(args, syn):
@@ -433,7 +434,7 @@ def login(args, syn):
     """Log in to Synapse, optionally caching credentials"""
     login_with_prompt(syn, args.synapseUser, args.synapsePassword, rememberMe=args.rememberMe, forced=True)
     profile = syn.getUserProfile()
-    print("Logged in as: {userName} ({ownerId})".format(**profile))
+    syn.logger.info("Logged in as: {userName} ({ownerId})".format(**profile))
 
 
 def test_encoding(args, syn):
@@ -461,13 +462,12 @@ def get_sts_token(args, syn):
         sts_string = json.dumps(resp)
     else:
         sts_string = str(resp)
-
-    print(sts_string)
+    syn.logger.info(sts_string)
 
 
 def migrate(args, syn):
     """Migrate Synapse entities to a new storage location"""
-    _init_console_Logging()
+    _init_console_logging()
 
     result = synapseutils.index_files_for_migration(
         syn,
@@ -547,7 +547,11 @@ def build_parser():
     parser.add_argument('-c', '--configPath', dest='configPath', default=synapseclient.client.CONFIG_FILE,
                         help='Path to configuration file used to connect to Synapse [default: %(default)s]')
 
-    parser.add_argument('--debug', dest='debug', action='store_true')
+    parser.add_argument('--debug', dest='debug', action='store_true', help='Set mode to debug mode, default is False')
+
+    parser.add_argument('--silent', dest='silent', action='store_true',
+                        help='Set mode to silent mode, default is False')
+
     parser.add_argument('-s', '--skip-checks', dest='skip_checks', action='store_true',
                         help='suppress checking for version upgrade messages and endpoint redirection')
 
@@ -1004,7 +1008,8 @@ def _authenticate_login(syn, user, password, **login_kwargs):
 def main():
     args = build_parser().parse_args()
     synapseclient.USER_AGENT['User-Agent'] = "synapsecommandlineclient " + synapseclient.USER_AGENT['User-Agent']
-    syn = synapseclient.Synapse(debug=args.debug, skip_checks=args.skip_checks, configPath=args.configPath)
+    syn = synapseclient.Synapse(debug=args.debug, skip_checks=args.skip_checks,
+                                configPath=args.configPath, silent=args.silent, )
     if not ('func' in args and args.func == login):
         # if we're not executing the "login" operation, automatically authenticate before running operation
         login_with_prompt(syn, args.synapseUser, args.synapsePassword, silent=True)

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -604,7 +604,6 @@ class Synapse(object):
         if self.silent is not True:
             cumulative_transfer_progress.printTransferProgress(*args, **kwargs)
 
-
     ############################################################
     #                   Get / Store methods                    #
     ############################################################

--- a/synapseclient/core/multithread_download/download_threads.py
+++ b/synapseclient/core/multithread_download/download_threads.py
@@ -17,7 +17,6 @@ import time
 
 from synapseclient.core.exceptions import SynapseError
 from synapseclient.core.pool_provider import get_executor
-from synapseclient.core.cumulative_transfer_progress import printTransferProgress
 
 # constants
 MAX_QUEUE_SIZE: int = 20
@@ -362,7 +361,6 @@ class _MultithreadedDownloader:
                 break
 
         return submitted_futures
-
 
     def _write_chunks(self, request, completed_futures, transfer_status):
         if completed_futures:

--- a/synapseclient/core/multithread_download/download_threads.py
+++ b/synapseclient/core/multithread_download/download_threads.py
@@ -363,8 +363,8 @@ class _MultithreadedDownloader:
 
         return submitted_futures
 
-    @staticmethod
-    def _write_chunks(request, completed_futures, transfer_status):
+
+    def _write_chunks(self, request, completed_futures, transfer_status):
         if completed_futures:
             with open(request.path, 'rb+') as file_write:
                 for chunk_future in completed_futures:
@@ -374,10 +374,14 @@ class _MultithreadedDownloader:
                     file_write.write(chunk_response.content)
 
                     transfer_status.transferred += len(chunk_data)
-                    printTransferProgress(transfer_status.transferred,
-                                          transfer_status.total_bytes_to_be_transferred,
-                                          'Downloading ', os.path.basename(request.path),
-                                          dt=transfer_status.elapsed_time())
+                    # printTransferProgress(transfer_status.transferred,
+                    #                       transfer_status.total_bytes_to_be_transferred,
+                    #                       'Downloading ', os.path.basename(request.path),
+                    #                       dt=transfer_status.elapsed_time())
+                    self._syn._print_transfer_progress(transfer_status.transferred,
+                                                       transfer_status.total_bytes_to_be_transferred,
+                                                       'Downloading ', os.path.basename(request.path),
+                                                       dt=transfer_status.elapsed_time())
 
     @staticmethod
     def _check_for_errors(request, completed_futures):

--- a/synapseclient/core/remote_file_storage_wrappers.py
+++ b/synapseclient/core/remote_file_storage_wrappers.py
@@ -185,7 +185,7 @@ class SFTPWrapper:
         return urllib_parse.urlunparse(parsedURL)
 
     @staticmethod
-    def download_file(url, localFilepath=None, username=None, password=None):
+    def download_file(url, localFilepath=None, username=None, password=None, show_progress=True):
         """
         Performs download of a file from an sftp server.
 
@@ -193,6 +193,7 @@ class SFTPWrapper:
         :param localFilepath:   location where to store file
         :param username:        username on server
         :param password:        password for authentication on  server
+        :param show_progress:   whether to print progress indicator to console
 
         :returns: localFilePath
 
@@ -212,7 +213,9 @@ class SFTPWrapper:
 
         # Download file
         with _retry_pysftp_connection(parsedURL.hostname, username=username, password=password) as sftp:
-            sftp.get(path, localFilepath, preserve_mtime=True, callback=printTransferProgress)
+            # sftp.get(path, localFilepath, preserve_mtime=True, callback=printTransferProgress)
+            sftp.get(path, localFilepath, preserve_mtime=True,
+                     callback=(printTransferProgress if show_progress else None))
         return localFilepath
 
 

--- a/synapseclient/core/upload/multipart_upload.py
+++ b/synapseclient/core/upload/multipart_upload.py
@@ -295,7 +295,14 @@ class UploadAttempt:
                 file_size,
             )
 
-            printTransferProgress(
+            # printTransferProgress(
+            #     progress,
+            #     file_size,
+            #     prefix='Uploading',
+            #     postfix=self._dest_file_name,
+            #     previouslyTransferred=previously_transferred,
+            # )
+            self._syn._print_transfer_progress(
                 progress,
                 file_size,
                 prefix='Uploading',
@@ -326,7 +333,7 @@ class UploadAttempt:
 
                 if part_size and not self._is_copy():
                     progress += part_size
-                    printTransferProgress(
+                    self._syn._print_transfer_progress(
                         min(progress, file_size),
                         file_size,
                         prefix='Uploading',

--- a/synapseclient/core/upload/multipart_upload.py
+++ b/synapseclient/core/upload/multipart_upload.py
@@ -27,7 +27,6 @@ from typing import List, Mapping
 
 from synapseclient.core import pool_provider
 from synapseclient.core.constants import concrete_types
-from synapseclient.core.cumulative_transfer_progress import printTransferProgress
 from synapseclient.core.exceptions import (
     _raise_for_status,  # why is is this a single underscore
     SynapseHTTPError,

--- a/tests/unit/synapseclient/core/multithread_download/unit_test_download_threads.py
+++ b/tests/unit/synapseclient/core/multithread_download/unit_test_download_threads.py
@@ -388,9 +388,8 @@ class MultithreadedDownloaderTests(TestCase):
         downloader._write_chunks(request, completed_futures, transfer_status)
         assert not mock_open.called
 
-    @mock.patch.object(download_threads, 'printTransferProgress')
     @mock.patch.object(download_threads, 'open')
-    def test_write_chunks(self, mock_open, mock_print_transfer_progress):
+    def test_write_chunks(self, mock_open):
         """Verify expected behavior writing out chunks to disk"""
         request = mock.Mock(path='/tmp/foo')
 
@@ -431,7 +430,7 @@ class MultithreadedDownloaderTests(TestCase):
         assert expected_writes == mock_write.write.call_args_list
 
         assert sum(len(c) for c in chunks) == transfer_status.transferred
-        assert expected_print_transfer_progresses == mock_print_transfer_progress.call_args_list
+        assert expected_print_transfer_progresses == downloader._syn._print_transfer_progress.call_args_list
 
     def test_check_for_errors__no_errors(self):
         """Verify check_for_errors when there were no errors"""

--- a/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
+++ b/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
@@ -788,8 +788,7 @@ class TestMultipartUpload:
             'associateObjectType': associate_object_type,
         }
 
-        with mock.patch.object(multipart_upload, '_multipart_upload') as mock_multipart_upload, \
-                mock.patch.object(multipart_upload, 'printTransferProgress') as mock_print_progress:
+        with mock.patch.object(multipart_upload, '_multipart_upload') as mock_multipart_upload:
             expected_upload_request = {
                 'concreteType': 'org.sagebionetworks.repo.model.file.MultipartUploadCopyRequest',
                 'fileName': None,
@@ -817,7 +816,7 @@ class TestMultipartUpload:
                 max_threads=None,
             )
 
-            assert not mock_print_progress.called
+            assert not syn._print_transfer_progress.called
 
     def test_multipart_copy__explicit_args(self):
         """Test multipart copy explicitly defining all args.
@@ -837,8 +836,7 @@ class TestMultipartUpload:
 
         storage_location_id = 5432
 
-        with mock.patch.object(multipart_upload, '_multipart_upload') as mock_multipart_upload, \
-                mock.patch.object(multipart_upload, 'printTransferProgress') as mock_print_progress:
+        with mock.patch.object(multipart_upload, '_multipart_upload') as mock_multipart_upload:
 
             # call specifying all optional kwargs
             kwargs = {
@@ -875,7 +873,7 @@ class TestMultipartUpload:
                 max_threads=kwargs['max_threads'],
             )
 
-            assert not mock_print_progress.called
+            assert not syn._print_transfer_progress.called
 
     def _multipart_upload_test(self, upload_side_effect, syn, *args, **kwargs):
         with mock.patch.object(

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -36,6 +36,7 @@ from synapseclient.core.exceptions import (
     SynapseMd5MismatchError,
     SynapseUnmetAccessRestrictions,
 )
+from synapseclient.core.logging_setup import DEFAULT_LOGGER_NAME, DEBUG_LOGGER_NAME, SILENT_LOGGER_NAME
 from synapseclient.core.upload import upload_functions
 import synapseclient.core.utils as utils
 from synapseclient.client import DEFAULT_STORAGE_LOCATION_ID
@@ -383,6 +384,7 @@ class TestDownloadFileHandle:
             key,
             destination,
             credentials=credentials,
+            show_progress=True,
             transfer_config_kwargs={'max_concurrency': self.syn.max_threads},
         )
 
@@ -2543,3 +2545,46 @@ class TestTableQuery:
             )
 
             assert (mock_download_result, expected_path) == actual_result
+
+
+class TestSilentCommandAndLogger:
+
+    def setup(self):
+        """
+        Set up three different synapse objects
+        """
+        self.syn = Synapse(debug=False, skip_checks=True)
+        self.syn_with_silent = Synapse(silent=True, debug=False, skip_checks=True)
+        self.syn_with_debug = Synapse(silent=False, debug=True, skip_checks=True)
+
+    def test_syn_silent(self):
+        """
+        Verify the silent property is set up correctly
+        """
+        assert self.syn.silent is None
+        assert self.syn_with_silent.silent is True
+        assert self.syn_with_debug.silent is False
+
+    def test_syn_logger_name(self):
+        """
+        According to the properties silent and debug, logger name should be different
+        """
+        assert self.syn.logger.name == DEFAULT_LOGGER_NAME
+        assert self.syn_with_silent.logger.name == SILENT_LOGGER_NAME
+        assert self.syn_with_debug.logger.name == DEBUG_LOGGER_NAME
+
+    @patch.object(client, 'cumulative_transfer_progress')
+    def test_print_transfer_progress(self, mock_ctp):
+        """
+        Verify the private method print_transfer_progress will run with property self.silent accordingly
+        """
+        mock_kwargs = {
+            'isBytes': False,
+            'dt': 10
+        }
+        self.syn_with_silent._print_transfer_progress("transferred", "toBeTransferred", 'Downloading ', mock_kwargs)
+        mock_ctp.printTransferProgress.assert_not_called()
+
+        self.syn._print_transfer_progress("transferred", "toBeTransferred", 'Downloading ', mock_kwargs)
+        mock_ctp.printTransferProgress.assert_called_once_with("transferred", "toBeTransferred", 'Downloading ',
+                                                               mock_kwargs)

--- a/tests/unit/synapseclient/unit_test_commandline.py
+++ b/tests/unit/synapseclient/unit_test_commandline.py
@@ -2,12 +2,11 @@
 
 """
 
-import argparse
 import base64
 import os
 
 import pytest
-from unittest.mock import call, Mock, patch, MagicMock
+from unittest.mock import call, Mock, patch
 
 import synapseclient.__main__ as cmdline
 from synapseclient.core.exceptions import SynapseAuthenticationError, SynapseNoCredentialsError


### PR DESCRIPTION
change

- add silent mode option for command line and pass in as an argument to create Synapse instance
-  If silent is true, the logger will change to silent user and won't print out the transfer progress on terminal
- add unit test for commandline.py/ client.py/ remote_storage_file_wrappers.py