### PR TITLE
[SYNPY-1398] Support `.[version]` syntax for input SynIDs

### DIFF
--- a/synapseclient/activity.py
+++ b/synapseclient/activity.py
@@ -55,7 +55,7 @@ For example, when storing a data entity, it's a good idea to record its source:
 import collections.abc
 
 from synapseclient.core.exceptions import SynapseError, SynapseMalformedEntityError
-from synapseclient.core.utils import is_url, is_synapse_id_str
+from synapseclient.core.utils import is_url, is_synapse_id_str, get_synid_and_version
 from synapseclient.entity import is_synapse_entity
 
 
@@ -277,16 +277,18 @@ class Activity(dict):
         elif isinstance(target, str):
             badargs = _get_any_bad_args(["url", "name"], locals())
             _raise_incorrect_used_usage(badargs, "Synapse entity")
-            vals = target.split(".")  # Handle synapseIds of from syn234.4
-            if not is_synapse_id_str(vals[0]):
+            if not is_synapse_id_str(target):
                 raise ValueError("%s is not a valid Synapse id" % target)
-            if len(vals) == 2:
-                if targetVersion and int(targetVersion) != int(vals[1]):
+            synid, version = get_synid_and_version(
+                target
+            )  # Handle synapseIds of from syn234.4
+            if version:
+                if targetVersion and int(targetVersion) != int(version):
                     raise ValueError(
                         "Two conflicting versions for %s were specified" % target
                     )
-                targetVersion = int(vals[1])
-            reference = {"targetId": vals[0]}
+                targetVersion = int(version)
+            reference = {"targetId": synid}
             if targetVersion:
                 reference["targetVersionNumber"] = int(targetVersion)
             resource = {

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1024,10 +1024,11 @@ class Synapse(object):
         Gets a Synapse entity from the repository service.
 
         Arguments:
-            entity:           A Synapse ID, a Synapse Entity object, a plain dictionary in which 'id' maps to a
-                                Synapse ID or a local file that is stored in Synapse (found by the file MD5)
+            entity:           A Synapse ID (e.g. syn123 or syn123.1, with .1 denoting version), a Synapse Entity object,
+                              a plain dictionary in which 'id' maps to a Synapse ID or a local file that is stored in
+                              Synapse (found by the file MD5)
             version:          The specific version to get.
-                                Defaults to the most recent version.
+                                Defaults to the most recent version. If not denoted in the entity input.
             downloadFile:     Whether associated files(s) should be downloaded.
                                 Defaults to True.
             downloadLocation: Directory where to download the Synapse File Entity.

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -353,18 +353,30 @@ def get_synid_and_version(
 ) -> typing.Tuple[str, typing.Union[int, None]]:
     """Extract the Synapse ID and version number from input entity
 
+    Arguments:
+            obj: May be a string, Entity object, or dictionary.
+
     Returns:
         A tuple containing the synapse ID and version number,
         where the version number may be an integer or None if
         the input object does not contain a versonNumber or
         .version notation (if string).
+
+    Example: Get synID and version from string object
+        Extract the synID and version number of the entity string ID
+
+            from synapseclient.core import utils
+            utils.get_synid_and_version("syn123.4")
+
+        The call above will return the following tuple:
+
+            ('syn123', 4)
     """
 
     if isinstance(obj, str):
         synapse_id_and_version = is_synapse_id_str(obj)
-        assert (
-            synapse_id_and_version
-        ), "The input string was not determined to be a syn ID."
+        if not synapse_id_and_version:
+            raise ValueError("The input string was not determined to be a syn ID.")
         m = re.match(r"(syn\d+)(?:\.(\d+))?", synapse_id_and_version)
         id = m.group(1)
         version = int(m.group(2)) if m.group(2) is not None else m.group(2)

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -24,8 +24,6 @@ import uuid
 import warnings
 import zipfile
 
-import synapseclient
-
 
 UNIX_EPOCH = datetime.datetime(1970, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
 ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.000Z"
@@ -341,7 +339,7 @@ def is_same_base_url(url1: str, url2: str) -> bool:
     return url1.scheme == url2.scheme and url1.hostname == url2.hostname
 
 
-def is_synapse_id_str(obj):
+def is_synapse_id_str(obj: str) -> typing.Union[str, None]:
     """If the input is a Synapse ID return it, otherwise return None"""
     if isinstance(obj, str):
         m = re.match(r"(syn\d+(\.\d+)?$)", obj)
@@ -364,14 +362,19 @@ def get_synid_and_version(
 
     if isinstance(obj, str):
         synapse_id_and_version = is_synapse_id_str(obj)
+        assert (
+            synapse_id_and_version
+        ), "The input string was not determined to be a syn ID."
         m = re.match(r"(syn\d+)(?:\.(\d+))?", synapse_id_and_version)
         id = m.group(1)
         version = int(m.group(2)) if m.group(2) is not None else m.group(2)
-    elif isinstance(obj, synapseclient.Entity):
-        id = id_of(obj)
-        version = None
-        if "versionNumber" in obj:
-            version = obj["versionNumber"]
+
+        return id, version
+
+    id = id_of(obj)
+    version = None
+    if "versionNumber" in obj:
+        version = obj["versionNumber"]
 
     return id, version
 

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -24,6 +24,8 @@ import uuid
 import warnings
 import zipfile
 
+import synapseclient
+
 
 UNIX_EPOCH = datetime.datetime(1970, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
 ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.000Z"
@@ -342,10 +344,36 @@ def is_same_base_url(url1: str, url2: str) -> bool:
 def is_synapse_id_str(obj):
     """If the input is a Synapse ID return it, otherwise return None"""
     if isinstance(obj, str):
-        m = re.match(r"(syn\d+$)", obj)
+        m = re.match(r"(syn\d+(\.\d+)?$)", obj)
         if m:
             return m.group(1)
     return None
+
+
+def get_synid_and_version(
+    obj: typing.Union[str, collections.abc.Mapping]
+) -> typing.Tuple[str, typing.Union[int, None]]:
+    """Extract the Synapse ID and version number from input entity
+
+    Returns:
+        A tuple containing the synapse ID and version number,
+        where the version number may be an integer or None if
+        the input object does not contain a versonNumber or
+        .version notation (if string).
+    """
+
+    if isinstance(obj, str):
+        synapse_id_and_version = is_synapse_id_str(obj)
+        m = re.match(r"(syn\d+)(?:\.(\d+))?", synapse_id_and_version)
+        id = m.group(1)
+        version = int(m.group(2)) if m.group(2) is not None else m.group(2)
+    elif isinstance(obj, synapseclient.Entity):
+        id = id_of(obj)
+        version = None
+        if "versionNumber" in obj:
+            version = obj["versionNumber"]
+
+    return id, version
 
 
 def bool_or_none(input_value: str) -> typing.Union[bool, None]:

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -92,8 +92,8 @@ def syncFromSynapse(
     manifest="all",
     downloadFile=True,
 ):
-    """Synchronizes all the files in a folder (including subfolders) from Synapse
-    and adds a readme manifest with file metadata.
+    """Synchronizes a File entity, or a Folder entity, meaning all the files in a folder
+    (including subfolders) from Synapse, and adds a readme manifest with file metadata.
 
     There are a few conversions around annotations to call out here.
 
@@ -132,11 +132,13 @@ def syncFromSynapse(
             [tables][synapseclient.Table], [links][synapseclient.Link])
 
 
-    This function will crawl all subfolders of the project/folder specified by
-    `entity` and download all files that have not already been downloaded. If
-    there are newer files in Synapse (or a local file has been edited outside of the
-    cache) since the last download then local the file will be replaced by the new
-    file unless "ifcollision" is changed.
+    When entity is a Project or Folder, this function will crawl all subfolders
+    of the project/folder specified by `entity` and download all files that have
+    not already been downloaded. When entity is a File the function will download the
+    latest version of the file unless version is denoted in the synid with .version
+    notiation (e.g. syn123.1) If there are newer files in Synapse (or a local file
+    has been edited outside of the cache) since the last download then local the file
+    will be replaced by the new file unless "ifcollision" is changed.
 
     If the files are being downloaded to a specific location outside of the Synapse
     cache a file (SYNAPSE_METADATA_MANIFEST.tsv) will also be added in the path that

--- a/tests/integration/synapseclient/integration_test.py
+++ b/tests/integration/synapseclient/integration_test.py
@@ -115,6 +115,11 @@ def test_entity_version(syn, project, schedule_for_cleanup):
     assert returnEntity["description"] == "This is a test entity..."
     assert returnEntity["versionLabel"] == "Prada remix"
 
+    # Try retrieving the entity with synid.version notation
+    entity_string = f"{entity['id']}.{entity['versionNumber']}"
+    returnEntity_using_string = syn.get(entity_string)
+    assert returnEntity == returnEntity_using_string
+
     # Try the older Entity again
     returnEntity = syn.get(entity, version=1)
     assert returnEntity.versionNumber == 1
@@ -123,6 +128,9 @@ def test_entity_version(syn, project, schedule_for_cleanup):
 
     # Delete version 2
     syn.delete(entity, version=2)
+    # Setting versionNumber to None, so we can retrieve the latest version
+    # and confirm it is now version 1.
+    entity.versionNumber = None
     returnEntity = syn.get(entity)
     assert returnEntity.versionNumber == 1
 

--- a/tests/integration/synapseclient/integration_test.py
+++ b/tests/integration/synapseclient/integration_test.py
@@ -128,10 +128,10 @@ def test_entity_version(syn, project, schedule_for_cleanup):
 
     # Delete version 2
     syn.delete(entity, version=2)
-    # Setting versionNumber to None, so we can retrieve the latest version
-    # and confirm it is now version 1.
-    entity.versionNumber = None
-    returnEntity = syn.get(entity)
+    # Let's retrieve the entity again using its synId this time,
+    # since the old entity object had versionNumber = 2
+    entity_id = entity.id
+    returnEntity = syn.get(entity_id)
     assert returnEntity.versionNumber == 1
 
 

--- a/tests/integration/synapseclient/test_command_line_client.py
+++ b/tests/integration/synapseclient/test_command_line_client.py
@@ -165,6 +165,11 @@ def test_command_line_client(test_state):
     current_file = test_state.syn.get(file_entity_id, downloadFile=False)
     current_version = current_file.versionNumber
 
+    # Get a previous version of the existing file using .version syntax
+    file_entity_v1 = f"{file_entity_id}.1"
+    v1_file = test_state.syn.get(file_entity_v1, downloadFile=False)
+    assert v1_file.versionNumber == 1
+
     # Store it without forcing version
     output = run(
         test_state,

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -101,6 +101,7 @@ def test_id_of():
 
 
 # TODO: Add a test for is_synapse_id_str(...)
+# https://sagebionetworks.jira.com/browse/SYNPY-1425
 
 
 def test_get_synid_and_version():
@@ -117,10 +118,9 @@ def test_get_synid_and_version():
 
     # Test 3: Ensure that a synID string with version syntax typo breaks
     synid_with_typo = "syn123.oops"
-    assertion_error = "The input string was not determined to be a syn ID."
-    with pytest.raises(AssertionError) as error:
+    error_msg = "The input string was not determined to be a syn ID."
+    with pytest.raises(ValueError, match=error_msg):
         utils.get_synid_and_version(synid_with_typo)
-        assert error == assertion_error
 
     # Test 4: Ensure that a versionable Entity obj with version works
     _, version = utils.get_synid_and_version({"foo": 1, "id": 123, "versionNumber": 2})

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -100,6 +100,37 @@ def test_id_of():
         assert utils.id_of(foo) == "123"
 
 
+# TODO: Add a test for is_synapse_id_str(...)
+
+
+def test_get_synid_and_version():
+    # Test 1: Ensure that a synID string with no version works
+    synid_no_version = "syn123"
+    id, version = utils.get_synid_and_version(synid_no_version)
+    assert id == synid_no_version
+    assert version == None
+
+    # Test 2: Ensure that a synID string with version syntax works
+    synid_with_version = "syn123.2"
+    id, version = utils.get_synid_and_version(synid_with_version)
+    assert (id, str(version)) == tuple(synid_with_version.split("."))
+
+    # Test 3: Ensure that a synID string with version syntax typo breaks
+    synid_with_typo = "syn123.oops"
+    assertion_error = "The input string was not determined to be a syn ID."
+    with pytest.raises(AssertionError) as error:
+        utils.get_synid_and_version(synid_with_typo)
+        assert error == assertion_error
+
+    # Test 4: Ensure that a versionable Entity obj with version works
+    _, version = utils.get_synid_and_version({"foo": 1, "id": 123, "versionNumber": 2})
+    assert version == 2
+
+    # Test 5: Ensure that an Entity obj with no version works
+    _, version = utils.get_synid_and_version({"foo": 1, "id": 123})
+    assert not version
+
+
 def test_concrete_type_of():
     """Verify behavior of utils#concrete_type_of"""
 


### PR DESCRIPTION
### problem

`syncToSynapse` fails for provenance pointing to a specific version of a synID using `syn[id].[version]` notation (e.g. `syn1234.5`). This revisits the discussion on the Python client adding support for synID`.[version]` notation.

![image](https://github.com/Sage-Bionetworks/synapsePythonClient/assets/32107699/560206a7-c784-44f9-8dc8-934ded728120)

---
### solution

The scope of this PR is constrained to allowing .version syntax in syncTo/FromSynapse `syn.get` and `synapse get` for the CLI

- [x] `syncToSynapse` supports `.[version]` notation
- [x] `syncFromSynapse` supports `.[version]` notation
- [x] `syn.get` supports `.[version]` notation
- [x] `synapse get` command supports `.[version]` notation
- [x] Corresponding documentation is updated to show new support
- [x] New unit/integration tests for feature coverage and error handling

---
### testing & preview

support for `syn.get(...)`  : 

<img width="329" alt="image" src="https://github.com/Sage-Bionetworks/synapsePythonClient/assets/32107699/d23cbc64-cb13-4195-aac8-4fa9aabf83c7">


support for `synapse get` for CLI : 

```
(synapsePythonClient) (synapseclient) bash-3.2$ synapse get syn53182713
Downloaded file: foo.txt
Creating /Users/jmedina/Documents/forks/synapsePythonClient/jout/foo.txt
(synapsePythonClient) (synapseclient) bash-3.2$ mv foo.txt foo_v2.txt
(synapsePythonClient) (synapseclient) bash-3.2$ synapse get syn53182713.1
Downloaded file: foo.txt
Creating /Users/jmedina/Documents/forks/synapsePythonClient/jout/foo.txt
(synapsePythonClient) (synapseclient) bash-3.2$ cat foo.txt
VERSION 1
(synapsePythonClient) (synapseclient) bash-3.2$ cat foo_v2.txt 
VERSION 2
(synapsePythonClient) (synapseclient) bash-3.2$ 
```

support for `syncFromSynapse` : 
![image](https://github.com/Sage-Bionetworks/synapsePythonClient/assets/32107699/2f383eb9-2276-4cfb-b12a-f10b4f3d2b62)

support for `syncToSynapse` : 
![image](https://github.com/Sage-Bionetworks/synapsePythonClient/assets/32107699/86ef8fc0-e1c6-44c0-a60a-465e1cfb74b5)
