### PR TITLE
update name of utils function: `is_synapse_id`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ install_requires = [
     "requests>=2.22.0,<3.0",
     "keyring>=15,<23.5",
     "deprecated>=1.2.4,<2.0",
+    "importlib-metadata<5.0",
 ]
 
 # on Linux specify a cryptography dependency that will not

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setuptools.setup(
     version=__version__,
     packages=setuptools.find_packages(exclude=["tests", "tests.*"]),
     # requirements
-    python_requires=">=3.7.*",
+    python_requires=">=3.7",
     install_requires=install_requires,
     extras_require={
         "pandas": ["pandas>=0.25.0,<2.0"],

--- a/synapseclient/activity.py
+++ b/synapseclient/activity.py
@@ -72,7 +72,7 @@ Activity
 import collections.abc
 
 from synapseclient.core.exceptions import SynapseError, SynapseMalformedEntityError
-from synapseclient.core.utils import is_url, is_synapse_id
+from synapseclient.core.utils import is_url, is_synapse_id_str
 from synapseclient.entity import is_synapse_entity
 
 
@@ -267,7 +267,7 @@ class Activity(dict):
             badargs = _get_any_bad_args(['url', 'name'], locals())
             _raise_incorrect_used_usage(badargs, 'Synapse entity')
             vals = target.split('.')  # Handle synapseIds of from syn234.4
-            if not is_synapse_id(vals[0]):
+            if not is_synapse_id_str(vals[0]):
                 raise ValueError('%s is not a valid Synapse id' % target)
             if len(vals) == 2:
                 if targetVersion and int(targetVersion) != int(vals[1]):

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -648,7 +648,7 @@ class Synapse(object):
         :param ensure_ascii:  If True, escapes all non-ASCII characters
         """
 
-        if utils.is_synapse_id(entity):
+        if utils.is_synapse_id_str(entity):
             entity = self._getEntity(entity)
         try:
             self.logger.info(json.dumps(entity, sort_keys=True, indent=2, ensure_ascii=ensure_ascii))
@@ -711,7 +711,7 @@ class Synapse(object):
             kwargs['downloadFile'] = False
             kwargs['path'] = entity
 
-        elif isinstance(entity, str) and not utils.is_synapse_id(entity):
+        elif isinstance(entity, str) and not utils.is_synapse_id_str(entity):
             raise SynapseFileNotFoundError(
                 ('The parameter %s is neither a local file path '
                  ' or a valid entity id' % entity)
@@ -1656,7 +1656,7 @@ class Synapse(object):
     def _getBenefactor(self, entity):
         """An Entity gets its ACL from its benefactor."""
 
-        if utils.is_synapse_id(entity) or is_synapse_entity(entity):
+        if utils.is_synapse_id_str(entity) or is_synapse_entity(entity):
             return self.restGET('/entity/%s/benefactor' % id_of(entity))
         return entity
 
@@ -3311,7 +3311,7 @@ class Synapse(object):
                 except ValueError:
                     # ignore aggregate column
                     pass
-        elif isinstance(x, SchemaBase) or utils.is_synapse_id(x):
+        elif isinstance(x, SchemaBase) or utils.is_synapse_id_str(x):
             for col in self.getTableColumns(x):
                 yield col
         elif isinstance(x, str):

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -300,7 +300,7 @@ def is_same_base_url(url1, url2):
             url1.hostname == url2.hostname)
 
 
-def is_synapse_id(obj):
+def is_synapse_id_str(obj):
     """If the input is a Synapse ID return it, otherwise return None"""
     if isinstance(obj, str):
         m = re.match(r'(syn\d+$)', obj)

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -303,7 +303,7 @@ def is_same_base_url(url1, url2):
 def is_synapse_id(obj):
     """If the input is a Synapse ID return it, otherwise return None"""
     if isinstance(obj, str):
-        m = re.match(r'(syn\d+)', obj)
+        m = re.match(r'(syn\d+$)', obj)
         if m:
             return m.group(1)
     return None

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -11,7 +11,7 @@ import typing
 from .monitor import notifyMe
 from synapseclient.entity import is_container
 from synapseclient.core import config
-from synapseclient.core.utils import id_of, is_url, is_synapse_id
+from synapseclient.core.utils import id_of, is_url, is_synapse_id_str
 from synapseclient import File, table
 from synapseclient.core.pool_provider import SingleThreadExecutor
 from synapseclient.core import utils
@@ -228,7 +228,7 @@ class _SyncDownloader:
     def sync(self, entity, path, ifcollision, followLink, downloadFile=True, manifest="all"):
         progress = CumulativeTransferProgress('Downloaded')
 
-        if is_synapse_id(entity):
+        if is_synapse_id_str(entity):
             # ensure that we seed with an actual entity
             entity = self._syn.get(
                 entity,
@@ -712,7 +712,7 @@ def _sortAndFixProvenance(syn, df):
                          )
                     )
 
-        elif not utils.is_url(item) and (utils.is_synapse_id(item) is None):
+        elif not utils.is_url(item) and (utils.is_synapse_id_str(item) is None):
             raise SynapseProvenanceError(
                 ("The provenance record for file: %s is incorrect.\n"
                  "Specifically %s, is neither a valid URL or synapseId.") % (path, item)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -79,7 +79,7 @@ def schedule_for_cleanup(request, syn):
 def _cleanup(syn, items):
     """cleanup junk created during testing"""
     for item in reversed(items):
-        if isinstance(item, Entity) or utils.is_synapse_id(item) or hasattr(item, 'deleteURI'):
+        if isinstance(item, Entity) or utils.is_synapse_id_str(item) or hasattr(item, 'deleteURI'):
             try:
                 syn.delete(item)
             except Exception as ex:


### PR DESCRIPTION
Fixes #947 , so that the utils function name is more descriptive.

The expected pattern has also been updated to be a little more stringent, that is, the synID should start with `syn` and end with a digit.