### PR TITLE
SYNPY-1111 handle no quiz result 404

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -604,8 +604,15 @@ class Synapse(object):
         # Check if userid or username exists
         syn_user = self.getUserProfile(user)
         # Get passing record
-        certification_status = self._get_certified_passing_record(syn_user['ownerId'])
-        return certification_status['passed']
+
+        try:
+            certification_status = self._get_certified_passing_record(syn_user['ownerId'])
+            return certification_status['passed']
+        except SynapseHTTPError as ex:
+            if ex.response.status_code == 404:
+                # user hasn't taken the quiz
+                return False
+            raise
 
     def onweb(self, entity, subpageId=None):
         """Opens up a browser window to the entity page or wiki-subpage.

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -2610,6 +2610,22 @@ def test_is_certified(response, syn):
         assert is_certified is response
 
 
+def test_is_certified__no_quiz_results(syn):
+    """Verify handling of a user that hasn't taken the quiz at all.
+    In this case the back end returns a 404 rather than a result."""
+    response = MagicMock(requests.Response)
+    response.status_code = 404
+    with patch.object(syn, "getUserProfile",
+                      return_value={"ownerId": "foobar"}) as patch_get_user,\
+         patch.object(syn,
+                      "_get_certified_passing_record",
+                      side_effect=SynapseHTTPError(response=response)) as patch_get_cert:
+        is_certified = syn.is_certified("test")
+    patch_get_user.assert_called_once_with("test")
+    patch_get_cert.assert_called_once_with("foobar")
+    assert is_certified is False
+
+
 def test_init_change_cache_path():
     """
     Verify that the user can customize the cache path.


### PR DESCRIPTION
If a user hasn't taken the quiz at all the backend returns a 404. We should handle that and return False from is_certified.