### PR TITLE
[SYNPY-1370] migrate to google style

### DIFF
--- a/synapseclient/annotations.py
+++ b/synapseclient/annotations.py
@@ -294,17 +294,19 @@ class Annotations(dict):
         Create an Annotations object taking key value pairs from a dictionary or from keyword arguments.
         System properties id, etag, creationDate and uri become attributes of the object.
 
-        :param id:  A Synapse ID, a Synapse Entity object, a plain dictionary in which 'id' maps to a Synapse ID
-        :param etag: etag of the Synapse Entity
-        :param values:  (Optional) dictionary of values to be copied into annotations
-        :param \**kwargs: additional key-value pairs to be added as annotations
+        Attributes:
+            id:  A Synapse ID, a Synapse Entity object, a plain dictionary in which 'id' maps to a Synapse ID
+            etag: etag of the Synapse Entity
+            values: (Optional) dictionary of values to be copied into annotations
+            **kwargs: additional key-value pairs to be added as annotations
 
-        Example::
+        Example: Creating a few instances
+            Creating and setting annotations
 
-            example1 = Annotations('syn123','40256475-6fb3-11ea-bb0a-9cb6d0d8d984', {'foo':'bar'})
-            example2 = Annotations('syn123','40256475-6fb3-11ea-bb0a-9cb6d0d8d984', foo='bar')
-            example3 = Annotations('syn123','40256475-6fb3-11ea-bb0a-9cb6d0d8d984')
-            example3['foo'] = 'bar'
+                example1 = Annotations('syn123','40256475-6fb3-11ea-bb0a-9cb6d0d8d984', {'foo':'bar'})
+                example2 = Annotations('syn123','40256475-6fb3-11ea-bb0a-9cb6d0d8d984', foo='bar')
+                example3 = Annotations('syn123','40256475-6fb3-11ea-bb0a-9cb6d0d8d984')
+                example3['foo'] = 'bar'
 
         """
         super().__init__()

--- a/synapseclient/evaluation.py
+++ b/synapseclient/evaluation.py
@@ -1,30 +1,28 @@
 """
-***********
-Evaluations
-***********
+# Evaluations
 
 An evaluation_ object represents a collection of Synapse Entities that will be processed in a particular way.  This
 could mean scoring Entries in a challenge or executing a processing pipeline.
 
-Imports::
+## Imports:
 
     from synapseclient import Evaluation, Submission, SubmissionStatus
 
-Evaluations can be retrieved by ID::
+## Evaluations can be retrieved by ID:
 
     evaluation = syn.getEvaluation(1901877)
 
-Like entities, evaluations are access controlled via ACLs. The :py:func:`synapseclient.Synapse.getPermissions` and
-:py:func:`synapseclient.Synapse.setPermissions` methods work for evaluations:
+Like entities, evaluations are access controlled via ACLs. The [`synapseclient.Synapse.getPermissions`][synapseclient.Synapse.getPermissions] and
+[`synapseclient.Synapse.setPermissions`][synapseclient.Synapse.setPermissions] methods work for evaluations:
 
     access = syn.getPermissions(evaluation, user_id)
 
-The :py:func:`synapseclient.Synapse.submit` method returns a Submission_ object::
+The [`synapseclient.Synapse.submit`][synapseclient.Synapse.submit] method returns a Submission_ object:
 
     entity = syn.get(synapse_id)
     submission = syn.submit(evaluation, entity, name='My Data', team='My Team')
 
-The Submission object can then be used to check the `status <#submission-status>`_ of the submission::
+The Submission object can then be used to check the `status <#submission-status>`_ of the submission:
 
     status = syn.getSubmissionStatus(submission)
 
@@ -34,8 +32,8 @@ The status of a submission may be:
     - **OPEN** indicating processing *has not* completed
     - **CLOSED** indicating processing *has* completed
 
-Submission status objects can be updated, usually by changing the *status* and *score* fields, and stored back to
-Synapse using :py:func:`synapseclient.Synapse.store`::
+Submission status objects can be updated, usually by changing the `status` and `score` fields, and stored back to
+Synapse using [`synapseclient.Synapse.store`][synapseclient.Synapse.store]:
 
     status.score = 0.99
     status.status = 'SCORED'
@@ -43,19 +41,17 @@ Synapse using :py:func:`synapseclient.Synapse.store`::
 
 See:
 
-- :py:func:`synapseclient.Synapse.getEvaluation`
-- :py:func:`synapseclient.Synapse.getEvaluationByContentSource`
-- :py:func:`synapseclient.Synapse.getEvaluationByName`
-- :py:func:`synapseclient.Synapse.submit`
-- :py:func:`synapseclient.Synapse.getSubmissions`
-- :py:func:`synapseclient.Synapse.getSubmission`
-- :py:func:`synapseclient.Synapse.getSubmissionStatus`
-- :py:func:`synapseclient.Synapse.getPermissions`
-- :py:func:`synapseclient.Synapse.setPermissions`
+- `synapseclient.Synapse.getEvaluation`
+- `synapseclient.Synapse.getEvaluationByContentSource`
+- `synapseclient.Synapse.getEvaluationByName`
+- `synapseclient.Synapse.submit`
+- `synapseclient.Synapse.getSubmissions`
+- `synapseclient.Synapse.getSubmission`
+- `synapseclient.Synapse.getSubmissionStatus`
+- `synapseclient.Synapse.getPermissions`
+- `synapseclient.Synapse.setPermissions`
 
-~~~~~~~~~~
-Evaluation
-~~~~~~~~~~
+## Evaluation
 
 .. autoclass:: synapseclient.evaluation.Evaluation
    :members: __init__


### PR DESCRIPTION
This PR will update the following documentation:

- [ ] Small few left: https://github.com/Sage-Bionetworks/synapsePythonClient/blob/develop/synapseclient/annotations.py 
- [ ] Evaluation - The section at the top of the file should be changed from RST into MD format. See [Table for an example](https://github.com/Sage-Bionetworks/synapsePythonClient/blob/develop/synapseclient/table.py): https://github.com/Sage-Bionetworks/synapsePythonClient/blob/develop/synapseclient/evaluation.py 
- [ ] Wiki The section at the top of the file should be changed from RST into MD format. See [Table for an example](https://github.com/Sage-Bionetworks/synapsePythonClient/blob/develop/synapseclient/table.py):: https://github.com/Sage-Bionetworks/synapsePythonClient/blob/develop/synapseclient/wiki.py 
- [ ] https://github.com/Sage-Bionetworks/synapsePythonClient/blob/develop/synapseclient/core/retry.py 
Should also add this to https://github.com/Sage-Bionetworks/synapsePythonClient/blob/develop/docs/reference/core.md
- [ ] https://github.com/Sage-Bionetworks/synapsePythonClient/blob/develop/synapseclient/core/version_check.py 
- [ ] https://github.com/Sage-Bionetworks/synapsePythonClient/blob/develop/synapseclient/core/upload/multipart_upload.py 
- [ ] https://github.com/Sage-Bionetworks/synapsePythonClient/blob/develop/synapseutils/sync.py 