### PR TITLE
[SYNPY-1197] Schema isn't always a entity

### DIFF
--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -1336,7 +1336,7 @@ def Table(schema, values, **kwargs):
     Combine a table schema and a set of values into some type of Table object
     depending on what type of values are given.
 
-    :param schema: a table :py:class:`Schema` object
+    :param schema: a table :py:class:`Schema` object or Synapse Id of Table.
     :param values: an object that holds the content of the tables
                       - a :py:class:`RowSet`
                       - a list of lists (or tuples) where each element is a row

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -1776,13 +1776,14 @@ class CsvFileTable(TableAbstractBaseClass):
 
             test_import_pandas()
             import pandas as pd
-            for col in schema.columns_to_store:
-                if col['columnType'] == 'DATE':
-                    def _trailing_date_time_millisecond(t):
-                        if isinstance(t, str):
-                            return t[:-3]
-                    df[col.name] = pd.to_datetime(df[col.name], errors='coerce').dt.strftime('%s%f')
-                    df[col.name] = df[col.name].apply(lambda x: _trailing_date_time_millisecond(x))
+            if isinstance(schema, Schema):
+                for col in schema.columns_to_store:
+                    if col['columnType'] == 'DATE':
+                        def _trailing_date_time_millisecond(t):
+                            if isinstance(t, str):
+                                return t[:-3]
+                        df[col.name] = pd.to_datetime(df[col.name], errors='coerce').dt.strftime('%s%f')
+                        df[col.name] = df[col.name].apply(lambda x: _trailing_date_time_millisecond(x))
 
             df.to_csv(f,
                       index=False,

--- a/tests/integration/synapseclient/test_tables.py
+++ b/tests/integration/synapseclient/test_tables.py
@@ -226,6 +226,7 @@ def test_tables_pandas(syn, project):
     # retrieve the table and verify
     results = syn.tableQuery('select * from %s' % table.schema.id, resultsAs='csv')
     df2 = results.asDataFrame(convert_to_datetime=True)
+    df1 = results.asDataFrame()
 
     # simulate rowId-version rownames for comparison
     df.index = ['%s_1' % i for i in range(1, 6)]
@@ -243,6 +244,8 @@ def test_tables_pandas(syn, project):
     # second .all() gives a bool that is ANDed value of that Series
 
     assert_frame_equal(df2, df)
+    # Test if string as schema can be passed in.
+    syn.store(Table(table.tableId, df1))
 
 
 def dontruntest_big_tables(syn, project):


### PR DESCRIPTION
When storing tables, it's not always going to be a Schemas object that gets passed in.  A synapse id is also possible.