### PR TITLE
[SYNPY-1298] Update annotation logic

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1437,7 +1437,9 @@ class Synapse(object):
             self._createAccessRequirementIfNone(properties)
 
         # Update annotations
-        if not bundle or check_annotations_changed(bundle["annotations"], annotations):
+        if (not bundle and annotations) or (
+            bundle and check_annotations_changed(bundle["annotations"], annotations)
+        ):
             annotations = self.set_annotations(
                 Annotations(properties["id"], properties["etag"], annotations)
             )

--- a/tests/integration/synapseclient/integration_test.py
+++ b/tests/integration/synapseclient/integration_test.py
@@ -9,7 +9,7 @@ from datetime import datetime
 import pytest
 from unittest.mock import patch
 
-from synapseclient import Entity, Team, UserProfile, client
+from synapseclient import Entity, Team, UserProfile, client, Synapse
 from synapseclient import Activity, Annotations, File, Folder, login, Project, Synapse
 from synapseclient.core.credentials import credential_provider
 from synapseclient.core.exceptions import (
@@ -414,6 +414,61 @@ def test_annotations(syn, project, schedule_for_cleanup):
         "present_time"
     ].strftime("%Y-%m-%d %H:%M:%S")
     assert annotation["maybe"] == [True, False]
+
+
+def test_annotations_on_file_during_create_no_annotations(
+    syn: Synapse, project: Project, schedule_for_cleanup
+):
+    # GIVEN a bogus file
+    path = utils.make_bogus_data_file()
+    schedule_for_cleanup(path)
+    file = File(path, parent=project["id"], description="test_annotations_on_file")
+
+    # AND the file is stored
+    with patch.object(syn, "set_annotations") as mock_set_annotations:
+        entity = syn.store(file)
+    schedule_for_cleanup(entity.id)
+
+    # WHEN I get the annotations
+    annotations = syn.get_annotations(entity)
+
+    # THEN I expect the annotations to be empty
+    assert hasattr(annotations, "id")
+    assert hasattr(annotations, "etag")
+    assert annotations.id == entity.id
+    assert annotations.etag == entity.etag
+    assert len(annotations) == 0
+
+    # AND set_annotations has not been called
+    assert not mock_set_annotations.called
+
+
+def test_annotations_on_file_during_create_with_annotations(
+    syn: Synapse, project: Project, schedule_for_cleanup
+):
+    # GIVEN a bogus file
+    path = utils.make_bogus_data_file()
+    schedule_for_cleanup(path)
+
+    # AND annotations have been set on the file
+    file = File(
+        path,
+        parent=project["id"],
+        description="test_annotations_on_file",
+        annotations={"label_1": "value_1", "label_2": "value_2"},
+    )
+
+    # AND the file is stored
+    entity = syn.store(file)
+    schedule_for_cleanup(entity.id)
+
+    # WHEN I get the annotations
+    annotations = syn.get_annotations(entity)
+
+    # THEN I expect the annotations to have been set
+    assert annotations["label_1"] == ["value_1"]
+    assert annotations["label_2"] == ["value_2"]
+    assert len(annotations) == 2
 
 
 def test_get_user_profile(syn):


### PR DESCRIPTION
**Problem:**
When an entity is created the `set_annotations` method is always being called even if the entity is being created without any annotations.

A side-effect of this is that it is causing some Integration test instability - It also saves an extra HTTP call when creating a new entity w/o annotations.

1. https://github.com/Sage-Bionetworks/synapsePythonClient/actions/runs/6501857782/job/17659897335#step:8:344
2. https://github.com/Sage-Bionetworks/synapsePythonClient/actions/runs/6511652889/job/17687757507#step:8:343

**Solution:**
Checking to see if we are creating the entity in the first place only call `set_annotations` if there are annotations to be set.

**Testing:**
I added 2 Integration tests around this logic.