### PR TITLE
[SYNPY-1283] Replace Broken Link URL

### DIFF
--- a/docs/build/html/articles/cli.html
+++ b/docs/build/html/articles/cli.html
@@ -293,7 +293,7 @@
 <h5>Positional Arguments<a class="headerlink" href="#Positional Arguments_repeat2" title="Permalink to this headline"></a></h5>
 <dl class="option-list">
 <dt><kbd>FILE</kbd></dt>
-<dd><p>A tsv file with file locations and metadata to be pushed to Synapse. See <a class="reference external" href="https://python-docs.synapse.org/build/html/articles/synapseutils.html?highlight=synapseutils#synapseutils.sync.syncToSynapse">https://python-docs.synapse.org/build/html/articles/synapseutils.html?highlight=synapseutils#synapseutils.sync.syncToSynapse</a> for details on the format of a manifest.</p>
+<dd><p>A tsv file with file locations and metadata to be pushed to Synapse. See <a class="reference external" href="https://python-docs.synapse.org/build/html/synapseutils.html#synapseutils.sync.syncToSynapse">https://python-docs.synapse.org/build/html/synapseutils.html#synapseutils.sync.syncToSynapse</a> for details on the format of a manifest.</p>
 </dd>
 </dl>
 </section>

--- a/docs/build/html/articles/cli.html
+++ b/docs/build/html/articles/cli.html
@@ -293,7 +293,7 @@
 <h5>Positional Arguments<a class="headerlink" href="#Positional Arguments_repeat2" title="Permalink to this headline"></a></h5>
 <dl class="option-list">
 <dt><kbd>FILE</kbd></dt>
-<dd><p>A tsv file with file locations and metadata to be pushed to Synapse. See <a class="reference external" href="https://python-docs.synapse.org/build/html/synapseutils.html#synapseutils.sync.syncToSynapse">https://python-docs.synapse.org/build/html/synapseutils.html#synapseutils.sync.syncToSynapse</a> for details on the format of a manifest.</p>
+<dd><p>A tsv file with file locations and metadata to be pushed to Synapse. See <a class="reference external" href="https://python-docs.synapse.org/build/html/articles/synapseutils.html?highlight=synapseutils#synapseutils.sync.syncToSynapse">https://python-docs.synapse.org/build/html/articles/synapseutils.html?highlight=synapseutils#synapseutils.sync.syncToSynapse</a> for details on the format of a manifest.</p>
 </dd>
 </dl>
 </section>

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -937,7 +937,7 @@ def build_parser():
         type=argparse.FileType("r"),
         help=(
             "A tsv file with file locations and metadata to be pushed to Synapse. "
-            "See https://python-docs.synapse.org/build/html/synapseutils.html#synapseutils.sync.syncToSynapse "
+            "See https://python-docs.synapse.org/build/html/articles/synapseutils.html?highlight=synapseutils#synapseutils.sync.syncToSynapse"
             "for details on the format of a manifest."
         ),
     )


### PR DESCRIPTION
This PR replaces a broken URL with the correct one pointing to the documentation of `synapseutils.sync.syncToSynapse` in `__main__.py.