### PR TITLE
[SYNPY-1302] add method to implement get entity permission api

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -5357,6 +5357,44 @@ class Permissions:
 
     @property
     def access_types(self):
+        """
+        Determine from the permissions set on this object what the access types are.
+
+
+        Returns:
+            A list of access type strings for this object based off of what permissions are set.
+
+        Example: Using this property
+            A permission that has nothing set
+
+                no_permissions = Permissions()
+                print(no_permissions.access_types)
+                # Prints: []
+
+            A permission that has can_view set to True and nothing else set
+
+                read_permission = Permissions()
+                read_permission.can_view = True
+                print(read_permission.access_types)
+                # Prints: ['READ']
+
+            Special Case: a permission that has can_view set to True and nothing else set on an entity created by you.
+            CHANGE_SETTINGS is bound to ownerId. Since the entity is created by you, the CHANGE_SETTINGS will always be True.
+               read_permission = Permissions()
+               read_permission.can_view = True
+               print(read_permission.access_types)
+               # Prints: ['READ','CHANGE_SETTINGS']
+
+
+            A permission that has can_view and can_edit set to True and nothing else set
+
+                read_write_permission = Permissions()
+                read_write_permission.can_view = True
+                read_write_permission.can_edit = True
+                print(read_write_permission.access_types)
+                # Prints: ['READ', 'UPDATE']
+
+        """
         access_types = []
         if self.can_view:
             access_types.append("READ")

--- a/tests/integration/synapseclient/integration_test.py
+++ b/tests/integration/synapseclient/integration_test.py
@@ -870,3 +870,293 @@ class TestPermissionsOnProject:
             "DOWNLOAD",
         ]
         assert set(expected_permissions) == set(permissions)
+
+
+class TestPermissionsOnEntityForCaller:
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup):
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    @tracer.start_as_current_span(
+        "integration_test::TestPermissionsOnEntityForCaller::test_get_permissions_default"
+    )
+    def test_get_permissions_default(self):
+        # GIVEN a project created with default permissions of administrator
+        project_with_default_permissions: Entity = self.syn.store(
+            Project(name=str(uuid.uuid4()) + "test_get_permissions_default_permissions")
+        )
+        self.schedule_for_cleanup(project_with_default_permissions)
+
+        # AND the user that created the project
+        # p1: UserProfile = self.syn.getUserProfile()
+
+        # WHEN I get the permissions for the user on the entity
+        permissions = self.syn.get_permissions(project_with_default_permissions.id)
+
+        # THEN I expect to see the default admin permissions
+        expected_permissions = [
+            "READ",
+            "DELETE",
+            "CHANGE_SETTINGS",
+            "UPDATE",
+            "CHANGE_PERMISSIONS",
+            "CREATE",
+            "MODERATE",
+            "DOWNLOAD",
+        ]
+        assert set(expected_permissions) == set(permissions.access_types)
+
+    @tracer.start_as_current_span(
+        "integration_test::TestPermissionsOnEntityForCaller::test_get_permissions_read_only_permissions_on_entity"
+    )
+    def test_get_permissions_read_only_permissions_on_entity(self):
+        # GIVEN a project created with default permissions of administrator
+        project_with_read_only_permissions: Entity = self.syn.store(
+            Project(
+                name=str(uuid.uuid4())
+                + "test_get_permissions_read_permissions_on_project"
+            )
+        )
+        self.schedule_for_cleanup(project_with_read_only_permissions)
+
+        # AND the user that created the project
+        p1: UserProfile = self.syn.getUserProfile()
+
+        # AND the permissions for the user on the entity are set to READ only
+        self.syn.setPermissions(
+            project_with_read_only_permissions, p1.ownerId, ["READ"]
+        )
+
+        # WHEN I get the permissions for the user on the entity
+        permissions = self.syn.get_permissions(project_with_read_only_permissions.id)
+
+        # THEN I expect to see read only permissions. CHANGE_SETTINGS is bound to ownerId. Since the entity is created by the Caller, the CHANGE_SETTINGS will always be True.
+        expected_permissions = ["READ", "CHANGE_SETTINGS"]
+
+        assert set(expected_permissions) == set(permissions.access_types)
+
+    @tracer.start_as_current_span(
+        "integration_test::TestPermissionsOnEntityForCaller::test_get_permissions_through_team_assigned_to_user"
+    )
+    def test_get_permissions_through_team_assigned_to_user(self):
+        # GIVEN a project created with default permissions of administrator
+        project_with_permissions_through_single_team: Entity = self.syn.store(
+            Project(
+                name=str(uuid.uuid4())
+                + "test_get_permissions_through_team_assigned_to_user_and_project"
+            )
+        )
+
+        # AND the user that created the project
+        p1: UserProfile = self.syn.getUserProfile()
+
+        # AND a team is created
+        name = "My Uniquely Named Team " + str(uuid.uuid4())
+        team = self.syn.store(
+            Team(
+                name=name,
+                description="A fake team for testing permissions assigned to a single project",
+            )
+        )
+
+        # Handle Cleanup - Note: When running this schedule for cleanup order can matter when there are dependent resources
+        self.schedule_for_cleanup(team)
+        self.schedule_for_cleanup(project_with_permissions_through_single_team)
+
+        # AND the permissions for the Team on the entity are set to all permissions except for DOWNLOAD
+        self.syn.setPermissions(
+            project_with_permissions_through_single_team,
+            team.id,
+            [
+                "READ",
+                "DELETE",
+                "CHANGE_SETTINGS",
+                "UPDATE",
+                "CHANGE_PERMISSIONS",
+                "CREATE",
+                "MODERATE",
+            ],
+        )
+
+        # AND the permissions for the user on the entity are set to NONE
+        self.syn.setPermissions(
+            project_with_permissions_through_single_team, p1.ownerId, []
+        )
+
+        # WHEN I get the permissions for the user on the entity
+        permissions = self.syn.get_permissions(
+            project_with_permissions_through_single_team.id
+        )
+
+        # THEN I expect to see the permissions of the team
+        expected_permissions = [
+            "READ",
+            "DELETE",
+            "CHANGE_SETTINGS",
+            "UPDATE",
+            "CHANGE_PERMISSIONS",
+            "CREATE",
+            "MODERATE",
+        ]
+        assert set(expected_permissions) == set(permissions.access_types)
+
+    @tracer.start_as_current_span(
+        "integration_test::TestPermissionsOnEntityForCaller::test_get_permissions_through_multiple_teams_assigned_to_user"
+    )
+    def test_get_permissions_through_multiple_teams_assigned_to_user(self):
+        # GIVEN a project created with default permissions of administrator
+        project_with_permissions_through_multiple_teams: Entity = self.syn.store(
+            Project(
+                name=str(uuid.uuid4())
+                + "test_get_permissions_through_two_teams_assigned_to_user_and_project"
+            )
+        )
+
+        # AND the user that created the project
+        p1: UserProfile = self.syn.getUserProfile()
+
+        # AND a team is created
+        name = "My Uniquely Named Team " + str(uuid.uuid4())
+        team_1 = self.syn.store(
+            Team(
+                name=name,
+                description="A fake team for testing permissions assigned to a single project - 1",
+            )
+        )
+
+        # AND a second team is created
+        name = "My Uniquely Named Team " + str(uuid.uuid4())
+        team_2 = self.syn.store(
+            Team(
+                name=name,
+                description="A fake team for testing permissions assigned to a single project - 2",
+            )
+        )
+
+        # Handle Cleanup - Note: When running this schedule for cleanup order can matter when there are dependent resources
+        self.schedule_for_cleanup(team_1)
+        self.schedule_for_cleanup(team_2)
+        self.schedule_for_cleanup(project_with_permissions_through_multiple_teams)
+
+        # AND the permissions for the Team 1 on the entity are set to all permissions except for DOWNLOAD
+        self.syn.setPermissions(
+            project_with_permissions_through_multiple_teams,
+            team_1.id,
+            [
+                "READ",
+                "DELETE",
+                "CHANGE_SETTINGS",
+                "UPDATE",
+                "CHANGE_PERMISSIONS",
+                "CREATE",
+                "MODERATE",
+            ],
+        )
+
+        # AND the permissions for the Team 2 on the entity are set to only READ and DOWNLOAD
+        self.syn.setPermissions(
+            project_with_permissions_through_multiple_teams,
+            team_2.id,
+            ["READ", "DOWNLOAD"],
+        )
+
+        # AND the permissions for the user on the entity are set to NONE
+        self.syn.setPermissions(
+            project_with_permissions_through_multiple_teams, p1.ownerId, []
+        )
+
+        # WHEN I get the permissions for the user on the entity
+        permissions = self.syn.get_permissions(
+            project_with_permissions_through_multiple_teams.id
+        )
+
+        # THEN I expect to see the permissions of both teams
+        expected_permissions = [
+            "READ",
+            "DELETE",
+            "CHANGE_SETTINGS",
+            "UPDATE",
+            "CHANGE_PERMISSIONS",
+            "CREATE",
+            "MODERATE",
+            "DOWNLOAD",
+        ]
+        assert set(expected_permissions) == set(permissions.access_types)
+
+    @tracer.start_as_current_span(
+        "integration_test::TestPermissionsOnEntityForCaller::test_get_permissions_for_project_with_public_and_registered_user"
+    )
+    def test_get_permissions_for_project_with_public_and_registered_user(self):
+        # GIVEN a project created with default permissions of administrator
+        project_with_permissions_for_public_and_authenticated_users: Entity = (
+            self.syn.store(
+                Project(
+                    name=str(uuid.uuid4())
+                    + "test_get_permissions_for_project_with_registered_user"
+                )
+            )
+        )
+        self.schedule_for_cleanup(
+            project_with_permissions_for_public_and_authenticated_users
+        )
+
+        # AND the user that created the project
+        p1: UserProfile = self.syn.getUserProfile()
+
+        # AND the permissions for PUBLIC are set to 'READ'
+        self.syn.setPermissions(
+            project_with_permissions_for_public_and_authenticated_users,
+            PUBLIC,
+            ["READ"],
+        )
+
+        # AND the permissions for AUTHENTICATED_USERS is set to 'READ, DOWNLOAD'
+        self.syn.setPermissions(
+            project_with_permissions_for_public_and_authenticated_users,
+            AUTHENTICATED_USERS,
+            ["READ", "DOWNLOAD"],
+        )
+
+        # AND the permissions for the user on the entity do NOT include DOWNLOAD
+        self.syn.setPermissions(
+            project_with_permissions_for_public_and_authenticated_users,
+            p1.ownerId,
+            [
+                "READ",
+                "DELETE",
+                "CHANGE_SETTINGS",
+                "UPDATE",
+                "CHANGE_PERMISSIONS",
+                "CREATE",
+                "MODERATE",
+            ],
+        )
+
+        # NOT APPLICABLE
+        # WHEN I get the permissions for a public user on the entity
+        # permissions = self.syn.getPermissions(
+        #    project_with_permissions_for_public_and_authenticated_users.id
+        # )
+
+        # THEN I expect to the public permissions
+        # expected_permissions = ["READ"]
+        # assert set(expected_permissions) == set(permissions)
+
+        # and WHEN I get the permissions for the user on the entity
+        permissions = self.syn.get_permissions(
+            project_with_permissions_for_public_and_authenticated_users.id
+        )
+
+        # THEN I expect to see the permissions of the user, and the authenticated user, and the public user
+        expected_permissions = [
+            "READ",
+            "DELETE",
+            "CHANGE_SETTINGS",
+            "UPDATE",
+            "CHANGE_PERMISSIONS",
+            "CREATE",
+            "MODERATE",
+            "DOWNLOAD",
+        ]
+        assert set(expected_permissions) == set(permissions.access_types)

--- a/tests/unit/synapseclient/unit_test_get_permissions.py
+++ b/tests/unit/synapseclient/unit_test_get_permissions.py
@@ -1,0 +1,93 @@
+from unittest.mock import patch
+
+import pytest
+
+from synapseclient.client import Permissions
+from synapseclient.entity import Entity
+from synapseclient.evaluation import Evaluation
+
+return_value = {
+    "canEdit": True,
+    "canView": True,
+    "canMove": True,
+    "canAddChild": True,
+    "canCertifiedUserEdit": False,
+    "canCertifiedUserAddChild": False,
+    "isCertifiedUser": True,
+    "canChangePermissions": True,
+    "canChangeSettings": True,
+    "canDelete": True,
+    "canDownload": True,
+    "canUpload": True,
+    "canEnableInheritance": True,
+    "ownerPrincipalId": 1111,
+    "canPublicRead": True,
+    "canModerate": True,
+    "isCertificationRequired": True,
+    "isEntityOpenData": False,
+}
+
+
+class TestGetPermissionsForCaller:
+    @pytest.fixture(autouse=True, scope="function")
+    def setup_method(self, syn):
+        self.syn = syn
+        self.syn.restGET = patch.object(
+            self.syn, "restGET", return_value=return_value
+        ).start()
+
+    def teardown_method(self):
+        self.syn.restGET.stop()
+
+    def assert_entity_permission(self, d: dict, e: Permissions):
+        """check if the values match between API output and function output"""
+        assert d["canView"] == e.can_view
+        assert d["canEdit"] == e.can_edit
+        assert d["canMove"] == e.can_move
+        assert d["canAddChild"] == e.can_add_child
+        assert d["canCertifiedUserEdit"] == e.can_certified_user_edit
+        assert d["canCertifiedUserAddChild"] == e.can_certified_user_add_child
+        assert d["isCertifiedUser"] == e.is_certified_user
+        assert d["canChangePermissions"] == e.can_change_permissions
+        assert d["canChangeSettings"] == e.can_change_settings
+        assert d["canDelete"] == e.can_delete
+        assert d["canDownload"] == e.can_download
+        assert d["canUpload"] == e.can_upload
+        assert d["canEnableInheritance"] == e.can_enable_inheritance
+        assert d["ownerPrincipalId"] == e.owner_principal_id
+        assert d["canPublicRead"] == e.can_public_read
+        assert d["canModerate"] == e.can_moderate
+        assert d["isCertificationRequired"] == e.is_certification_required
+        assert d["isEntityOpenData"] == e.is_entity_open_data
+
+    def test_get_permissions_with_input_as_str(self):
+        """test that entity permission object is created correctly from a dictionary"""
+        entity_id = "syn123"
+        result = self.syn.get_permissions(entity_id)
+        self.syn.restGET.assert_called_once_with(f"/entity/{entity_id}/permissions")
+        assert isinstance(result, Permissions)
+        self.assert_entity_permission(return_value, result)
+
+    def test_get_permissions_with_input_as_Entity(self):
+        """test that entity permission object is created correctly from a dictionary"""
+        entity = Entity(parentId="parent", id="fake")
+        result = self.syn.get_permissions(entity)
+        self.syn.restGET.assert_called_once_with(f"/entity/fake/permissions")
+        assert isinstance(result, Permissions)
+        self.assert_entity_permission(return_value, result)
+
+    def test_get_permissions_with_input_as_Mapping(self):
+        """test that entity permission object is created correctly from a dictionary"""
+        entity = {"parentId": "parent", "id": "fake"}
+        result = self.syn.get_permissions(entity)
+        self.syn.restGET.assert_called_once_with(f"/entity/fake/permissions")
+        assert isinstance(result, Permissions)
+        self.assert_entity_permission(return_value, result)
+
+    def test_get_permissions_with_input_as_Evaluation(self):
+        """test that entity permission object is created correctly from a dictionary"""
+        entity = Evaluation(contentSource="syn1234", id="fake")
+        result = self.syn.get_permissions(entity)
+        self.syn.restGET.assert_called_once_with(f"/entity/fake/permissions")
+        assert isinstance(result, Permissions)
+        self.assert_entity_permission(return_value, result)


### PR DESCRIPTION
Problem:
The original `getPermission` method uses /acl endpoint only that shows [inconsistent behavior in the case of publicly downloadable content from Synapse.](https://sagebionetworks.jira.com/browse/PLFM-8079) 

Solution:
create a `get_permissions` method that implements [GET /entity/{id}/permissions API](https://rest-docs.synapse.org/rest/GET/entity/id/permissions.html). These API factors in the entity's ACL and the user's group membership when determining the caller's permission to the entity.  

Example:
<img width="1324" alt="Screenshot 2023-12-15 at 9 31 28 AM" src="https://github.com/Sage-Bionetworks/synapsePythonClient/assets/90745557/51836744-3d47-424c-b9ed-58018fe8065b">


Testing:
Unit tests and integration tests are included in the PR. 