### PR TITLE
omit the doc directory from code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    docs/*


### PR DESCRIPTION
**Problem:**
Our docs directory is going to hold test scripts used during tutorials and other one-off processes. We are not going to test these through unit/integration tests and should not count against our code coverage.

**Solution:**
Exclude the docs directory.

**Testing:**
This PR will serve as the test to verify that the docs directory is excluded from the coverage report.

The code coverage % is going up it looks like by around the amount I'd be expecting. Once merged I'll give in the metrics again to make sure it is updated in the `develop` branch.
![image](https://github.com/Sage-Bionetworks/synapsePythonClient/assets/17128019/539ce51f-3d4a-4dcf-90a2-a67f744ba3ff)
