### PR TITLE
[SYNPY-1226] use viewbase for datasets

### DIFF
--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -1092,7 +1092,8 @@ class Dataset(ViewBase):
                 items_to_add = self._add_folder_files(syn, folder)
                 self.add_items(items_to_add, self.force)
             self.folders_to_add = set()
-
+        # Must set this scopeIds is used to get all annotations from the
+        # entities
         self.scopeIds = [item['entityId'] for item in self.properties.datasetItems]
         super()._before_synapse_store(syn)
         # Reset attribute to force-add items from folders.

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -785,6 +785,93 @@ class MaterializedViewSchema(SchemaBase):
         )
 
 
+class ViewBase(SchemaBase):
+    """
+    This is a helper class for EntityViewSchema and SubmissionViewSchema
+    containing the common methods for both.
+    """
+    _synapse_entity_type = ""
+    _property_keys = SchemaBase._property_keys + ['viewTypeMask', 'scopeIds']
+    _local_keys = SchemaBase._local_keys + ['addDefaultViewColumns', 'addAnnotationColumns',
+                                            'ignoredAnnotationColumnNames']
+
+    def add_scope(self, entities):
+        """
+        :param entities: a Project, Folder, Evaluation object or its ID, can also be a list of them
+        """
+        if isinstance(entities, list):
+            # add ids to a temp list so that we don't partially modify scopeIds on an exception in id_of()
+            temp_list = [id_of(entity) for entity in entities]
+            self.scopeIds.extend(temp_list)
+        else:
+            self.scopeIds.append(id_of(entities))
+
+    def _filter_duplicate_columns(self, syn, columns_to_add):
+        """
+        If a column to be added has the same name and same type as an existing column, it will be considered a duplicate
+         and not added.
+        :param syn:             a :py:class:`synapseclient.client.Synapse` object that is logged in
+        :param columns_to_add:  iterable collection of type :py:class:`synapseclient.table.Column` objects
+        :return: a filtered list of columns to add
+        """
+
+        # no point in making HTTP calls to retrieve existing Columns if we not adding any new columns
+        if not columns_to_add:
+            return columns_to_add
+
+        # set up Column name/type tracking
+        # map of str -> set(str), where str is the column type as a string and set is a set of column name strings
+        column_type_to_annotation_names = {}
+
+        # add to existing columns the columns that user has added but not yet created in synapse
+        column_generator = itertools.chain(syn.getColumns(self.columnIds),
+                                           self.columns_to_store) if self.columns_to_store \
+            else syn.getColumns(self.columnIds)
+
+        for column in column_generator:
+            column_name = column['name']
+            column_type = column['columnType']
+
+            column_type_to_annotation_names.setdefault(column_type, set()).add(column_name)
+
+        valid_columns = []
+        for column in columns_to_add:
+            new_col_name = column['name']
+            new_col_type = column['columnType']
+
+            typed_col_name_set = column_type_to_annotation_names.setdefault(new_col_type, set())
+            if new_col_name not in typed_col_name_set:
+                typed_col_name_set.add(new_col_name)
+                valid_columns.append(column)
+        return valid_columns
+
+    def _before_synapse_store(self, syn):
+        # get the default EntityView columns from Synapse and add them to the columns list
+        additional_columns = []
+        view_type = self._synapse_entity_type.split(".")[-1].lower()
+        mask = self.get("viewTypeMask")
+
+        if self.addDefaultViewColumns:
+            additional_columns.extend(
+                syn._get_default_view_columns(view_type, view_type_mask=mask)
+            )
+
+        # get default annotations
+        if self.addAnnotationColumns:
+            anno_columns = [x for x in syn._get_annotation_view_columns(self.scopeIds, view_type,
+                                                                        view_type_mask=mask)
+                            if x['name'] not in self.ignoredAnnotationColumnNames]
+            additional_columns.extend(anno_columns)
+
+        self.addColumns(self._filter_duplicate_columns(syn, additional_columns))
+
+        # set these boolean flags to false so they are not repeated.
+        self.addDefaultViewColumns = False
+        self.addAnnotationColumns = False
+
+        super(ViewBase, self)._before_synapse_store(syn)
+
+
 class Dataset(ViewBase):
     """
     A Dataset is an :py:class:`synapseclient.entity.Entity` that defines a
@@ -1013,93 +1100,6 @@ class Dataset(ViewBase):
         # Remap `datasetItems` back to `items` before storing (since `items`
         # is the accepted field name in the API, not `datasetItems`).
         self.properties.items = self.properties.datasetItems
-
-
-class ViewBase(SchemaBase):
-    """
-    This is a helper class for EntityViewSchema and SubmissionViewSchema
-    containing the common methods for both.
-    """
-    _synapse_entity_type = ""
-    _property_keys = SchemaBase._property_keys + ['viewTypeMask', 'scopeIds']
-    _local_keys = SchemaBase._local_keys + ['addDefaultViewColumns', 'addAnnotationColumns',
-                                            'ignoredAnnotationColumnNames']
-
-    def add_scope(self, entities):
-        """
-        :param entities: a Project, Folder, Evaluation object or its ID, can also be a list of them
-        """
-        if isinstance(entities, list):
-            # add ids to a temp list so that we don't partially modify scopeIds on an exception in id_of()
-            temp_list = [id_of(entity) for entity in entities]
-            self.scopeIds.extend(temp_list)
-        else:
-            self.scopeIds.append(id_of(entities))
-
-    def _filter_duplicate_columns(self, syn, columns_to_add):
-        """
-        If a column to be added has the same name and same type as an existing column, it will be considered a duplicate
-         and not added.
-        :param syn:             a :py:class:`synapseclient.client.Synapse` object that is logged in
-        :param columns_to_add:  iterable collection of type :py:class:`synapseclient.table.Column` objects
-        :return: a filtered list of columns to add
-        """
-
-        # no point in making HTTP calls to retrieve existing Columns if we not adding any new columns
-        if not columns_to_add:
-            return columns_to_add
-
-        # set up Column name/type tracking
-        # map of str -> set(str), where str is the column type as a string and set is a set of column name strings
-        column_type_to_annotation_names = {}
-
-        # add to existing columns the columns that user has added but not yet created in synapse
-        column_generator = itertools.chain(syn.getColumns(self.columnIds),
-                                           self.columns_to_store) if self.columns_to_store \
-            else syn.getColumns(self.columnIds)
-
-        for column in column_generator:
-            column_name = column['name']
-            column_type = column['columnType']
-
-            column_type_to_annotation_names.setdefault(column_type, set()).add(column_name)
-
-        valid_columns = []
-        for column in columns_to_add:
-            new_col_name = column['name']
-            new_col_type = column['columnType']
-
-            typed_col_name_set = column_type_to_annotation_names.setdefault(new_col_type, set())
-            if new_col_name not in typed_col_name_set:
-                typed_col_name_set.add(new_col_name)
-                valid_columns.append(column)
-        return valid_columns
-
-    def _before_synapse_store(self, syn):
-        # get the default EntityView columns from Synapse and add them to the columns list
-        additional_columns = []
-        view_type = self._synapse_entity_type.split(".")[-1].lower()
-        mask = self.get("viewTypeMask")
-
-        if self.addDefaultViewColumns:
-            additional_columns.extend(
-                syn._get_default_view_columns(view_type, view_type_mask=mask)
-            )
-
-        # get default annotations
-        if self.addAnnotationColumns:
-            anno_columns = [x for x in syn._get_annotation_view_columns(self.scopeIds, view_type,
-                                                                        view_type_mask=mask)
-                            if x['name'] not in self.ignoredAnnotationColumnNames]
-            additional_columns.extend(anno_columns)
-
-        self.addColumns(self._filter_duplicate_columns(syn, additional_columns))
-
-        # set these boolean flags to false so they are not repeated.
-        self.addDefaultViewColumns = False
-        self.addAnnotationColumns = False
-
-        super(ViewBase, self)._before_synapse_store(syn)
 
 
 class EntityViewSchema(ViewBase):

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -781,234 +781,6 @@ class MaterializedViewSchema(SchemaBase):
         )
 
 
-class Dataset(SchemaBase):
-    """
-    A Dataset is an :py:class:`synapseclient.entity.Entity` that defines a
-    flat list of entities as a tableview (a.k.a. a "dataset").
-
-    :param name:            The name for the Dataset object
-    :param description:     User readable description of the schema
-    :param columns:         A list of :py:class:`Column` objects or their IDs
-    :param parent:          The Synapse Project to which this Dataset belongs
-    :param properties:      A map of Synapse properties
-    :param annotations:     A map of user defined annotations
-    :param dataset_items:   A list of items characterized by entityId and versionNumber
-    :param folder:          A list of Folder IDs
-    :param local_state:     Internal use only
-
-    Example::
-
-        from synapseclient import Dataset
-
-        # Create a Dataset with pre-defined DatasetItems. Default Dataset columns
-        # are used if no schema is provided.
-        dataset_items = [
-            {'entityId': "syn000", 'versionNumber: 1},
-            {...},
-        ]
-        dataset = syn.store(Dataset(
-            name="My Dataset",
-            parent=project,
-            dataset_items=dataset_items))
-
-        # Add/remove specific Synapse IDs to/from the Dataset
-        dataset.add_item({'entityId': "syn111", 'versionNumber': 1})
-        dataset.remove_item("syn000")
-        dataset = syn.store(dataset)
-
-        # Add a list of Synapse IDs to the Dataset
-        new_items = [
-            {'entityId': "syn222", 'versionNumber': 2},
-            {'entityId': "syn333", 'versionNumber': 1}
-        ]
-        dataset.add_items(new_items)
-        dataset = syn.store(dataset)
-
-    Folders can easily be added recursively to a dataset, that is, all files
-    within the folder (including sub-folders) will be added.  Note that using
-    the following methods will add files with the latest version number ONLY.
-    If another version number is desired, use :py:classmethod:`synapseclient.table.add_item`
-    or :py:classmethod:`synapseclient.table.add_items`.
-
-    Example::
-
-        # Add a single Folder to the Dataset
-        dataset.add_folder("syn123")
-
-        # Add a list of Folders, overwriting any existing files in the dataset
-        dataset.add_folders(["syn456", "syn789"], force=True)
-
-        dataset = syn.store(dataset)
-
-    empty() can be used to truncate a dataset, that is, remove all current
-    items from the set.
-
-    Example::
-
-        dataset.empty()
-        dataset = syn.store(dataset)
-
-    To get the number of entities in the dataset, use len().
-
-    Example::
-
-        print(f"{dataset.name} has {len(dataset)} items.")
-
-    To create a snapshot version of the Dataset, use
-    :py:classmethod:`synapseclient.client.create_snapshot_version`.
-
-    Example::
-
-        syn = synapseclient.login()
-        syn.create_snapshot_version(
-            dataset.id,
-            label="v1.0",
-            comment="This is version 1")
-    """
-    _synapse_entity_type: str = "org.sagebionetworks.repo.model.table.Dataset"
-    _property_keys: List[str] = SchemaBase._property_keys + ['datasetItems']
-    _local_keys: List[str] = SchemaBase._local_keys + ['folders_to_add', 'force']
-
-    def __init__(self, name=None, columns=None, parent=None, properties=None,
-                 annotations=None, local_state=None, dataset_items=None,
-                 folders=None, force=None, **kwargs):
-        self.properties.setdefault('datasetItems', [])
-        self.__dict__.setdefault('folders_to_add', set())
-        self.__dict__.setdefault('force', False)
-        super(Dataset, self).__init__(
-            name=name, columns=columns, properties=properties,
-            annotations=annotations, local_state=local_state, parent=parent,
-            **kwargs
-        )
-
-        if force:
-            self.force = True
-        if dataset_items:
-            self.add_items(dataset_items, force)
-        if folders:
-            self.add_folders(folders, force)
-
-    def __len__(self):
-        return len(self.properties.datasetItems)
-
-    @staticmethod
-    def _check_needed_keys(keys: List[str]):
-        required_keys = {'entityId', 'versionNumber'}
-        if required_keys - keys:
-            raise LookupError("DatasetItem missing a required property: %s" %
-                              str(required_keys - keys))
-        return True
-
-    def add_item(self, dataset_item: Dict[str, str], force: bool = True):
-        """
-        :param dataset_item:    a single dataset item
-        :param force:           force add item
-        """
-        if isinstance(dataset_item, dict) and self._check_needed_keys(dataset_item.keys()):
-            if not self.has_item(dataset_item.get('entityId')):
-                self.properties.datasetItems.append(dataset_item)
-            else:
-                if force:
-                    self.remove_item(dataset_item.get('entityId'))
-                    self.properties.datasetItems.append(dataset_item)
-                else:
-                    raise ValueError(
-                        f"Duplicate item found: {dataset_item.get('entityId')}. "
-                        "Set force=True to overwrite the existing item.")
-        else:
-            raise ValueError("Not a DatasetItem? %s" % str(dataset_item))
-
-    def add_items(self, dataset_items: List[Dict[str, str]], force: bool = True):
-        """
-        :param dataset_items:   a list of dataset items
-        :param force:           force add items
-        """
-        for dataset_item in dataset_items:
-            self.add_item(dataset_item, force)
-
-    def remove_item(self, item_id: str):
-        """
-        :param item_id: a single dataset item Synapse ID
-        """
-        item_id = id_of(item_id)
-        if item_id.startswith("syn"):
-            for i, curr_item in enumerate(self.properties.datasetItems):
-                if curr_item.get('entityId') == item_id:
-                    del self.properties.datasetItems[i]
-                    break
-        else:
-            raise ValueError("Not a Synapse ID: %s" % str(item_id))
-
-    def empty(self):
-        self.properties.datasetItems = []
-
-    def has_item(self, item_id):
-        """
-        :param item_id: a single dataset item Synapse ID
-        """
-        return any(item['entityId'] == item_id for item in self.properties.datasetItems)
-
-    def add_folder(self, folder: str, force: bool = True):
-        """
-        :param folder:  a single Synapse Folder ID
-        :param force:   force add items from folder
-        """
-        if not self.__dict__.get('folders_to_add', None):
-            self.__dict__['folders_to_add'] = set()
-        self.__dict__['folders_to_add'].add(folder)
-        if self.force != force:
-            self.force = force
-
-    def add_folders(self, folders: List[str], force: bool = True):
-        """
-        :param folders: a list of Synapse Folder IDs
-        :param force:   force add items from folders
-        """
-        if isinstance(folders, list) or isinstance(folders, set) or \
-                isinstance(folders, tuple):
-            self.force = force
-            for folder in folders:
-                self.add_folder(folder, force)
-        else:
-            raise ValueError(f"Not a list of Folder IDs: {folders}")
-
-    def _add_folder_files(self, syn, folder):
-        files = []
-        children = syn.getChildren(folder)
-        for child in children:
-            if child.get("type") == "org.sagebionetworks.repo.model.Folder":
-                files.extend(self._add_folder_files(syn, child.get("id")))
-            elif child.get("type") == "org.sagebionetworks.repo.model.FileEntity":
-                files.append({
-                    'entityId': child.get("id"),
-                    'versionNumber': child.get('versionNumber')
-                })
-            else:
-                raise ValueError(f"Not a Folder?: {folder}")
-        return files
-
-    def _before_synapse_store(self, syn):
-        # Add default Dataset columns if schema is not provided.
-        if not self.properties.columnIds and not self.columns_to_store:
-            self.addColumns(syn._get_default_view_columns("dataset"))
-
-        super()._before_synapse_store(syn)
-
-        # Add files from folders (if any) before storing dataset.
-        if self.folders_to_add:
-            for folder in self.folders_to_add:
-                items_to_add = self._add_folder_files(syn, folder)
-                self.add_items(items_to_add, self.force)
-            self.folders_to_add = set()
-
-        # Reset attribute to force-add items from folders.
-        self.force = True
-
-        # Remap `datasetItems` back to `items` before storing (since `items`
-        # is the accepted field name in the API, not `datasetItems`).
-        self.properties.items = self.properties.datasetItems
-
-
 class ViewBase(SchemaBase):
     """
     This is a helper class for EntityViewSchema and SubmissionViewSchema
@@ -1246,6 +1018,234 @@ class SubmissionViewSchema(ViewBase):
         # add the scopes last so that we can append the passed in scopes to those defined in properties
         if scopes is not None:
             self.add_scope(scopes)
+
+
+class Dataset(ViewBase):
+    """
+    A Dataset is an :py:class:`synapseclient.entity.Entity` that defines a
+    flat list of entities as a tableview (a.k.a. a "dataset").
+
+    :param name:            The name for the Dataset object
+    :param description:     User readable description of the schema
+    :param columns:         A list of :py:class:`Column` objects or their IDs
+    :param parent:          The Synapse Project to which this Dataset belongs
+    :param properties:      A map of Synapse properties
+    :param annotations:     A map of user defined annotations
+    :param dataset_items:   A list of items characterized by entityId and versionNumber
+    :param folder:          A list of Folder IDs
+    :param local_state:     Internal use only
+
+    Example::
+
+        from synapseclient import Dataset
+
+        # Create a Dataset with pre-defined DatasetItems. Default Dataset columns
+        # are used if no schema is provided.
+        dataset_items = [
+            {'entityId': "syn000", 'versionNumber: 1},
+            {...},
+        ]
+        dataset = syn.store(Dataset(
+            name="My Dataset",
+            parent=project,
+            dataset_items=dataset_items))
+
+        # Add/remove specific Synapse IDs to/from the Dataset
+        dataset.add_item({'entityId': "syn111", 'versionNumber': 1})
+        dataset.remove_item("syn000")
+        dataset = syn.store(dataset)
+
+        # Add a list of Synapse IDs to the Dataset
+        new_items = [
+            {'entityId': "syn222", 'versionNumber': 2},
+            {'entityId': "syn333", 'versionNumber': 1}
+        ]
+        dataset.add_items(new_items)
+        dataset = syn.store(dataset)
+
+    Folders can easily be added recursively to a dataset, that is, all files
+    within the folder (including sub-folders) will be added.  Note that using
+    the following methods will add files with the latest version number ONLY.
+    If another version number is desired, use :py:classmethod:`synapseclient.table.add_item`
+    or :py:classmethod:`synapseclient.table.add_items`.
+
+    Example::
+
+        # Add a single Folder to the Dataset
+        dataset.add_folder("syn123")
+
+        # Add a list of Folders, overwriting any existing files in the dataset
+        dataset.add_folders(["syn456", "syn789"], force=True)
+
+        dataset = syn.store(dataset)
+
+    empty() can be used to truncate a dataset, that is, remove all current
+    items from the set.
+
+    Example::
+
+        dataset.empty()
+        dataset = syn.store(dataset)
+
+    To get the number of entities in the dataset, use len().
+
+    Example::
+
+        print(f"{dataset.name} has {len(dataset)} items.")
+
+    To create a snapshot version of the Dataset, use
+    :py:classmethod:`synapseclient.client.create_snapshot_version`.
+
+    Example::
+
+        syn = synapseclient.login()
+        syn.create_snapshot_version(
+            dataset.id,
+            label="v1.0",
+            comment="This is version 1")
+    """
+    _synapse_entity_type: str = "org.sagebionetworks.repo.model.table.Dataset"
+    _property_keys: List[str] = SchemaBase._property_keys + ['datasetItems']
+    _local_keys: List[str] = SchemaBase._local_keys + ['folders_to_add', 'force']
+
+    def __init__(self, name=None, columns=None, parent=None, properties=None,
+                 annotations=None, local_state=None, dataset_items=None,
+                 folders=None, force=None, **kwargs):
+        self.properties.setdefault('datasetItems', [])
+        self.__dict__.setdefault('folders_to_add', set())
+        self.__dict__.setdefault('force', False)
+        super(Dataset, self).__init__(
+            name=name, columns=columns, properties=properties,
+            annotations=annotations, local_state=local_state, parent=parent,
+            **kwargs
+        )
+
+        if force:
+            self.force = True
+        if dataset_items:
+            self.add_items(dataset_items, force)
+        if folders:
+            self.add_folders(folders, force)
+
+    def __len__(self):
+        return len(self.properties.datasetItems)
+
+    @staticmethod
+    def _check_needed_keys(keys: List[str]):
+        required_keys = {'entityId', 'versionNumber'}
+        if required_keys - keys:
+            raise LookupError("DatasetItem missing a required property: %s" %
+                              str(required_keys - keys))
+        return True
+
+    def add_item(self, dataset_item: Dict[str, str], force: bool = True):
+        """
+        :param dataset_item:    a single dataset item
+        :param force:           force add item
+        """
+        if isinstance(dataset_item, dict) and self._check_needed_keys(dataset_item.keys()):
+            if not self.has_item(dataset_item.get('entityId')):
+                self.properties.datasetItems.append(dataset_item)
+            else:
+                if force:
+                    self.remove_item(dataset_item.get('entityId'))
+                    self.properties.datasetItems.append(dataset_item)
+                else:
+                    raise ValueError(
+                        f"Duplicate item found: {dataset_item.get('entityId')}. "
+                        "Set force=True to overwrite the existing item.")
+        else:
+            raise ValueError("Not a DatasetItem? %s" % str(dataset_item))
+
+    def add_items(self, dataset_items: List[Dict[str, str]], force: bool = True):
+        """
+        :param dataset_items:   a list of dataset items
+        :param force:           force add items
+        """
+        for dataset_item in dataset_items:
+            self.add_item(dataset_item, force)
+
+    def remove_item(self, item_id: str):
+        """
+        :param item_id: a single dataset item Synapse ID
+        """
+        item_id = id_of(item_id)
+        if item_id.startswith("syn"):
+            for i, curr_item in enumerate(self.properties.datasetItems):
+                if curr_item.get('entityId') == item_id:
+                    del self.properties.datasetItems[i]
+                    break
+        else:
+            raise ValueError("Not a Synapse ID: %s" % str(item_id))
+
+    def empty(self):
+        self.properties.datasetItems = []
+
+    def has_item(self, item_id):
+        """
+        :param item_id: a single dataset item Synapse ID
+        """
+        return any(item['entityId'] == item_id for item in self.properties.datasetItems)
+
+    def add_folder(self, folder: str, force: bool = True):
+        """
+        :param folder:  a single Synapse Folder ID
+        :param force:   force add items from folder
+        """
+        if not self.__dict__.get('folders_to_add', None):
+            self.__dict__['folders_to_add'] = set()
+        self.__dict__['folders_to_add'].add(folder)
+        if self.force != force:
+            self.force = force
+
+    def add_folders(self, folders: List[str], force: bool = True):
+        """
+        :param folders: a list of Synapse Folder IDs
+        :param force:   force add items from folders
+        """
+        if isinstance(folders, list) or isinstance(folders, set) or \
+                isinstance(folders, tuple):
+            self.force = force
+            for folder in folders:
+                self.add_folder(folder, force)
+        else:
+            raise ValueError(f"Not a list of Folder IDs: {folders}")
+
+    def _add_folder_files(self, syn, folder):
+        files = []
+        children = syn.getChildren(folder)
+        for child in children:
+            if child.get("type") == "org.sagebionetworks.repo.model.Folder":
+                files.extend(self._add_folder_files(syn, child.get("id")))
+            elif child.get("type") == "org.sagebionetworks.repo.model.FileEntity":
+                files.append({
+                    'entityId': child.get("id"),
+                    'versionNumber': child.get('versionNumber')
+                })
+            else:
+                raise ValueError(f"Not a Folder?: {folder}")
+        return files
+
+    def _before_synapse_store(self, syn):
+        # Add default Dataset columns if schema is not provided.
+        if not self.properties.columnIds and not self.columns_to_store:
+            self.addColumns(syn._get_default_view_columns("dataset"))
+
+        super()._before_synapse_store(syn)
+
+        # Add files from folders (if any) before storing dataset.
+        if self.folders_to_add:
+            for folder in self.folders_to_add:
+                items_to_add = self._add_folder_files(syn, folder)
+                self.add_items(items_to_add, self.force)
+            self.folders_to_add = set()
+
+        # Reset attribute to force-add items from folders.
+        self.force = True
+
+        # Remap `datasetItems` back to `items` before storing (since `items`
+        # is the accepted field name in the API, not `datasetItems`).
+        self.properties.items = self.properties.datasetItems
 
 
 # add Schema to the map of synapse entity types to their Python representations

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -785,6 +785,236 @@ class MaterializedViewSchema(SchemaBase):
         )
 
 
+class Dataset(ViewBase):
+    """
+    A Dataset is an :py:class:`synapseclient.entity.Entity` that defines a
+    flat list of entities as a tableview (a.k.a. a "dataset").
+
+    :param name:            The name for the Dataset object
+    :param description:     User readable description of the schema
+    :param columns:         A list of :py:class:`Column` objects or their IDs
+    :param parent:          The Synapse Project to which this Dataset belongs
+    :param properties:      A map of Synapse properties
+    :param annotations:     A map of user defined annotations
+    :param dataset_items:   A list of items characterized by entityId and versionNumber
+    :param folder:          A list of Folder IDs
+    :param local_state:     Internal use only
+
+    Example::
+
+        from synapseclient import Dataset
+
+        # Create a Dataset with pre-defined DatasetItems. Default Dataset columns
+        # are used if no schema is provided.
+        dataset_items = [
+            {'entityId': "syn000", 'versionNumber': 1},
+            {...},
+        ]
+        dataset = syn.store(Dataset(
+            name="My Dataset",
+            parent=project,
+            dataset_items=dataset_items))
+
+        # Add/remove specific Synapse IDs to/from the Dataset
+        dataset.add_item({'entityId': "syn111", 'versionNumber': 1})
+        dataset.remove_item("syn000")
+        dataset = syn.store(dataset)
+
+        # Add a list of Synapse IDs to the Dataset
+        new_items = [
+            {'entityId': "syn222", 'versionNumber': 2},
+            {'entityId': "syn333", 'versionNumber': 1}
+        ]
+        dataset.add_items(new_items)
+        dataset = syn.store(dataset)
+
+    Folders can easily be added recursively to a dataset, that is, all files
+    within the folder (including sub-folders) will be added.  Note that using
+    the following methods will add files with the latest version number ONLY.
+    If another version number is desired, use :py:classmethod:`synapseclient.table.add_item`
+    or :py:classmethod:`synapseclient.table.add_items`.
+
+    Example::
+
+        # Add a single Folder to the Dataset
+        dataset.add_folder("syn123")
+
+        # Add a list of Folders, overwriting any existing files in the dataset
+        dataset.add_folders(["syn456", "syn789"], force=True)
+
+        dataset = syn.store(dataset)
+
+    empty() can be used to truncate a dataset, that is, remove all current
+    items from the set.
+
+    Example::
+
+        dataset.empty()
+        dataset = syn.store(dataset)
+
+    To get the number of entities in the dataset, use len().
+
+    Example::
+
+        print(f"{dataset.name} has {len(dataset)} items.")
+
+    To create a snapshot version of the Dataset, use
+    :py:classmethod:`synapseclient.client.create_snapshot_version`.
+
+    Example::
+
+        syn = synapseclient.login()
+        syn.create_snapshot_version(
+            dataset.id,
+            label="v1.0",
+            comment="This is version 1")
+    """
+    _synapse_entity_type: str = "org.sagebionetworks.repo.model.table.Dataset"
+    _property_keys: List[str] = ViewBase._property_keys + ['datasetItems']
+    _local_keys: List[str] = ViewBase._local_keys + ['folders_to_add', 'force']
+
+    def __init__(self, name=None, columns=None, parent=None, properties=None,
+                 addDefaultViewColumns=True, addAnnotationColumns=True, ignoredAnnotationColumnNames=[],
+                 annotations=None, local_state=None, dataset_items=None,
+                 folders=None, force=False, **kwargs):
+        self.properties.setdefault('datasetItems', [])
+        self.__dict__.setdefault('folders_to_add', set())
+        self.ignoredAnnotationColumnNames = set(ignoredAnnotationColumnNames)
+        self.viewTypeMask = EntityViewType.DATASET.value
+        super(Dataset, self).__init__(
+            name=name, columns=columns, properties=properties,
+            annotations=annotations, local_state=local_state, parent=parent,
+            **kwargs
+        )
+
+        self.force = force
+        if dataset_items:
+            self.add_items(dataset_items, force)
+        if folders:
+            self.add_folders(folders, force)
+
+        # HACK: make sure we don't try to add columns to schemas that we retrieve from synapse
+        is_from_normal_constructor = not (properties or local_state)
+        # allowing annotations because user might want to update annotations all at once
+        self.addDefaultViewColumns = addDefaultViewColumns and is_from_normal_constructor
+        self.addAnnotationColumns = addAnnotationColumns and is_from_normal_constructor
+
+    def __len__(self):
+        return len(self.properties.datasetItems)
+
+    @staticmethod
+    def _check_needed_keys(keys: List[str]):
+        required_keys = {'entityId', 'versionNumber'}
+        if required_keys - keys:
+            raise LookupError("DatasetItem missing a required property: %s" %
+                              str(required_keys - keys))
+        return True
+
+    def add_item(self, dataset_item: Dict[str, str], force: bool = True):
+        """
+        :param dataset_item:    a single dataset item
+        :param force:           force add item
+        """
+        if isinstance(dataset_item, dict) and self._check_needed_keys(dataset_item.keys()):
+            if not self.has_item(dataset_item.get('entityId')):
+                self.properties.datasetItems.append(dataset_item)
+            else:
+                if force:
+                    self.remove_item(dataset_item.get('entityId'))
+                    self.properties.datasetItems.append(dataset_item)
+                else:
+                    raise ValueError(
+                        f"Duplicate item found: {dataset_item.get('entityId')}. "
+                        "Set force=True to overwrite the existing item.")
+        else:
+            raise ValueError("Not a DatasetItem? %s" % str(dataset_item))
+
+    def add_items(self, dataset_items: List[Dict[str, str]], force: bool = True):
+        """
+        :param dataset_items:   a list of dataset items
+        :param force:           force add items
+        """
+        for dataset_item in dataset_items:
+            self.add_item(dataset_item, force)
+
+    def remove_item(self, item_id: str):
+        """
+        :param item_id: a single dataset item Synapse ID
+        """
+        item_id = id_of(item_id)
+        if item_id.startswith("syn"):
+            for i, curr_item in enumerate(self.properties.datasetItems):
+                if curr_item.get('entityId') == item_id:
+                    del self.properties.datasetItems[i]
+                    break
+        else:
+            raise ValueError("Not a Synapse ID: %s" % str(item_id))
+
+    def empty(self):
+        self.properties.datasetItems = []
+
+    def has_item(self, item_id):
+        """
+        :param item_id: a single dataset item Synapse ID
+        """
+        return any(item['entityId'] == item_id for item in self.properties.datasetItems)
+
+    def add_folder(self, folder: str, force: bool = True):
+        """
+        :param folder:  a single Synapse Folder ID
+        :param force:   force add items from folder
+        """
+        if not self.__dict__.get('folders_to_add', None):
+            self.__dict__['folders_to_add'] = set()
+        self.__dict__['folders_to_add'].add(folder)
+        # if self.force != force:
+        self.force = force
+
+    def add_folders(self, folders: List[str], force: bool = True):
+        """
+        :param folders: a list of Synapse Folder IDs
+        :param force:   force add items from folders
+        """
+        if isinstance(folders, list) or isinstance(folders, set) or \
+                isinstance(folders, tuple):
+            self.force = force
+            for folder in folders:
+                self.add_folder(folder, force)
+        else:
+            raise ValueError(f"Not a list of Folder IDs: {folders}")
+
+    def _add_folder_files(self, syn, folder):
+        files = []
+        children = syn.getChildren(folder)
+        for child in children:
+            if child.get("type") == "org.sagebionetworks.repo.model.Folder":
+                files.extend(self._add_folder_files(syn, child.get("id")))
+            elif child.get("type") == "org.sagebionetworks.repo.model.FileEntity":
+                files.append({
+                    'entityId': child.get("id"),
+                    'versionNumber': child.get('versionNumber')
+                })
+            else:
+                raise ValueError(f"Not a Folder?: {folder}")
+        return files
+
+    def _before_synapse_store(self, syn):
+        # Add files from folders (if any) before storing dataset.
+        if self.folders_to_add:
+            for folder in self.folders_to_add:
+                items_to_add = self._add_folder_files(syn, folder)
+                self.add_items(items_to_add, self.force)
+            self.folders_to_add = set()
+
+        self.scopeIds = [item['entityId'] for item in self.properties.datasetItems]
+        super()._before_synapse_store(syn)
+        # Reset attribute to force-add items from folders.
+        self.force = True
+        # Remap `datasetItems` back to `items` before storing (since `items`
+        # is the accepted field name in the API, not `datasetItems`).
+        self.properties.items = self.properties.datasetItems
+
+
 class ViewBase(SchemaBase):
     """
     This is a helper class for EntityViewSchema and SubmissionViewSchema
@@ -1022,238 +1252,6 @@ class SubmissionViewSchema(ViewBase):
         # add the scopes last so that we can append the passed in scopes to those defined in properties
         if scopes is not None:
             self.add_scope(scopes)
-
-
-class Dataset(ViewBase):
-    """
-    A Dataset is an :py:class:`synapseclient.entity.Entity` that defines a
-    flat list of entities as a tableview (a.k.a. a "dataset").
-
-    :param name:            The name for the Dataset object
-    :param description:     User readable description of the schema
-    :param columns:         A list of :py:class:`Column` objects or their IDs
-    :param parent:          The Synapse Project to which this Dataset belongs
-    :param properties:      A map of Synapse properties
-    :param annotations:     A map of user defined annotations
-    :param dataset_items:   A list of items characterized by entityId and versionNumber
-    :param folder:          A list of Folder IDs
-    :param local_state:     Internal use only
-
-    Example::
-
-        from synapseclient import Dataset
-
-        # Create a Dataset with pre-defined DatasetItems. Default Dataset columns
-        # are used if no schema is provided.
-        dataset_items = [
-            {'entityId': "syn000", 'versionNumber': 1},
-            {...},
-        ]
-        dataset = syn.store(Dataset(
-            name="My Dataset",
-            parent=project,
-            dataset_items=dataset_items))
-
-        # Add/remove specific Synapse IDs to/from the Dataset
-        dataset.add_item({'entityId': "syn111", 'versionNumber': 1})
-        dataset.remove_item("syn000")
-        dataset = syn.store(dataset)
-
-        # Add a list of Synapse IDs to the Dataset
-        new_items = [
-            {'entityId': "syn222", 'versionNumber': 2},
-            {'entityId': "syn333", 'versionNumber': 1}
-        ]
-        dataset.add_items(new_items)
-        dataset = syn.store(dataset)
-
-    Folders can easily be added recursively to a dataset, that is, all files
-    within the folder (including sub-folders) will be added.  Note that using
-    the following methods will add files with the latest version number ONLY.
-    If another version number is desired, use :py:classmethod:`synapseclient.table.add_item`
-    or :py:classmethod:`synapseclient.table.add_items`.
-
-    Example::
-
-        # Add a single Folder to the Dataset
-        dataset.add_folder("syn123")
-
-        # Add a list of Folders, overwriting any existing files in the dataset
-        dataset.add_folders(["syn456", "syn789"], force=True)
-
-        dataset = syn.store(dataset)
-
-    empty() can be used to truncate a dataset, that is, remove all current
-    items from the set.
-
-    Example::
-
-        dataset.empty()
-        dataset = syn.store(dataset)
-
-    To get the number of entities in the dataset, use len().
-
-    Example::
-
-        print(f"{dataset.name} has {len(dataset)} items.")
-
-    To create a snapshot version of the Dataset, use
-    :py:classmethod:`synapseclient.client.create_snapshot_version`.
-
-    Example::
-
-        syn = synapseclient.login()
-        syn.create_snapshot_version(
-            dataset.id,
-            label="v1.0",
-            comment="This is version 1")
-    """
-    _synapse_entity_type: str = "org.sagebionetworks.repo.model.table.Dataset"
-    _property_keys: List[str] = ViewBase._property_keys + ['datasetItems']
-    _local_keys: List[str] = ViewBase._local_keys + ['folders_to_add', 'force']
-
-    def __init__(self, name=None, columns=None, parent=None, properties=None,
-                 addDefaultViewColumns=True, addAnnotationColumns=True, ignoredAnnotationColumnNames=[],
-                 annotations=None, local_state=None, dataset_items=None,
-                 folders=None, force=False, **kwargs):
-        self.properties.setdefault('datasetItems', [])
-        self.__dict__.setdefault('folders_to_add', set())
-        self.ignoredAnnotationColumnNames = set(ignoredAnnotationColumnNames)
-        self.viewTypeMask = EntityViewType.DATASET.value
-        super(Dataset, self).__init__(
-            name=name, columns=columns, properties=properties,
-            annotations=annotations, local_state=local_state, parent=parent,
-            **kwargs
-        )
-
-        self.force = force
-        if dataset_items:
-            self.add_items(dataset_items, force)
-        if folders:
-            self.add_folders(folders, force)
-
-        # HACK: make sure we don't try to add columns to schemas that we retrieve from synapse
-        is_from_normal_constructor = not (properties or local_state)
-        # allowing annotations because user might want to update annotations all at once
-        self.addDefaultViewColumns = addDefaultViewColumns and is_from_normal_constructor
-        self.addAnnotationColumns = addAnnotationColumns and is_from_normal_constructor
-
-    def __len__(self):
-        return len(self.properties.datasetItems)
-
-    @staticmethod
-    def _check_needed_keys(keys: List[str]):
-        required_keys = {'entityId', 'versionNumber'}
-        if required_keys - keys:
-            raise LookupError("DatasetItem missing a required property: %s" %
-                              str(required_keys - keys))
-        return True
-
-    def add_item(self, dataset_item: Dict[str, str], force: bool = True):
-        """
-        :param dataset_item:    a single dataset item
-        :param force:           force add item
-        """
-        if isinstance(dataset_item, dict) and self._check_needed_keys(dataset_item.keys()):
-            if not self.has_item(dataset_item.get('entityId')):
-                self.properties.datasetItems.append(dataset_item)
-            else:
-                if force:
-                    self.remove_item(dataset_item.get('entityId'))
-                    self.properties.datasetItems.append(dataset_item)
-                else:
-                    raise ValueError(
-                        f"Duplicate item found: {dataset_item.get('entityId')}. "
-                        "Set force=True to overwrite the existing item.")
-        else:
-            raise ValueError("Not a DatasetItem? %s" % str(dataset_item))
-
-    def add_items(self, dataset_items: List[Dict[str, str]], force: bool = True):
-        """
-        :param dataset_items:   a list of dataset items
-        :param force:           force add items
-        """
-        for dataset_item in dataset_items:
-            self.add_item(dataset_item, force)
-
-    def remove_item(self, item_id: str):
-        """
-        :param item_id: a single dataset item Synapse ID
-        """
-        item_id = id_of(item_id)
-        if item_id.startswith("syn"):
-            for i, curr_item in enumerate(self.properties.datasetItems):
-                if curr_item.get('entityId') == item_id:
-                    del self.properties.datasetItems[i]
-                    break
-        else:
-            raise ValueError("Not a Synapse ID: %s" % str(item_id))
-
-    def empty(self):
-        self.properties.datasetItems = []
-
-    def has_item(self, item_id):
-        """
-        :param item_id: a single dataset item Synapse ID
-        """
-        return any(item['entityId'] == item_id for item in self.properties.datasetItems)
-
-    def add_folder(self, folder: str, force: bool = True):
-        """
-        :param folder:  a single Synapse Folder ID
-        :param force:   force add items from folder
-        """
-        if not self.__dict__.get('folders_to_add', None):
-            self.__dict__['folders_to_add'] = set()
-        self.__dict__['folders_to_add'].add(folder)
-        # if self.force != force:
-        self.force = force
-
-    def add_folders(self, folders: List[str], force: bool = True):
-        """
-        :param folders: a list of Synapse Folder IDs
-        :param force:   force add items from folders
-        """
-        if isinstance(folders, list) or isinstance(folders, set) or \
-                isinstance(folders, tuple):
-            self.force = force
-            for folder in folders:
-                self.add_folder(folder, force)
-        else:
-            raise ValueError(f"Not a list of Folder IDs: {folders}")
-
-    def _add_folder_files(self, syn, folder):
-        files = []
-        children = syn.getChildren(folder)
-        for child in children:
-            if child.get("type") == "org.sagebionetworks.repo.model.Folder":
-                files.extend(self._add_folder_files(syn, child.get("id")))
-            elif child.get("type") == "org.sagebionetworks.repo.model.FileEntity":
-                files.append({
-                    'entityId': child.get("id"),
-                    'versionNumber': child.get('versionNumber')
-                })
-            else:
-                raise ValueError(f"Not a Folder?: {folder}")
-        return files
-
-    def _before_synapse_store(self, syn):
-        # Add files from folders (if any) before storing dataset.
-        if self.folders_to_add:
-            for folder in self.folders_to_add:
-                items_to_add = self._add_folder_files(syn, folder)
-                self.add_items(items_to_add, self.force)
-            self.folders_to_add = set()
-
-        self.scopeIds = [item['entityId'] for item in self.properties.datasetItems]
-        super()._before_synapse_store(syn)
-
-        # Reset attribute to force-add items from folders.
-        self.force = True
-
-        # Remap `datasetItems` back to `items` before storing (since `items`
-        # is the accepted field name in the API, not `datasetItems`).
-        self.properties.items = self.properties.datasetItems
 
 
 # add Schema to the map of synapse entity types to their Python representations


### PR DESCRIPTION
* Add default annotations
* Add all annotations

Here's how you test this branch:

1. Go on Synapse and add to your download list
2. Create a new Python virtualenv
3. Install this specific branch
    ```
    pip install pandas
    pip install https://github.com/thomasyu888/synapsePythonClient/archive/refs/heads/SYNPY-1226-use-viewbase-for-datasets.zip
    ```
4. Test feature. (You will want to replace the synapse ids)
    ```
    import synapseclient
    syn = synapseclient.login()
    dataset_items = [
        {"entityId": "syn2334", "versionNumber": 1}
    ]
    dataset = synapseclient.Dataset(
       name="My test dataset", parent="syn33333",
       dataset_items=dataset_items
    )
    syn.store(dataset)
    ```
5. confirm your dataset online has all expected annotations