### PR TITLE
SYNPY-1115 table provenance not applied on a store

### DIFF
--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -11,7 +11,7 @@ import urllib.request as urllib_request
 import uuid
 
 import pytest
-from unittest.mock import ANY, call, create_autospec, Mock, patch
+from unittest.mock import ANY, call, create_autospec, MagicMock, Mock, patch
 
 import synapseclient
 from synapseclient.annotations import convert_old_annotation_json
@@ -35,6 +35,7 @@ from synapseclient.core.exceptions import (
     SynapseFileNotFoundError,
     SynapseHTTPError,
     SynapseMd5MismatchError,
+    SynapseProvenanceError,
     SynapseUnmetAccessRestrictions,
 )
 from synapseclient.core.upload import upload_functions
@@ -2131,6 +2132,82 @@ def test_store__existing_no_update(syn):
 
         # should not have attempted an update
         assert not mock_updatentity.called
+
+
+def test_store_self_stored_obj__provenance_applied(syn):
+    """Verify that any object with its own _synapse_store mechanism (e.g. a table) will have
+    any passed provenance applied"""
+
+    obj = Mock()
+    del obj._before_synapse_store
+    obj._synapse_store = lambda x: x
+
+    activity_kwargs = {
+        'activity': MagicMock(spec=synapseclient.Activity),
+        'activityName': 'test name',
+        'activityDescription': 'test description',
+        'used': ['syn123'],
+        'executed': ['syn456'],
+    }
+
+    with patch.object(syn, '_apply_provenance') as mock_apply_provenance:
+        stored = syn.store(obj, **activity_kwargs)
+        assert mock_apply_provenance.called_once_with(obj, **activity_kwargs)
+        assert stored == mock_apply_provenance.return_value
+
+
+def test_apply_provenance__duplicate_args(syn):
+    """Verify that a SynapseProvenanceError is raised if both used/executed and an Activity is passed"""
+    with pytest.raises(SynapseProvenanceError):
+        syn._apply_provenance(
+            Mock(),
+            activity=MagicMock(spec=synapseclient.Activity),
+            used=['syn123'],
+            executed=['syn456'],
+            activityName='test name',
+            activityDescription='test description',
+        )
+
+
+def test_apply_provenance__activity(syn):
+    """Verify _apply_provenance behavior when an Activity is passed"""
+
+    obj = Mock()
+    activity = synapseclient.Activity(used=['syn123'])
+    with patch.object(syn, 'setProvenance') as mock_set_provenance, \
+            patch.object(syn, '_getEntity') as mock_get_entity:
+        result = syn._apply_provenance(obj, activity=activity)
+
+        mock_set_provenance.assert_called_once_with(obj, activity)
+        mock_get_entity.assert_called_once_with(obj)
+        assert result is mock_get_entity.return_value
+
+
+def test_apply_provenance__used_executed(syn):
+    """Verify _apply_provenance behavior with used and executed args"""
+
+    obj = Mock()
+
+    used = ['syn123']
+    executed = ['syn456']
+    name = 'test name'
+    description = 'test description'
+
+    expected_activity = synapseclient.Activity(used=used, executed=executed, name=name, description=description)
+
+    with patch.object(syn, 'setProvenance') as mock_set_provenance, \
+            patch.object(syn, '_getEntity') as mock_get_entity:
+        result = syn._apply_provenance(
+            obj,
+            used=used,
+            executed=executed,
+            activityName=name,
+            activityDescription=description
+        )
+
+        mock_set_provenance.assert_called_once_with(obj, expected_activity)
+        mock_get_entity.assert_called_once_with(obj)
+        assert result is mock_get_entity.return_value
 
 
 def test_get_submission_with_annotations(syn):


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/SYNPY-1115

Table objects have a defined **_synapse_store** method which short circuits the normal entity storage during a Synapse#store. This also prevents any passed provenance from being applied to a table during a table store.

This factors out the provenance handling into a private helper that is also used to apply provenance after an object is stored via a _synape_store call.