### PR TITLE
[SYNPY-1186] When a username is a number,  getUserProfile cannot retrieve the user

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -673,8 +673,8 @@ class Synapse(object):
         :returns: The user profile for the user of interest.
 
         Example::
-            my_profile = syn.getUserProfile()
-            freds_profile = syn.getUserProfile('fredcommo')
+            my_profile = syn.get_user_profile_by_id()
+            freds_profile = syn.get_user_profile_by_id(1234567)
         """
         if id:
             if not isinstance(id, int):

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -624,13 +624,13 @@ class Synapse(object):
     @functools.lru_cache()
     def get_user_profile_by_username(
         self,
-        id: str = None,
+        username: str = None,
         sessionToken: str = None,
     ) -> UserProfile:
         """
         Get the details about a Synapse user.
         Retrieves information on the current user if 'id' is omitted or is empty string.
-        :param id:           The userName of a user
+        :param username:           The userName of a user
         :param sessionToken: The session token to use to find the user profile
         :returns: The user profile for the user of interest.
 
@@ -638,17 +638,16 @@ class Synapse(object):
             my_profile = syn.get_user_name_profile()
             freds_profile = syn.get_user_name_profile('fredcommo')
         """
-        if id:
-            if isinstance(id, str):
-                principals = self._findPrincipals(id)
-                for principal in principals:
-                    if principal.get("userName", None).lower() == id.lower():
-                        id = principal["ownerId"]
-                        break
-                else:
-                    raise ValueError(f"Can't find user '{id}'")
+        if not isinstance(username, str) and username is not None:
+            raise TypeError("username must be string or None")
+        if isinstance(username, str):
+            principals = self._findPrincipals(username)
+            for principal in principals:
+                if principal.get("userName", None).lower() == username.lower():
+                    id = principal["ownerId"]
+                    break
             else:
-                raise TypeError("id must be a 'userName' string")
+                raise ValueError(f"Can't find user '{username}'")
         else:
             id = ""
         uri = f"/userProfile/{id}"

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -622,7 +622,7 @@ class Synapse(object):
             self.restDELETE("/secretKey", endpoint=self.authEndpoint)
 
     @functools.lru_cache()
-    def get_user_name_profile(
+    def get_user_profile(
         self,
         id: Union[str, UserProfile, TeamMember] = None,
         sessionToken: str = None,
@@ -666,7 +666,7 @@ class Synapse(object):
         )
 
     @functools.lru_cache()
-    def get_user_id_profile(
+    def get_user_profile_by_id(
         self,
         id: int = None,
         sessionToken: str = None,

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -630,17 +630,19 @@ class Synapse(object):
         """
         Get the details about a Synapse user.
         Retrieves information on the current user if 'id' is omitted or is empty string.
-        :param username:           The userName of a user
+        :param username:     The userName of a user
         :param sessionToken: The session token to use to find the user profile
         :returns: The user profile for the user of interest.
 
         Example::
-            my_profile = syn.get_user_name_profile()
-            freds_profile = syn.get_user_name_profile('fredcommo')
+            my_profile = syn.get_user_profile_by_username()
+            freds_profile = syn.get_user_profile_by_username('fredcommo')
         """
-        if not isinstance(username, str) and username is not None:
+        is_none = username is None
+        is_str = isinstance(username, str)
+        if not is_str and not is_none:
             raise TypeError("username must be string or None")
-        if isinstance(username, str):
+        if is_str:
             principals = self._findPrincipals(username)
             for principal in principals:
                 if principal.get("userName", None).lower() == username.lower():

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -639,10 +639,13 @@ class Synapse(object):
             freds_profile = syn.get_user_name_profile('fredcommo')
         """
         if id:
+            # For UserProfile
             if isinstance(id, collections.abc.Mapping) and "ownerId" in id:
                 id = id.ownerId
+            # For TeamMember
             elif isinstance(id, TeamMember):
                 id = id.member.ownerId
+            # For userName
             elif isinstance(id, str):
                 principals = self._findPrincipals(id)
                 if len(principals) == 1:
@@ -653,7 +656,7 @@ class Synapse(object):
                             id = principal["ownerId"]
                             break
                     else:  # no break
-                        raise ValueError('Can\'t find user "%s": ' % id)
+                        raise ValueError(f"Can't find user '{id}'")
             else:
                 raise TypeError("id must be a string, UserProfile, or TeamMember")
         else:
@@ -682,7 +685,7 @@ class Synapse(object):
             my_profile = syn.getUserProfile()
             freds_profile = syn.getUserProfile('fredcommo')
         """
-        if not id:
+        if id is None:
             id = ""
         uri = f"/userProfile/{id}"
         return UserProfile(

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -666,7 +666,7 @@ class Synapse(object):
     ) -> UserProfile:
         """
         Get the details about a Synapse user.
-        Retrieves information on the current user if 'id' is omitted or is empty string.
+        Retrieves information on the current user if 'id' is omitted.
         :param id:           The ownerId of a user
         :param sessionToken: The session token to use to find the user profile
         :returns: The user profile for the user of interest.

--- a/tests/unit/synapseclient/unit_test_get_user_profile.py
+++ b/tests/unit/synapseclient/unit_test_get_user_profile.py
@@ -70,7 +70,7 @@ class TestGetUserProfileByUserName:
             self.syn.get_user_profile_by_username("not_a_user")
 
     def test_that_get_user_profile_raises_type_error_when_id_is_not_allowed_type(self):
-        with pytest.raises(TypeError, match="id must be a 'userName' string"):
+        with pytest.raises(TypeError, match="username must be string or None"):
             self.syn.get_user_profile_by_username(1234567)
 
 

--- a/tests/unit/synapseclient/unit_test_get_user_profile.py
+++ b/tests/unit/synapseclient/unit_test_get_user_profile.py
@@ -1,0 +1,108 @@
+import pytest
+from unittest.mock import patch
+
+from synapseclient.team import UserProfile
+
+
+test_user_profile = {
+    "ownerId": "1234567",
+    "etag": "test-etag",
+    "firstName": "Test",
+    "lastName": "User",
+    "emails": ["test.user@example.com"],
+    "openIds": [],
+    "userName": "test_user",
+    "displayName": "Test User",
+    "summary": "This is a test user",
+    "position": "Test Position",
+    "location": "Test Location",
+    "industry": "Test Industry",
+    "company": "Test Company",
+    "profilePicureFileHandleId": "test-file-handle",
+    "url": "https://example.com",
+    "notificationSettings": {"sendEmailNotifications": False},
+    "createdOn": "2022-01-01T00:00:00.000Z",
+}
+
+
+class TestGetUserProfile:
+    principals = [
+        {
+            "ownerId": "7654321",
+            "firstName": "test",
+            "lastName": "person",
+            "userName": "abc",
+            "isIndividual": True,
+        },
+        {
+            "ownerId": "1234567",
+            "firstName": "test_2",
+            "lastName": "person_2",
+            "userName": "test_user",
+            "isIndividual": True,
+        },
+    ]
+
+    @pytest.fixture(autouse=True, scope="function")
+    def setup_method(self, syn):
+        self.syn = syn
+        self.syn.restGET = patch.object(
+            self.syn, "restGET", return_value=test_user_profile
+        ).start()
+        self.syn._findPrincipals = patch.object(
+            self.syn, "_findPrincipals", return_value=self.principals
+        ).start()
+
+    def teardown_method(self):
+        self.syn.restGET.stop()
+        self.syn._findPrincipals.stop()
+
+    def test_that_get_user_profile_returns_expected_with_no_id(self):
+        result = self.syn.get_user_profile()
+        self.syn.restGET.assert_called_once_with("/userProfile/", headers=None)
+        assert result == test_user_profile
+
+    def test_that_get_user_profile_returns_expected_with_username(self):
+        result = self.syn.get_user_profile("test_user")
+        self.syn.restGET.assert_called_once_with("/userProfile/1234567", headers=None)
+        assert result == test_user_profile
+
+    # def test_that_get_user_profile_returns_expected_with_user_profile(self):
+    #     ...
+
+    # def test_that_get_user_profile_returns_expected_with_team_member(self):
+    #     ...
+
+    def test_that_get_user_profile_raises_value_error_when_user_does_not_exist(
+        self, syn
+    ):
+        with pytest.raises(ValueError, match="Can't find user *"):
+            self.syn.get_user_profile("not_a_user")
+
+    def test_that_get_user_profile_raises_type_error_when_id_is_not_allowed_type(self):
+        with pytest.raises(
+            TypeError, match="id must be a string, UserProfile, or TeamMember"
+        ):
+            self.syn.get_user_profile(1234567)
+
+
+class TestGetUserProfileByID:
+    @pytest.fixture(autouse=True, scope="function")
+    def setup_method(self, syn):
+        self.syn = syn
+        self.syn.restGET = patch.object(
+            self.syn, "restGET", return_value=test_user_profile
+        ).start()
+
+    def teardown_method(self):
+        self.syn.restGET.stop()
+
+    def test_that_get_user_profile_by_id_returns_expected_when_id_id_defined(self):
+        result = self.syn.get_user_profile_by_id(1234567)
+        self.syn.restGET.assert_called_once_with("/userProfile/1234567", headers=None)
+        assert result == test_user_profile
+
+    def test_that_get_user_profile_by_id_raises_type_error_when_id_is_not_defined(self):
+        result = self.syn.get_user_profile_by_id()
+        self.syn.restGET.assert_called_once_with("/userProfile/", headers=None)
+        assert result == test_user_profile

--- a/tests/unit/synapseclient/unit_test_get_user_profile.py
+++ b/tests/unit/synapseclient/unit_test_get_user_profile.py
@@ -23,7 +23,7 @@ test_user_profile = {
 }
 
 
-class TestGetUserProfile:
+class TestGetUserProfileByUserName:
     principals = [
         {
             "ownerId": "7654321",
@@ -56,32 +56,22 @@ class TestGetUserProfile:
         self.syn._findPrincipals.stop()
 
     def test_that_get_user_profile_returns_expected_with_no_id(self):
-        result = self.syn.get_user_profile()
+        result = self.syn.get_user_profile_by_username()
         self.syn.restGET.assert_called_once_with("/userProfile/", headers=None)
         assert result == test_user_profile
 
     def test_that_get_user_profile_returns_expected_with_username(self):
-        result = self.syn.get_user_profile("test_user")
+        result = self.syn.get_user_profile_by_username("test_user")
         self.syn.restGET.assert_called_once_with("/userProfile/1234567", headers=None)
         assert result == test_user_profile
 
-    # def test_that_get_user_profile_returns_expected_with_user_profile(self):
-    #     ...
-
-    # def test_that_get_user_profile_returns_expected_with_team_member(self):
-    #     ...
-
-    def test_that_get_user_profile_raises_value_error_when_user_does_not_exist(
-        self, syn
-    ):
+    def test_that_get_user_profile_raises_value_error_when_user_does_not_exist(self):
         with pytest.raises(ValueError, match="Can't find user *"):
-            self.syn.get_user_profile("not_a_user")
+            self.syn.get_user_profile_by_username("not_a_user")
 
     def test_that_get_user_profile_raises_type_error_when_id_is_not_allowed_type(self):
-        with pytest.raises(
-            TypeError, match="id must be a string, UserProfile, or TeamMember"
-        ):
-            self.syn.get_user_profile(1234567)
+        with pytest.raises(TypeError, match="id must be a 'userName' string"):
+            self.syn.get_user_profile_by_username(1234567)
 
 
 class TestGetUserProfileByID:
@@ -95,12 +85,16 @@ class TestGetUserProfileByID:
     def teardown_method(self):
         self.syn.restGET.stop()
 
-    def test_that_get_user_profile_by_id_returns_expected_when_id_id_defined(self):
+    def test_that_get_user_profile_by_id_returns_expected_when_id_is_defined(self):
         result = self.syn.get_user_profile_by_id(1234567)
         self.syn.restGET.assert_called_once_with("/userProfile/1234567", headers=None)
         assert result == test_user_profile
 
-    def test_that_get_user_profile_by_id_raises_type_error_when_id_is_not_defined(self):
+    def test_that_get_user_profile_by_id_returns_expected_when_id_is_not_defined(self):
         result = self.syn.get_user_profile_by_id()
         self.syn.restGET.assert_called_once_with("/userProfile/", headers=None)
         assert result == test_user_profile
+
+    def test_that_get_user_profile_by_id_raises_type_error_when_id_is_not_int(self):
+        with pytest.raises(TypeError, match="id must be an 'ownerId' integer"):
+            self.syn.get_user_profile_by_id("1234567")

--- a/tests/unit/synapseclient/unit_test_get_user_profile.py
+++ b/tests/unit/synapseclient/unit_test_get_user_profile.py
@@ -1,8 +1,6 @@
 import pytest
 from unittest.mock import patch
 
-from synapseclient.team import UserProfile
-
 
 test_user_profile = {
     "ownerId": "1234567",


### PR DESCRIPTION
**Problem:**

When a user calls the `getUserProfile` method with a username that is a number, the appropriate `UserProfile` is not retrieved. This essentially boils down to the fact that we currently allow people to pass `userName`s and `ownerId`s to `getUserProfile`, and that people are allowed to create usernames on Synapse that are just a string of numbers.

**Solution:**

Split `getUserProfile` into two separate functions. One that accepts `userName` as a string only, and one that only will accept an `ownerId` in the form of an integer.  

A complication of this solution is that `getUserProfile` is used in a number of places, some of which also allow `userName`s or `ownerId`s. This refactoring and the eventual deprecation of `getUserProfile` will need to be done in a future PR.
