### PR TITLE
[SYNPY-1316] Moved install_requires back to setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,26 +43,7 @@ zip_safe = False
 include_package_data = True
 packages = find:
 python_requires = >=3.8
-# on Linux specify a cryptography dependency that will not
-# require a Rust compiler to compile from source (< 3.4).
-# on Linux cryptography is a transitive dependency
-# (keyring -> SecretStorage -> cryptography)
-# SecretStorage doesn't pin a version so otherwise if cryptography
-# is not already installed the dependency will resolve to the latest
-# and will require Rust if a precompiled wheel cannot be used
-# (e.g. old version of pip or no wheel available for an architecture).
-# if a newer version of cryptography is already installed that is
-# fine we don't want to trigger a downgrade, hence the conditional
-# addition of the versioned dependency.
-install_requires =
-    # "requests>=2.22.0,<2.30.0; python_version<'3.10'",
-    requests>=2.22.0,<3.0
-    urllib3>=1.26.18,<2
-    # "urllib3>=2; python_version>='3.10'",
-    keyring>=15,<23.5
-    keyrings.alt==3.1; sys_platform == "linux"
-    cryptography<3.4; sys_platform == "linux"
-    deprecated>=1.2.4,<2.0
+#install_requires is defined in the setup.py
 tests_require =
     pytest>=6.0.0,<7.0
     pytest-mock>=3.0,<4.0

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 import os
 from setuptools import setup
 
+import platform
 import json
 
 # make sure not to overwrite existing .synapseConfig with our example one
@@ -15,4 +16,33 @@ data_files = (
 with open("synapseclient/synapsePythonClient") as config:
     __version__ = json.load(config)["latestVersion"]
 
-setup(data_files=data_files, version=__version__)
+install_requires = [
+    # "requests>=2.22.0,<2.30.0; python_version<'3.10'",
+    "requests>=2.22.0,<3.0",
+    "urllib3>=1.26.18,<2",
+    # "urllib3>=2; python_version>='3.10'",
+    "keyring>=15,<23.5",
+    "deprecated>=1.2.4,<2.0",
+]
+
+# on Linux specify a cryptography dependency that will not
+# require a Rust compiler to compile from source (< 3.4).
+# on Linux cryptography is a transitive dependency
+# (keyring -> SecretStorage -> cryptography)
+# SecretStorage doesn't pin a version so otherwise if cryptography
+# is not already installed the dependency will resolve to the latest
+# and will require Rust if a precompiled wheel cannot be used
+# (e.g. old version of pip or no wheel available for an architecture).
+# if a newer version of cryptography is already installed that is
+# fine we don't want to trigger a downgrade, hence the conditional
+# addition of the versioned dependency.
+if platform.system() == "Linux":
+    install_requires.append("keyrings.alt==3.1")
+    try:
+        import cryptography  # noqa
+
+        # already installed, don't need to install (or downgrade)
+    except ImportError:
+        install_requires.append("cryptography<3.4")
+
+setup(data_files=data_files, version=__version__, install_requires=install_requires)


### PR DESCRIPTION
Problem:
Installing the python client forces a downgrade of the `cryptography` package to `<3.4` - It is not optional as the comments of the file are implying

Solution:
Move back to setting the `install_requires` in the `setup.py` file instead of the `setup.cfg` file. The `setup.cfg` was not created with this kind of use-case in mind.

Testing:
I tested this locally and in some docker images when I had and had not installed `cruptography` before hand