### PR TITLE
SYNPY-1114 containerized sftp integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,15 +90,18 @@ jobs:
             mv test.synapseConfig ~/.synapseConfig
 
             if [ "${{ startsWith(matrix.os, 'ubuntu') }}" == "true" ]; then
-              # on linux only we can build and run a docker container to handle be an SFTP host for our SFTP tests
+              # on linux only we can build and run a docker container to serve as an SFTP host for our SFTP tests.
+              # Docker is not available on GH Action runners on Mac and Windows.
 
               docker build -t sftp_tests - < tests/integration/synapseclient/core/upload/Dockerfile_sftp
               docker run -d sftp_tests:latest
+
+              # get the internal IP address of the just launched container
               export SFTP_HOST=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker ps -q))
 
               printf "[sftp://$SFTP_HOST]\nusername: test\npassword: test\n" >> ~/.synapseConfig
 
-              # host used in pysftp tests
+              # add to known_hosts so the ssh connections can be made without any prompting/errors
               mkdir -p ~/.ssh
               ssh-keyscan -H $SFTP_HOST >> ~/.ssh/known_hosts
             fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
+
+        # if changing the below change the run-integration-tests versions and the check-deploy versions
         python: [3.6, 3.7, 3.8, 3.9]
 
     runs-on: ${{ matrix.os }}
@@ -75,19 +77,31 @@ jobs:
       # the target server where N is the number of supported python versions.
       - name: run-integration-tests
         shell: bash
+
+        # keep versions consistent with the first and last from the strategy matrix
         if: ${{ contains(fromJSON('[3.6, 3.9]'), matrix.python) }}
         run: |
           if [ -z "${{ secrets.encrypted_d17283647768_key }}" ]  || [ -z "${{ secrets.encrypted_d17283647768_key }}" ]; then
             echo "No test configuration decryption keys available, skipping integration tests"
 
           else
-            # host used in pysftp tests
-            mkdir -p ~/.ssh
-            ssh-keyscan -H ec2-54-159-43-147.compute-1.amazonaws.com >> ~/.ssh/known_hosts
-
             # decrypt the encrypted test synapse configuration
             openssl aes-256-cbc -K ${{ secrets.encrypted_d17283647768_key }} -iv ${{ secrets.encrypted_d17283647768_iv }} -in test.synapseConfig.enc -out test.synapseConfig -d
             mv test.synapseConfig ~/.synapseConfig
+
+            if [ "${{ startsWith(matrix.os, 'ubuntu') }}" == "true" ]; then
+              # on linux only we can build and run a docker container to handle be an SFTP host for our SFTP tests
+
+              docker build -t sftp_tests - < tests/integration/synapseclient/core/upload/Dockerfile_sftp
+              docker run -d sftp_tests:latest
+              export SFTP_HOST=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker ps -q))
+
+              printf "[sftp://$SFTP_HOST]\nusername: test\npassword: test\n" >> ~/.synapseConfig
+
+              # host used in pysftp tests
+              mkdir -p ~/.ssh
+              ssh-keyscan -H $SFTP_HOST >> ~/.ssh/known_hosts
+            fi
 
             pytest -sv tests/integration
           fi
@@ -233,7 +247,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
-        python: [3.6, 3.7, 3.8]
+
+        # python versions should be consistent with the strategy matrix and the runs-integration-tests versions
+        python: [3.6, 3.7, 3.8, 3.9]
 
     runs-on: ${{ matrix.os }}
 

--- a/tests/integration/synapseclient/core/upload/Dockerfile_sftp
+++ b/tests/integration/synapseclient/core/upload/Dockerfile_sftp
@@ -1,0 +1,8 @@
+FROM ubuntu:latest
+RUN apt update && apt install  openssh-server sudo -y
+RUN useradd -m -s /bin/sh test
+#RUN useradd -rm -d /home/ubuntu -s /bin/bash -g root -G sudo -u 1000 test 
+RUN  echo 'test:test' | chpasswd
+RUN service ssh start
+EXPOSE 22
+CMD ["/usr/sbin/sshd","-D"]

--- a/tests/integration/synapseclient/core/upload/Dockerfile_sftp
+++ b/tests/integration/synapseclient/core/upload/Dockerfile_sftp
@@ -1,8 +1,11 @@
+# a Docker image with a running SSH service that can be used with the SFTP integration tests.
+# A username/password test/test user is available to test with.
+
 FROM ubuntu:latest
-RUN apt update && apt install  openssh-server sudo -y
+RUN apt update && apt install  openssh-server -y
 RUN useradd -m -s /bin/sh test
-#RUN useradd -rm -d /home/ubuntu -s /bin/bash -g root -G sudo -u 1000 test 
-RUN  echo 'test:test' | chpasswd
+RUN echo 'test:test' | chpasswd
 RUN service ssh start
 EXPOSE 22
 CMD ["/usr/sbin/sshd","-D"]
+

--- a/tests/integration/synapseclient/core/upload/test_sftp_upload.py
+++ b/tests/integration/synapseclient/core/upload/test_sftp_upload.py
@@ -8,31 +8,63 @@ import tempfile
 import shutil
 
 import pytest
+import unittest
 
 from synapseclient import File
 import synapseclient.core.utils as utils
 from synapseclient.core.remote_file_storage_wrappers import SFTPWrapper
 
-SFTP_SERVER_PREFIX = "sftp://ec2-54-159-43-147.compute-1.amazonaws.com"
-SFTP_USER_HOME_PATH = "/home/sftpuser"
 
-DESTINATIONS = [{"uploadType": "SFTP",
-                 "description": 'EC2 subfolder A',
-                 "supportsSubfolders": True,
-                 "url": SFTP_SERVER_PREFIX + SFTP_USER_HOME_PATH + "/folder_A",
-                 "banner": "Uploading file to EC2\n"},
-                {"uploadType": "SFTP",
-                 "supportsSubfolders": True,
-                 "description": 'EC2 subfolder B',
-                 "url": SFTP_SERVER_PREFIX + SFTP_USER_HOME_PATH + "/folder_B",
-                 "banner": "Uploading file to EC2 version 2\n"}
-                ]
+def get_sftp_server_prefix():
+    return f"sftp://{os.environ.get('SFTP_HOST')}/"
+
+
+def get_user_home_path(username):
+    return f"/home/{username}"
+
+
+def check_test_preconditions():
+    # in order to run SFTP tests an SFTP_HOST (a domain or IP) must be defined
+    # that maps to credentials in the synapse config
+
+    skip_tests = False
+    reason = ''
+    if not os.environ.get('SFTP_HOST'):
+        skip_tests = True
+        reason = 'SFTP_HOST environment variable not set'
+
+    return skip_tests, reason
 
 
 @pytest.fixture(scope="module", autouse=True)
+@unittest.skipIf(*check_test_preconditions())
 def project_setting_id(request, syn, project):
+    server_prefix = get_sftp_server_prefix()
+    username, _ = syn._getUserCredentials(server_prefix)
+    user_home_path = get_user_home_path(username)
+
+    external_storage_destination_settings = [
+        {
+            "uploadType": "SFTP",
+            "description": 'subfolder A',
+            "supportsSubfolders": True,
+            "url": server_prefix + user_home_path + "/folder_A",
+            "banner": "Uploading file to EC2\n"
+        },
+        {
+            "uploadType": "SFTP",
+            "supportsSubfolders": True,
+            "description": 'subfolder B',
+            "url": server_prefix + username + "/folder_B",
+            "banner": "Uploading file to EC2 version 2\n"
+        }
+    ]
+
     # Create the upload destinations
-    destinations = [syn.createStorageLocationSetting('ExternalStorage', **x)['storageLocationId'] for x in DESTINATIONS]
+    destinations = [
+        syn.createStorageLocationSetting('ExternalStorage', **x)['storageLocationId']
+        for x in external_storage_destination_settings
+    ]
 
     sftp_project_setting_id = syn.setStorageLocation(project, destinations)['id']
 
@@ -41,6 +73,7 @@ def project_setting_id(request, syn, project):
     request.addfinalizer(delete_project_setting)
 
 
+@unittest.skipIf(*check_test_preconditions())
 def test_synStore_sftpIntegration(syn, project, schedule_for_cleanup):
     """Creates a File Entity on an sftp server and add the external url. """
     filepath = utils.make_bogus_binary_file(1 * utils.MB - 777771)
@@ -65,31 +98,37 @@ def test_synStore_sftpIntegration(syn, project, schedule_for_cleanup):
             print(traceback.format_exc())
 
 
+@unittest.skipIf(*check_test_preconditions())
 def test_synGet_sftpIntegration(syn, project):
     # Create file by uploading directly to sftp and creating entity from URL
-    serverURL = SFTP_SERVER_PREFIX + SFTP_USER_HOME_PATH + '/test_synGet_sftpIntegration/' + str(uuid.uuid1())
+    server_prefix = get_sftp_server_prefix()
+    username, password = syn._getUserCredentials(server_prefix)
+    server_url = server_prefix + get_user_home_path(username) + '/test_synGet_sftpIntegration/' + str(uuid.uuid1())
     filepath = utils.make_bogus_binary_file(1 * utils.MB - 777771)
 
-    username, password = syn._getUserCredentials(SFTP_SERVER_PREFIX)
-
-    url = SFTPWrapper.upload_file(filepath, url=serverURL, username=username, password=password)
+    url = SFTPWrapper.upload_file(filepath, url=server_url, username=username, password=password)
     file = syn.store(File(path=url, parent=project, synapseStore=False))
 
     junk = syn.get(file, downloadLocation=os.getcwd(), downloadFile=True)
     filecmp.cmp(filepath, junk.path)
 
 
+@unittest.skipIf(*check_test_preconditions())
 def test_utils_sftp_upload_and_download(syn):
     """Tries to upload a file to an sftp file """
-    serverURL = SFTP_SERVER_PREFIX + SFTP_USER_HOME_PATH + '/test_utils_sftp_upload_and_download/' + str(uuid.uuid1())
+    server_prefix = get_sftp_server_prefix()
+    username, password = syn._getUserCredentials(server_prefix)
+    user_home_path = get_user_home_path(username)
+
+    server_url = server_prefix + user_home_path + '/test_utils_sftp_upload_and_download/' + str(uuid.uuid1())
     filepath = utils.make_bogus_binary_file(1 * utils.MB - 777771)
 
     tempdir = tempfile.mkdtemp()
 
-    username, password = syn._getUserCredentials(SFTP_SERVER_PREFIX)
+    username, password = syn._getUserCredentials(server_prefix)
 
     try:
-        url = SFTPWrapper.upload_file(filepath, url=serverURL, username=username, password=password)
+        url = SFTPWrapper.upload_file(filepath, url=server_url, username=username, password=password)
 
         # Get with a specified localpath
         junk = SFTPWrapper.download_file(url, tempdir, username=username, password=password)


### PR DESCRIPTION
This replaces the use of a fixed EC2 instance as a storage location for Python integration tests with a container that is created during the GH Actions CI run.

This is simpler and has no external dependency. The one downside is that Windows and Mac integration tests cannot use it because GH Actions doesn't support containers for those platforms, and you can't share a container across matrix jobs.

The SFTP integration tests look for an "SFTP_HOST" environment variable and will test against those, using matching credentials found in the synapseConfig.