### PR TITLE
[SYNPY-49] Aggregate acl based on groups

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -2108,7 +2108,11 @@ class Synapse(object):
                 "Unknown Synapse user (%s).  %s." % (principalId, supplementalMessage)
             )
 
-    def getPermissions(self, entity: Union[Entity, Evaluation, str, collections.abc.Mapping], principalId: str = None):
+    def getPermissions(
+        self,
+        entity: Union[Entity, Evaluation, str, collections.abc.Mapping],
+        principalId: str = None,
+    ):
         """Get the permissions that a user or group has on an Entity.
 
         :param entity:      An Entity or Synapse ID to lookup
@@ -2125,14 +2129,14 @@ class Synapse(object):
         team_list = self._find_teams_for_principal(principal_id)
         team_ids = [int(team.id) for team in team_list]
         effective_permission_set = set()
-        
+
         # This user_profile_bundle is being used to verify that the principal_id is a registered user of the system
         user_profile_bundle = self._get_user_bundle(principal_id, 1)
-        
+
         # Loop over all permissions in the returned ACL and add it to the effective_permission_set
-        # if the principalId in the ACL matches 
-        # 1) the one we are looking for, 
-        # 2) a team the entity is a member of, 
+        # if the principalId in the ACL matches
+        # 1) the one we are looking for,
+        # 2) a team the entity is a member of,
         # 3) PUBLIC
         # 4) A user_profile_bundle exists for the principal_id
         for permissions in acl["resourceAccess"]:
@@ -2140,7 +2144,10 @@ class Synapse(object):
                 permissions["principalId"] == principal_id
                 or permissions["principalId"] in team_ids
                 or permissions["principalId"] == PUBLIC
-                or (permissions["principalId"] == AUTHENTICATED_USERS and user_profile_bundle is not None)
+                or (
+                    permissions["principalId"] == AUTHENTICATED_USERS
+                    and user_profile_bundle is not None
+                )
             ):
                 effective_permission_set = effective_permission_set.union(
                     permissions["accessType"]

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -613,7 +613,7 @@ class Synapse(object):
             self.restDELETE("/secretKey", endpoint=self.authEndpoint)
 
     @memoize
-    def getUserProfile(self, id=None, sessionToken=None, refresh=False):
+    def getUserProfile(self, id=None, sessionToken=None, refresh=False) -> UserProfile:
         """
         Get the details about a Synapse user.
         Retrieves information on the current user if 'id' is omitted.

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -118,7 +118,7 @@ from synapseclient.core.upload.upload_functions import (
     upload_synapse_s3,
 )
 from synapseclient.core.dozer import doze
-
+from typing import Union
 
 PRODUCTION_ENDPOINTS = {
     "repoEndpoint": "https://repo-prod.prod.sagebase.org/repo/v1",
@@ -613,7 +613,12 @@ class Synapse(object):
             self.restDELETE("/secretKey", endpoint=self.authEndpoint)
 
     @memoize
-    def getUserProfile(self, id=None, sessionToken=None, refresh=False) -> UserProfile:
+    def getUserProfile(
+        self,
+        id: Union[str, int, UserProfile, TeamMember] = None,
+        sessionToken: str = None,
+        refresh: bool = False,
+    ) -> UserProfile:
         """
         Get the details about a Synapse user.
         Retrieves information on the current user if 'id' is omitted.
@@ -686,6 +691,22 @@ class Synapse(object):
             https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/quiz/PassingRecord.html
         """
         response = self.restGET(f"/user/{userid}/certifiedUserPassingRecord")
+        return response
+
+    def _get_user_bundle(self, userid: int, mask: int) -> dict:
+        """Retrieve the user bundle for the given user.
+
+        :params userid: Synapse user Id
+        :params mask: Bit field indicating which components to include in the bundle.
+
+        :returns: Synapse User Bundle
+            https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/UserBundle.html
+        """
+        try:
+            response = self.restGET(f"/user/{userid}/bundle?mask={mask}")
+        except SynapseHTTPError as ex:
+            if ex.response.status_code == 404:
+                return None
         return response
 
     def is_certified(self, user: typing.Union[str, int]) -> bool:
@@ -2056,7 +2077,7 @@ class Synapse(object):
             else:
                 return self.restPOST(uri, json.dumps(acl))
 
-    def _getUserbyPrincipalIdOrName(self, principalId=None):
+    def _getUserbyPrincipalIdOrName(self, principalId: str = None):
         """
         Given either a string, int or None finds the corresponding user where None implies PUBLIC
 
@@ -2087,7 +2108,7 @@ class Synapse(object):
                 "Unknown Synapse user (%s).  %s." % (principalId, supplementalMessage)
             )
 
-    def getPermissions(self, entity, principalId=None):
+    def getPermissions(self, entity: Union[Entity, Evaluation, str, collections.abc.Mapping], principalId: str = None):
         """Get the permissions that a user or group has on an Entity.
 
         :param entity:      An Entity or Synapse ID to lookup
@@ -2104,10 +2125,22 @@ class Synapse(object):
         team_list = self._find_teams_for_principal(principal_id)
         team_ids = [int(team.id) for team in team_list]
         effective_permission_set = set()
+        
+        # This user_profile_bundle is being used to verify that the principal_id is a registered user of the system
+        user_profile_bundle = self._get_user_bundle(principal_id, 1)
+        
+        # Loop over all permissions in the returned ACL and add it to the effective_permission_set
+        # if the principalId in the ACL matches 
+        # 1) the one we are looking for, 
+        # 2) a team the entity is a member of, 
+        # 3) PUBLIC
+        # 4) A user_profile_bundle exists for the principal_id
         for permissions in acl["resourceAccess"]:
             if "principalId" in permissions and (
-                permissions["principalId"] == int(principal_id)
+                permissions["principalId"] == principal_id
                 or permissions["principalId"] in team_ids
+                or permissions["principalId"] == PUBLIC
+                or (permissions["principalId"] == AUTHENTICATED_USERS and user_profile_bundle is not None)
             ):
                 effective_permission_set = effective_permission_set.union(
                     permissions["accessType"]
@@ -3110,9 +3143,7 @@ class Synapse(object):
         for result in self._GET_paginated("/teams?fragment=%s" % name):
             yield Team(**result)
 
-    def _find_teams_for_principal(
-        self, principal_id: str
-    ) -> typing.Generator[Team, None, None]:
+    def _find_teams_for_principal(self, principal_id: str) -> typing.Iterator[Team]:
         """
         Retrieve a list of teams for the matching principal ID. If the principalId that is passed in is a team itself,
         or not found, this will return a generator that yields no results.
@@ -3121,7 +3152,7 @@ class Synapse(object):
 
         :return:  A generator that yields objects of type :py:class:`synapseclient.team.Team`
         """
-        for result in self._GET_paginated("/user/%s/team" % principal_id):
+        for result in self._GET_paginated(f"/user/{principal_id}/team"):
             yield Team(**result)
 
     def getTeam(self, id):

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -2087,7 +2087,7 @@ class Synapse(object):
                 "Unknown Synapse user (%s).  %s." % (principalId, supplementalMessage)
             )
 
-    def getPermissions(self, entity, principal_id=None):
+    def getPermissions(self, entity, principalId=None):
         """Get the permissions that a user or group has on an Entity.
 
         :param entity:      An Entity or Synapse ID to lookup
@@ -2098,7 +2098,7 @@ class Synapse(object):
                   or an empty array
 
         """
-        principal_id = self._getUserbyPrincipalIdOrName(principal_id)
+        principal_id = self._getUserbyPrincipalIdOrName(principalId)
         acl = self._getACL(entity)
 
         team_list = self._find_teams_for_principal(principal_id)

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -2087,7 +2087,7 @@ class Synapse(object):
                 "Unknown Synapse user (%s).  %s." % (principalId, supplementalMessage)
             )
 
-    def getPermissions(self, entity, principalId=None):
+    def getPermissions(self, entity, principal_id=None):
         """Get the permissions that a user or group has on an Entity.
 
         :param entity:      An Entity or Synapse ID to lookup
@@ -2098,21 +2098,21 @@ class Synapse(object):
                   or an empty array
 
         """
-        principalId = self._getUserbyPrincipalIdOrName(principalId)
+        principal_id = self._getUserbyPrincipalIdOrName(principal_id)
         acl = self._getACL(entity)
 
-        teamList = self._findTeamsForPrincipal(principalId)
-        teamIds = [int(team.id) for team in teamList]
-        effectivePermissionSet = set()
+        team_list = self._find_teams_for_principal(principal_id)
+        team_ids = [int(team.id) for team in team_list]
+        effective_permission_set = set()
         for permissions in acl["resourceAccess"]:
             if "principalId" in permissions and (
-                permissions["principalId"] == int(principalId)
-                or permissions["principalId"] in teamIds
+                permissions["principalId"] == int(principal_id)
+                or permissions["principalId"] in team_ids
             ):
-                effectivePermissionSet = effectivePermissionSet.union(
+                effective_permission_set = effective_permission_set.union(
                     permissions["accessType"]
                 )
-        return list(effectivePermissionSet)
+        return list(effective_permission_set)
 
     def setPermissions(
         self,
@@ -3110,16 +3110,18 @@ class Synapse(object):
         for result in self._GET_paginated("/teams?fragment=%s" % name):
             yield Team(**result)
 
-    def _findTeamsForPrincipal(self, principalId):
+    def _find_teams_for_principal(
+        self, principal_id: str
+    ) -> typing.Generator[Team, None, None]:
         """
         Retrieve a list of teams for the matching principal ID. If the principalId that is passed in is a team itself,
         or not found, this will return an empty list.
 
-        :param principalId: Identifier of a user or group.
+        :param principal_id: Identifier of a user or group.
 
-        :return:  A list of objects of type :py:class:`synapseclient.team.Team`
+        :return:  A generator that yields objects of type :py:class:`synapseclient.team.Team`
         """
-        for result in self._GET_paginated("/user/%s/team" % principalId):
+        for result in self._GET_paginated("/user/%s/team" % principal_id):
             yield Team(**result)
 
     def getTeam(self, id):

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -3112,7 +3112,7 @@ class Synapse(object):
 
     def _findTeamsForPrincipal(self, principalId):
         """
-        Retrieve a list of teams for the matching principal ID. If the principalId that is passed in is a team itself, 
+        Retrieve a list of teams for the matching principal ID. If the principalId that is passed in is a team itself,
         or not found, this will return an empty list.
 
         :param principalId: Identifier of a user or group.

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -3115,7 +3115,7 @@ class Synapse(object):
     ) -> typing.Generator[Team, None, None]:
         """
         Retrieve a list of teams for the matching principal ID. If the principalId that is passed in is a team itself,
-        or not found, this will return an empty list.
+        or not found, this will return a generator that yields no results.
 
         :param principal_id: Identifier of a user or group.
 

--- a/tests/integration/synapseclient/integration_test.py
+++ b/tests/integration/synapseclient/integration_test.py
@@ -531,7 +531,8 @@ class TestPermissionsOnProject:
         # GIVEN a project created with default permissions of administrator
         project_with_read_only_permissions: Entity = self.syn.store(
             Project(
-                name=str(uuid.uuid4()) + "test_get_permissions_read_permissions_on_project"
+                name=str(uuid.uuid4())
+                + "test_get_permissions_read_permissions_on_project"
             )
         )
         self.schedule_for_cleanup(project_with_read_only_permissions)
@@ -557,7 +558,8 @@ class TestPermissionsOnProject:
         # GIVEN a project created with default permissions of administrator
         project_with_permissions_through_single_team: Entity = self.syn.store(
             Project(
-                name=str(uuid.uuid4()) + "test_get_permissions_through_team_assigned_to_user_and_project"
+                name=str(uuid.uuid4())
+                + "test_get_permissions_through_team_assigned_to_user_and_project"
             )
         )
 
@@ -618,7 +620,8 @@ class TestPermissionsOnProject:
         # GIVEN a project created with default permissions of administrator
         project_with_permissions_through_multiple_teams: Entity = self.syn.store(
             Project(
-                name=str(uuid.uuid4()) + "test_get_permissions_through_two_teams_assigned_to_user_and_project"
+                name=str(uuid.uuid4())
+                + "test_get_permissions_through_two_teams_assigned_to_user_and_project"
             )
         )
 

--- a/tests/integration/synapseclient/integration_test.py
+++ b/tests/integration/synapseclient/integration_test.py
@@ -9,7 +9,7 @@ from datetime import datetime
 import pytest
 from unittest.mock import patch
 
-from synapseclient import client
+from synapseclient import Entity, Team, UserProfile, client
 from synapseclient import Activity, Annotations, File, Folder, login, Project, Synapse
 from synapseclient.core.credentials import credential_provider
 from synapseclient.core.exceptions import (
@@ -491,3 +491,204 @@ def testMoveProject(syn, schedule_for_cleanup):
     pytest.raises(SynapseHTTPError, syn.move, proj1, proj2)
     schedule_for_cleanup(proj1)
     schedule_for_cleanup(proj2)
+
+
+class TestPermissionsOnProject:
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup):
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    def test_get_permissions_default(self):
+        # GIVEN a project created with default permissions of administrator
+        project_with_default_permissions: Entity = self.syn.store(
+            Project(name=str(uuid.uuid4()) + "test_get_permissions_default_permissions")
+        )
+        self.schedule_for_cleanup(project_with_default_permissions)
+
+        # AND the user that created the project
+        p1: UserProfile = self.syn.getUserProfile()
+
+        # WHEN I get the permissions for the user on the entity
+        permissions = self.syn.getPermissions(
+            project_with_default_permissions.id, p1.ownerId
+        )
+
+        # THEN I expect to see the default admin permissions
+        expected_permissions = [
+            "READ",
+            "DELETE",
+            "CHANGE_SETTINGS",
+            "UPDATE",
+            "CHANGE_PERMISSIONS",
+            "CREATE",
+            "MODERATE",
+            "DOWNLOAD",
+        ]
+        assert set(expected_permissions) == set(permissions)
+
+    def test_get_permissions_read_only_permissions_on_entity(self):
+        # GIVEN a project created with default permissions of administrator
+        project_with_read_only_permissions: Entity = self.syn.store(
+            Project(
+                name=str(uuid.uuid4()) + "test_get_permissions_read_permissions_on_project"
+            )
+        )
+        self.schedule_for_cleanup(project_with_read_only_permissions)
+
+        # AND the user that created the project
+        p1: UserProfile = self.syn.getUserProfile()
+
+        # AND the permissions for the user on the entity are set to READ only
+        self.syn.setPermissions(
+            project_with_read_only_permissions, p1.ownerId, ["READ"]
+        )
+
+        # WHEN I get the permissions for the user on the entity
+        permissions = self.syn.getPermissions(
+            project_with_read_only_permissions.id, p1.ownerId
+        )
+
+        # THEN I expect to see read only permissions
+        expected_permissions = ["READ"]
+        assert set(expected_permissions) == set(permissions)
+
+    def test_get_permissions_through_team_assigned_to_user(self):
+        # GIVEN a project created with default permissions of administrator
+        project_with_permissions_through_single_team: Entity = self.syn.store(
+            Project(
+                name=str(uuid.uuid4()) + "test_get_permissions_through_team_assigned_to_user_and_project"
+            )
+        )
+
+        # AND the user that created the project
+        p1: UserProfile = self.syn.getUserProfile()
+
+        # AND a team is created
+        name = "My Uniquely Named Team " + str(uuid.uuid4())
+        team = self.syn.store(
+            Team(
+                name=name,
+                description="A fake team for testing permissions assigned to a single project",
+            )
+        )
+
+        # Handle Cleanup - Note: When running this schedule for cleanup order can matter when there are dependent resources
+        self.schedule_for_cleanup(team)
+        self.schedule_for_cleanup(project_with_permissions_through_single_team)
+
+        # AND the permissions for the Team on the entity are set to all permissions except for DOWNLOAD
+        self.syn.setPermissions(
+            project_with_permissions_through_single_team,
+            team.id,
+            [
+                "READ",
+                "DELETE",
+                "CHANGE_SETTINGS",
+                "UPDATE",
+                "CHANGE_PERMISSIONS",
+                "CREATE",
+                "MODERATE",
+            ],
+        )
+
+        # AND the permissions for the user on the entity are set to NONE
+        self.syn.setPermissions(
+            project_with_permissions_through_single_team, p1.ownerId, []
+        )
+
+        # WHEN I get the permissions for the user on the entity
+        permissions = self.syn.getPermissions(
+            project_with_permissions_through_single_team.id, p1.ownerId
+        )
+
+        # THEN I expect to see the permissions of the team
+        expected_permissions = [
+            "READ",
+            "DELETE",
+            "CHANGE_SETTINGS",
+            "UPDATE",
+            "CHANGE_PERMISSIONS",
+            "CREATE",
+            "MODERATE",
+        ]
+        assert set(expected_permissions) == set(permissions)
+
+    def test_get_permissions_through_multiple_teams_assigned_to_user(self):
+        # GIVEN a project created with default permissions of administrator
+        project_with_permissions_through_multiple_teams: Entity = self.syn.store(
+            Project(
+                name=str(uuid.uuid4()) + "test_get_permissions_through_two_teams_assigned_to_user_and_project"
+            )
+        )
+
+        # AND the user that created the project
+        p1: UserProfile = self.syn.getUserProfile()
+
+        # AND a team is created
+        name = "My Uniquely Named Team " + str(uuid.uuid4())
+        team_1 = self.syn.store(
+            Team(
+                name=name,
+                description="A fake team for testing permissions assigned to a single project - 1",
+            )
+        )
+
+        # AND a second team is created
+        name = "My Uniquely Named Team " + str(uuid.uuid4())
+        team_2 = self.syn.store(
+            Team(
+                name=name,
+                description="A fake team for testing permissions assigned to a single project - 2",
+            )
+        )
+
+        # Handle Cleanup - Note: When running this schedule for cleanup order can matter when there are dependent resources
+        self.schedule_for_cleanup(team_1)
+        self.schedule_for_cleanup(team_2)
+        self.schedule_for_cleanup(project_with_permissions_through_multiple_teams)
+
+        # AND the permissions for the Team 1 on the entity are set to all permissions except for DOWNLOAD
+        self.syn.setPermissions(
+            project_with_permissions_through_multiple_teams,
+            team_1.id,
+            [
+                "READ",
+                "DELETE",
+                "CHANGE_SETTINGS",
+                "UPDATE",
+                "CHANGE_PERMISSIONS",
+                "CREATE",
+                "MODERATE",
+            ],
+        )
+
+        # AND the permissions for the Team 2 on the entity are set to only READ and DOWNLOAD
+        self.syn.setPermissions(
+            project_with_permissions_through_multiple_teams,
+            team_2.id,
+            ["READ", "DOWNLOAD"],
+        )
+
+        # AND the permissions for the user on the entity are set to NONE
+        self.syn.setPermissions(
+            project_with_permissions_through_multiple_teams, p1.ownerId, []
+        )
+
+        # WHEN I get the permissions for the user on the entity
+        permissions = self.syn.getPermissions(
+            project_with_permissions_through_multiple_teams.id, p1.ownerId
+        )
+
+        # THEN I expect to see the permissions of both teams
+        expected_permissions = [
+            "READ",
+            "DELETE",
+            "CHANGE_SETTINGS",
+            "UPDATE",
+            "CHANGE_PERMISSIONS",
+            "CREATE",
+            "MODERATE",
+            "DOWNLOAD",
+        ]
+        assert set(expected_permissions) == set(permissions)

--- a/tests/integration/synapseclient/integration_test.py
+++ b/tests/integration/synapseclient/integration_test.py
@@ -23,6 +23,7 @@ from synapseclient.core.version_check import version_check
 PUBLIC = 273949  # PrincipalId of public "user"
 AUTHENTICATED_USERS = 273948
 
+
 def test_login(syn):
     try:
         config = configparser.RawConfigParser()
@@ -698,16 +699,19 @@ class TestPermissionsOnProject:
         ]
         assert set(expected_permissions) == set(permissions)
 
-
     def test_get_permissions_for_project_with_public_and_registered_user(self):
         # GIVEN a project created with default permissions of administrator
-        project_with_permissions_for_public_and_authenticated_users: Entity = self.syn.store(
-            Project(
-                name=str(uuid.uuid4())
-                + "test_get_permissions_for_project_with_registered_user"
+        project_with_permissions_for_public_and_authenticated_users: Entity = (
+            self.syn.store(
+                Project(
+                    name=str(uuid.uuid4())
+                    + "test_get_permissions_for_project_with_registered_user"
+                )
             )
         )
-        self.schedule_for_cleanup(project_with_permissions_for_public_and_authenticated_users)
+        self.schedule_for_cleanup(
+            project_with_permissions_for_public_and_authenticated_users
+        )
 
         # AND the user that created the project
         p1: UserProfile = self.syn.getUserProfile()
@@ -728,15 +732,17 @@ class TestPermissionsOnProject:
 
         # AND the permissions for the user on the entity do NOT include DOWNLOAD
         self.syn.setPermissions(
-            project_with_permissions_for_public_and_authenticated_users, p1.ownerId, [
+            project_with_permissions_for_public_and_authenticated_users,
+            p1.ownerId,
+            [
                 "READ",
                 "DELETE",
                 "CHANGE_SETTINGS",
                 "UPDATE",
                 "CHANGE_PERMISSIONS",
                 "CREATE",
-                "MODERATE"
-            ]
+                "MODERATE",
+            ],
         )
 
         # WHEN I get the permissions for a public user on the entity
@@ -745,11 +751,9 @@ class TestPermissionsOnProject:
         )
 
         # THEN I expect to the public permissions
-        expected_permissions = [
-            "READ"
-        ]
+        expected_permissions = ["READ"]
         assert set(expected_permissions) == set(permissions)
-        
+
         # and WHEN I get the permissions for an authenticated user on the entity
         permissions = self.syn.getPermissions(
             project_with_permissions_for_public_and_authenticated_users.id, p1.ownerId

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -3469,7 +3469,7 @@ class TestPermissionsOnProject:
             "_getUserbyPrincipalIdOrName",
             # AND a user with id of 456
             return_value=456,
-        ) as patch_get_user, patch.object(
+        ), patch.object(
             self.syn,
             "_getACL",
             return_value={
@@ -3490,12 +3490,12 @@ class TestPermissionsOnProject:
                     }
                 ]
             },
-        ) as patch_get_acl, patch.object(
+        ), patch.object(
             self.syn,
             "_find_teams_for_principal",
             # AND the user is a part of no teams
             return_value=[],
-        ) as patch_find_teams:
+        ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")
 
@@ -3519,7 +3519,7 @@ class TestPermissionsOnProject:
             "_getUserbyPrincipalIdOrName",
             # AND a user with id of 456
             return_value=456,
-        ) as patch_get_user, patch.object(
+        ), patch.object(
             self.syn,
             "_getACL",
             return_value={
@@ -3540,12 +3540,12 @@ class TestPermissionsOnProject:
                     }
                 ]
             },
-        ) as patch_get_acl, patch.object(
+        ), patch.object(
             self.syn,
             "_find_teams_for_principal",
             # AND the user is a part of no teams
             return_value=[],
-        ) as patch_find_teams:
+        ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")
 
@@ -3560,7 +3560,7 @@ class TestPermissionsOnProject:
             "_getUserbyPrincipalIdOrName",
             # AND a user with id of 456
             return_value=456,
-        ) as patch_get_user, patch.object(
+        ), patch.object(
             self.syn,
             "_getACL",
             return_value={
@@ -3581,12 +3581,12 @@ class TestPermissionsOnProject:
                     }
                 ]
             },
-        ) as patch_get_acl, patch.object(
+        ), patch.object(
             self.syn,
             "_find_teams_for_principal",
             # AND the user is assigned to a team
             return_value=[Team(id=999)],
-        ) as patch_find_teams:
+        ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")
 
@@ -3610,7 +3610,7 @@ class TestPermissionsOnProject:
             "_getUserbyPrincipalIdOrName",
             # AND a user with id of 456
             return_value=456,
-        ) as patch_get_user, patch.object(
+        ), patch.object(
             self.syn,
             "_getACL",
             return_value={
@@ -3639,12 +3639,12 @@ class TestPermissionsOnProject:
                     },
                 ]
             },
-        ) as patch_get_acl, patch.object(
+        ), patch.object(
             self.syn,
             "_find_teams_for_principal",
             # AND the user is assigned to both of the teams
             return_value=[Team(id=888), Team(id=999)],
-        ) as patch_find_teams:
+        ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")
 

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -3495,6 +3495,10 @@ class TestPermissionsOnProject:
             "_find_teams_for_principal",
             # AND the user is a part of no teams
             return_value=[],
+        ), patch.object(
+            self.syn,
+            "_get_user_bundle",
+            return_value=None,
         ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")
@@ -3545,6 +3549,10 @@ class TestPermissionsOnProject:
             "_find_teams_for_principal",
             # AND the user is a part of no teams
             return_value=[],
+        ), patch.object(
+            self.syn,
+            "_get_user_bundle",
+            return_value=None,
         ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")
@@ -3586,6 +3594,10 @@ class TestPermissionsOnProject:
             "_find_teams_for_principal",
             # AND the user is assigned to a team
             return_value=[Team(id=999)],
+        ), patch.object(
+            self.syn,
+            "_get_user_bundle",
+            return_value=None,
         ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")
@@ -3644,6 +3656,10 @@ class TestPermissionsOnProject:
             "_find_teams_for_principal",
             # AND the user is assigned to both of the teams
             return_value=[Team(id=888), Team(id=999)],
+        ), patch.object(
+            self.syn,
+            "_get_user_bundle",
+            return_value=None,
         ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")


### PR DESCRIPTION
**Problem:**
During the previous logic in `getPermissions` only if the ACL returned for the entity matched the ID of the user exactly would permissions be returned. This means that any permissions given through the Teams the user is a part of were not returned.

**Solution**
Modified the logic in `getPermissions` to retrieve a list of Teams the user is a part of. Then - When we are looking over the ACL for the entity return a unique list of permissions granted on the entity for 1) The user, 2) All teams the user is a member of.


**Testing**

1. Unit tests:

- synapsePythonClient/tests/unit/synapseclient/unit_test_client.py::TestPermissionsOnProject::test_get_permissions_with_defined_set_for_access PASSED
- synapsePythonClient/tests/unit/synapseclient/unit_test_client.py::TestPermissionsOnProject::test_get_permissions_with_no_permissions_for_user PASSED
- synapsePythonClient/tests/unit/synapseclient/unit_test_client.py::TestPermissionsOnProject::test_get_permissions_with_permissions_given_through_single_team PASSED
- synapsePythonClient/tests/unit/synapseclient/unit_test_client.py::TestPermissionsOnProject::test_get_permissions_with_permissions_given_through_multiple_teams PASSED

2. Integration tests:
- synapsePythonClient/tests/integration/synapseclient/integration_test.py::TestPermissionsOnProject::test_get_permissions_default PASSED
- synapsePythonClient/tests/integration/synapseclient/integration_test.py::TestPermissionsOnProject::test_get_permissions_read_only_permissions_on_entity PASSED
- synapsePythonClient/tests/integration/synapseclient/integration_test.py::TestPermissionsOnProject::test_get_permissions_through_team_assigned_to_user PASSED
- synapsePythonClient/tests/integration/synapseclient/integration_test.py::TestPermissionsOnProject::test_get_permissions_through_multiple_teams_assigned_to_user PASSED
3. I also ran some manual testing with this example python code to verify functionality:
```
    permissionForUser = syn.getPermissions('syn51317219', 3481671)
    print(permissionForUser)
    permissionForGroup = syn.getPermissions('syn51317219', 273957)
    print(permissionForGroup)
    permissionForGroup2 = syn.getPermissions('syn51317219', 3453016)
    print(permissionForGroup2)
```