### PR TITLE
[SYNPY-1333] Print transfer progress for FTP

### DIFF
--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -486,7 +486,9 @@ class TestDownloadFileHandle:
                 destination=destination,
             )
 
-            mock_url_retrieve.assert_called_once_with(url, expected_destination)
+            mock_url_retrieve.assert_called_once_with(
+                url=url, filename=expected_destination, reporthook=ANY
+            )
             assert download_path == expected_destination
 
     def test_download_from_url__synapse_auth(self, mocker):


### PR DESCRIPTION
**Problem:**
When a file is being downloaded from an FTP link there is no indication that anything is occurring.

**Solution:**
Adding in a reporthook function that will print the transfer progress based on the block number, read size, and total size.

**Testing:**

1. I tested this out with a script similar to what tom added in the Jira:
```
import synapseclient

syn = synapseclient.Synapse(debug=True)
syn.login()


file_ent = synapseclient.File(
    "ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR197/048/SRR19761348/SRR19761348_1.fastq.gz",
    name="SRR19761348_1.fastq.gz",
    # This parameter will store this file as a link
    synapseStore=False,
    parent="syn52569429",
)
file_ent = syn.store(obj=file_ent)
syn.get(entity=file_ent, downloadFile=True)

```

After running the script I get:
`Downloading  [--------------------]0.63%   9.0MB/1.4GB (3.1MB/s) SRR19761348_1.fastq.gz`

This is just like downloading synapse stored file which look like:
`Downloading  [####################]100.00%   12.0bytes/12.0bytes (4.5kB/s) my_super_cool_junk_file.txt`