### PR TITLE
SYNPY-1284: Fix location where url expiration is coming from

### DIFF
--- a/synapseclient/core/multithread_download/download_threads.py
+++ b/synapseclient/core/multithread_download/download_threads.py
@@ -186,12 +186,8 @@ def _pre_signed_url_expiration_time(url: str) -> datetime:
     :return: datetime in UTC of when the url will expire
     """
     parsed_query: dict = parse_qs(urlparse(url).query)
-    time_made: str = parsed_query["X-Amz-Date"][0]
-    time_made_datetime: datetime.datetime = datetime.datetime.strptime(
-        time_made, ISO_AWS_STR_FORMAT
-    )
-    expires: str = parsed_query["X-Amz-Expires"][0]
-    return time_made_datetime + datetime.timedelta(seconds=int(expires))
+    expires: int = int(parsed_query["Expires"][0])
+    return datetime.datetime.utcfromtimestamp(expires)
 
 
 def _get_new_session() -> Session:

--- a/tests/unit/synapseclient/core/multithread_download/unit_test_download_threads.py
+++ b/tests/unit/synapseclient/core/multithread_download/unit_test_download_threads.py
@@ -131,20 +131,24 @@ def test_generate_chunk_ranges():
 
 
 def test_pre_signed_url_expiration_time():
+    # GIVEN a pre signed URL with an expiration date of: Jul 22 2013 20:12:07 in seconds since epoch UTC
     url = (
         "https://s3.amazonaws.com/examplebucket/test.txt"
         "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
         "&X-Amz-Credential=your-access-key-id/20130721/us-east-1/s3/aws4_request"
-        "&X-Amz-Date=20130721T201207Z"
-        "&X-Amz-Expires=86400"
+        "&Expires=1374523927"
         "&X-Amz-SignedHeaders=host"
         "&X-Amz-Signature=signature-value"
     )
 
+    # WHEN I get the expiration time from the pre signed URL
+    expiration_time = download_threads._pre_signed_url_expiration_time(url)
+
+    # THEN I expect the expiration time to be Jul 22 2013 20:12:07
     expected = datetime.datetime(
-        year=2013, month=7, day=21, hour=20, minute=12, second=7
-    ) + datetime.timedelta(seconds=86400)
-    assert expected == download_threads._pre_signed_url_expiration_time(url)
+        year=2013, month=7, day=22, hour=20, minute=12, second=7
+    )
+    assert expected == expiration_time
 
 
 @mock.patch.object(download_threads, "_MultithreadedDownloader")


### PR DESCRIPTION
**Problem:**

- We stopped receiving a creation timestamp and a seconds until expire timestamp. Instead we now receive a expiration at x timestamp.
- We also needed to support the old method of receiving the expire timestamp

**Solution:**

- Updated the location where the expiration timestamp was coming from. We now no longer need to do any math to add the creation date to the expiration time as we directly get exactly when the expiration will occur.
- Kept the old path solution if we receive those fields in the URL

**Testing:**
1. I ran the affected integration tests
2. While running the test I verified that the correct UTC datetime object was created with the proper values for seconds since epoch

![image](https://github.com/Sage-Bionetworks/synapsePythonClient/assets/17128019/5cdd0c9b-434c-4617-8476-dca9f2a4e69f)
