### PR TITLE
[SYNPY-570] Make sure warning doesn't appear ifcollision is overwrite.local

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1120,12 +1120,11 @@ class Synapse(object):
     ):
         # always overwrite if we are downloading to .synapseCache
         if utils.normalize_path(downloadLocation) == synapseCache_location:
-            if ifcollision is not None:
+            if ifcollision is not None and ifcollision != "overwrite.local":
                 self.logger.warning(
                     "\n"
                     + "!" * 50
-                    + "\nifcollision="
-                    + ifcollision
+                    + f"\nifcollision={ifcollision} "
                     + "is being IGNORED because the download destination is synapse's cache."
                     ' Instead, the behavior is "overwrite.local". \n' + "!" * 50 + "\n"
                 )

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1039,7 +1039,9 @@ class Synapse(object):
             )
         return download_dir
 
-    def _download_file_entity(self, downloadLocation, entity, ifcollision, submission):
+    def _download_file_entity(
+        self, downloadLocation: str, entity: Entity, ifcollision: str, submission: str
+    ):
         # set the initial local state
         entity.path = None
         entity.files = []

--- a/tests/unit/synapseclient/unit_test_tables.py
+++ b/tests/unit/synapseclient/unit_test_tables.py
@@ -774,12 +774,12 @@ def test_downloadTableColumns(syn, downloadLocation):
         "fileSummary": [
             {
                 "status": "SUCCESS",
-                "fileHandleId": 1,
+                "fileHandleId": "1",  # NOTE: These are strings because thats the API return type
                 "zipEntryName": "entry1",
             },
             {
                 "status": "SUCCESS",
-                "fileHandleId": 3,
+                "fileHandleId": "3",  # NOTE: These are strings because thats the API return type
                 "zipEntryName": "entry2",
             },
         ],

--- a/tests/unit/synapseclient/unit_test_tables.py
+++ b/tests/unit/synapseclient/unit_test_tables.py
@@ -774,12 +774,12 @@ def test_downloadTableColumns(syn, downloadLocation):
         "fileSummary": [
             {
                 "status": "SUCCESS",
-                "fileHandleId": "1",  # NOTE: These are strings because thats the API return type
+                "fileHandleId": 1,
                 "zipEntryName": "entry1",
             },
             {
                 "status": "SUCCESS",
-                "fileHandleId": "3",  # NOTE: These are strings because thats the API return type
+                "fileHandleId": 3,
                 "zipEntryName": "entry2",
             },
         ],


### PR DESCRIPTION
Prior to this change, syncFromSynapse seems to always throw a warning with the default parameters.  This will silence that