### PR TITLE
[SYNPY-1283] Adds Missing Trailing Space (Broken Link Fix)

### DIFF
--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -937,7 +937,7 @@ def build_parser():
         type=argparse.FileType("r"),
         help=(
             "A tsv file with file locations and metadata to be pushed to Synapse. "
-            "See https://python-docs.synapse.org/build/html/articles/synapseutils.html?highlight=synapseutils#synapseutils.sync.syncToSynapse"
+            "See https://python-docs.synapse.org/build/html/articles/synapseutils.html?highlight=synapseutils#synapseutils.sync.syncToSynapse "
             "for details on the format of a manifest."
         ),
     )


### PR DESCRIPTION
This PR follows-on from #989 to add a trailing space to the URL that I replaced earlier.

<img width="744" alt="image-20231021-011604" src="https://github.com/Sage-Bionetworks/synapsePythonClient/assets/52762200/ec65424c-7ccf-4627-a2f9-c84b1c564705">
