### PR TITLE
[SYNPY-1219] update Entity __init__ to be compatible with Dataset

### DIFF
--- a/synapseclient/entity.py
+++ b/synapseclient/entity.py
@@ -139,6 +139,7 @@ See also:
 """
 
 import collections.abc
+import itertools
 import io
 import os
 import inspect
@@ -429,15 +430,12 @@ class Entity(collections.abc.MutableMapping):
         f.write(self.__class__.__name__)
         f.write("(")
         f.write(", ".join(
-            {"%s=%s" % (str(key), value.__repr__(),)
-             for key, value in list([k_v for k_v in self.__dict__.items()
-                                     if not (k_v[0] in ['properties', 'annotations'] or k_v[0].startswith('__'))])}))
-        f.write(", ")
-        f.write(", ".join(
-            {"%s=%s" % (str(key), self.properties[key].__repr__(),) for key in self.properties}))
-        f.write(", ")
-        f.write(", ".join(
-            {"%s=%s" % (str(key), value.__repr__(),) for key, value in self.annotations.items()}))
+            {"%s=%s" % (str(key), value.__repr__(),) for key, value in
+                itertools.chain(
+                    list([k_v for k_v in self.__dict__.items()
+                          if not (k_v[0] in ['properties', 'annotations'] or k_v[0].startswith('__'))]),
+                    self.properties.items(),
+                    self.annotations.items())}))
         f.write(")")
         return f.getvalue()
 

--- a/synapseclient/entity.py
+++ b/synapseclient/entity.py
@@ -240,6 +240,9 @@ class Entity(collections.abc.MutableMapping):
                 if 'annotations' in properties and isinstance(properties['annotations'], collections.abc.Mapping):
                     annotations.update(properties['annotations'])
                     del properties['annotations']
+
+                # Re-map `items` to `datasetItems` to avoid namespace conflicts
+                # between Dataset schema and the items() builtin method.
                 if 'items' in properties:
                     properties['datasetItems'] = properties['items']
                     del properties['items']

--- a/synapseclient/entity.py
+++ b/synapseclient/entity.py
@@ -139,7 +139,6 @@ See also:
 """
 
 import collections.abc
-import itertools
 import io
 import os
 import inspect
@@ -427,12 +426,15 @@ class Entity(collections.abc.MutableMapping):
         f.write(self.__class__.__name__)
         f.write("(")
         f.write(", ".join(
-            {"%s=%s" % (str(key), value.__repr__(),) for key, value in
-                itertools.chain(
-                    list([k_v for k_v in self.__dict__.items()
-                          if not (k_v[0] in ['properties', 'annotations'] or k_v[0].startswith('__'))]),
-                    self.properties.items(),
-                    self.annotations.items())}))
+            {"%s=%s" % (str(key), value.__repr__(),)
+             for key, value in list([k_v for k_v in self.__dict__.items()
+                                     if not (k_v[0] in ['properties', 'annotations'] or k_v[0].startswith('__'))])}))
+        f.write(", ")
+        f.write(", ".join(
+            {"%s=%s" % (str(key), self.properties[key].__repr__(),) for key in self.properties}))
+        f.write(", ")
+        f.write(", ".join(
+            {"%s=%s" % (str(key), value.__repr__(),) for key, value in self.annotations.items()}))
         f.write(")")
         return f.getvalue()
 

--- a/synapseclient/entity.py
+++ b/synapseclient/entity.py
@@ -239,6 +239,9 @@ class Entity(collections.abc.MutableMapping):
                 if 'annotations' in properties and isinstance(properties['annotations'], collections.abc.Mapping):
                     annotations.update(properties['annotations'])
                     del properties['annotations']
+                if 'items' in properties:
+                    properties['datasetItems'] = properties['items']
+                    del properties['items']
                 self.__dict__['properties'].update(properties)
             else:
                 raise SynapseMalformedEntityError(


### PR DESCRIPTION
Due to there being a property named `items` in the Dataset schema, calling `self.properties.items()` results in a TypeError in the `__repr__()` method.

This PR will address #913 by utilizing the good ol' fashion way of getting a dictionary value by using its key instead.

**Before fix:**
```python
>>> dataset = syn.get("syn29430164")
>>> repr(dataset)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/vchung/Desktop/synapsePythonClient/synapseclient/entity.py", line 434, in __repr__
    self.properties.items(),
TypeError: 'list' object is not callable
>>> 
```

**After fix:**
```python
>>> repr(dataset)
"Entity(, modifiedBy='3393723', versionNumber=1, isLatestVersion=True, items=[{'entityId': 'syn20685093', 'versionNumber': 1}], parentId='syn20682803', name='Pokedex', etag='83c7c33b-253a-426a-b49d-e4cb57a67bdb', createdOn='2022-04-15T07:12:47.508Z', modifiedOn='2022-04-15T17:48:32.935Z', createdBy='3393723', columnIds=['81721', '81722', '81724'], concreteType='org.sagebionetworks.repo.model.table.Dataset', versionLabel='1', id='syn29430164', )"
```

If this is merged after #911 , then the proper entity type will be returned:

```python
>>> syn.get("syn29430164")
Dataset(columns_to_store=[], columnIds=['81721', '81722', '81724'], versionNumber=1, parentId='syn20682803', id='syn29430164', modifiedOn='2022-04-15T17:48:32.935Z', items=[{'entityId': 'syn20685093', 'versionNumber': 1}], name='Pokedex', createdOn='2022-04-15T07:12:47.508Z', createdBy='3393723', isLatestVersion=True, etag='83c7c33b-253a-426a-b49d-e4cb57a67bdb', concreteType='org.sagebionetworks.repo.model.table.Dataset', modifiedBy='3393723', versionLabel='1', )
```

Note: because of the updated code changes, a trailing comma will be present if the entity does not have annotations. Not sure if this is a big deal?