### PR TITLE
Synpy 1142 generalize retry backoff logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,8 @@ jobs:
             export EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY="${{secrets.EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY}}"
 
              # use loadscope to avoid issues running tests concurrently that share scoped fixtures
-            pytest -sv tests/integration -n auto --dist loadscope
+#            pytest -sv tests/integration -n auto --dist loadscope
+            pytest -sv tests/integration/synapseclient/test_evaluations.py::test_teams -n auto --dist loadscope
           fi
 
   # on a GitHub release, build the pip package and upload it as a GitHub release asset

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
             export EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY="${{secrets.EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY}}"
 
              # use loadscope to avoid issues running tests concurrently that share scoped fixtures
-#            pytest -sv tests/integration -n auto --dist loadscope
+            # pytest -sv tests/integration -n auto --dist loadscope
             pytest -sv tests/integration/synapseclient/test_evaluations.py::test_teams -n auto --dist loadscope
           fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,8 +133,8 @@ jobs:
             export EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY="${{secrets.EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY}}"
 
              # use loadscope to avoid issues running tests concurrently that share scoped fixtures
-            # pytest -sv tests/integration -n auto --dist loadscope
-            pytest -sv tests/integration/synapseclient/test_evaluations.py::test_teams -n auto --dist loadscope
+            pytest -sv tests/integration -n auto --dist loadscope
+            # pytest -sv tests/integration/synapseclient/test_evaluations.py::test_teams -n auto --dist loadscope
           fi
 
   # on a GitHub release, build the pip package and upload it as a GitHub release asset

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,6 @@ jobs:
 
              # use loadscope to avoid issues running tests concurrently that share scoped fixtures
             pytest -sv tests/integration -n auto --dist loadscope
-            # pytest -sv tests/integration/synapseclient/test_evaluations.py::test_teams -n auto --dist loadscope
           fi
 
   # on a GitHub release, build the pip package and upload it as a GitHub release asset

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -3143,7 +3143,7 @@ class Synapse(object):
         }
 
         result = with_retry(lambda: self.restGET(uri + '/get/%s' % async_job_id['token'], endpoint=endpoint),
-                            self._waitForAsync_evaluator, evaluator_info=retry_info,
+                            self._waitForAsync_evaluator, evaluator_info=retry_info, retries=10,
                             wait=self.table_query_sleep, back_off=self.table_query_backoff,
                             max_wait=self.table_query_max_sleep)
 

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -3196,7 +3196,6 @@ class Synapse(object):
                                           isBytes=False)
         return result
 
-
     def getColumn(self, id):
         """
         Gets a Column object from Synapse by ID.

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -94,7 +94,7 @@ from synapseclient.core.version_check import version_check
 from synapseclient.core.pool_provider import DEFAULT_NUM_THREADS
 from synapseclient.core.utils import id_of, get_properties, MB, memoize, is_json, extract_synapse_id_from_query, \
     find_data_file_handle, extract_zip_file_to_directory, is_integer, require_param
-from synapseclient.core.retry import with_retry
+from synapseclient.core.retry import with_retry_network
 from synapseclient.core import sts_transfer
 from synapseclient.core.upload.multipart_upload import multipart_upload_file, multipart_upload_string
 from synapseclient.core.remote_file_storage_wrappers import S3ClientWrapper, SFTPWrapper
@@ -1973,7 +1973,7 @@ class Synapse(object):
 
                 # pass along synapse auth credentials only if downloading directly from synapse
                 auth = self.credentials if self._is_synapse_uri(url) else None
-                response = with_retry(
+                response = with_retry_network(
                     lambda: self._requests_session.get(
                         url,
                         headers=self._generate_headers(range_header),
@@ -3855,7 +3855,7 @@ class Synapse(object):
 
         auth = kwargs.pop('auth', self.credentials)
         requests_method_fn = getattr(requests_session, method)
-        response = with_retry(
+        response = with_retry_network(
             lambda: requests_method_fn(
                 uri,
                 data=data,

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -3193,8 +3193,6 @@ class Synapse(object):
                 retry_info['lastMessage'] = message
                 retry_info['lastProgress'] = progress
                 retry_info['lastTotal'] = total
-            # sleep = min(self.table_query_max_sleep, sleep * self.table_query_backoff)
-            # doze(sleep)
             return True
         else:
             return False

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -40,7 +40,7 @@ RETRYABLE_CONNECTION_EXCEPTIONS = [
 
 def with_retry_network(function, verbose=False,
                        retry_status_codes=[429, 500, 502, 503, 504], expected_status_codes=[], retry_errors=[],
-                       retry_exceptions=[], retries=3, wait=1, back_off=2, max_wait=30):
+                       retry_exceptions=None, retries=3, wait=1, back_off=2, max_wait=30):
     logger = _get_logger(verbose)
 
     def _handle_status_code(response):
@@ -76,7 +76,7 @@ def with_retry_network(function, verbose=False,
                       back_off=back_off, max_wait=max_wait)
 
 
-def with_retry(function, retry_evaluator=None, verbose=False, retry_errors=[], retry_exceptions=[],
+def with_retry(function, retry_evaluator=None, verbose=False, retry_errors=[], retry_exceptions=None,
                retries=DEFAULT_RETRIES, wait=DEFAULT_WAIT, back_off=DEFAULT_BACK_OFF, max_wait=DEFAULT_MAX_WAIT):
     """
     Retries the given function under certain conditions.
@@ -127,7 +127,9 @@ def with_retry(function, retry_evaluator=None, verbose=False, retry_errors=[], r
 
         # Check if we got a retry-able exception
         if exc is not None:
-            if not retry_exceptions or (
+            # if users didn't pass in the retry_exceptions then it's None and we will retry no matter what exception
+            # occurs, otherwise if users pass in the empty list, then no exception will trigger retry.
+            if retry_exceptions is None or (
                     (exc.__class__.__name__ in retry_exceptions or
                      exc.__class__ in retry_exceptions or
                      any([msg.lower() in str(exc_info[1]).lower() for msg in retry_errors]))

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -134,8 +134,7 @@ def with_retry(function, retry_evaluator=None, verbose=False, retry_errors=[], r
         if retries >= 0 and retry:
             randomized_wait = wait*random.uniform(0.5, 1.5)
             logger.debug(('total wait time {total_wait:5.0f} seconds\n '
-                          '... Retrying in {wait:5.1f} seconds...'.format(total_wait=total_wait,
-                          wait=randomized_wait)))
+                          '... Retrying in {wait:5.1f} seconds...'.format(total_wait=total_wait, wait=randomized_wait)))
             total_wait += randomized_wait
             doze(randomized_wait)
             wait = min(max_wait, wait*back_off)

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -88,6 +88,7 @@ def with_retry(function, verbose=False,
         # Wait then retry
         retries -= 1
         if retries >= 0 and retry:
+            sys.stdout.write(f"here is retry -> {retries}")
             randomized_wait = wait*random.uniform(0.5, 1.5)
             logger.debug(('total wait time {total_wait:5.0f} seconds\n '
                           '... Retrying in {wait:5.1f} seconds...'.format(total_wait=total_wait, wait=randomized_wait)))

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -7,19 +7,58 @@ from synapseclient.core.utils import is_json
 from synapseclient.core.dozer import doze
 
 
-def with_retry(function, verbose=False,
+def handle_status_code(response, retry_status_codes, retry_info, logger):
+    retry = False
+    if response is None or not hasattr(response, 'status_code'):
+        return retry
+    if response.status_code in retry_status_codes:
+        response_message = _get_message(response)
+        retry = True
+        logger.debug("retrying on status code: %s" % str(response.status_code))
+        # TODO: this was originally printed regardless of 'verbose' was that behavior correct?
+        logger.debug(str(response_message))
+        if (response.status_code == 429) and (retry_info['wait'] > 10):
+            logger.warning('%s...\n' % response_message)
+            logger.warning('Retrying in %i seconds' % retry_info['wait'])
+
+    elif response.status_code not in range(200, 299):
+        # For all other non 200 messages look for retryable errors in the body or reason field
+        response_message = _get_message(response)
+        if any([msg.lower() in response_message.lower() for msg in retry_info['retry_errors']]):
+            retry = True
+            logger.debug('retrying %s' % response_message)
+        # special case for message throttling
+        elif 'Please slow down.  You may send a maximum of 10 message' in response:
+            retry = True
+            retry_info['wait'] = 16
+            logger.debug("retrying " + response_message)
+    # retry_info['retry'] = retry
+    return retry
+
+def with_retry_network(function, verbose=False,
+               retry_status_codes=[429, 500, 502, 503, 504], retry_errors=[], retry_exceptions=[],
+               retries=3, wait=1, back_off=2, max_wait=30):
+
+    return with_retry(function, handle_status_code, verbose=verbose, retry_status_codes=retry_status_codes,
+                      retry_errors=retry_errors, retry_exceptions=retry_exceptions, retries=retries, wait=wait,
+                      back_off=back_off, max_wait=max_wait)
+
+
+def with_retry(function, retry_evaluator=None, verbose=False,
                retry_status_codes=[429, 500, 502, 503, 504], retry_errors=[], retry_exceptions=[],
                retries=3, wait=1, back_off=2, max_wait=30):
     """
     Retries the given function under certain conditions.
 
     :param function:           A function with no arguments.  If arguments are needed, use a lambda (see example).
+    :param retry_evaluator:    Determined whether to retry again.
     :param retry_status_codes: What status codes to retry upon in the case of a SynapseHTTPError.
     :param retry_errors:       What reasons to retry upon, if function().response.json()['reason'] exists.
     :param retry_exceptions:   What types of exceptions, specified as strings, to retry upon.
     :param retries:            How many times to retry maximum.
     :param wait:               How many seconds to wait between retries.
     :param back_off:           Exponential constant to increase wait for between progressive failures.
+    :param max_wait:           How long for the max wait time, default is 30 secs.
 
     :returns: function()
 
@@ -35,17 +74,29 @@ def with_retry(function, verbose=False,
         logger = logging.getLogger(DEFAULT_LOGGER_NAME)
 
     # Retry until we succeed or run out of tries
-    total_wait = 0
+    # total_wait = 0
+    retry_info = {
+        'retries': retries,
+        'wait': wait,
+        'total_wait': 0,
+        'max_wait': max_wait,
+        'back_off': back_off,
+        'retry_errors': retry_errors
+    }
+
     while True:
         # Start with a clean slate
         exc = None
         exc_info = None
-        retry = False
+        did_retry = False
+        # retry_info['retry'] = False
         response = None
 
         # Try making the call
         try:
             response = function()
+            if retry_evaluator and retry_evaluator(response, retry_status_codes, retry_info, logger):
+                did_retry = _retry(retry_info, logger)
         except Exception as ex:
             exc = ex
             exc_info = sys.exc_info()
@@ -53,49 +104,26 @@ def with_retry(function, verbose=False,
             if hasattr(ex, 'response'):
                 response = ex.response
 
-        # Check if we got a retry-able error
-        if response is not None and hasattr(response, 'status_code'):
-            if response.status_code in retry_status_codes:
-                response_message = _get_message(response)
-                retry = True
-                logger.debug("retrying on status code: %s" % str(response.status_code))
-                # TODO: this was originally printed regardless of 'verbose' was that behavior correct?
-                logger.debug(str(response_message))
-                if (response.status_code == 429) and (wait > 10):
-                    logger.warning('%s...\n' % response_message)
-                    logger.warning('Retrying in %i seconds' % wait)
-
-            elif response.status_code not in range(200, 299):
-                # For all other non 200 messages look for retryable errors in the body or reason field
-                response_message = _get_message(response)
-                if any([msg.lower() in response_message.lower() for msg in retry_errors]):
-                    retry = True
-                    logger.debug('retrying %s' % response_message)
-                # special case for message throttling
-                elif 'Please slow down.  You may send a maximum of 10 message' in response:
-                    retry = True
-                    wait = 16
-                    logger.debug("retrying " + response_message)
-
         # Check if we got a retry-able exception
         if exc is not None:
             if (exc.__class__.__name__ in retry_exceptions or
                     exc.__class__ in retry_exceptions or
                     any([msg.lower() in str(exc_info[1]).lower() for msg in retry_errors])):
-                retry = True
+                did_retry = _retry(retry_info, logger)
                 logger.debug("retrying exception: " + str(exc))
 
-        # Wait then retry
-        retries -= 1
-        if retries >= 0 and retry:
-            sys.stdout.write(f"here is retry -> {retries}")
-            randomized_wait = wait*random.uniform(0.5, 1.5)
-            logger.debug(('total wait time {total_wait:5.0f} seconds\n '
-                          '... Retrying in {wait:5.1f} seconds...'.format(total_wait=total_wait, wait=randomized_wait)))
-            total_wait += randomized_wait
-            doze(randomized_wait)
-            wait = min(max_wait, wait*back_off)
+        if did_retry:
             continue
+
+        # Wait then retry
+        # if retries >= 0 and retry_info['retry']:
+        #     randomized_wait = wait*random.uniform(0.5, 1.5)
+        #     logger.debug(('total wait time {total_wait:5.0f} seconds\n '
+        #                   '... Retrying in {wait:5.1f} seconds...'.format(total_wait=total_wait, wait=randomized_wait)))
+        #     total_wait += randomized_wait
+        #     doze(randomized_wait)
+        #     wait = min(max_wait, wait*back_off)
+        #     continue
 
         # Out of retries, re-raise the exception or return the response
         if exc_info is not None and exc_info[0] is not None:
@@ -103,6 +131,20 @@ def with_retry(function, verbose=False,
             raise exc
         return response
 
+
+def _retry(retry_info, logger):
+    # Wait then retry
+    retry_info['retries'] -= 1
+    if retry_info['retries'] >= 0:
+        randomized_wait = retry_info['wait'] * random.uniform(0.5, 1.5)
+        logger.debug(('total wait time {total_wait:5.0f} seconds\n '
+                      '... Retrying in {wait:5.1f} seconds...'.format(total_wait=retry_info['total_wait'],
+                                                                      wait=randomized_wait)))
+        retry_info['total_wait'] += randomized_wait
+        doze(randomized_wait)
+        retry_info['wait'] = min(retry_info['max_wait'], retry_info['wait'] * retry_info['back_off'])
+        return True
+    return False
 
 def _get_message(response):
     """
@@ -119,3 +161,11 @@ def _get_message(response):
     except (AttributeError, ValueError):
         # The response can be truncated. In which case, the message cannot be retrieved.
         return None
+
+
+def handle_exception(exc, retry_exceptions, exc_info, retry_info, logger):
+    if (exc.__class__.__name__ in retry_exceptions or
+            exc.__class__ in retry_exceptions or
+            any([msg.lower() in str(exc_info[1]).lower() for msg in retry_info['retry_errors']])):
+        retry_info['retry'] = True
+        logger.debug("retrying exception: " + str(exc))

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -35,9 +35,10 @@ def handle_status_code(response, retry_status_codes, retry_info, logger):
     # retry_info['retry'] = retry
     return retry
 
+
 def with_retry_network(function, verbose=False,
-               retry_status_codes=[429, 500, 502, 503, 504], retry_errors=[], retry_exceptions=[],
-               retries=3, wait=1, back_off=2, max_wait=30):
+                       retry_status_codes=[429, 500, 502, 503, 504], retry_errors=[], retry_exceptions=[],
+                       retries=3, wait=1, back_off=2, max_wait=30):
 
     return with_retry(function, handle_status_code, verbose=verbose, retry_status_codes=retry_status_codes,
                       retry_errors=retry_errors, retry_exceptions=retry_exceptions, retries=retries, wait=wait,
@@ -119,7 +120,8 @@ def with_retry(function, retry_evaluator=None, verbose=False,
         # if retries >= 0 and retry_info['retry']:
         #     randomized_wait = wait*random.uniform(0.5, 1.5)
         #     logger.debug(('total wait time {total_wait:5.0f} seconds\n '
-        #                   '... Retrying in {wait:5.1f} seconds...'.format(total_wait=total_wait, wait=randomized_wait)))
+        #                   '... Retrying in {wait:5.1f} seconds...'.format(total_wait=total_wait,
+        #                   wait=randomized_wait)))
         #     total_wait += randomized_wait
         #     doze(randomized_wait)
         #     wait = min(max_wait, wait*back_off)
@@ -145,6 +147,7 @@ def _retry(retry_info, logger):
         retry_info['wait'] = min(retry_info['max_wait'], retry_info['wait'] * retry_info['back_off'])
         return True
     return False
+
 
 def _get_message(response):
     """

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -81,7 +81,8 @@ def with_retry_network(function, verbose=False,
 
 
 def with_retry(function, retry_evaluator=None, evaluator_info=None, verbose=False, retry_errors=[],
-               retry_exceptions=None, retries=DEFAULT_RETRIES, wait=DEFAULT_WAIT, back_off=DEFAULT_BACK_OFF, max_wait=DEFAULT_MAX_WAIT):
+               retry_exceptions=None, retries=DEFAULT_RETRIES, wait=DEFAULT_WAIT, back_off=DEFAULT_BACK_OFF,
+               max_wait=DEFAULT_MAX_WAIT):
     """
     Retries the given function under certain conditions.
 

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -7,53 +7,78 @@ from synapseclient.core.utils import is_json
 from synapseclient.core.dozer import doze
 
 
-def handle_status_code(response, retry_status_codes, retry_info, logger):
-    retry = False
-    if response is None or not hasattr(response, 'status_code'):
-        return retry
-    if response.status_code in retry_status_codes:
-        response_message = _get_message(response)
-        retry = True
-        logger.debug("retrying on status code: %s" % str(response.status_code))
-        # TODO: this was originally printed regardless of 'verbose' was that behavior correct?
-        logger.debug(str(response_message))
-        if (response.status_code == 429) and (retry_info['wait'] > 10):
-            logger.warning('%s...\n' % response_message)
-            logger.warning('Retrying in %i seconds' % retry_info['wait'])
-
-    elif response.status_code not in range(200, 299):
-        # For all other non 200 messages look for retryable errors in the body or reason field
-        response_message = _get_message(response)
-        if any([msg.lower() in response_message.lower() for msg in retry_info['retry_errors']]):
-            retry = True
-            logger.debug('retrying %s' % response_message)
-        # special case for message throttling
-        elif 'Please slow down.  You may send a maximum of 10 message' in response:
-            retry = True
-            retry_info['wait'] = 16
-            logger.debug("retrying " + response_message)
-    # retry_info['retry'] = retry
-    return retry
+# def _handle_status_code(response, retry_status_codes, retry_info, logger):
+#     retry = False
+#     if response is None or not hasattr(response, 'status_code'):
+#         return retry
+#     if response.status_code in retry_status_codes:
+#         response_message = _get_message(response)
+#         retry = True
+#         logger.debug("retrying on status code: %s" % str(response.status_code))
+#         # TODO: this was originally printed regardless of 'verbose' was that behavior correct?
+#         logger.debug(str(response_message))
+#         if (response.status_code == 429) and (retry_info['wait'] > 10):
+#             logger.warning('%s...\n' % response_message)
+#             logger.warning('Retrying in %i seconds' % retry_info['wait'])
+#
+#     elif response.status_code not in range(200, 299):
+#         # For all other non 200 messages look for retryable errors in the body or reason field
+#         response_message = _get_message(response)
+#         if any([msg.lower() in response_message.lower() for msg in retry_info['retry_errors']]):
+#             retry = True
+#             logger.debug('retrying %s' % response_message)
+#         # special case for message throttling
+#         elif 'Please slow down.  You may send a maximum of 10 message' in response:
+#             retry = True
+#             retry_info['wait'] = 16
+#             logger.debug("retrying " + response_message)
+#     # retry_info['retry'] = retry
+#     return retry
 
 
 def with_retry_network(function, verbose=False,
                        retry_status_codes=[429, 500, 502, 503, 504], retry_errors=[], retry_exceptions=[],
                        retries=3, wait=1, back_off=2, max_wait=30):
+    logger = _get_logger(verbose)
 
-    return with_retry(function, handle_status_code, verbose=verbose, retry_status_codes=retry_status_codes,
+    def _handle_status_code(response):
+        retry = False
+        if response is None or not hasattr(response, 'status_code'):
+            return retry
+        if response.status_code in retry_status_codes:
+            response_message = _get_message(response)
+            retry = True
+            logger.debug("retrying on status code: %s" % str(response.status_code))
+            # TODO: this was originally printed regardless of 'verbose' was that behavior correct?
+            logger.debug(str(response_message))
+            # if (response.status_code == 429) and (wait > 10):
+            #     logger.warning('%s...\n' % response_message)
+            #     logger.warning('Retrying in %i seconds' % wait)
+
+        elif response.status_code not in range(200, 299):
+            # For all other non 200 messages look for retryable errors in the body or reason field
+            response_message = _get_message(response)
+            if any([msg.lower() in response_message.lower() for msg in retry_errors]):
+                retry = True
+                logger.debug('retrying %s' % response_message)
+            # special case for message throttling
+            elif 'Please slow down.  You may send a maximum of 10 message' in response:
+                logger.debug("retrying " + response_message)
+                raise SynapseThrottling(response_message, wait=16)
+        return retry
+    return with_retry(function, _handle_status_code, verbose=verbose,
                       retry_errors=retry_errors, retry_exceptions=retry_exceptions, retries=retries, wait=wait,
                       back_off=back_off, max_wait=max_wait)
 
 
-def with_retry(function, retry_evaluator=None, verbose=False,
-               retry_status_codes=[429, 500, 502, 503, 504], retry_errors=[], retry_exceptions=[],
+def with_retry(function, retry_evaluator=None, verbose=False, retry_errors=[], retry_exceptions=[],
                retries=3, wait=1, back_off=2, max_wait=30):
     """
     Retries the given function under certain conditions.
 
     :param function:           A function with no arguments.  If arguments are needed, use a lambda (see example).
     :param retry_evaluator:    Determined whether to retry again.
-    :param retry_status_codes: What status codes to retry upon in the case of a SynapseHTTPError.
+    # :param retry_status_codes: What status codes to retry upon in the case of a SynapseHTTPError.
     :param retry_errors:       What reasons to retry upon, if function().response.json()['reason'] exists.
     :param retry_exceptions:   What types of exceptions, specified as strings, to retry upon.
     :param retries:            How many times to retry maximum.
@@ -69,35 +94,25 @@ def with_retry(function, retry_evaluator=None, verbose=False,
         result = self._with_retry(lambda: foo("1", "2", "3"), **STANDARD_RETRY_PARAMS)
     """
 
-    if verbose:
-        logger = logging.getLogger(DEBUG_LOGGER_NAME)
-    else:
-        logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+    logger = _get_logger(verbose)
 
     # Retry until we succeed or run out of tries
-    # total_wait = 0
-    retry_info = {
-        'retries': retries,
-        'wait': wait,
-        'total_wait': 0,
-        'max_wait': max_wait,
-        'back_off': back_off,
-        'retry_errors': retry_errors
-    }
-
+    total_wait = 0
     while True:
         # Start with a clean slate
         exc = None
         exc_info = None
-        did_retry = False
-        # retry_info['retry'] = False
+        retry = False
         response = None
 
         # Try making the call
         try:
             response = function()
-            if retry_evaluator and retry_evaluator(response, retry_status_codes, retry_info, logger):
-                did_retry = _retry(retry_info, logger)
+            if retry_evaluator:
+                retry = retry_evaluator(response)
+        except SynapseThrottling as throttling_ex:
+            retry = True
+            wait = throttling_ex.wait
         except Exception as ex:
             exc = ex
             exc_info = sys.exc_info()
@@ -109,23 +124,22 @@ def with_retry(function, retry_evaluator=None, verbose=False,
         if exc is not None:
             if (exc.__class__.__name__ in retry_exceptions or
                     exc.__class__ in retry_exceptions or
+                    not retry_errors or
                     any([msg.lower() in str(exc_info[1]).lower() for msg in retry_errors])):
-                did_retry = _retry(retry_info, logger)
+                retry = True
                 logger.debug("retrying exception: " + str(exc))
 
-        if did_retry:
-            continue
-
         # Wait then retry
-        # if retries >= 0 and retry_info['retry']:
-        #     randomized_wait = wait*random.uniform(0.5, 1.5)
-        #     logger.debug(('total wait time {total_wait:5.0f} seconds\n '
-        #                   '... Retrying in {wait:5.1f} seconds...'.format(total_wait=total_wait,
-        #                   wait=randomized_wait)))
-        #     total_wait += randomized_wait
-        #     doze(randomized_wait)
-        #     wait = min(max_wait, wait*back_off)
-        #     continue
+        retries -= 1
+        if retries >= 0 and retry:
+            randomized_wait = wait*random.uniform(0.5, 1.5)
+            logger.debug(('total wait time {total_wait:5.0f} seconds\n '
+                          '... Retrying in {wait:5.1f} seconds...'.format(total_wait=total_wait,
+                          wait=randomized_wait)))
+            total_wait += randomized_wait
+            doze(randomized_wait)
+            wait = min(max_wait, wait*back_off)
+            continue
 
         # Out of retries, re-raise the exception or return the response
         if exc_info is not None and exc_info[0] is not None:
@@ -134,19 +148,12 @@ def with_retry(function, retry_evaluator=None, verbose=False,
         return response
 
 
-def _retry(retry_info, logger):
-    # Wait then retry
-    retry_info['retries'] -= 1
-    if retry_info['retries'] >= 0:
-        randomized_wait = retry_info['wait'] * random.uniform(0.5, 1.5)
-        logger.debug(('total wait time {total_wait:5.0f} seconds\n '
-                      '... Retrying in {wait:5.1f} seconds...'.format(total_wait=retry_info['total_wait'],
-                                                                      wait=randomized_wait)))
-        retry_info['total_wait'] += randomized_wait
-        doze(randomized_wait)
-        retry_info['wait'] = min(retry_info['max_wait'], retry_info['wait'] * retry_info['back_off'])
-        return True
-    return False
+def _get_logger(verbose):
+    if verbose:
+        logger = logging.getLogger(DEBUG_LOGGER_NAME)
+    else:
+        logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+    return logger
 
 
 def _get_message(response):
@@ -166,9 +173,7 @@ def _get_message(response):
         return None
 
 
-def handle_exception(exc, retry_exceptions, exc_info, retry_info, logger):
-    if (exc.__class__.__name__ in retry_exceptions or
-            exc.__class__ in retry_exceptions or
-            any([msg.lower() in str(exc_info[1]).lower() for msg in retry_info['retry_errors']])):
-        retry_info['retry'] = True
-        logger.debug("retrying exception: " + str(exc))
+class SynapseThrottling(Exception):
+    def __init__(self, message, wait):
+        super().__init__(message)
+        self.wait = wait

--- a/synapseclient/core/upload/multipart_upload.py
+++ b/synapseclient/core/upload/multipart_upload.py
@@ -25,7 +25,7 @@ import threading
 import time
 from typing import List, Mapping
 
-from synapseclient.core.retry import with_retry
+from synapseclient.core.retry import with_retry_network
 from synapseclient.core import pool_provider
 from synapseclient.core.constants import concrete_types
 from synapseclient.core.exceptions import (
@@ -238,7 +238,7 @@ class UploadAttempt:
                 return session.put(part_url, body, headers=signed_headers)
             try:
                 # use our backoff mechanism here, we have encountered 500s on puts to AWS signed urls
-                response = with_retry(put_fn, retry_exceptions=[requests.exceptions.ConnectionError])
+                response = with_retry_network(put_fn, retry_exceptions=[requests.exceptions.ConnectionError])
                 _raise_for_status(response)
 
                 # completed upload part to s3 successfully

--- a/tests/integration/synapseclient/test_evaluations.py
+++ b/tests/integration/synapseclient/test_evaluations.py
@@ -200,5 +200,5 @@ def test_teams(syn, project, schedule_for_cleanup):
     #         if tries > 0:
     #             time.sleep(sleep_time)
     #             sleep_time *= 2
-    found_team = with_retry(function=lambda: anonymous_syn.getTeam(42), retry_errors=[ValueError], retries=8)
+    found_team = with_retry(function=lambda: anonymous_syn.getTeam(42), retry_exceptions=[ValueError], retries=8)
     assert team == found_team

--- a/tests/integration/synapseclient/test_evaluations.py
+++ b/tests/integration/synapseclient/test_evaluations.py
@@ -5,7 +5,7 @@ import uuid
 import random
 
 import pytest
-import unittest
+# import unittest
 
 from synapseclient import Evaluation, File, SubmissionViewSchema, Synapse, Team
 from synapseclient.core.exceptions import SynapseHTTPError

--- a/tests/integration/synapseclient/test_evaluations.py
+++ b/tests/integration/synapseclient/test_evaluations.py
@@ -200,6 +200,6 @@ def test_teams(syn, project, schedule_for_cleanup):
     #         if tries > 0:
     #             time.sleep(sleep_time)
     #             sleep_time *= 2
-    found_team = with_retry(function=lambda: anonymous_syn.getTeam(name), retry_errors=[ValueError],
+    found_team = with_retry(function=lambda: anonymous_syn.getTeam(name),
                             retries=8)
     assert team == found_team

--- a/tests/integration/synapseclient/test_evaluations.py
+++ b/tests/integration/synapseclient/test_evaluations.py
@@ -180,18 +180,6 @@ def test_teams(syn, project, schedule_for_cleanup):
     assert found is not None, "Couldn't find user {} in team".format(p.userName)
 
     # needs to be retried 'cause appending to the search index is asynchronous
-    # tries = 8
-    # sleep_time = 1
-    # found_team = None
-    # while tries > 0:
-    #     try:
-    #         found_team = anonymous_syn.getTeam(name)
-    #         break
-    #     except ValueError:
-    #         tries -= 1
-    #         if tries > 0:
-    #             time.sleep(sleep_time)
-    #             sleep_time *= 2
     found_team = with_retry(function=lambda: anonymous_syn.getTeam(name),
                             retries=8)
     assert team == found_team

--- a/tests/integration/synapseclient/test_evaluations.py
+++ b/tests/integration/synapseclient/test_evaluations.py
@@ -166,7 +166,7 @@ def test_evaluations(syn, project, schedule_for_cleanup):
     pytest.raises(SynapseHTTPError, syn.getEvaluation, ev)
 
 
-@unittest.skip(reason='Unstable timing, particularly on dev stack, SYNPY-816')
+# @unittest.skip(reason='Unstable timing, particularly on dev stack, SYNPY-816')
 def test_teams(syn, project, schedule_for_cleanup):
     name = "My Uniquely Named Team " + str(uuid.uuid4())
     team = syn.store(Team(name=name, description="A fake team for testing..."))
@@ -200,5 +200,6 @@ def test_teams(syn, project, schedule_for_cleanup):
     #         if tries > 0:
     #             time.sleep(sleep_time)
     #             sleep_time *= 2
-    found_team = with_retry(function=lambda: anonymous_syn.getTeam(42), retry_exceptions=[ValueError], retries=8)
+    found_team = with_retry(function=lambda: anonymous_syn.getTeam(name),
+                            retries=5)
     assert team == found_team

--- a/tests/integration/synapseclient/test_evaluations.py
+++ b/tests/integration/synapseclient/test_evaluations.py
@@ -9,6 +9,7 @@ import unittest
 
 from synapseclient import Evaluation, File, SubmissionViewSchema, Synapse, Team
 from synapseclient.core.exceptions import SynapseHTTPError
+from synapseclient.core.retry import with_retry
 
 
 def test_evaluations(syn, project, schedule_for_cleanup):
@@ -187,16 +188,17 @@ def test_teams(syn, project, schedule_for_cleanup):
     assert found is not None, "Couldn't find user {} in team".format(p.userName)
 
     # needs to be retried 'cause appending to the search index is asynchronous
-    tries = 8
-    sleep_time = 1
-    found_team = None
-    while tries > 0:
-        try:
-            found_team = anonymous_syn.getTeam(name)
-            break
-        except ValueError:
-            tries -= 1
-            if tries > 0:
-                time.sleep(sleep_time)
-                sleep_time *= 2
+    # tries = 8
+    # sleep_time = 1
+    # found_team = None
+    # while tries > 0:
+    #     try:
+    #         found_team = anonymous_syn.getTeam(name)
+    #         break
+    #     except ValueError:
+    #         tries -= 1
+    #         if tries > 0:
+    #             time.sleep(sleep_time)
+    #             sleep_time *= 2
+    found_team = with_retry(function=lambda: anonymous_syn.getTeam(42), retry_errors=[ValueError], retries=8)
     assert team == found_team

--- a/tests/integration/synapseclient/test_evaluations.py
+++ b/tests/integration/synapseclient/test_evaluations.py
@@ -5,7 +5,7 @@ import uuid
 import random
 
 import pytest
-# import unittest
+import unittest
 
 from synapseclient import Evaluation, File, SubmissionViewSchema, Synapse, Team
 from synapseclient.core.exceptions import SynapseHTTPError
@@ -166,7 +166,7 @@ def test_evaluations(syn, project, schedule_for_cleanup):
     pytest.raises(SynapseHTTPError, syn.getEvaluation, ev)
 
 
-# @unittest.skip(reason='Unstable timing, particularly on dev stack, SYNPY-816')
+@unittest.skip(reason='Unstable timing, particularly on dev stack, SYNPY-816')
 def test_teams(syn, project, schedule_for_cleanup):
     name = "My Uniquely Named Team " + str(uuid.uuid4())
     team = syn.store(Team(name=name, description="A fake team for testing..."))

--- a/tests/integration/synapseclient/test_evaluations.py
+++ b/tests/integration/synapseclient/test_evaluations.py
@@ -200,6 +200,6 @@ def test_teams(syn, project, schedule_for_cleanup):
     #         if tries > 0:
     #             time.sleep(sleep_time)
     #             sleep_time *= 2
-    found_team = with_retry(function=lambda: anonymous_syn.getTeam(name),
-                            retries=5)
+    found_team = with_retry(function=lambda: anonymous_syn.getTeam(name), retry_errors=[ValueError],
+                            retries=8)
     assert team == found_team

--- a/tests/unit/synapseclient/core/unit_test_retry.py
+++ b/tests/unit/synapseclient/core/unit_test_retry.py
@@ -5,7 +5,7 @@ from synapseclient.core.retry import with_retry, with_retry_network
 from synapseclient.core.exceptions import SynapseError
 
 
-def test_with_retry():
+def test_with_retry_network():
     retryParams = {"retries": 3, "wait": 0}
     response = MagicMock()
     function = MagicMock()
@@ -72,3 +72,7 @@ def test_with_retry__no_status_code():
 
     response = with_retry(fn, retry_exceptions=[ValueError])
     assert 2 == response
+
+
+# def test_
+

--- a/tests/unit/synapseclient/core/unit_test_retry.py
+++ b/tests/unit/synapseclient/core/unit_test_retry.py
@@ -62,6 +62,7 @@ def test_with_retry_network():
     pytest.raises(SynapseError, with_retry_network, function, **retryParams)
     assert function.call_count == 1 + 4 + 3 + 4 + 4 + 1
 
+
 @pytest.mark.parametrize('values', (
     None,
     [],

--- a/tests/unit/synapseclient/core/unit_test_retry.py
+++ b/tests/unit/synapseclient/core/unit_test_retry.py
@@ -53,9 +53,14 @@ def test_with_retry_network():
     def foo():
         raise SynapseError("Bar")
     function.side_effect = foo
-    pytest.raises(SynapseError, with_retry, function, **retryParams)
-    assert function.call_count == 1 + 4 + 3 + 4 + 1
+    # since users didn't pass in any exception so the retry method will retry 3 times
+    pytest.raises(SynapseError, with_retry_network, function, **retryParams)
+    assert function.call_count == 1 + 4 + 3 + 4 + 4
 
+    # since users pass in sepecific exception so the retry method won't retru if meet other exception
+    retryParams = {"retries": 3, "wait": 0, "retry_exceptions": [ValueError]}
+    pytest.raises(SynapseError, with_retry_network, function, **retryParams)
+    assert function.call_count == 1 + 4 + 3 + 4 + 4 + 1
 
 @pytest.mark.parametrize('values', (
     None,

--- a/tests/unit/synapseclient/core/unit_test_retry.py
+++ b/tests/unit/synapseclient/core/unit_test_retry.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import MagicMock
 
-from synapseclient.core.retry import with_retry
+from synapseclient.core.retry import with_retry, with_retry_network
 from synapseclient.core.exceptions import SynapseError
 
 
@@ -13,12 +13,12 @@ def test_with_retry():
 
     # -- No failures --
     response.status_code.__eq__.side_effect = lambda x: x == 250
-    with_retry(function, verbose=True, **retryParams)
+    with_retry_network(function, verbose=True, **retryParams)
     assert function.call_count == 1
 
     # -- Always fail --
     response.status_code.__eq__.side_effect = lambda x: x == 503
-    with_retry(function, verbose=True, **retryParams)
+    with_retry_network(function, verbose=True, **retryParams)
     assert function.call_count == 1 + 4
 
     # -- Fail then succeed --
@@ -30,7 +30,7 @@ def test_with_retry():
             return count != 3
         return x == 503
     response.status_code.__eq__.side_effect = theCharm
-    with_retry(function, verbose=True, **retryParams)
+    with_retry_network(function, verbose=True, **retryParams)
     assert function.call_count == 1 + 4 + 3
 
     # -- Retry with an error message --
@@ -41,7 +41,7 @@ def test_with_retry():
     response.headers.__contains__.side_effect = lambda x: x == 'content-type'
     response.headers.get.side_effect = lambda x, default_value: "application/json" if x == 'content-type' else None
     response.json.return_value = {"reason": retryErrorMessages[0]}
-    with_retry(function, **retryParams)
+    with_retry_network(function, **retryParams)
     assert response.headers.get.called
     assert function.call_count == 1 + 4 + 3 + 4
 

--- a/tests/unit/synapseclient/core/unit_test_retry.py
+++ b/tests/unit/synapseclient/core/unit_test_retry.py
@@ -72,7 +72,3 @@ def test_with_retry__no_status_code():
 
     response = with_retry(fn, retry_exceptions=[ValueError])
     assert 2 == response
-
-
-# def test_
-

--- a/tests/unit/synapseclient/core/unit_test_retry.py
+++ b/tests/unit/synapseclient/core/unit_test_retry.py
@@ -57,8 +57,8 @@ def test_with_retry_network():
     pytest.raises(SynapseError, with_retry_network, function, **retryParams)
     assert function.call_count == 1 + 4 + 3 + 4 + 4
 
-    # since users pass in sepecific exception so the retry method won't retru if meet other exception
-    retryParams = {"retries": 3, "wait": 0, "retry_exceptions": [ValueError]}
+    # since users pass in exception which is empty list so the retry method won't retry
+    retryParams = {"retries": 3, "wait": 0, "retry_exceptions": []}
     pytest.raises(SynapseError, with_retry_network, function, **retryParams)
     assert function.call_count == 1 + 4 + 3 + 4 + 4 + 1
 

--- a/tests/unit/synapseclient/core/unit_test_retry.py
+++ b/tests/unit/synapseclient/core/unit_test_retry.py
@@ -54,12 +54,12 @@ def test_with_retry_network():
         raise SynapseError("Bar")
     function.side_effect = foo
     # since users didn't pass in any exception so the retry method will retry 3 times
-    pytest.raises(SynapseError, with_retry_network, function, **retryParams)
+    pytest.raises(SynapseError, with_retry, function, **retryParams)
     assert function.call_count == 1 + 4 + 3 + 4 + 4
 
     # since users pass in exception which is empty list so the retry method won't retry
     retryParams = {"retries": 3, "wait": 0, "retry_exceptions": []}
-    pytest.raises(SynapseError, with_retry_network, function, **retryParams)
+    pytest.raises(SynapseError, with_retry, function, **retryParams)
     assert function.call_count == 1 + 4 + 3 + 4 + 4 + 1
 
 


### PR DESCRIPTION
Change

- wrap the with_retry method with "with_retry_network" and generalize the logic with back_off
- fix the unit test and integration test after this consolidation