### PR TITLE
SYNPY-1119 add option to limit storage location migration to specific source storage locations

### DIFF
--- a/docs/S3Storage.rst
+++ b/docs/S3Storage.rst
@@ -200,7 +200,7 @@ of its contents using the
     import synapseutils
 
     entity_id = 'syn123'  # a Synapse entity whose contents need to be migrated, e.g. a Project or Folder
-    storage_location_id = '12345'  # the id of the storage location being migrated to
+    dest_storage_location_id = '12345'  # the id of the destination storage location being migrated to
 
     # a path on disk where this utility can create a sqlite database to store its index.
     # nothing needs to exist at this path, but it must be a valid path on a volume with sufficient
@@ -211,13 +211,14 @@ of its contents using the
     result = synapseutils.index_files_for_migration(
         syn,
         entity_id,
-        storage_location_id,
+        dest_storage_location_id,
         db_path,
 
         # optional args, see function documentation linked above for a description of these parameters
+        source_storage_location_ids=['54321', '98765'],
         file_version_strategy='new',
-        include_table_files=false,
-        continue_on_error=true
+        include_table_files=False,
+        continue_on_error=True
     )
 
 If called on a container (e.g. a Project or Folder) the *index_files_for_migration* function will recursively

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -472,8 +472,9 @@ def migrate(args, syn):
     result = synapseutils.index_files_for_migration(
         syn,
         args.id,
-        args.storage_location_id,
+        args.dest_storage_location_id,
         args.db_path,
+        source_storage_location_ids=args.source_storage_location_ids,
         file_version_strategy=args.file_version_strategy,
         include_table_files=args.include_table_files,
         continue_on_error=args.continue_on_error,
@@ -490,11 +491,12 @@ def migrate(args, syn):
         indexed_count + already_migrated_count,
         indexed_count,
         already_migrated_count,
-        args.storage_location_id,
+        args.dest_storage_location_id,
         errored_count
     )
 
     if indexed_count == 0:
+
         logging.info("No files found needing migration.")
 
     elif args.dryRun:
@@ -934,8 +936,11 @@ def build_parser():
         help='Migrate Synapse entities to a different storage location'
     )
     parser_migrate.add_argument('id', type=str, help='Synapse id')
-    parser_migrate.add_argument('storage_location_id', type=str, help='Synapse storage location id')
+    parser_migrate.add_argument('dest_storage_location_id', type=str, help='Destination Synapse storage location id')
     parser_migrate.add_argument('db_path', type=str, help='Local system path where a record keeping file can be stored')
+    parser_migrate.add_argument('--source_storage_location_ids', type=str, nargs='*',
+                                help="Source Synapse storage location ids. If specified only files in these storage "
+                                "locations will be migrated.")
     parser_migrate.add_argument('--file_version_strategy', type=str, default='new',
                                 help="""one of 'new', 'latest', 'all', 'skip'
                                      new creates a new version of each entity,

--- a/synapseutils/migrate_functions.py
+++ b/synapseutils/migrate_functions.py
@@ -313,7 +313,7 @@ def _ensure_schema(cursor):
     # ensure we have the sqlite schema we need to be able to record and sort our
     # entity file handle migration.
 
-    # one-row table records the parameters used to create the index
+    # one-row table of a json dictionary records the parameters used to create the index
     cursor.execute("create table if not exists migration_settings (settings text not null)")
 
     # our representation of migratable file handles is flat including both file entities
@@ -797,6 +797,7 @@ def _verify_storage_location_ownership(syn, storage_location_id):
 
 
 def _retrieve_index_settings(cursor):
+    # index settings are stored as a json-string in a one-row table
     import sqlite3
     settings = None
     try:

--- a/synapseutils/migrate_functions.py
+++ b/synapseutils/migrate_functions.py
@@ -929,8 +929,13 @@ def _index_file_entity(
         for (entity, version) in entity_versions:
             from_storage_location_id = entity._file_handle['storageLocationId']
 
-            if not source_storage_location_ids or str(from_storage_location_id) in source_storage_location_ids:
-                # if source_storage_location_ids specified we only index files that were among those
+            if (
+                    not source_storage_location_ids or
+                    str(from_storage_location_id) in source_storage_location_ids or
+                    str(from_storage_location_id) == str(to_storage_location_id)
+            ):
+                # we only include files that are among the relevant storage locations
+                # in the index. files in storage locations we aren't migrating to or from aren't included.
 
                 migration_status = _MigrationStatus.INDEXED.value \
                     if str(from_storage_location_id) != str(to_storage_location_id) \
@@ -1022,7 +1027,15 @@ def _index_table_entity(
     for row_id, row_version, file_handles in _get_file_handle_rows(syn, entity_id):
         for col_id, file_handle in file_handles.items():
             existing_storage_location_id = file_handle['storageLocationId']
-            if not source_storage_location_ids or existing_storage_location_id in source_storage_location_ids:
+
+            if (
+                    not source_storage_location_ids or
+                    str(existing_storage_location_id) in source_storage_location_ids or
+                    str(existing_storage_location_id) == str(dest_storage_location_id)
+            ):
+                # we only include files that are among the relevant storage locations
+                # in the index. files in storage locations we aren't migrating to or from aren't included.
+
                 migration_status = _MigrationStatus.INDEXED.value \
                     if str(dest_storage_location_id) != str(existing_storage_location_id) \
                     else _MigrationStatus.ALREADY_MIGRATED.value

--- a/synapseutils/migrate_functions.py
+++ b/synapseutils/migrate_functions.py
@@ -797,18 +797,18 @@ def _verify_storage_location_ownership(syn, storage_location_id):
 
 
 def _retrieve_index_settings(cursor):
-    results = cursor.execute("select settings from migration_settings")
-
-    row = results.fetchone()
+    import sqlite3
     settings = None
-    if row:
-        try:
+    try:
+        results = cursor.execute("select settings from migration_settings")
+        row = results.fetchone()
+        if row:
             settings = json.loads(row[0])
-        except ValueError as ex:
-            raise ValueError(
-                "Unable to parse index settings, the index may be corrupt or created by an older version "
-                "of this function. You will need to re-create the index."
-            ) from ex
+    except (sqlite3.OperationalError, ValueError) as ex:
+        raise ValueError(
+            "Unable to parse index settings, the index may be corrupt or created by an older version "
+            "of this function. You will need to re-create the index."
+        ) from ex
 
     return settings
 

--- a/tests/unit/synapseclient/unit_test_commandline.py
+++ b/tests/unit/synapseclient/unit_test_commandline.py
@@ -43,7 +43,7 @@ def test_migrate__default_args(syn):
     when using the default options"""
 
     entity_id = 'syn12345'
-    storage_location_id = '98766'
+    dest_storage_location_id = '98766'
     db_path = '/tmp/foo/bar'
 
     parser = cmdline.build_parser()
@@ -52,12 +52,12 @@ def test_migrate__default_args(syn):
     args = parser.parse_args([
         'migrate',
         'syn12345',
-        storage_location_id,
+        dest_storage_location_id,
         db_path,
     ])
 
     assert args.id == entity_id
-    assert args.storage_location_id == storage_location_id
+    assert args.dest_storage_location_id == dest_storage_location_id
     assert args.db_path == db_path
     assert args.file_version_strategy == 'new'
     assert args.include_table_files is False
@@ -72,7 +72,8 @@ def test_migrate__fully_specified_args(mocker, syn):
     when the arguments are fully specified"""
 
     entity_id = 'syn12345'
-    storage_location_id = '98766'
+    dest_storage_location_id = '98766'
+    source_storage_location_ids = ['12345', '23456']
     db_path = '/tmp/foo/bar'
 
     parser = cmdline.build_parser()
@@ -81,8 +82,9 @@ def test_migrate__fully_specified_args(mocker, syn):
     args = parser.parse_args([
         'migrate',
         entity_id,
-        storage_location_id,
+        dest_storage_location_id,
         db_path,
+        '--source_storage_location_ids', *source_storage_location_ids,
         '--file_version_strategy', 'all',
         '--dryRun',
         '--include_table_files',
@@ -92,7 +94,8 @@ def test_migrate__fully_specified_args(mocker, syn):
     ])
 
     assert args.id == entity_id
-    assert args.storage_location_id == storage_location_id
+    assert args.dest_storage_location_id == dest_storage_location_id
+    assert args.source_storage_location_ids == source_storage_location_ids
     assert args.db_path == db_path
     assert args.file_version_strategy == 'all'
     assert args.include_table_files is True
@@ -110,8 +113,9 @@ def test_migrate__fully_specified_args(mocker, syn):
     mock_index.assert_called_once_with(
         syn,
         args.id,
-        args.storage_location_id,
+        args.dest_storage_location_id,
         args.db_path,
+        source_storage_location_ids=args.source_storage_location_ids,
         file_version_strategy='all',
         include_table_files=True,
         continue_on_error=True,

--- a/tests/unit/synapseutils/unit_test_synapseutils_migrate.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_migrate.py
@@ -225,7 +225,15 @@ class TestIndex:
         }
         syn.get.return_value = mock_file
 
-        _index_file_entity(cursor, syn, entity_id, parent_id, to_storage_location_id, file_version_strategy)
+        _index_file_entity(
+            cursor,
+            syn,
+            entity_id,
+            parent_id,
+            to_storage_location_id,
+            [from_storage_location_id],
+            file_version_strategy,
+        )
 
         row = cursor.execute(
             """
@@ -292,6 +300,8 @@ class TestIndex:
         mock_file_3_size = 1234
         mock_file_3._file_handle = {
             'contentSize': mock_file_3_size,
+
+            # already migrated
             'storageLocationId': to_storage_location_id
         }
         mock_file_3.versionNumber = 3
@@ -307,7 +317,15 @@ class TestIndex:
             {'versionNumber': 3},
         ]
 
-        _index_file_entity(cursor, syn, entity_id, parent_id, to_storage_location_id, 'all')
+        _index_file_entity(
+            cursor,
+            syn,
+            entity_id,
+            parent_id,
+            to_storage_location_id,
+            None,
+            'all'
+        )
 
         result = cursor.execute(
             """
@@ -421,7 +439,7 @@ class TestIndex:
             file_handle_4,
         ]
 
-        _index_table_entity(cursor, syn, table_id, parent_id, to_storage_location_id)
+        _index_table_entity(cursor, syn, table_id, parent_id, to_storage_location_id, None)
 
         result = cursor.execute(
             """
@@ -480,7 +498,8 @@ class TestIndex:
         parent_id = 'syn321'
         file_id = 'syn456'
         sub_folder_id = 'syn654'
-        storage_location_id = '1234'
+        dest_storage_location_id = '1234'
+        source_storage_location_ids = ['3333', '4444']
         file_version_strategy = 'new'
         include_table_files = False
         continue_on_error = True
@@ -511,7 +530,8 @@ class TestIndex:
             syn,
             project,
             parent_id,
-            storage_location_id,
+            dest_storage_location_id,
+            source_storage_location_ids,
             file_version_strategy,
             include_table_files,
             continue_on_error,
@@ -528,7 +548,8 @@ class TestIndex:
                     syn,
                     child,
                     project_id,
-                    storage_location_id,
+                    dest_storage_location_id,
+                    source_storage_location_ids,
                     file_version_strategy,
                     include_table_files,
                     continue_on_error
@@ -564,7 +585,8 @@ class TestIndex:
         folder_id = 'syn123'
         parent_id = 'syn321'
         table_id = 'syn456'
-        storage_location_id = '1234'
+        dest_storage_location_id = '1234'
+        source_storage_location_ids = ['1111', '2222']
         file_version_strategy = 'skip'
         include_table_files = True
         continue_on_error = False
@@ -589,7 +611,8 @@ class TestIndex:
             syn,
             folder,
             parent_id,
-            storage_location_id,
+            dest_storage_location_id,
+            source_storage_location_ids,
             file_version_strategy,
             include_table_files,
             continue_on_error,
@@ -604,7 +627,8 @@ class TestIndex:
                 syn,
                 table_dict,
                 folder_id,
-                storage_location_id,
+                dest_storage_location_id,
+                source_storage_location_ids,
                 file_version_strategy,
                 include_table_files,
                 continue_on_error
@@ -636,7 +660,8 @@ class TestIndex:
         cursor = conn.cursor()
         syn = mock.MagicMock(synapseclient.Synapse)
         parent_id = 'syn123'
-        storage_location_id = '1234'
+        dest_storage_location_id = '1234'
+        source_storage_location_ids = ['1111', '2222']
         file_version_strategy = 'new'
         include_table_files = True
         continue_on_error = True
@@ -655,7 +680,8 @@ class TestIndex:
             syn,
             entity,
             parent_id,
-            storage_location_id,
+            dest_storage_location_id,
+            source_storage_location_ids,
             file_version_strategy,
             include_table_files,
             continue_on_error
@@ -675,7 +701,8 @@ class TestIndex:
 
         syn = mock.MagicMock(synapseclient.Synapse)
         parent_id = 'syn123'
-        storage_location_id = '1234'
+        dest_storage_location_id = '1234'
+        source_storage_location_ids = ['1111', '2222']
         file_version_strategy = 'new'
         include_table_files = False
         continue_on_error = True
@@ -694,7 +721,8 @@ class TestIndex:
             syn,
             entity,
             parent_id,
-            storage_location_id,
+            dest_storage_location_id,
+            source_storage_location_ids,
             file_version_strategy,
             include_table_files,
             continue_on_error
@@ -706,7 +734,8 @@ class TestIndex:
             syn,
             entity_id,
             parent_id,
-            storage_location_id,
+            dest_storage_location_id,
+            source_storage_location_ids,
             file_version_strategy
         )
 
@@ -723,7 +752,8 @@ class TestIndex:
 
         syn = mock.MagicMock(synapseclient.Synapse)
         parent_id = 'syn123'
-        storage_location_id = '1234'
+        dest_storage_location_id = '1234'
+        source_storage_location_ids = ['1111', '2222']
         file_version_strategy = 'skip'
         include_table_files = True
         continue_on_error = True
@@ -742,7 +772,8 @@ class TestIndex:
             syn,
             entity,
             parent_id,
-            storage_location_id,
+            dest_storage_location_id,
+            source_storage_location_ids,
             file_version_strategy,
             include_table_files,
             continue_on_error
@@ -754,7 +785,8 @@ class TestIndex:
             syn,
             entity,
             parent_id,
-            storage_location_id
+            dest_storage_location_id,
+            source_storage_location_ids,
         )
 
         conn.commit.assert_called_once_with()
@@ -770,7 +802,8 @@ class TestIndex:
 
         syn = mock.MagicMock(synapseclient.Synapse)
         parent_id = 'syn123'
-        storage_location_id = '1234'
+        dest_storage_location_id = '1234'
+        source_storage_location_ids = ['1111', '2222']
         file_version_strategy = 'latest'
         include_table_files = False
         continue_on_error = True
@@ -789,7 +822,8 @@ class TestIndex:
             syn,
             entity,
             parent_id,
-            storage_location_id,
+            dest_storage_location_id,
+            source_storage_location_ids,
             file_version_strategy,
             include_table_files,
             continue_on_error
@@ -802,7 +836,8 @@ class TestIndex:
             syn,
             entity,
             parent_id,
-            storage_location_id,
+            dest_storage_location_id,
+            source_storage_location_ids,
             file_version_strategy,
             include_table_files,
             continue_on_error,
@@ -820,7 +855,8 @@ class TestIndex:
 
         syn = mock.MagicMock(synapseclient.Synapse)
         parent_id = 'syn123'
-        storage_location_id = '1234'
+        dest_storage_location_id = '1234'
+        source_storage_location_ids = ['1111', '2222']
         file_version_strategy = 'new'
         include_table_files = False
         continue_on_error = True
@@ -841,7 +877,8 @@ class TestIndex:
             syn,
             entity,
             parent_id,
-            storage_location_id,
+            dest_storage_location_id,
+            source_storage_location_ids,
             file_version_strategy,
             include_table_files,
             continue_on_error
@@ -853,7 +890,8 @@ class TestIndex:
             syn,
             entity_id,
             parent_id,
-            storage_location_id,
+            dest_storage_location_id,
+            source_storage_location_ids,
             file_version_strategy
         )
 
@@ -884,7 +922,8 @@ class TestIndex:
 
         syn = mock.MagicMock(synapseclient.Synapse)
         parent_id = 'syn123'
-        storage_location_id = '1234'
+        dest_storage_location_id = '1234'
+        source_storage_location_ids = ['1111', '2222']
         file_version_strategy = 'new'
         include_table_files = False
         continue_on_error = False
@@ -906,7 +945,8 @@ class TestIndex:
                 syn,
                 entity,
                 parent_id,
-                storage_location_id,
+                dest_storage_location_id,
+                source_storage_location_ids,
                 file_version_strategy,
                 include_table_files,
                 continue_on_error
@@ -921,7 +961,8 @@ class TestIndex:
 
         syn = mock.MagicMock(synapseclient.Synapse)
         entity_id = 'syn123'
-        storage_location_id = '1234'
+        dest_storage_location_id = '1234'
+        source_storage_location_ids = ['1111', '2222']
         db_path = '/tmp/foo'
         file_version_strategy = 'wizzle'  # invalid
         include_table_files = False
@@ -931,7 +972,8 @@ class TestIndex:
             index_files_for_migration(
                 syn,
                 entity_id,
-                storage_location_id,
+                dest_storage_location_id,
+                source_storage_location_ids,
                 db_path,
                 file_version_strategy,
                 include_table_files,
@@ -944,7 +986,8 @@ class TestIndex:
 
         syn = mock.MagicMock(synapseclient.Synapse)
         entity_id = 'syn123'
-        storage_location_id = '1234'
+        dest_storage_location_id = '1234'
+        source_storage_location_ids = ['1111', '2222']
         db_path = '/tmp/foo'
         file_version_strategy = 'skip'
         include_table_files = False
@@ -954,7 +997,8 @@ class TestIndex:
             index_files_for_migration(
                 syn,
                 entity_id,
-                storage_location_id,
+                dest_storage_location_id,
+                source_storage_location_ids,
                 db_path,
                 file_version_strategy,
                 include_table_files,
@@ -968,7 +1012,8 @@ class TestIndex:
     def test_index_files_for_migration(self, mock_sqlite_connect, mock_index_entity, mock_verify_index_settings):
         syn = mock.MagicMock(synapseclient.Synapse)
         entity_id = 'syn123'
-        storage_location_id = '1234'
+        dest_storage_location_id = '1234'
+        source_storage_location_ids = ['1111', '2222']
         db_path = '/tmp/foo'
         file_version_strategy = 'all'
         include_table_files = False
@@ -985,8 +1030,9 @@ class TestIndex:
         result = index_files_for_migration(
             syn,
             entity_id,
-            storage_location_id,
+            dest_storage_location_id,
             db_path,
+            source_storage_location_ids,
             file_version_strategy,
             include_table_files,
             continue_on_error
@@ -996,7 +1042,8 @@ class TestIndex:
             mock_cursor,
             db_path,
             entity_id,
-            storage_location_id,
+            dest_storage_location_id,
+            source_storage_location_ids,
             file_version_strategy,
             include_table_files
         )
@@ -1007,7 +1054,8 @@ class TestIndex:
             syn,
             entity,
             None,
-            storage_location_id,
+            dest_storage_location_id,
+            source_storage_location_ids,
             file_version_strategy,
             include_table_files,
             continue_on_error,
@@ -1027,7 +1075,8 @@ class TestIndex:
     ):
         syn = mock.MagicMock(synapseclient.Synapse)
         entity_id = 'syn123'
-        storage_location_id = '1234'
+        dest_storage_location_id = '1234'
+        source_storage_location_ids = ['1111', '2222']
         db_path = '/tmp/foo'
         file_version_strategy = 'all'
         include_table_files = False
@@ -1049,8 +1098,9 @@ class TestIndex:
             index_files_for_migration(
                 syn,
                 entity_id,
-                storage_location_id,
+                dest_storage_location_id,
                 db_path,
+                source_storage_location_ids,
                 file_version_strategy,
                 include_table_files,
                 continue_on_error
@@ -1061,7 +1111,8 @@ class TestIndex:
             mock_cursor,
             db_path,
             entity_id,
-            storage_location_id,
+            dest_storage_location_id,
+            source_storage_location_ids,
             file_version_strategy,
             include_table_files
         )
@@ -1072,7 +1123,8 @@ class TestIndex:
             syn,
             entity,
             None,
-            storage_location_id,
+            dest_storage_location_id,
+            source_storage_location_ids,
             file_version_strategy,
             include_table_files,
             continue_on_error,
@@ -1230,22 +1282,14 @@ class TestMigrate:
             cursor = conn.cursor()
             _ensure_schema(cursor)
 
-            cursor.execute(
-                """
-                    insert into migration_settings (
-                        root_id,
-                        storage_location_id,
-                        file_version_strategy,
-                        include_table_files
-                    ) values (?, ?, ?, ?)
-                """,
-                (
-                    project.id,
-                    new_storage_location_id,
-                    'new',
-                    1
-                )
-            )
+            settings_str = json.dumps({
+                'root_id': project.id,
+                'dest_storage_location_id': new_storage_location_id,
+                'source_storage_location_ids': [old_storage_location, '1234'],
+                'file_version_strategy': 'new',
+                'include_table_files': 1,
+            })
+            cursor.execute("insert into migration_settings (settings) values (?)", (settings_str,))
 
             migration_values = [
                 (
@@ -1702,10 +1746,7 @@ def _verify_schema(cursor):
 
     expected_table_columns = {
         'migration_settings': {
-            'root_id',
-            'storage_location_id',
-            'file_version_strategy',
-            'include_table_files'
+            'settings',
         },
         'migrations': {
             'id',
@@ -1770,7 +1811,8 @@ def test__verify_index_settings__retrieve_index_settings():
         _ensure_schema(cursor)
 
         root_id = 'syn123'
-        storage_location_id = '12345'
+        dest_storage_location_id = '12345'
+        source_storage_location_ids = ['54321', '87654']
         file_version_strategy = 'latest'
         include_table_files = False
 
@@ -1778,14 +1820,16 @@ def test__verify_index_settings__retrieve_index_settings():
             cursor,
             db_path,
             root_id,
-            storage_location_id,
+            dest_storage_location_id,
+            source_storage_location_ids,
             file_version_strategy,
             include_table_files
         )
 
         settings = _retrieve_index_settings(cursor)
         assert settings['root_id'] == root_id
-        assert settings['storage_location_id'] == storage_location_id
+        assert settings['dest_storage_location_id'] == dest_storage_location_id
+        assert settings['source_storage_location_ids'] == source_storage_location_ids
         assert settings['file_version_strategy'] == file_version_strategy
         assert settings['include_table_files'] == include_table_files
 
@@ -1794,7 +1838,8 @@ def test__verify_index_settings__retrieve_index_settings():
             cursor,
             db_path,
             root_id,
-            storage_location_id,
+            dest_storage_location_id,
+            source_storage_location_ids,
             file_version_strategy,
             include_table_files
         )
@@ -1805,7 +1850,8 @@ def test__verify_index_settings__retrieve_index_settings():
                 cursor,
                 db_path,
                 'changed',
-                storage_location_id,
+                dest_storage_location_id,
+                source_storage_location_ids,
                 file_version_strategy,
                 include_table_files
             )
@@ -1817,6 +1863,7 @@ def test__verify_index_settings__retrieve_index_settings():
                 db_path,
                 root_id,
                 'changed',
+                source_storage_location_ids,
                 file_version_strategy,
                 include_table_files
             )
@@ -1827,7 +1874,20 @@ def test__verify_index_settings__retrieve_index_settings():
                 cursor,
                 db_path,
                 root_id,
-                storage_location_id,
+                dest_storage_location_id,
+                'changed',
+                file_version_strategy,
+                include_table_files
+            )
+        assert 'changed' in str(ex.value)
+
+        with pytest.raises(ValueError) as ex:
+            _verify_index_settings(
+                cursor,
+                db_path,
+                root_id,
+                dest_storage_location_id,
+                source_storage_location_ids,
                 'changed',
                 include_table_files
             )
@@ -1838,7 +1898,8 @@ def test__verify_index_settings__retrieve_index_settings():
                 cursor,
                 db_path,
                 root_id,
-                storage_location_id,
+                dest_storage_location_id,
+                source_storage_location_ids,
                 file_version_strategy,
                 'changed'
             )

--- a/tests/unit/synapseutils/unit_test_synapseutils_migrate.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_migrate.py
@@ -1555,23 +1555,13 @@ def test_migrate__shared_file_handles(mocker, syn):
         cursor = conn.cursor()
         _ensure_schema(cursor)
 
-        cursor.execute(
-            """
-                insert into migration_settings (
-                    root_id,
-                    storage_location_id,
-                    file_version_strategy,
-                    include_table_files
-                ) values (?, ?, ?, ?)
-            """,
-            (
-                project.id,
-                new_storage_location_id,
-                'all',
-                0,
-            )
-        )
-
+        settings_str = json.dumps({
+            'root_id': project.id,
+            'dest_storage_location_id': new_storage_location_id,
+            'file_version_strategy': 'all',
+            'include_table_files': 0,
+        })
+        cursor.execute("insert into migration_settings (settings) values (?)", (settings_str,))
         cursor.executemany(
             """
                 insert into migrations (


### PR DESCRIPTION
Currently *synapseutils.index_files_for_migration* will index all files not already in the destination storage location. @Aryllen requested an option to limit migration to files in specific storage locations since it may be the case that she will have a Project/Folder with files in multiple storage locations and only wants those in the specific storage locations migrated.