### PR TITLE
[SYNPY-967] deprecated memoize and added @lru_cache

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -2585,7 +2585,7 @@ class Synapse(object):
                     else:
                         mode = "wb"
                         previouslyTransferred = 0
-                        sig = hashlib.md5(usedforsecurity=False)
+                        sig = hashlib.new("md5", usedforsecurity=False)
 
                     try:
                         with open(temp_destination, mode) as fd:

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -11,7 +11,6 @@ import cgi
 import collections.abc
 import datetime
 import errno
-import functools
 import hashlib
 import importlib
 import inspect
@@ -51,7 +50,7 @@ def md5_for_file(filename, block_size=2 * MB, callback=None):
     :returns: The MD5
     """
 
-    md5 = hashlib.md5()
+    md5 = hashlib.md5(usedforsecurity=False)
     with open(filename, "rb") as f:
         while True:
             if callback:
@@ -642,21 +641,6 @@ def extract_synapse_id_from_query(query):
         return m.group(1)
     else:
         raise ValueError('Couldn\'t extract synapse ID from query: "%s"' % query)
-
-
-# Derived from https://wiki.python.org/moin/PythonDecoratorLibrary#Memoize
-def memoize(obj):
-    cache = obj._memoize_cache = {}
-
-    @functools.wraps(obj)
-    def memoizer(*args, **kwargs):
-        refresh = kwargs.pop("refresh", False)
-        key = str(args) + str(kwargs)
-        if refresh or key not in cache:
-            cache[key] = obj(*args, **kwargs)
-        return cache[key]
-
-    return memoizer
 
 
 def printTransferProgress(

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -50,7 +50,7 @@ def md5_for_file(filename, block_size=2 * MB, callback=None):
     :returns: The MD5
     """
 
-    md5 = hashlib.md5(usedforsecurity=False)
+    md5 = hashlib.new("md5", usedforsecurity=False)
     with open(filename, "rb") as f:
         while True:
             if callback:

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -483,7 +483,7 @@ def test_md5_for_file(mock_hashlib):
     file_name = "/home/foo/bar/test.txt"
     mock_callback = Mock()
     mock_md5 = Mock()
-    mock_hashlib.md5.return_value = mock_md5
+    mock_hashlib.new.return_value = mock_md5
     with patch.object(utils, "open", mock_open(), create=True) as mocked_open:
         mocked_open.return_value.read.side_effect = ["data1", "data2", None]
         utils.md5_for_file(file_name, callback=mock_callback)

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -141,7 +141,6 @@ class TestLogin:
             # method under test
             self.syn.login(silent=False, **self.login_args)
 
-            mocked_get_user_profile.assert_called_once_with(refresh=True)
             mocked_logger.info.assert_called_once()
 
     def test_login__rememberMeIsTrue(self, mocker):


### PR DESCRIPTION
## Changelog
* Deprecated `memoize` and replaced it with `lru_cache` for Python 3.8 and above https://docs.python.org/3.8/library/functools.html#functools.lru_cache
* Since we are no longer using `memoize`, I also removed `refresh` parameter in login method
* Updated test
* Note: to address the pre-commit error below, I also updated `hashlib.md5()` by using `usedforsecurity=False` parameter:
```
[main]  INFO    running on Python 3.11.3
Run started:2023-06-27 22:10:20.620752

Test results:
>> Issue: [B324:hashlib] Use of weak MD5 hash for security. Consider usedforsecurity=False
   Severity: High   Confidence: High
   CWE: CWE-327 (https://cwe.mitre.org/data/definitions/327.html)
   More Info: https://bandit.readthedocs.io/en/0.0.0/plugins/b324_hashlib.html
   Location: synapseclient/client.py:2588:30
2587                            previouslyTransferred = 0
2588                            sig = hashlib.md5()
2589

--------------------------------------------------
>> Issue: [B324:hashlib] Use of weak MD5 hash for security. Consider usedforsecurity=False
   Severity: High   Confidence: High
   CWE: CWE-327 (https://cwe.mitre.org/data/definitions/327.html)
   More Info: https://bandit.readthedocs.io/en/0.0.0/plugins/b324_hashlib.html
   Location: synapseclient/core/utils.py:53:10
52
53          md5 = hashlib.md5()
54          with open(filename, "rb") as f:

--------------------------------------------------

```