### PR TITLE
Synpy 959 file entity path separator in windows

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -907,7 +907,7 @@ class Synapse(object):
             if downloadPath is None or not os.path.exists(downloadPath):
                 return
 
-        entity.path = downloadPath
+        entity.path = os.path.normpath(downloadPath)
         entity.files = [os.path.basename(downloadPath)]
         entity.cacheDir = os.path.dirname(downloadPath)
 

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -907,6 +907,7 @@ class Synapse(object):
             if downloadPath is None or not os.path.exists(downloadPath):
                 return
 
+        # converts the path format from forward slashes back to backward slashes on Windows
         entity.path = os.path.normpath(downloadPath)
         entity.files = [os.path.basename(downloadPath)]
         entity.cacheDir = os.path.dirname(downloadPath)

--- a/tests/integration/synapseclient/integration_test_Entity.py
+++ b/tests/integration/synapseclient/integration_test_Entity.py
@@ -507,7 +507,7 @@ def test_download_local_file_URL_path(syn, project, schedule_for_cleanup):
 
     localFileEntity = syn.store(File(dataFileHandleId=filehandle['id'], parent=project))
     e = syn.get(localFileEntity.id)
-    assert path == e.path
+    assert path == utils.normalize_path(e.path)
 
 
 # SYNPY-424
@@ -566,7 +566,7 @@ def test_store__changing_externalURL_by_changing_path(syn, project, schedule_for
 
     assert ext.externalURL != url
     assert utils.normalize_path(temp_path) == utils.file_url_to_path(ext.externalURL)
-    assert temp_path == ext.path
+    assert temp_path == utils.normalize_path(ext.path)
     assert not ext.synapseStore
 
 

--- a/tests/integration/synapseutils/test_synapseutils_sync.py
+++ b/tests/integration/synapseutils/test_synapseutils_sync.py
@@ -173,7 +173,7 @@ def test_syncFromSynapse(test_state):
 
     assert len(output) == len(uploaded_paths)
     for f in output:
-        assert f.path in uploaded_paths
+        assert utils.normalize_path(f.path) in uploaded_paths
 
 
 def test_syncFromSynapse__children_contain_non_file(test_state):
@@ -240,7 +240,7 @@ def test_syncFromSynapse_Links(test_state):
 
     assert len(output) == len(uploaded_paths)
     for f in output:
-        assert f.path in uploaded_paths
+        assert utils.normalize_path(f.path) in uploaded_paths
 
 
 def test_write_manifest_data__unicode_characters_in_rows(test_state):

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -520,7 +520,7 @@ def test_download_file_entity__correct_local_state(syn):
     with patch.object(syn.cache, 'get', return_value=mock_cache_path):
         syn._download_file_entity(downloadLocation=None, entity=file_entity, ifcollision="overwrite.local",
                                   submission=None)
-        assert mock_cache_path == file_entity.path
+        assert mock_cache_path == utils.normalize_path(file_entity.path)
         assert os.path.dirname(mock_cache_path) == file_entity.cacheDir
         assert 1 == len(file_entity.files)
         assert os.path.basename(mock_cache_path) == file_entity.files[0]


### PR DESCRIPTION
Change

- fix the issue for the ticket that is "FileEntity 'path' property has the wrong separator for Windows"
https://sagebionetworks.jira.com/browse/SYNPY-959
- fix the unit tests and integration tests since this change