### PR TITLE
SYNPY-1024 remove Evaluation status

### DIFF
--- a/synapseclient/evaluation.py
+++ b/synapseclient/evaluation.py
@@ -130,10 +130,7 @@ class Evaluation(DictObject):
         return '/evaluation/%s' % id
 
     def __init__(self, **kwargs):
-        kwargs['status'] = kwargs.get('status', 'OPEN')
         kwargs['contentSource'] = kwargs.get('contentSource', '')
-        if kwargs['status'] not in ['OPEN', 'PLANNED', 'CLOSED', 'COMPLETED']:
-            raise ValueError('Evaluation Status must be one of [OPEN, PLANNED, CLOSED, COMPLETED]')
         if not kwargs['contentSource'].startswith('syn'):  # Verify that synapse Id given
             raise ValueError('The "contentSource" parameter must be specified as a Synapse Entity when creating an'
                              ' Evaluation')

--- a/tests/integration/synapseclient/test_evaluations.py
+++ b/tests/integration/synapseclient/test_evaluations.py
@@ -15,7 +15,7 @@ def test_evaluations(syn, project, schedule_for_cleanup):
     # Create an Evaluation
     name = 'Test Evaluation %s' % str(uuid.uuid4())
     ev = Evaluation(name=name, description='Evaluation for testing',
-                    contentSource=project['id'], status='CLOSED')
+                    contentSource=project['id'])
     ev = syn.store(ev)
 
     try:
@@ -29,7 +29,6 @@ def test_evaluations(syn, project, schedule_for_cleanup):
         assert ev['id'] == evalNamed['id']
         assert ev['name'] == evalNamed['name']
         assert ev['ownerId'] == evalNamed['ownerId']
-        assert ev['status'] == evalNamed['status']
 
         # -- Get the Evaluation by project
         evalProj = syn.getEvaluationByContentSource(project)
@@ -41,13 +40,6 @@ def test_evaluations(syn, project, schedule_for_cleanup):
         assert ev['id'] == evalProj['id']
         assert ev['name'] == evalProj['name']
         assert ev['ownerId'] == evalProj['ownerId']
-        assert ev['status'] == evalProj['status']
-
-        # Update the Evaluation
-        ev['status'] = 'OPEN'
-        ev = syn.store(ev, createOrUpdate=True)
-        schedule_for_cleanup(ev)
-        assert ev.status == 'OPEN'
 
         # Add the current user as a participant
         myOwnerId = int(syn.getUserProfile()['ownerId'])

--- a/tests/unit/synapseclient/unit_test_Evaluation.py
+++ b/tests/unit/synapseclient/unit_test_Evaluation.py
@@ -9,9 +9,9 @@ from synapseclient import (Evaluation, Submission, SubmissionStatus,
 def test_Evaluation():
     """Test the construction and accessors of Evaluation objects."""
 
-    # Status can only be one of ['OPEN', 'PLANNED', 'CLOSED', 'COMPLETED']
-    pytest.raises(ValueError, Evaluation, name='foo', description='bar', status='BAH')
-    pytest.raises(ValueError, Evaluation, name='foo', description='bar', status='OPEN', contentSource='a')
+    # contentSource must be specified and must be a synapse id
+    pytest.raises(ValueError, Evaluation, name='foo', description='bar')
+    pytest.raises(ValueError, Evaluation, name='foo', description='bar', contentSource='a')
 
     # Assert that the values are
     ev = Evaluation(name='foobar2', description='bar', status='OPEN', contentSource='syn1234')

--- a/tests/unit/synapseclient/unit_test_Evaluation.py
+++ b/tests/unit/synapseclient/unit_test_Evaluation.py
@@ -9,15 +9,18 @@ from synapseclient import (Evaluation, Submission, SubmissionStatus,
 def test_Evaluation():
     """Test the construction and accessors of Evaluation objects."""
 
-    # contentSource must be specified and must be a synapse id
-    pytest.raises(ValueError, Evaluation, name='foo', description='bar')
-    pytest.raises(ValueError, Evaluation, name='foo', description='bar', contentSource='a')
+    content_source_missing_ex = 'The "contentSource" parameter must be specified'
+    with pytest.raises(ValueError, match=content_source_missing_ex):
+        # with no contentSource
+        Evaluation(name='foo', description='bar')
+    with pytest.raises(ValueError, match=content_source_missing_ex):
+        # with non-synapse id contentSource
+        Evaluation(name='foo', description='bar', contentSource='a')
 
     # Assert that the values are
-    ev = Evaluation(name='foobar2', description='bar', status='OPEN', contentSource='syn1234')
+    ev = Evaluation(name='foobar2', description='bar', contentSource='syn1234')
     assert ev['name'] == ev.name
     assert ev['description'] == ev.description
-    assert ev['status'] == ev.status
 
 
 def test_Submission():


### PR DESCRIPTION
Per https://sagebionetworks.jira.com/browse/PLFM-2631 the status field is no longer used as part of the Evaluation and is not a field of [Evaluation](https://rest-docs.synapse.org/rest/org/sagebionetworks/evaluation/model/Evaluation.html). The client still accepts a status kwarg and auto populates one of one is not passed. This field is being ignored in the backend so it can be removed.