### PR TITLE
[SYNPY-1316] Updating to caching logic to take in MD5 key

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1070,7 +1070,6 @@ class Synapse(object):
                         entity,
                         ifcollision,
                         submission,
-                        file_handle.get("contentMd5", None),
                     )
                 else:  # no filehandle means that we do not have DOWNLOAD permission
                     warning_message = (
@@ -1103,7 +1102,6 @@ class Synapse(object):
         entity: Entity,
         ifcollision: str,
         submission: str,
-        expected_md5: typing.Union[str, None],
     ):
         # set the initial local state
         entity.path = None
@@ -1114,15 +1112,6 @@ class Synapse(object):
         # this location could be either in .synapseCache or a user specified location to which the user previously
         # downloaded the file
         cached_file_path = self.cache.get(entity.dataFileHandleId, downloadLocation)
-
-        # This is to handle for cases where the names of the files in the cache and the
-        # requested file name match - But there is a difference in content.
-        if (
-            expected_md5 is not None
-            and cached_file_path is not None
-            and utils.md5_for_file(cached_file_path).hexdigest() != expected_md5
-        ):
-            cached_file_path = None
 
         # location in .synapseCache where the file would be corresponding to its FileHandleId
         synapseCache_location = self.cache.get_cache_dir(entity.dataFileHandleId)

--- a/synapseclient/core/cache.py
+++ b/synapseclient/core/cache.py
@@ -353,7 +353,7 @@ class Cache:
         file_handle_id: typing.Union[collections.abc.Mapping, str],
         path: str = None,
         delete: bool = None,
-    ) -> list[str]:
+    ) -> typing.List[str]:
         """
         Remove a file from the cache.
 

--- a/synapseclient/core/cache.py
+++ b/synapseclient/core/cache.py
@@ -451,7 +451,7 @@ class Cache:
 
         count = 0
         for cache_dir in self._cache_dirs():
-            # utils.get_modified_time returns None if the cache map file doesn't
+            # _get_modified_time returns None if the cache map file doesn't
             # exist and n > None evaluates to True in python 2.7(wtf?). I'm guessing it's
             # OK to purge directories in the cache that have no .cacheMap file
 

--- a/tests/unit/synapseclient/core/unit_test_Cache.py
+++ b/tests/unit/synapseclient/core/unit_test_Cache.py
@@ -555,11 +555,11 @@ class TestModificationsToCacheContent:
 
         # AND a file created in my cache directory
         file_path = utils.touch(
-            os.path.join(my_cache.get_cache_dir(101201), "file1.ext")
+            os.path.join(my_cache.get_cache_dir(131201), "file1.ext")
         )
 
         # AND the file is added to the cache
-        my_cache.add(file_handle_id=101201, path=file_path)
+        my_cache.add(file_handle_id=131201, path=file_path)
 
         # WHEN we modify the file timestamp
         new_time_stamp = cache._get_modified_time(file_path) + 1
@@ -568,7 +568,7 @@ class TestModificationsToCacheContent:
         # THEN we expect the file to be modified
         unmodified = my_cache._cache_item_unmodified(
             cache_map_entry=my_cache._read_cache_map(
-                cache_dir=my_cache.get_cache_dir(101201)
+                cache_dir=my_cache.get_cache_dir(131201)
             ).get(file_path),
             path=file_path,
         )
@@ -580,12 +580,12 @@ class TestModificationsToCacheContent:
         my_cache = cache.Cache(cache_root_dir=tmp_dir)
 
         # AND a file created in my cache directory
-        file_path = os.path.join(my_cache.get_cache_dir(101201), "file1.ext")
+        file_path = os.path.join(my_cache.get_cache_dir(121201), "file1.ext")
         utils.touch(file_path)
         utils.make_bogus_binary_file(filepath=file_path)
 
         # AND the file is added to the cache
-        my_cache.add(file_handle_id=101201, path=file_path)
+        my_cache.add(file_handle_id=121201, path=file_path)
 
         # WHEN we replace the file with another of the same name
         os.remove(file_path)
@@ -595,7 +595,7 @@ class TestModificationsToCacheContent:
         # THEN we expect the file to be modified
         unmodified = my_cache._cache_item_unmodified(
             cache_map_entry=my_cache._read_cache_map(
-                cache_dir=my_cache.get_cache_dir(101201)
+                cache_dir=my_cache.get_cache_dir(121201)
             ).get(file_path),
             path=file_path,
         )
@@ -608,16 +608,16 @@ class TestModificationsToCacheContent:
 
         # AND a file created in my cache directory
         file_path = utils.touch(
-            os.path.join(my_cache.get_cache_dir(101201), "file1.ext")
+            os.path.join(my_cache.get_cache_dir(111201), "file1.ext")
         )
 
         # AND the file is added to the cache
-        my_cache.add(file_handle_id=101201, path=file_path)
+        my_cache.add(file_handle_id=111201, path=file_path)
 
         # THEN we expect the file to be unmodified
         unmodified = my_cache._cache_item_unmodified(
             cache_map_entry=my_cache._read_cache_map(
-                cache_dir=my_cache.get_cache_dir(101201)
+                cache_dir=my_cache.get_cache_dir(111201)
             ).get(file_path),
             path=file_path,
         )

--- a/tests/unit/synapseclient/core/unit_test_Cache.py
+++ b/tests/unit/synapseclient/core/unit_test_Cache.py
@@ -555,7 +555,10 @@ class TestModificationsToCacheContent:
 
         # AND a file created in my cache directory
         file_path = utils.touch(
-            os.path.join(my_cache.get_cache_dir(131201), "file1.ext")
+            os.path.join(
+                my_cache.get_cache_dir(131201),
+                "file1_test_cache_item_unmodified_modified_items_is_modified_timestamp.ext",
+            )
         )
 
         # AND the file is added to the cache
@@ -580,7 +583,10 @@ class TestModificationsToCacheContent:
         my_cache = cache.Cache(cache_root_dir=tmp_dir)
 
         # AND a file created in my cache directory
-        file_path = os.path.join(my_cache.get_cache_dir(121201), "file1.ext")
+        file_path = os.path.join(
+            my_cache.get_cache_dir(121201),
+            "file1_test_cache_item_unmodified_modified_items_is_modified_timestamp.ext",
+        )
         utils.touch(file_path)
         utils.make_bogus_binary_file(filepath=file_path)
 
@@ -608,7 +614,10 @@ class TestModificationsToCacheContent:
 
         # AND a file created in my cache directory
         file_path = utils.touch(
-            os.path.join(my_cache.get_cache_dir(111201), "file1.ext")
+            os.path.join(
+                my_cache.get_cache_dir(111201),
+                "file1_test_cache_item_unmodified_not_modified.ext",
+            )
         )
 
         # AND the file is added to the cache

--- a/tests/unit/synapseclient/core/unit_test_Cache.py
+++ b/tests/unit/synapseclient/core/unit_test_Cache.py
@@ -616,9 +616,10 @@ class TestModificationsToCacheContent:
         my_cache = cache.Cache(cache_root_dir=tmp_dir)
 
         # AND a file created in my cache directory
+        another_tmp_dir = tempfile.mkdtemp()
         file_path = utils.touch(
             os.path.join(
-                my_cache.get_cache_dir(111201),
+                another_tmp_dir,
                 "file1_test_cache_item_unmodified_not_modified.ext",
             )
         )
@@ -627,7 +628,7 @@ class TestModificationsToCacheContent:
         my_cache.add(file_handle_id=111201, path=file_path)
 
         # THEN we expect the file to be unmodified
-        with Lock(my_cache.cache_map_file_name, dir=my_cache.get_cache_dir(111201)):
+        with Lock(my_cache.cache_map_file_name, dir=tmp_dir):
             unmodified = my_cache._cache_item_unmodified(
                 cache_map_entry=my_cache._read_cache_map(
                     cache_dir=my_cache.get_cache_dir(111201)

--- a/tests/unit/synapseclient/core/unit_test_Cache.py
+++ b/tests/unit/synapseclient/core/unit_test_Cache.py
@@ -9,6 +9,7 @@ import random
 from unittest.mock import patch, call
 from collections import OrderedDict
 from multiprocessing import Process
+from synapseclient.core.lock import Lock
 
 import synapseclient.core.cache as cache
 import synapseclient.core.utils as utils
@@ -569,12 +570,13 @@ class TestModificationsToCacheContent:
         utils.touch(file_path, (new_time_stamp, new_time_stamp))
 
         # THEN we expect the file to be modified
-        unmodified = my_cache._cache_item_unmodified(
-            cache_map_entry=my_cache._read_cache_map(
-                cache_dir=my_cache.get_cache_dir(131201)
-            ).get(file_path),
-            path=file_path,
-        )
+        with Lock(my_cache.cache_map_file_name, dir=my_cache.get_cache_dir(111201)):
+            unmodified = my_cache._cache_item_unmodified(
+                cache_map_entry=my_cache._read_cache_map(
+                    cache_dir=my_cache.get_cache_dir(131201)
+                ).get(file_path),
+                path=file_path,
+            )
         assert unmodified is False
 
     def test_cache_item_unmodified_modified_items_is_modified_timestamp(self):
@@ -599,12 +601,13 @@ class TestModificationsToCacheContent:
         utils.make_bogus_binary_file(filepath=file_path)
 
         # THEN we expect the file to be modified
-        unmodified = my_cache._cache_item_unmodified(
-            cache_map_entry=my_cache._read_cache_map(
-                cache_dir=my_cache.get_cache_dir(121201)
-            ).get(file_path),
-            path=file_path,
-        )
+        with Lock(my_cache.cache_map_file_name, dir=my_cache.get_cache_dir(111201)):
+            unmodified = my_cache._cache_item_unmodified(
+                cache_map_entry=my_cache._read_cache_map(
+                    cache_dir=my_cache.get_cache_dir(121201)
+                ).get(file_path),
+                path=file_path,
+            )
         assert unmodified is False
 
     def test_cache_item_unmodified_not_modified(self):
@@ -624,10 +627,11 @@ class TestModificationsToCacheContent:
         my_cache.add(file_handle_id=111201, path=file_path)
 
         # THEN we expect the file to be unmodified
-        unmodified = my_cache._cache_item_unmodified(
-            cache_map_entry=my_cache._read_cache_map(
-                cache_dir=my_cache.get_cache_dir(111201)
-            ).get(file_path),
-            path=file_path,
-        )
+        with Lock(my_cache.cache_map_file_name, dir=my_cache.get_cache_dir(111201)):
+            unmodified = my_cache._cache_item_unmodified(
+                cache_map_entry=my_cache._read_cache_map(
+                    cache_dir=my_cache.get_cache_dir(111201)
+                ).get(file_path),
+                path=file_path,
+            )
         assert unmodified is True

--- a/tests/unit/synapseclient/core/unit_test_Cache.py
+++ b/tests/unit/synapseclient/core/unit_test_Cache.py
@@ -477,3 +477,148 @@ def test_purge_raise_value_error():
     with pytest.raises(ValueError) as ve:
         my_cache.purge(before_date=mock_before_date, after_date=mock_after_date)
     assert str(ve.value) == "Before date should be larger than after date"
+
+
+class TestModificationsToCacheContent:
+    def test_get_cache_modified_time_no_cache_entry(self):
+        # GIVEN a temp directory and a cache object
+        tmp_dir = tempfile.mkdtemp()
+        my_cache = cache.Cache(cache_root_dir=tmp_dir)
+
+        # WHEN we call _get_cache_modified_time with None
+        cache_modified_time = my_cache._get_cache_modified_time(None)
+
+        # THEN we expect None to be returned
+        assert cache_modified_time is None
+
+    def test_get_cache_modified_time_has_cache_entry(self):
+        # GIVEN a temp directory and a cache object
+        tmp_dir = tempfile.mkdtemp()
+        my_cache = cache.Cache(cache_root_dir=tmp_dir)
+
+        # WHEN we call _get_cache_modified_time with a cache entry
+        cache_modified_time = my_cache._get_cache_modified_time("1111")
+
+        # THEN we expect the cache entry to be returned
+        assert "1111" == cache_modified_time
+
+    def test_get_cache_modified_time_has_cache_entry_dict(self):
+        # GIVEN a temp directory and a cache object
+        tmp_dir = tempfile.mkdtemp()
+        my_cache = cache.Cache(cache_root_dir=tmp_dir)
+
+        # WHEN we call _get_cache_modified_time with a cache entry
+        cache_modified_time = my_cache._get_cache_modified_time(
+            {"modified_time": "1111"}
+        )
+
+        # THEN we expect the cache entry to be returned
+        assert "1111" == cache_modified_time
+
+    def test_get_cache_content_md5_no_cache_entry(self):
+        # GIVEN a temp directory and a cache object
+        tmp_dir = tempfile.mkdtemp()
+        my_cache = cache.Cache(cache_root_dir=tmp_dir)
+
+        # WHEN we call _get_cache_content_md5 with None
+        cache_modified_time = my_cache._get_cache_content_md5(None)
+
+        # THEN we expect None to be returned
+        assert cache_modified_time is None
+
+    def test_get_cache_content_md5_is_not_in_expected_format(self):
+        # GIVEN a temp directory and a cache object
+        tmp_dir = tempfile.mkdtemp()
+        my_cache = cache.Cache(cache_root_dir=tmp_dir)
+
+        # WHEN we call _get_cache_content_md5 with a cache entry
+        cache_modified_time = my_cache._get_cache_content_md5("2222")
+
+        # THEN we expect None to be returned
+        assert cache_modified_time is None
+
+    def test_get_cache_content_md5_has_cache_entry_dict(self):
+        # GIVEN a temp directory and a cache object
+        tmp_dir = tempfile.mkdtemp()
+        my_cache = cache.Cache(cache_root_dir=tmp_dir)
+
+        # WHEN we call _get_cache_content_md5 with a cache entry
+        cache_modified_time = my_cache._get_cache_content_md5({"content_md5": "2222"})
+
+        # THEN we expect the cache entry to be returned
+        assert "2222" == cache_modified_time
+
+    def test_cache_item_unmodified_modified_items_is_modified_timestamp(self):
+        # GIVEN a temp directory and a cache object
+        tmp_dir = tempfile.mkdtemp()
+        my_cache = cache.Cache(cache_root_dir=tmp_dir)
+
+        # AND a file created in my cache directory
+        file_path = utils.touch(
+            os.path.join(my_cache.get_cache_dir(101201), "file1.ext")
+        )
+
+        # AND the file is added to the cache
+        my_cache.add(file_handle_id=101201, path=file_path)
+
+        # WHEN we modify the file timestamp
+        new_time_stamp = cache._get_modified_time(file_path) + 1
+        utils.touch(file_path, (new_time_stamp, new_time_stamp))
+
+        # THEN we expect the file to be modified
+        unmodified = my_cache._cache_item_unmodified(
+            cache_map_entry=my_cache._read_cache_map(
+                cache_dir=my_cache.get_cache_dir(101201)
+            ).get(file_path),
+            path=file_path,
+        )
+        assert unmodified is False
+
+    def test_cache_item_unmodified_modified_items_is_modified_timestamp(self):
+        # GIVEN a temp directory and a cache object
+        tmp_dir = tempfile.mkdtemp()
+        my_cache = cache.Cache(cache_root_dir=tmp_dir)
+
+        # AND a file created in my cache directory
+        file_path = os.path.join(my_cache.get_cache_dir(101201), "file1.ext")
+        utils.touch(file_path)
+        utils.make_bogus_binary_file(filepath=file_path)
+
+        # AND the file is added to the cache
+        my_cache.add(file_handle_id=101201, path=file_path)
+
+        # WHEN we replace the file with another of the same name
+        os.remove(file_path)
+        utils.touch(file_path)
+        utils.make_bogus_binary_file(filepath=file_path)
+
+        # THEN we expect the file to be modified
+        unmodified = my_cache._cache_item_unmodified(
+            cache_map_entry=my_cache._read_cache_map(
+                cache_dir=my_cache.get_cache_dir(101201)
+            ).get(file_path),
+            path=file_path,
+        )
+        assert unmodified is False
+
+    def test_cache_item_unmodified_not_modified(self):
+        # GIVEN a temp directory and a cache object
+        tmp_dir = tempfile.mkdtemp()
+        my_cache = cache.Cache(cache_root_dir=tmp_dir)
+
+        # AND a file created in my cache directory
+        file_path = utils.touch(
+            os.path.join(my_cache.get_cache_dir(101201), "file1.ext")
+        )
+
+        # AND the file is added to the cache
+        my_cache.add(file_handle_id=101201, path=file_path)
+
+        # THEN we expect the file to be unmodified
+        unmodified = my_cache._cache_item_unmodified(
+            cache_map_entry=my_cache._read_cache_map(
+                cache_dir=my_cache.get_cache_dir(101201)
+            ).get(file_path),
+            path=file_path,
+        )
+        assert unmodified is True

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -753,7 +753,6 @@ def test_download_file_entity__correct_local_state(syn: Synapse):
             entity=file_entity,
             ifcollision="overwrite.local",
             submission=None,
-            expected_md5=None,
         )
         assert mock_cache_path == utils.normalize_path(file_entity.path)
         assert os.path.dirname(mock_cache_path) == file_entity.cacheDir


### PR DESCRIPTION
Problem:
In the `.cacheMap` file there is a key-value pair of path to file for a particular file handle ID and it's associated modified time, for example:
`{"/home/bfauble/synapseTestFiles/bryansTestProject/temp/file_1.txt": "2023-11-03T21:46:48.000Z"}`

In cases where we are downloading files into the same directory and a file with the same name is matching the current cache mechanism can incorrectly assume the file is already present in the directory and not attempt to download a new copy with `ifcollision='overwrite.local`

Solution:
- When we are adding new items to the cache store the file MD5 at the time of caching too. When we are checking for a cache hit verify if the local file has a different modification time and (if present) that the md5's match. If neither pass treat this as a cache miss.
- The way this is written will allow for backwards compatibility if a cache entry only has a timestamp - it will continue to remain in the timestamp format until there is a cache miss.

Testing:
- All passing integration and unit tests
- I also verified the before/after functionality of my `.cacheMap` when the new key is and is not present and the expected cache hit/miss occurs
- I also verified changing the MD5 value in the `.cacheMap` correct sees it as a cache miss
- I also verified that changing the file prompts a cache miss