### PR TITLE
SYNPY-1118 better migration handling for shared file handles

### DIFF
--- a/synapseutils/migrate_functions.py
+++ b/synapseutils/migrate_functions.py
@@ -619,7 +619,7 @@ def migrate_indexed_files(
         pending_file_handle_ids = set()
         completed_file_handle_ids = set()
 
-        # we keep track of the entity keys (e.d. syn id + version) so that we know
+        # we keep track of the entity keys (syn id + version) so that we know
         # if we encounter the same one twice. normally we wouldn't but when we backtrack
         # to update any entities skipped because of a shared file handle we might
         # query for the same key as is already being operated on.


### PR DESCRIPTION
Fixes an issue where file handles shared by multiple files could end up getting migrated twice concurrently, producing an error on the second attempt.