### PR TITLE
[SYNPY-1207] Update property name

### DIFF
--- a/synapseclient/entity.py
+++ b/synapseclient/entity.py
@@ -244,7 +244,7 @@ class Entity(collections.abc.MutableMapping):
                 # Re-map `items` to `datasetItems` to avoid namespace conflicts
                 # between Dataset schema and the items() builtin method.
                 if 'items' in properties:
-                    properties['dataset_items'] = properties['items']
+                    properties['datasetItems'] = properties['items']
                     del properties['items']
                 self.__dict__['properties'].update(properties)
             else:

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -865,13 +865,13 @@ class Dataset(SchemaBase):
             comment="This is version 1")
     """
     _synapse_entity_type: str = "org.sagebionetworks.repo.model.table.Dataset"
-    _property_keys: List[str] = SchemaBase._property_keys + ['dataset_items']
+    _property_keys: List[str] = SchemaBase._property_keys + ['datasetItems']
     _local_keys: List[str] = SchemaBase._local_keys + ['folders_to_add', 'force']
 
     def __init__(self, name=None, columns=None, parent=None, properties=None,
                  annotations=None, local_state=None, dataset_items=None,
                  folder_ids=None, force=None, **kwargs):
-        self.properties.setdefault('dataset_items', [])
+        self.properties.setdefault('datasetItems', [])
         self.__dict__.setdefault('folders_to_add', set())
         self.__dict__.setdefault('force', False)
         super(Dataset, self).__init__(
@@ -893,7 +893,7 @@ class Dataset(SchemaBase):
             self.add_folders(folder_ids, force)
 
     def __len__(self):
-        return len(self.properties.dataset_items)
+        return len(self.properties.datasetItems)
 
     def _check_needed_keys(syn, keys: List[str]):
         required_keys = {'entityId', 'versionNumber'}
@@ -909,11 +909,11 @@ class Dataset(SchemaBase):
         """
         if isinstance(dataset_item, dict) and self._check_needed_keys(dataset_item.keys()):
             if not self.has_item(dataset_item.get('entityId')):
-                self.properties.dataset_items.append(dataset_item)
+                self.properties.datasetItems.append(dataset_item)
             else:
                 if force:
                     self.remove_item(dataset_item.get('entityId'))
-                    self.properties.dataset_items.append(dataset_item)
+                    self.properties.datasetItems.append(dataset_item)
                 else:
                     raise ValueError(
                         f"Duplicate item found: {dataset_item.get('entityId')}. "
@@ -935,21 +935,21 @@ class Dataset(SchemaBase):
         """
         item_id = id_of(item_id)
         if item_id.startswith("syn"):
-            for i, curr_item in enumerate(self.properties.dataset_items):
+            for i, curr_item in enumerate(self.properties.datasetItems):
                 if curr_item.get('entityId') == item_id:
-                    del self.properties.dataset_items[i]
+                    del self.properties.datasetItems[i]
                     break
         else:
             raise ValueError("Not a Synapse ID: %s" % str(item_id))
 
     def empty(self):
-        self.properties.dataset_items = []
+        self.properties.datasetItems = []
 
     def has_item(self, item_id):
         """
         :param item_id: a single dataset item Synapse ID
         """
-        return any(item['entityId'] == item_id for item in self.properties.dataset_items)
+        return any(item['entityId'] == item_id for item in self.properties.datasetItems)
 
     def add_folder(self, folder_id: str, force: bool = False):
         """
@@ -1003,9 +1003,9 @@ class Dataset(SchemaBase):
         # Reset attribute to force-add items from folders.
         self.force = False
 
-        # Remap `dataset_items` back to `items` before storing (since `items`
-        # is the accepted field name in the API, not `dataset_items`).
-        self.properties.items = self.properties.dataset_items
+        # Remap `datasetItems` back to `items` before storing (since `items`
+        # is the accepted field name in the API, not `datasetItems`).
+        self.properties.items = self.properties.datasetItems
 
 
 class ViewBase(SchemaBase):

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -871,7 +871,7 @@ class Dataset(SchemaBase):
 
     def __init__(self, name=None, columns=None, parent=None, properties=None,
                  annotations=None, local_state=None, dataset_items=None,
-                 folder=None, force=None, **kwargs):
+                 folders=None, force=None, **kwargs):
         self.properties.setdefault('datasetItems', [])
         self.__dict__.setdefault('folders_to_add', set())
         self.__dict__.setdefault('force', False)

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -871,7 +871,7 @@ class Dataset(SchemaBase):
 
     def __init__(self, name=None, columns=None, parent=None, properties=None,
                  annotations=None, local_state=None, dataset_items=None,
-                 folder_ids=None, force=None, **kwargs):
+                 folder=None, force=None, **kwargs):
         self.properties.setdefault('datasetItems', [])
         self.__dict__.setdefault('folders_to_add', set())
         self.__dict__.setdefault('force', False)

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -881,7 +881,7 @@ class Dataset(SchemaBase):
         )
 
         # Add default Dataset columns if schema is not provided.
-        if columns is None:
+        if not self.properties.columnIds and columns is None:
             self.addColumns(['81721', '81722', '81723', '81724', '81725',
                              '81728', '81729', '81730', '81731', '81732',
                              '81726', '81727', '81733', '112368', '112369'])


### PR DESCRIPTION
This will make it so all properties are consistent with styling; currently, `dataset_items` is using snake case while all other properties are using camel case. 