### PR TITLE
Synpy 198 error entity undownloadable

### DIFF
--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -119,6 +119,7 @@ def get(args, syn):
         if "path" in entity:
             syn.logger.info('Creating %s', entity.path)
 
+
 def sync(args, syn):
     synapseutils.syncToSynapse(syn, manifestFile=args.manifestFile,
                                dryRun=args.dryRun, sendMessages=args.sendMessages,

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -116,8 +116,8 @@ def get(args, syn):
             else:
                 syn.logger.info('WARNING: No files associated with entity %s\n', entity.id)
                 syn.logger.info(entity)
-        syn.logger.info('Creating %s', entity.path)
-
+        if "path" in entity:
+            syn.logger.info('Creating %s', entity.path)
 
 def sync(args, syn):
     synapseutils.syncToSynapse(syn, manifestFile=args.manifestFile,

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -721,22 +721,17 @@ class Synapse(object):
             version = kwargs.get('version', None)
             bundle = self._getEntityBundle(entity, version)
         # Check and warn for unmet access requirements
-        # self._check_entity_restrictions(bundle['restrictionInformation'], entity, kwargs.get('downloadFile', True))
-        self._check_entity_restrictions(bundle, kwargs.get('downloadFile', True))
+        self._check_entity_restrictions(bundle, entity, kwargs.get('downloadFile', True))
 
         return self._getWithEntityBundle(entityBundle=bundle, entity=entity, **kwargs)
 
-    # def _check_entity_restrictions(self, restrictionInformation, entity, downloadFile):
-    def _check_entity_restrictions(self, bundle, downloadFile):
+    def _check_entity_restrictions(self, bundle, entity, downloadFile):
         restrictionInformation = bundle['restrictionInformation']
         if restrictionInformation['hasUnmetAccessRequirement']:
             warning_message = ("\nThis entity has access restrictions. Please visit the web page for this entity "
                                "(syn.onweb(\"%s\")). Click the downward pointing arrow next to the file's name to "
-                               "review and fulfill its download requirement(s).\n" % id_of(bundle['entity']['id']))
-            # warning_message = ("\nThis entity has access restrictions. Please visit the web page for this entity "
-            #                    "(syn.onweb(\"%s\")). Click the downward pointing arrow next to the file's name to "
-            #                    "review and fulfill its download requirement(s).\n" % id_of(entity))
-            if downloadFile and bundle['entityType'] not in ["project", "folder"]:
+                               "review and fulfill its download requirement(s).\n" % id_of(entity))
+            if downloadFile and bundle.get('entityType') not in ('project', 'folder'):
                 raise SynapseUnmetAccessRestrictions(warning_message)
             warnings.warn(warning_message)
 

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -737,7 +737,6 @@ class Synapse(object):
             #                    "(syn.onweb(\"%s\")). Click the downward pointing arrow next to the file's name to "
             #                    "review and fulfill its download requirement(s).\n" % id_of(entity))
             if downloadFile and bundle['entityType'] not in ["project", "folder"]:
-            # if downloadFile:
                 raise SynapseUnmetAccessRestrictions(warning_message)
             warnings.warn(warning_message)
 

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -721,16 +721,23 @@ class Synapse(object):
             version = kwargs.get('version', None)
             bundle = self._getEntityBundle(entity, version)
         # Check and warn for unmet access requirements
-        self._check_entity_restrictions(bundle['restrictionInformation'], entity, kwargs.get('downloadFile', True))
+        # self._check_entity_restrictions(bundle['restrictionInformation'], entity, kwargs.get('downloadFile', True))
+        self._check_entity_restrictions(bundle, kwargs.get('downloadFile', True))
 
         return self._getWithEntityBundle(entityBundle=bundle, entity=entity, **kwargs)
 
-    def _check_entity_restrictions(self, restrictionInformation, entity, downloadFile):
+    # def _check_entity_restrictions(self, restrictionInformation, entity, downloadFile):
+    def _check_entity_restrictions(self, bundle, downloadFile):
+        restrictionInformation = bundle['restrictionInformation']
         if restrictionInformation['hasUnmetAccessRequirement']:
             warning_message = ("\nThis entity has access restrictions. Please visit the web page for this entity "
                                "(syn.onweb(\"%s\")). Click the downward pointing arrow next to the file's name to "
-                               "review and fulfill its download requirement(s).\n" % id_of(entity))
-            if downloadFile:
+                               "review and fulfill its download requirement(s).\n" % id_of(bundle['entity']['id']))
+            # warning_message = ("\nThis entity has access restrictions. Please visit the web page for this entity "
+            #                    "(syn.onweb(\"%s\")). Click the downward pointing arrow next to the file's name to "
+            #                    "review and fulfill its download requirement(s).\n" % id_of(entity))
+            if downloadFile and bundle['entityType'] not in ["project", "folder"]:
+            # if downloadFile:
                 raise SynapseUnmetAccessRestrictions(warning_message)
             warnings.warn(warning_message)
 

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -933,30 +933,99 @@ def test_getChildren__nextPageToken(syn):
 
 def test_check_entity_restrictions__no_unmet_restriction(syn):
     with patch("warnings.warn") as mocked_warn:
-        restriction_requirements = {'hasUnmetAccessRequirement': False}
+        bundle = {'entity': {
+                      'id': 'syn123',
+                      'name': 'anonymous',
+                      'concreteType': 'org.sagebionetworks.repo.model.FileEntity',
+                      'parentId': 'syn12345'},
+                  'restrictionInformation': {
+                      'hasUnmetAccessRequirement': False}
+                  }
+        syn._check_entity_restrictions(bundle, True)
+        # restriction_requirements = {'hasUnmetAccessRequirement': False}
 
-        syn._check_entity_restrictions(restriction_requirements, "syn123", True)
-
+        # syn._check_entity_restrictions(restriction_requirements, "syn123", True)
         mocked_warn.assert_not_called()
 
 
-def test_check_entity_restrictions__unmet_restriction_downloadFile_is_True(syn):
+def test_check_entity_restrictions__unmet_restriction_entity_file_with_downloadFile_is_True(syn):
     with patch("warnings.warn") as mocked_warn:
-        restriction_requirements = {'hasUnmetAccessRequirement': True}
+        bundle = {'entity': {
+                      'id': 'syn123',
+                      'name': 'anonymous',
+                      'concreteType': 'org.sagebionetworks.repo.model.FileEntity',
+                      'parentId': 'syn12345'},
+                  'entityType': 'file',
+                  'restrictionInformation': {
+                      'hasUnmetAccessRequirement': True}
+        }
+        pytest.raises(SynapseUnmetAccessRestrictions, syn._check_entity_restrictions, bundle, True)
 
-        pytest.raises(SynapseUnmetAccessRestrictions, syn._check_entity_restrictions, restriction_requirements,
-                      "syn123", True)
+        # restriction_requirements = {'hasUnmetAccessRequirement': True}
 
-        mocked_warn.assert_not_called()
+        # pytest.raises(SynapseUnmetAccessRestrictions, syn._check_entity_restrictions, restriction_requirements,
+        #               "syn123", True)
+
+    mocked_warn.assert_not_called()
+
+
+def test_check_entity_restrictions__unmet_restriction_entity_project_with_downloadFile_is_True(syn):
+    with patch("warnings.warn") as mocked_warn:
+        bundle = {'entity': {
+                      'id': 'syn123',
+                      'name': 'anonymous',
+                      'concreteType': 'org.sagebionetworks.repo.model.FileEntity',
+                      'parentId': 'syn12345'},
+                  'entityType': 'project',
+                  'restrictionInformation': {
+                      'hasUnmetAccessRequirement': True}
+        }
+        syn._check_entity_restrictions(bundle, True)
+    mocked_warn.assert_called_with('\nThis entity has access restrictions. Please visit the web page for this entity '
+                                   '(syn.onweb("syn123")). Click the downward pointing arrow next to the file\'s name '
+                                   'to review and fulfill its download requirement(s).\n')
+
+
+def test_check_entity_restrictions__unmet_restriction_entity_folder_with_downloadFile_is_True(syn):
+    with patch("warnings.warn") as mocked_warn:
+        bundle = {'entity': {
+                      'id': 'syn123',
+                      'name': 'anonymous',
+                      'concreteType': 'org.sagebionetworks.repo.model.FileEntity',
+                      'parentId': 'syn12345'},
+                  'entityType': 'folder',
+                  'restrictionInformation': {
+                      'hasUnmetAccessRequirement': True}
+        }
+        syn._check_entity_restrictions(bundle, True)
+    mocked_warn.assert_called_with('\nThis entity has access restrictions. Please visit the web page for this entity '
+                                   '(syn.onweb("syn123")). Click the downward pointing arrow next to the file\'s name '
+                                   'to review and fulfill its download requirement(s).\n')
 
 
 def test_check_entity_restrictions__unmet_restriction_downloadFile_is_False(syn):
     with patch("warnings.warn") as mocked_warn:
-        restriction_requirements = {'hasUnmetAccessRequirement': True}
-
-        syn._check_entity_restrictions(restriction_requirements, "syn123", False)
-
+        bundle = {'entity': {
+            'id': 'syn123',
+            'name': 'anonymous',
+            'concreteType': 'org.sagebionetworks.repo.model.FileEntity',
+            'parentId': 'syn12345'},
+            'entityType': 'file',
+            'restrictionInformation': {
+                'hasUnmetAccessRequirement': True}
+        }
+        syn._check_entity_restrictions(bundle, False)
+        # restriction_requirements = {'hasUnmetAccessRequirement': True}
+        # syn._check_entity_restrictions(restriction_requirements, "syn123", False)
         mocked_warn.assert_called_once()
+
+        bundle['entityType'] = 'project'
+        syn._check_entity_restrictions(bundle, False)
+        assert mocked_warn.call_count == 2
+
+        bundle['entityType'] = 'folder'
+        syn._check_entity_restrictions(bundle, False)
+        assert mocked_warn.call_count == 3
 
 
 class TestGetColumns(object):

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -958,7 +958,7 @@ def test_check_entity_restrictions__unmet_restriction_entity_file_with_downloadF
                   'entityType': 'file',
                   'restrictionInformation': {
                       'hasUnmetAccessRequirement': True}
-        }
+                  }
         pytest.raises(SynapseUnmetAccessRestrictions, syn._check_entity_restrictions, bundle, True)
 
         # restriction_requirements = {'hasUnmetAccessRequirement': True}
@@ -979,7 +979,7 @@ def test_check_entity_restrictions__unmet_restriction_entity_project_with_downlo
                   'entityType': 'project',
                   'restrictionInformation': {
                       'hasUnmetAccessRequirement': True}
-        }
+                  }
         syn._check_entity_restrictions(bundle, True)
     mocked_warn.assert_called_with('\nThis entity has access restrictions. Please visit the web page for this entity '
                                    '(syn.onweb("syn123")). Click the downward pointing arrow next to the file\'s name '
@@ -996,7 +996,7 @@ def test_check_entity_restrictions__unmet_restriction_entity_folder_with_downloa
                   'entityType': 'folder',
                   'restrictionInformation': {
                       'hasUnmetAccessRequirement': True}
-        }
+                  }
         syn._check_entity_restrictions(bundle, True)
     mocked_warn.assert_called_with('\nThis entity has access restrictions. Please visit the web page for this entity '
                                    '(syn.onweb("syn123")). Click the downward pointing arrow next to the file\'s name '

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -942,10 +942,8 @@ def test_check_entity_restrictions__no_unmet_restriction(syn):
                 'hasUnmetAccessRequirement': False
             }
         }
-        syn._check_entity_restrictions(bundle, True)
-        # restriction_requirements = {'hasUnmetAccessRequirement': False}
-
-        # syn._check_entity_restrictions(restriction_requirements, "syn123", True)
+        entity = 'syn123'
+        syn._check_entity_restrictions(bundle, entity, True)
         mocked_warn.assert_not_called()
 
 
@@ -961,13 +959,8 @@ def test_check_entity_restrictions__unmet_restriction_entity_file_with_downloadF
                 'hasUnmetAccessRequirement': True
             }
         }
-        pytest.raises(SynapseUnmetAccessRestrictions, syn._check_entity_restrictions, bundle, True)
-
-        # restriction_requirements = {'hasUnmetAccessRequirement': True}
-
-        # pytest.raises(SynapseUnmetAccessRestrictions, syn._check_entity_restrictions, restriction_requirements,
-        #               "syn123", True)
-
+        entity = 'syn123'
+        pytest.raises(SynapseUnmetAccessRestrictions, syn._check_entity_restrictions, bundle, entity, True)
     mocked_warn.assert_not_called()
 
 
@@ -983,7 +976,8 @@ def test_check_entity_restrictions__unmet_restriction_entity_project_with_downlo
                 'hasUnmetAccessRequirement': True
             }
         }
-        syn._check_entity_restrictions(bundle, True)
+        entity = 'syn123'
+        syn._check_entity_restrictions(bundle, entity, True)
     mocked_warn.assert_called_with('\nThis entity has access restrictions. Please visit the web page for this entity '
                                    '(syn.onweb("syn123")). Click the downward pointing arrow next to the file\'s name '
                                    'to review and fulfill its download requirement(s).\n')
@@ -1001,7 +995,8 @@ def test_check_entity_restrictions__unmet_restriction_entity_folder_with_downloa
                 'hasUnmetAccessRequirement': True
             }
         }
-        syn._check_entity_restrictions(bundle, True)
+        entity = 'syn123'
+        syn._check_entity_restrictions(bundle, entity, True)
     mocked_warn.assert_called_with('\nThis entity has access restrictions. Please visit the web page for this entity '
                                    '(syn.onweb("syn123")). Click the downward pointing arrow next to the file\'s name '
                                    'to review and fulfill its download requirement(s).\n')
@@ -1018,17 +1013,17 @@ def test_check_entity_restrictions__unmet_restriction_downloadFile_is_False(syn)
             'restrictionInformation': {
                 'hasUnmetAccessRequirement': True}
         }
-        syn._check_entity_restrictions(bundle, False)
-        # restriction_requirements = {'hasUnmetAccessRequirement': True}
-        # syn._check_entity_restrictions(restriction_requirements, "syn123", False)
+        entity = 'syn123'
+
+        syn._check_entity_restrictions(bundle, entity, False)
         mocked_warn.assert_called_once()
 
         bundle['entityType'] = 'project'
-        syn._check_entity_restrictions(bundle, False)
+        syn._check_entity_restrictions(bundle, entity, False)
         assert mocked_warn.call_count == 2
 
         bundle['entityType'] = 'folder'
-        syn._check_entity_restrictions(bundle, False)
+        syn._check_entity_restrictions(bundle, entity, False)
         assert mocked_warn.call_count == 3
 
 

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -934,13 +934,14 @@ def test_getChildren__nextPageToken(syn):
 def test_check_entity_restrictions__no_unmet_restriction(syn):
     with patch("warnings.warn") as mocked_warn:
         bundle = {'entity': {
-                      'id': 'syn123',
-                      'name': 'anonymous',
-                      'concreteType': 'org.sagebionetworks.repo.model.FileEntity',
-                      'parentId': 'syn12345'},
-                  'restrictionInformation': {
-                      'hasUnmetAccessRequirement': False}
-                  }
+            'id': 'syn123',
+            'name': 'anonymous',
+            'concreteType': 'org.sagebionetworks.repo.model.FileEntity',
+            'parentId': 'syn12345'},
+            'restrictionInformation': {
+                'hasUnmetAccessRequirement': False
+            }
+        }
         syn._check_entity_restrictions(bundle, True)
         # restriction_requirements = {'hasUnmetAccessRequirement': False}
 
@@ -951,14 +952,15 @@ def test_check_entity_restrictions__no_unmet_restriction(syn):
 def test_check_entity_restrictions__unmet_restriction_entity_file_with_downloadFile_is_True(syn):
     with patch("warnings.warn") as mocked_warn:
         bundle = {'entity': {
-                      'id': 'syn123',
-                      'name': 'anonymous',
-                      'concreteType': 'org.sagebionetworks.repo.model.FileEntity',
-                      'parentId': 'syn12345'},
-                  'entityType': 'file',
-                  'restrictionInformation': {
-                      'hasUnmetAccessRequirement': True}
-                  }
+            'id': 'syn123',
+            'name': 'anonymous',
+            'concreteType': 'org.sagebionetworks.repo.model.FileEntity',
+            'parentId': 'syn12345'},
+            'entityType': 'file',
+            'restrictionInformation': {
+                'hasUnmetAccessRequirement': True
+            }
+        }
         pytest.raises(SynapseUnmetAccessRestrictions, syn._check_entity_restrictions, bundle, True)
 
         # restriction_requirements = {'hasUnmetAccessRequirement': True}
@@ -972,14 +974,15 @@ def test_check_entity_restrictions__unmet_restriction_entity_file_with_downloadF
 def test_check_entity_restrictions__unmet_restriction_entity_project_with_downloadFile_is_True(syn):
     with patch("warnings.warn") as mocked_warn:
         bundle = {'entity': {
-                      'id': 'syn123',
-                      'name': 'anonymous',
-                      'concreteType': 'org.sagebionetworks.repo.model.FileEntity',
-                      'parentId': 'syn12345'},
-                  'entityType': 'project',
-                  'restrictionInformation': {
-                      'hasUnmetAccessRequirement': True}
-                  }
+            'id': 'syn123',
+            'name': 'anonymous',
+            'concreteType': 'org.sagebionetworks.repo.model.FileEntity',
+            'parentId': 'syn12345'},
+            'entityType': 'project',
+            'restrictionInformation': {
+                'hasUnmetAccessRequirement': True
+            }
+        }
         syn._check_entity_restrictions(bundle, True)
     mocked_warn.assert_called_with('\nThis entity has access restrictions. Please visit the web page for this entity '
                                    '(syn.onweb("syn123")). Click the downward pointing arrow next to the file\'s name '
@@ -989,14 +992,15 @@ def test_check_entity_restrictions__unmet_restriction_entity_project_with_downlo
 def test_check_entity_restrictions__unmet_restriction_entity_folder_with_downloadFile_is_True(syn):
     with patch("warnings.warn") as mocked_warn:
         bundle = {'entity': {
-                      'id': 'syn123',
-                      'name': 'anonymous',
-                      'concreteType': 'org.sagebionetworks.repo.model.FileEntity',
-                      'parentId': 'syn12345'},
-                  'entityType': 'folder',
-                  'restrictionInformation': {
-                      'hasUnmetAccessRequirement': True}
-                  }
+            'id': 'syn123',
+            'name': 'anonymous',
+            'concreteType': 'org.sagebionetworks.repo.model.FileEntity',
+            'parentId': 'syn12345'},
+            'entityType': 'folder',
+            'restrictionInformation': {
+                'hasUnmetAccessRequirement': True
+            }
+        }
         syn._check_entity_restrictions(bundle, True)
     mocked_warn.assert_called_with('\nThis entity has access restrictions. Please visit the web page for this entity '
                                    '(syn.onweb("syn123")). Click the downward pointing arrow next to the file\'s name '

--- a/tests/unit/synapseclient/unit_test_commandline.py
+++ b/tests/unit/synapseclient/unit_test_commandline.py
@@ -10,6 +10,7 @@ from unittest.mock import call, Mock, patch, MagicMock
 
 import synapseclient.__main__ as cmdline
 from synapseclient.core.exceptions import SynapseAuthenticationError, SynapseNoCredentialsError
+from synapseclient.entity import File
 import synapseutils
 
 
@@ -534,9 +535,7 @@ class TestGetFunction:
         assert self.syn.logger.info.call_args_list == [call('WARNING: No files associated with entity %s\n', 'syn123'),
                                                        call(mock_entity)]
 
-        mock_entity2 = MagicMock(id='syn123', path='./tmp_path')
-        mock_dict = {'path': './tmp_path'}
-        mock_entity2.__contains__.side_effect = mock_dict.__contains__
+        mock_entity2 = File(path='./tmp_path', parent='syn123')
 
         self.syn.get.return_value = mock_entity2
         mock_os.path.exists.return_value = True

--- a/tests/unit/synapseclient/unit_test_commandline.py
+++ b/tests/unit/synapseclient/unit_test_commandline.py
@@ -6,7 +6,7 @@ import base64
 import os
 
 import pytest
-from unittest.mock import call, Mock, patch
+from unittest.mock import call, Mock, patch, MagicMock
 
 import synapseclient.__main__ as cmdline
 from synapseclient.core.exceptions import SynapseAuthenticationError, SynapseNoCredentialsError
@@ -485,3 +485,51 @@ def test_command_auto_login(mock_login_with_prompt, syn):
     cmdline.perform_main(args, syn)
 
     mock_login_with_prompt.assert_called_once_with(syn, 'test_user', None, silent=True)
+
+
+class TestGetFunction:
+    @patch('synapseclient.client.Synapse')
+    def setup(self, mock_syn):
+        self.syn = mock_syn
+
+    @patch.object(synapseutils, 'syncFromSynapse')
+    def test_get__with_arg_recursive(self, mock_syncFromSynapse):
+        parser = cmdline.build_parser()
+        args = parser.parse_args(['get', '-r', 'syn123'])
+        cmdline.get(args, self.syn)
+
+        mock_syncFromSynapse.assert_called_once_with(self.syn, 'syn123', './', followLink=False)
+
+    @patch.object(cmdline, '_getIdsFromQuery')
+    def test_get__with_arg_queryString(self, mock_getIdsFromQuery):
+        parser = cmdline.build_parser()
+        args = parser.parse_args(['get', '-q', 'test_query'])
+        mock_getIdsFromQuery.return_value = ['syn123', 'syn456']
+        cmdline.get(args, self.syn)
+
+        mock_getIdsFromQuery.assert_called_once_with('test_query', self.syn, './')
+        assert self.syn.get.call_args_list == [call('syn123', downloadLocation='./'),
+                                               call('syn456', downloadLocation='./')]
+
+    @patch.object(cmdline, 'os')
+    def test_get__with_id_path(self, mock_os):
+        parser = cmdline.build_parser()
+        args = parser.parse_args(['get', './temp/path'])
+        mock_os.path.isfile.return_value = True
+        self.syn.get.return_value = {}
+        cmdline.get(args, self.syn)
+
+        self.syn.get.assert_called_once_with('./temp/path', version=None, limitSearch=None, downloadFile=False)
+
+    @patch.object(cmdline, 'os')
+    def test_get__with_normal_id(self, mock_os):
+        parser = cmdline.build_parser()
+        args = parser.parse_args(['get', 'syn123'])
+        mock_os.path.isfile.return_value = False
+        mock_entity = MagicMock(id='syn123')
+        self.syn.get.return_value = mock_entity
+        cmdline.get(args, self.syn)
+
+        self.syn.get.assert_called_once_with('syn123', version=None, followLink=False, downloadLocation='./')
+        assert self.syn.logger.info.call_args_list == [call('WARNING: No files associated with entity %s\n', 'syn123'),
+                                                       call(mock_entity)]


### PR DESCRIPTION
Change

- If the entity id is project or folder and downloadFile is True, the synapse get method with restriction should not raise the error msg but only warning msg
- modified the _check_entity_restrictions private function and pass in the whole bundle to check the entity type
- add unit tests and fix the issue that changed from the modification in client.py