### PR TITLE
[SYNPY-1349] Detect annotation type

### DIFF
--- a/synapseclient/models/__init__.py
+++ b/synapseclient/models/__init__.py
@@ -1,8 +1,6 @@
 # These are all of the models that are used by the Synapse client.
 from synapseclient.models.annotations import (
     Annotations,
-    AnnotationsValue,
-    AnnotationsValueType,
 )
 from synapseclient.models.file import File
 from synapseclient.models.folder import Folder
@@ -22,8 +20,6 @@ __all__ = [
     "Folder",
     "Project",
     "Annotations",
-    "AnnotationsValue",
-    "AnnotationsValueType",
     "Table",
     "Column",
     "ColumnType",

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -1,8 +1,9 @@
 import asyncio
 from dataclasses import dataclass
-from typing import Dict, Union
+from datetime import date, datetime
+from typing import Dict, List, Union
 from opentelemetry import trace, context
-from synapseclient.models import AnnotationsValue, Annotations
+from synapseclient.models import Annotations
 
 # import uuid
 
@@ -77,7 +78,19 @@ class File:
     """An optional replacement for the name of the uploaded file. This is distinct
     from the entity name. If omitted the file will retain its original name."""
 
-    annotations: Optional[Dict[str, AnnotationsValue]] = None
+    annotations: Optional[
+        Dict[
+            str,
+            Union[
+                List[str],
+                List[bool],
+                List[float],
+                List[int],
+                List[date],
+                List[datetime],
+            ],
+        ]
+    ] = None
     """Additional metadata associated with the folder. The key is the name of your
     desired annotations. The value is an object containing a list of values
     (use empty list to represent no values for key) and the value type associated with

--- a/synapseclient/models/folder.py
+++ b/synapseclient/models/folder.py
@@ -1,5 +1,6 @@
 import asyncio
 from dataclasses import dataclass, field
+from datetime import date, datetime
 from typing import Dict, List, Union
 from typing import Optional, TYPE_CHECKING
 from opentelemetry import trace, context
@@ -8,7 +9,7 @@ from opentelemetry import trace, context
 
 from synapseclient import Synapse
 from synapseclient.entity import Folder as Synapse_Folder
-from synapseclient.models import File, Annotations, AnnotationsValue
+from synapseclient.models import File, Annotations
 
 if TYPE_CHECKING:
     from synapseclient.models import Project
@@ -57,7 +58,19 @@ class Folder:
     folders: Optional[List["Folder"]] = field(default_factory=list)
     """Folders that exist within this folder."""
 
-    annotations: Optional[Dict[str, AnnotationsValue]] = None
+    annotations: Optional[
+        Dict[
+            str,
+            Union[
+                List[str],
+                List[bool],
+                List[float],
+                List[int],
+                List[date],
+                List[datetime],
+            ],
+        ]
+    ] = None
     """Additional metadata associated with the folder. The key is the name of your
     desired annotations. The value is an object containing a list of values
     (use empty list to represent no values for key) and the value type associated with

--- a/synapseclient/models/project.py
+++ b/synapseclient/models/project.py
@@ -1,6 +1,7 @@
 import asyncio
 from dataclasses import dataclass, field
-from typing import List, Dict
+from datetime import date, datetime
+from typing import List, Dict, Union
 
 # import uuid
 
@@ -9,7 +10,7 @@ from opentelemetry import trace, context
 
 from typing import Optional
 
-from synapseclient.models import Folder, File, Annotations, AnnotationsValue
+from synapseclient.models import Folder, File, Annotations
 from synapseclient import Synapse
 
 
@@ -54,7 +55,19 @@ class Project:
     folders: Optional[List["Folder"]] = field(default_factory=list)
     """Any folders that are at the root directory of the project."""
 
-    annotations: Optional[Dict[str, AnnotationsValue]] = None
+    annotations: Optional[
+        Dict[
+            str,
+            Union[
+                List[str],
+                List[bool],
+                List[float],
+                List[int],
+                List[date],
+                List[datetime],
+            ],
+        ]
+    ] = None
     """Additional metadata associated with the folder. The key is the name of your
     desired annotations. The value is an object containing a list of values
     (use empty list to represent no values for key) and the value type associated with

--- a/test_scripts/oop_poc_file.py
+++ b/test_scripts/oop_poc_file.py
@@ -9,12 +9,12 @@ The following actions are shown in this script:
 """
 import asyncio
 import os
+
 from synapseclient.models import (
     File,
     Folder,
-    AnnotationsValueType,
-    AnnotationsValue,
 )
+from datetime import date, datetime, timedelta, timezone
 import synapseclient
 
 from opentelemetry import trace
@@ -50,21 +50,19 @@ def create_random_file(
 async def store_file():
     # Creating annotations for my file ==================================================
     annotations_for_my_file = {
-        "my_key_string": AnnotationsValue(
-            type=AnnotationsValueType.STRING, value=["b", "a", "c"]
-        ),
-        "my_key_bool": AnnotationsValue(
-            type=AnnotationsValueType.BOOLEAN, value=[False, False, False]
-        ),
-        "my_key_double": AnnotationsValue(
-            type=AnnotationsValueType.DOUBLE, value=[1.2, 3.4, 5.6]
-        ),
-        "my_key_long": AnnotationsValue(
-            type=AnnotationsValueType.LONG, value=[1, 2, 3]
-        ),
-        "my_key_timestamp": AnnotationsValue(
-            type=AnnotationsValueType.TIMESTAMP_MS, value=[1701362964066, 1577862000000]
-        ),
+        "my_single_key_string": "a",
+        "my_key_string": ["b", "a", "c"],
+        "my_key_bool": [False, False, False],
+        "my_key_double": [1.2, 3.4, 5.6],
+        "my_key_long": [1, 2, 3],
+        "my_key_date": [date.today(), date.today() - timedelta(days=1)],
+        "my_key_datetime": [
+            datetime.today(),
+            datetime.today() - timedelta(days=1),
+            datetime.now(tz=timezone(timedelta(hours=-5))),
+            datetime(2023, 12, 7, 13, 0, 0, tzinfo=timezone(timedelta(hours=0))),
+            datetime(2023, 12, 7, 13, 0, 0, tzinfo=timezone(timedelta(hours=-7))),
+        ],
     }
 
     name_of_file = "my_file_with_random_data.txt"
@@ -83,6 +81,12 @@ async def store_file():
     file = await file.store()
 
     print(file)
+
+    # Updating and storing an annotation =================================================
+    file_copy = await File(id=file.id).get()
+    file_copy.annotations["my_key_string"] = ["new", "values", "here"]
+    stored_file = await file_copy.store()
+    print(stored_file)
 
     # Downloading a file =================================================================
     downloaded_file_copy = await File(id=file.id).get(

--- a/test_scripts/oop_poc_folder.py
+++ b/test_scripts/oop_poc_folder.py
@@ -13,10 +13,9 @@ import os
 from synapseclient.models import (
     File,
     Folder,
-    AnnotationsValueType,
-    AnnotationsValue,
 )
 import synapseclient
+from datetime import date, datetime, timedelta, timezone
 
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
@@ -51,21 +50,19 @@ def create_random_file(
 async def store_folder():
     # Creating annotations for my folder ==================================================
     annotations_for_my_folder = {
-        "my_key_string": AnnotationsValue(
-            type=AnnotationsValueType.STRING, value=["b", "a", "c"]
-        ),
-        "my_key_bool": AnnotationsValue(
-            type=AnnotationsValueType.BOOLEAN, value=[False, False, False]
-        ),
-        "my_key_double": AnnotationsValue(
-            type=AnnotationsValueType.DOUBLE, value=[1.2, 3.4, 5.6]
-        ),
-        "my_key_long": AnnotationsValue(
-            type=AnnotationsValueType.LONG, value=[1, 2, 3]
-        ),
-        "my_key_timestamp": AnnotationsValue(
-            type=AnnotationsValueType.TIMESTAMP_MS, value=[1701362964066, 1577862000000]
-        ),
+        "my_single_key_string": "a",
+        "my_key_string": ["b", "a", "c"],
+        "my_key_bool": [False, False, False],
+        "my_key_double": [1.2, 3.4, 5.6],
+        "my_key_long": [1, 2, 3],
+        "my_key_date": [date.today(), date.today() - timedelta(days=1)],
+        "my_key_datetime": [
+            datetime.today(),
+            datetime.today() - timedelta(days=1),
+            datetime.now(tz=timezone(timedelta(hours=-5))),
+            datetime(2023, 12, 7, 13, 0, 0, tzinfo=timezone(timedelta(hours=0))),
+            datetime(2023, 12, 7, 13, 0, 0, tzinfo=timezone(timedelta(hours=-7))),
+        ],
     }
 
     # Creating a folder ==================================================================
@@ -79,6 +76,12 @@ async def store_folder():
     folder = await folder.store()
 
     print(folder)
+
+    # Updating and storing an annotation =================================================
+    folder_copy = await Folder(id=folder.id).get()
+    folder_copy.annotations["my_key_string"] = ["new", "values", "here"]
+    stored_folder = await folder_copy.store()
+    print(stored_folder)
 
     # Storing several files to a folder ==================================================
     files_to_store = []
@@ -117,9 +120,7 @@ async def store_folder():
 
     # Updating the annotations in bulk for a number of folders and files ==================
     new_annotations = {
-        "my_new_key_string": AnnotationsValue(
-            type=AnnotationsValueType.STRING, value=["b", "a", "c"]
-        ),
+        "my_new_key_string": ["b", "a", "c"],
     }
 
     for file in folder_copy.files:


### PR DESCRIPTION
**Problem:**
Working with annotations was previously requiring a lot more verbose information. I was forcing a Type to be defined.

**Solution:**
Using the same logic that is in the current python client convert based off the class types into the appropriate type for the Synapse REST API. This allows us to simply define a list or singular annotation.

**Testing:**
See the test scripts.