### PR TITLE
[SYNPY-1358] Correction of timestamp in annotations from manifest file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ build/*
 /venv
 
 .vscode/
+CONFIGFILE

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -327,6 +327,18 @@ def is_synapse_id_str(obj):
 
 
 def datetime_or_none(datetime_str: str) -> typing.Union[datetime.datetime, None]:
+    """Attempts to convert a string to a datetime object. Returns None if it fails.
+
+    Some of the expected formats of datetime_str are:
+    - 2023-12-04T07:00:00Z
+    - 2001-01-01 15:00:00+07:00
+    - 2001-01-01 15:00:00-07:00
+    - 2023-12-04 07:00:00+00:00
+    - 2019-01-01
+
+    :param datetime_str: The string to convert to a datetime object
+    :return: The datetime object or None if the conversion fails
+    """
     try:
         return datetime.datetime.fromisoformat(datetime_str.replace("Z", "+00:00"))
     except Exception:

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -340,15 +340,16 @@ def is_date(dt):
 
 def to_list(value):
     """Convert the value (an iterable or a scalar value) to a list."""
-    possible_datetime = None
     if isinstance(value, collections.abc.Iterable) and not isinstance(value, str):
         values = []
         for val in value:
+            possible_datetime = None
             if isinstance(val, str):
                 possible_datetime = datetime_or_none(value)
             values.append(val if possible_datetime is None else possible_datetime)
         return values
     else:
+        possible_datetime = None
         if isinstance(value, str):
             possible_datetime = datetime_or_none(value)
         return [value if possible_datetime is None else possible_datetime]

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -424,11 +424,18 @@ def to_unix_epoch_time(dt: typing.Union[datetime.date, datetime.datetime, str]) 
             tzinfo=current_timezone
         )
     else:
+        # If the datetime is not timezone aware, assume it is in the local timezone.
+        # This is required in order for windows to work with the `astimezone` method.
+        if dt.tzinfo is None:
+            current_timezone = datetime.datetime.now().astimezone().tzinfo
+            dt = dt.replace(tzinfo=current_timezone)
         datetime_utc = dt.astimezone(datetime.timezone.utc)
     return int((datetime_utc - UNIX_EPOCH).total_seconds() * 1000)
 
 
-def to_unix_epoch_time_secs(dt: typing.Union[datetime.date, datetime.datetime]) -> int:
+def to_unix_epoch_time_secs(
+    dt: typing.Union[datetime.date, datetime.datetime]
+) -> float:
     """
     Convert either `datetime.date or datetime.datetime objects <http://docs.python.org/2/library/datetime.html>`_
     to UNIX time.
@@ -439,6 +446,11 @@ def to_unix_epoch_time_secs(dt: typing.Union[datetime.date, datetime.datetime]) 
             tzinfo=current_timezone
         )
     else:
+        # If the datetime is not timezone aware, assume it is in the local timezone.
+        # This is required in order for windows to work with the `astimezone` method.
+        if dt.tzinfo is None:
+            current_timezone = datetime.datetime.now().astimezone().tzinfo
+            dt = dt.replace(tzinfo=current_timezone)
         datetime_utc = dt.astimezone(datetime.timezone.utc)
     return (datetime_utc - UNIX_EPOCH).total_seconds()
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -156,4 +156,5 @@ def setup_otel():
 @pytest.fixture(autouse=True)
 def set_timezone():
     os.environ["TZ"] = "UTC"
-    time.tzset()
+    if platform.system() != "Windows":
+        time.tzset()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,7 @@
 import logging
 import platform
 import uuid
-import os
+import os, time
 import sys
 import shutil
 import tempfile
@@ -151,3 +151,9 @@ def setup_otel():
             )
     else:
         trace.set_tracer_provider(TracerProvider(sampler=ALWAYS_OFF))
+
+
+@pytest.fixture(autouse=True)
+def set_timezone():
+    os.environ["TZ"] = "UTC"
+    time.tzset()

--- a/tests/integration/synapseclient/integration_test_Entity.py
+++ b/tests/integration/synapseclient/integration_test_Entity.py
@@ -1,3 +1,4 @@
+import datetime
 import uuid
 import filecmp
 import os
@@ -82,7 +83,7 @@ def test_Entity(syn: Synapse, project: Project, schedule_for_cleanup):
     ), ("description= %s" % a_file.description)
     assert a_file["foo"][0] == "An arbitrary value", "foo= %s" % a_file["foo"][0]
     assert a_file["bar"] == [33, 44, 55]
-    assert a_file["bday"][0] == Datetime(2013, 3, 15)
+    assert a_file["bday"][0] == Datetime(2013, 3, 15, tzinfo=datetime.timezone.utc)
     assert a_file.contentType == "text/flapdoodle", (
         "contentType= %s" % a_file.contentType
     )
@@ -107,7 +108,7 @@ def test_Entity(syn: Synapse, project: Project, schedule_for_cleanup):
     a_file = syn.store(a_file, forceVersion=False)
     assert a_file["foo"][0] == "Another arbitrary chunk of text data"
     assert a_file["bar"] == [33, 44, 55]
-    assert a_file["bday"][0] == Datetime(2013, 3, 15)
+    assert a_file["bday"][0] == Datetime(2013, 3, 15, tzinfo=datetime.timezone.utc)
     assert a_file.new_key[0] == "A newly created value"
     assert a_file.path == path
     assert a_file.versionNumber == 1, "unexpected version number: " + str(
@@ -134,7 +135,7 @@ def test_Entity(syn: Synapse, project: Project, schedule_for_cleanup):
     link = syn.get(link, followLink=True)
     assert link["foo"][0] == "Another arbitrary chunk of text data"
     assert link["bar"] == [33, 44, 55]
-    assert link["bday"][0] == Datetime(2013, 3, 15)
+    assert link["bday"][0] == Datetime(2013, 3, 15, tzinfo=datetime.timezone.utc)
     assert link.new_key[0] == "A newly created value"
     assert utils.equal_paths(link.path, path)
     assert link.versionNumber == 1, "unexpected version number: " + str(

--- a/tests/integration/synapseclient/test_tables.py
+++ b/tests/integration/synapseclient/test_tables.py
@@ -5,7 +5,7 @@ import random
 import tempfile
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from pandas.testing import assert_frame_equal
 import pytest
@@ -564,7 +564,9 @@ def test_synapse_integer_columns_with_missing_values_from_dataframe(
 
 @tracer.start_as_current_span("test_tables::test_store_table_datetime")
 def test_store_table_datetime(syn, project):
-    current_datetime = datetime.fromtimestamp(round(time.time(), 3))
+    current_datetime = datetime.fromtimestamp(round(time.time(), 3)).replace(
+        tzinfo=timezone.utc
+    )
     schema = syn.store(
         Schema("testTable", [Column(name="testerino", columnType="DATE")], project)
     )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import platform
 import urllib.request
 
 from unittest import mock
@@ -46,7 +47,8 @@ def test_confirm_connections_blocked():
 @pytest.fixture(autouse=True)
 def set_timezone():
     os.environ["TZ"] = "UTC"
-    time.tzset()
+    if platform.system() != "Windows":
+        time.tzset()
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,6 +3,7 @@ import urllib.request
 
 from unittest import mock
 import pytest
+import os, time
 
 from synapseclient import Synapse
 from synapseclient.core.logging_setup import SILENT_LOGGER_NAME
@@ -40,6 +41,12 @@ def test_confirm_connections_blocked():
     with pytest.raises(ValueError) as cm_ex:
         urllib.request.urlopen("http://example.com")
     assert _BLOCKED_CONNECTION_MESSAGE == str(cm_ex.value)
+
+
+@pytest.fixture(autouse=True)
+def set_timezone():
+    os.environ["TZ"] = "UTC"
+    time.tzset()
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/synapseclient/unit_test_annotations.py
+++ b/tests/unit/synapseclient/unit_test_annotations.py
@@ -2,6 +2,7 @@
 ############################################################
 
 from datetime import datetime as Datetime
+import datetime
 from math import pi
 import time
 import uuid
@@ -155,10 +156,10 @@ def test_round_trip_annotations():
             "zoo": [123.1, 456.2, 789.3],
             "species": ["Moose"],
             "birthdays": [
-                Datetime(1969, 4, 28),
-                Datetime(1973, 12, 8),
-                Datetime(2008, 1, 3),
-                Datetime(2013, 3, 15),
+                Datetime(1969, 4, 28, tzinfo=datetime.timezone.utc),
+                Datetime(1973, 12, 8, tzinfo=datetime.timezone.utc),
+                Datetime(2008, 1, 3, tzinfo=datetime.timezone.utc),
+                Datetime(2013, 3, 15, tzinfo=datetime.timezone.utc),
             ],
             "facts": [
                 True,
@@ -206,7 +207,7 @@ def test_idempotent_annotations():
 
 
 def test_submission_status_annotations_round_trip():
-    april_28_1969 = Datetime(1969, 4, 28)
+    april_28_1969 = Datetime(1969, 4, 28, tzinfo=datetime.timezone.utc)
     a = Annotations(
         "syn123",
         "7bdb83e9-a50a-46e4-987a-4962559f090f",


### PR DESCRIPTION
**Problem:**

1. When a timestamp is given in a manifest.tsv file the current code is storing the data as a string annotation instead of a date.
2. When a datetime or date object is created we did not account for the timezone of the current machine or what is defined in the datetime object.
3. When the UTC timestamp was coming back from the synapse API the code was always converting the timestamp into local time, however, UTC time is what synapse is giving us.

**Solution:**

1. I added logic when creating timestamps from the manifest.tsv file to check the format of the string. If it matches a date format we are going to use that type in order to create the annotation.
2. I am taking into account the timezone of the current machine or, if defined, the timezone defined on the datetime object.
3. For data coming back from the synapse server we are now taking it in as UTC time which allows anyone who needs to use it have the correct time. This also allows for the timestamp to correct print in the manifest.tsv

**Testing:**

1. I manually tested with several annotations. For example given this manifest file:
```
path    parent  name    id      synapseStore    contentType     used    executed        activityName    activityDescription     my_key_timestamp_date_yesterday my_key_long     my_key_bool     my_key_string   my_key_double   my_key_timestamp_datetime       my_key_timestamp_date
/home/bfauble/annotationTesting/file.txt        syn52919599     file.txt        syn53085003     True    text/plain                                      2023-12-04T07:00:00Z    1       False   b       1.2     2023-12-05 23:37:02.995000+00:00        2023-12-05 07:00:00+00:00
```
![image](https://github.com/Sage-Bionetworks/synapsePythonClient/assets/17128019/68305e3f-9921-450e-8047-5a6f482bc0bb)
2. I update the unit and integration tests to allow for this logic.