### PR TITLE
Fix for int test on windows for file rename

### DIFF
--- a/tests/integration/synapseclient/integration_test_Entity.py
+++ b/tests/integration/synapseclient/integration_test_Entity.py
@@ -400,6 +400,7 @@ def test_get_with_cache_hit_and_miss_with_ifcollision(
 
     # GIVEN another bogus file with the same name and non matching MD5 data
     new_bogus_file = utils.make_bogus_binary_file()
+    os.remove(filepath)
     os.rename(new_bogus_file, filepath)
     assert utils.md5_for_file(filepath).hexdigest() != original_file_md5
 


### PR DESCRIPTION
Problem:
Windows doesn't overwrite in an os.rename

`FileExistsError: [WinError 183] Cannot create a file when that file already exists: 'c:/users/runner~1/appdata/local/temp/tmplrhaqh7f.dat' -> 'c:/users/runner~1/appdata/local/temp/tmpj45y4tsc.dat'`

Solution:
Delete destination file before rename