### PR TITLE
SYNPY-1103 multipart copy part size

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ data_files =\
     else []
 
 test_deps = [
-    "pytest>=5.0.0,<6.0",
+    "pytest>=5.0.0,<7.0",
+    "pytest-mock>=3.0,<4.0",
     "flake8>=3.7.0,<4.0"
 ]
 

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -513,16 +513,20 @@ def migrate(args, syn):
             force=args.force,
         )
 
-        counts = result.get_counts_by_status()
-        migrated_count = counts['MIGRATED']
-        errored_count = counts['ERRORED']
+        if result:
+            # result is None if not using the arg and the user declined to
+            # continue with the migration
 
-        logging.info(
-            "Completed migration of %s. %s files migrated. %s errors encountered",
-            args.id,
-            migrated_count,
-            errored_count,
-        )
+            counts = result.get_counts_by_status()
+            migrated_count = counts['MIGRATED']
+            errored_count = counts['ERRORED']
+
+            logging.info(
+                "Completed migration of %s. %s files migrated. %s errors encountered",
+                args.id,
+                migrated_count,
+                errored_count,
+            )
 
     if args.csv_log_path:
         logging.info("Writing csv log to %s", args.csv_log_path)


### PR DESCRIPTION
Use the part size recommended in https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/MultipartUploadCopyRequest.html rather than using the same default part size as an upload. In particular ensure that we don't exceed the maximum 10000 part limit (this was being enforced for uploads but not for copies).

Also fixes an issue where if you declined to proceed with a migration it would produce an exception rather than exiting cleanly.