### PR TITLE
[SYNPY-1412] Fixing typing issue in copy_functions

### DIFF
--- a/synapseutils/copy_functions.py
+++ b/synapseutils/copy_functions.py
@@ -238,11 +238,11 @@ def _copy_cached_file_handles(cache: Cache, copiedFileHandles: dict) -> None:
 
 def changeFileMetaData(
     syn: synapseclient.Synapse,
-    entity: typing.Union[str, synapseclient.entity.Entity],
+    entity: typing.Union[str, synapseclient.Entity],
     downloadAs: str = None,
     contentType: str = None,
     forceVersion: bool = True,
-) -> synapseclient.entity.Entity:
+) -> synapseclient.Entity:
     """
     Change File Entity metadata like the download as name.
 

--- a/synapseutils/copy_functions.py
+++ b/synapseutils/copy_functions.py
@@ -238,11 +238,11 @@ def _copy_cached_file_handles(cache: Cache, copiedFileHandles: dict) -> None:
 
 def changeFileMetaData(
     syn: synapseclient.Synapse,
-    entity: typing.Union[str, synapseclient.Entity],
+    entity: typing.Union[str, Entity],
     downloadAs: str = None,
     contentType: str = None,
     forceVersion: bool = True,
-) -> synapseclient.Entity:
+) -> Entity:
     """
     Change File Entity metadata like the download as name.
 


### PR DESCRIPTION
### problem

Importing `Entity` from `entity.py` was not working on Jupyter Notebook. This cell was executed after launching notebook off the latest `develop` branch on SynPy:

![image](https://github.com/Sage-Bionetworks/synapsePythonClient/assets/32107699/764b2a90-fe4f-434b-863a-bd703c6ada43)

### solution

The solution was to have the type hints refer to the `Entity` class which is already imported at the top of `copy_functions.py` instead of calling it again from `synapseclient.entity.py`.

### testing & preview

With this change there are no import errors for `synapseutils`:

![image](https://github.com/Sage-Bionetworks/synapsePythonClient/assets/32107699/3f873849-9372-4c23-a7fe-9f588cbd5007)
