### PR TITLE
[SYNPY-1209] Support materialized views

### DIFF
--- a/synapseclient/__init__.py
+++ b/synapseclient/__init__.py
@@ -281,7 +281,7 @@ from .core.version_check import check_for_updates, release_notes
 from .entity import Entity, Project, Folder, File, Link, DockerRepository
 from .evaluation import Evaluation, Submission, SubmissionStatus
 from .table import Schema, EntityViewSchema, Column, RowSet, Row, as_table_columns, Table, PartialRowset, \
-    EntityViewType, build_table, SubmissionViewSchema
+    EntityViewType, build_table, SubmissionViewSchema, MaterializedViewSchema
 from .team import Team, UserProfile, UserGroupHeader, TeamMember
 from .wiki import Wiki
 

--- a/synapseclient/__init__.py
+++ b/synapseclient/__init__.py
@@ -297,6 +297,7 @@ __all__ = [
     'Synapse', 'Activity', 'Entity', 'Project', 'Folder', 'File', 'Link', 'DockerRepository', 'Evaluation',
     'Submission', 'SubmissionStatus', 'Schema', 'EntityViewSchema', 'Column', 'Row', 'RowSet', 'Table', 'PartialRowset',
     'Team', 'UserProfile', 'UserGroupHeader', 'TeamMember', 'Wiki', 'Annotations', 'SubmissionViewSchema',
+    'MaterializedViewSchema',
     # functions
     'login', 'build_table', 'as_table_columns', 'check_for_updates', 'release_notes',
     # enum

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -1006,6 +1006,7 @@ class SubmissionViewSchema(ViewBase):
 entity_type_to_class[Schema._synapse_entity_type] = Schema
 entity_type_to_class[EntityViewSchema._synapse_entity_type] = EntityViewSchema
 entity_type_to_class[SubmissionViewSchema._synapse_entity_type] = SubmissionViewSchema
+entity_type_to_class[MaterializedViewSchema._synapse_entity_type] = MaterializedViewSchema
 
 
 class SelectColumn(DictObject):

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -748,10 +748,25 @@ class Schema(SchemaBase):
 
 
 class MaterializedViewSchema(SchemaBase):
-    """_summary_
+    """
+    A MaterializedViewSchema is an :py:class:`synapseclient.entity.Entity` that defines a set of columns in a
+    materialized view along with the SQL statement.
 
-    Args:
-        SchemaBase (_type_): _description_
+    :param name:            the name for the Materialized View Schema object
+    :param description:     User readable description of the schema
+    :param definingSQL:     The synapse SQL statement that defines the data in the materialized view. The SQL may
+                            contain JOIN clauses on multiple tables.
+    :param columns:         a list of :py:class:`Column` objects or their IDs
+    :param parent:          the project in Synapse to which this Materialized View belongs
+    :param properties:      A map of Synapse properties
+    :param annotations:     A map of user defined annotations
+    :param local_state:     Internal use only
+
+    Example::
+
+        defining_sql = "SELECT * FROM syn111 F JOIN syn2222 P on (F.patient_id = P.patient_id)"
+
+        schema = syn.store(MaterializedViewSchema(name='MyTable', parent=project, definingSQL=defining_sql))
     """
     _synapse_entity_type = 'org.sagebionetworks.repo.model.table.MaterializedView'
     _property_keys = SchemaBase._property_keys + ['definingSQL']

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -747,6 +747,24 @@ class Schema(SchemaBase):
                                      annotations=annotations, local_state=local_state, parent=parent, **kwargs)
 
 
+class MaterializedViewSchema(SchemaBase):
+    """_summary_
+
+    Args:
+        SchemaBase (_type_): _description_
+    """
+    _synapse_entity_type = 'org.sagebionetworks.repo.model.table.MaterializedView'
+    _property_keys = SchemaBase._property_keys + ['definingSQL']
+    def __init__(self, name=None, columns=None, parent=None, definingSQL=None, properties=None, annotations=None, local_state=None,
+                 **kwargs):
+        if definingSQL is not None:
+            kwargs['definingSQL'] = definingSQL
+        super(MaterializedViewSchema, self).__init__(
+            name=name, columns=columns, properties=properties,
+            annotations=annotations, local_state=local_state, parent=parent, **kwargs
+        )
+
+
 class ViewBase(SchemaBase):
     """
     This is a helper class for EntityViewSchema and SubmissionViewSchema

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -755,8 +755,8 @@ class MaterializedViewSchema(SchemaBase):
     """
     _synapse_entity_type = 'org.sagebionetworks.repo.model.table.MaterializedView'
     _property_keys = SchemaBase._property_keys + ['definingSQL']
-    def __init__(self, name=None, columns=None, parent=None, definingSQL=None, properties=None, annotations=None, local_state=None,
-                 **kwargs):
+    def __init__(self, name=None, columns=None, parent=None, definingSQL=None, properties=None, annotations=None,
+                 local_state=None, **kwargs):
         if definingSQL is not None:
             kwargs['definingSQL'] = definingSQL
         super(MaterializedViewSchema, self).__init__(

--- a/tests/integration/synapseclient/test_tables.py
+++ b/tests/integration/synapseclient/test_tables.py
@@ -227,7 +227,6 @@ def test_materialized_view(syn, project):
     assert all(view_df.columns == ["F.Name", "F.Born", "F.Hipness", "F.Living", "P.Name", "P.Age"])
 
 
-
 def test_tables_csv(syn, project):
 
     # Define schema

--- a/tests/unit/synapseclient/unit_test_tables.py
+++ b/tests/unit/synapseclient/unit_test_tables.py
@@ -20,7 +20,7 @@ import synapseclient.table
 from synapseclient.table import Column, Schema, CsvFileTable, TableQueryResult, cast_values, \
     as_table_columns, Table, build_table, RowSet, SelectColumn, EntityViewSchema, RowSetTable, Row, PartialRow, \
     PartialRowset, SchemaBase, _get_view_type_mask_for_deprecated_type, EntityViewType, _get_view_type_mask, \
-    MAX_NUM_TABLE_COLUMNS, SubmissionViewSchema, escape_column_name, join_column_names
+    MAX_NUM_TABLE_COLUMNS, SubmissionViewSchema, escape_column_name, join_column_names, MaterializedViewSchema
 
 from synapseclient.core.utils import from_unix_epoch_time
 from unittest.mock import patch
@@ -147,6 +147,28 @@ def test_schema():
     assert len(schema.columns_to_store) == 3
     assert Column(name='Living', columnType='BOOLEAN') not in schema.columns_to_store
     assert Column(name='Hipness', columnType='DOUBLE') in schema.columns_to_store
+
+
+def test_materialized_view():
+    """Test creation of materialized view
+    """
+    mat_view = MaterializedViewSchema(
+        name='My Table',
+        parent="syn1000001",
+        definingSQL="SELECT * FROM syn111 F JOIN syn2222 P on (F.patient_id = P.patient_id)"
+    )
+    mat_view._synapse_entity_type == "org.sagebionetworks.repo.model.table.MaterializedView"
+
+    assert not mat_view.has_columns()
+
+    mat_view.addColumn(Column(id='1', name='Name', columnType='STRING'))
+
+    assert mat_view.has_columns()
+    assert mat_view.properties.columnIds == ['1']
+
+    mat_view.removeColumn('1')
+    assert not mat_view.has_columns()
+    assert mat_view.properties.columnIds == []
 
 
 def test_RowSetTable():


### PR DESCRIPTION
Supports materialized views as described here: https://sagebionetworks.jira.com/wiki/spaces/PLFM/pages/2514321554/Synapse+Joins

Heres how you test this branch:

1. Create a new Python virtualenv
2. Install this specific branch
    ```
    pip install pandas
    pip install https://github.com/thomasyu888/synapsePythonClient/archive/refs/heads/synpy-1209-materializedviews.zip
    ```
3. Run code with replacements of synapse ids and join
    ```
    from synapseclient.table import MaterializedViewSchema
    import synapseclient
    syn = synapseclient.Synapse()
    # no need to specify staging endpoints anymore
    # syn.setEndpoints(**synapseclient.client.STAGING_ENDPOINTS)
    syn = synapseclient.login()
    
    temp = MaterializedViewSchema(
        name="test-material-view",
        parent="syn34234",
        definingSQL="SELECT * FROM syn111 F JOIN syn2222 P on (F.PATIENT_ID = P.PATIENT_ID)"
    )
    ent = syn.store(temp)
    
    temp = syn.tableQuery(f"select * from {ent.id}")
    temp.asDataFrame()
    # Clean up materialized view
    syn.delete(ent)
    ```
4. Check in the UI.
