### PR TITLE
SYNPY-1141-get_command_line_nargs_error

### DIFF
--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -92,6 +92,7 @@ def get(args, syn):
     if args.recursive:
         if args.version is not None:
             raise ValueError('You cannot specify a version making a recursive download.')
+        _check_args_with_id(args)
         synapseutils.syncFromSynapse(syn, args.id, args.downloadLocation, followLink=args.followLink,
                                      manifest=args.manifest)
     elif args.queryString is not None:
@@ -101,6 +102,7 @@ def get(args, syn):
         for id in ids:
             syn.get(id, downloadLocation=args.downloadLocation)
     else:
+        _check_args_with_id(args)
         # search by MD5
         if isinstance(args.id, str) and os.path.isfile(args.id):
             entity = syn.get(args.id, version=args.version, limitSearch=args.limitSearch, downloadFile=False)
@@ -119,6 +121,11 @@ def get(args, syn):
                 syn.logger.info(entity)
         if "path" in entity:
             syn.logger.info('Creating %s', entity.path)
+
+
+def _check_args_with_id(args):
+    if args.id is None:
+        raise ValueError(f'For the {args.subparser} command, the following synapse ID sucha as syn123 are required')
 
 
 def sync(args, syn):
@@ -561,7 +568,7 @@ def build_parser():
     parser.add_argument('-s', '--skip-checks', dest='skip_checks', action='store_true',
                         help='suppress checking for version upgrade messages and endpoint redirection')
 
-    subparsers = parser.add_subparsers(title='commands',
+    subparsers = parser.add_subparsers(title='commands', dest='subparser',
                                        description='The following commands are available:',
                                        help='For additional help: "synapse <COMMAND> -h"')
 
@@ -585,7 +592,7 @@ def build_parser():
                             default=True, help='Download file using a multiple threaded implementation. '
                             'This flag will be removed in the future when multi-threaded download '
                             'is deemed fully stable and becomes the default implementation.')
-    parser_get.add_argument('id', metavar='syn123', nargs='?', type=str,
+    parser_get.add_argument('id', metavar='syn123 or local_file_path', nargs='?', type=str,
                             help='Synapse ID of form syn123 of desired data object.')
     # add no manifest option
     parser_get.add_argument('--manifest', type=str, choices=['all', 'root', 'suppress'],

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -92,7 +92,7 @@ def get(args, syn):
     if args.recursive:
         if args.version is not None:
             raise ValueError('You cannot specify a version making a recursive download.')
-        _check_args_with_id(args)
+        _validate_id_arg(args)
         synapseutils.syncFromSynapse(syn, args.id, args.downloadLocation, followLink=args.followLink,
                                      manifest=args.manifest)
     elif args.queryString is not None:
@@ -102,7 +102,7 @@ def get(args, syn):
         for id in ids:
             syn.get(id, downloadLocation=args.downloadLocation)
     else:
-        _check_args_with_id(args)
+        _validate_id_arg(args)
         # search by MD5
         if isinstance(args.id, str) and os.path.isfile(args.id):
             entity = syn.get(args.id, version=args.version, limitSearch=args.limitSearch, downloadFile=False)
@@ -123,9 +123,9 @@ def get(args, syn):
             syn.logger.info('Creating %s', entity.path)
 
 
-def _check_args_with_id(args):
+def _validate_id_arg(args):
     if args.id is None:
-        raise ValueError(f'For the {args.subparser} command, the following synapse ID sucha as syn123 are required')
+        raise ValueError(f'Missing expected id argument for use with the {args.subparser} command')
 
 
 def sync(args, syn):
@@ -592,7 +592,7 @@ def build_parser():
                             default=True, help='Download file using a multiple threaded implementation. '
                             'This flag will be removed in the future when multi-threaded download '
                             'is deemed fully stable and becomes the default implementation.')
-    parser_get.add_argument('id', metavar='syn123 or local_file_path', nargs='?', type=str,
+    parser_get.add_argument('id', metavar='local path', nargs='?', type=str,
                             help='Synapse ID of form syn123 of desired data object.')
     # add no manifest option
     parser_get.add_argument('--manifest', type=str, choices=['all', 'root', 'suppress'],

--- a/tests/unit/synapseclient/unit_test_commandline.py
+++ b/tests/unit/synapseclient/unit_test_commandline.py
@@ -572,3 +572,18 @@ class TestGetFunction:
                                                        call(mock_entity),
                                                        call('Downloaded file: %s', './base_tmp_path'),
                                                        call('Creating %s', './tmp_path')]
+
+    def test_get__without_synapse_id(self):
+        # test normal get command without synapse ID
+        parser = cmdline.build_parser()
+        with pytest.raises(ValueError) as ve:
+            args = parser.parse_args(['get'])
+            cmdline.get(args, self.syn)
+        assert str(ve.value) == "For the get command, the following synapse ID sucha as syn123 are required"
+
+        # test get command with -r but without synapse ID
+        parser = cmdline.build_parser()
+        with pytest.raises(ValueError) as ve:
+            args = parser.parse_args(['get', '-r'])
+            cmdline.get(args, self.syn)
+        assert str(ve.value) == "For the get command, the following synapse ID sucha as syn123 are required"

--- a/tests/unit/synapseclient/unit_test_commandline.py
+++ b/tests/unit/synapseclient/unit_test_commandline.py
@@ -579,11 +579,11 @@ class TestGetFunction:
         with pytest.raises(ValueError) as ve:
             args = parser.parse_args(['get'])
             cmdline.get(args, self.syn)
-        assert str(ve.value) == "For the get command, the following synapse ID sucha as syn123 are required"
+        assert str(ve.value) == "Missing expected id argument for use with the get command"
 
         # test get command with -r but without synapse ID
         parser = cmdline.build_parser()
         with pytest.raises(ValueError) as ve:
             args = parser.parse_args(['get', '-r'])
             cmdline.get(args, self.syn)
-        assert str(ve.value) == "For the get command, the following synapse ID sucha as syn123 are required"
+        assert str(ve.value) == "Missing expected id argument for use with the get command"


### PR DESCRIPTION
Change

- fix the issue for the confused msg when enter get command without synapse ID
 `TypeError: 'NoneType' object is not subscriptable`
- add unit test for the value error case