### PR TITLE
Creating a decorator to be used in async class methods

### DIFF
--- a/docs/reference/core.md
+++ b/docs/reference/core.md
@@ -42,6 +42,9 @@ functions.  Use at your own risk.
 
 ::: synapseclient.core.utils
 
+## Async Utils
+
+::: synapseclient.core.async_utils
 
 ## Versions
 ::: synapseclient.core.version_check

--- a/synapseclient/core/async_utils.py
+++ b/synapseclient/core/async_utils.py
@@ -7,7 +7,7 @@ tracer = trace.get_tracer("synapseclient")
 
 
 def otel_trace_method(
-    method_to_trace_name: Union[Callable[..., str], None] = None,
+    method_to_trace_name: Union[Callable[..., str], None] = None
 ) -> Callable[..., Callable[..., Coroutine[Any, Any, None]]]:
     """
     Decorator to trace a method with OpenTelemetry in an async environment. This function
@@ -19,7 +19,7 @@ def otel_trace_method(
     Example: Decorating a method within a class that will be traced with OpenTelemetry.
         Setting the trace name:
 
-            @otel_trace_method(method_to_trace_name=lambda self: f"Project_Store: {self.name}")
+            @otel_trace_method(method_to_trace_name=lambda self, **kwargs: f"Project_Store: {self.name}")
             async def store(self):
 
     Args:
@@ -42,7 +42,7 @@ def otel_trace_method(
                 else None
             )
             with tracer.start_as_current_span(trace_name or f"Synaspse::{f.__name__}"):
-                await f(self, *arg, **kwargs)
+                return await f(self, *arg, **kwargs)
 
         return wrapper
 

--- a/synapseclient/core/async_utils.py
+++ b/synapseclient/core/async_utils.py
@@ -1,5 +1,5 @@
 """This utility class is to hold any utilities that are needed for async operations."""
-from typing import Any, Callable, Coroutine
+from typing import Any, Callable, Coroutine, Union
 from opentelemetry import trace
 
 
@@ -7,7 +7,7 @@ tracer = trace.get_tracer("synapseclient")
 
 
 def otel_trace_method(
-    method_to_trace_name,
+    method_to_trace_name: Union[Callable[..., str], None] = None,
 ) -> Callable[..., Callable[..., Coroutine[Any, Any, None]]]:
     """
     Decorator to trace a method with OpenTelemetry in an async environment. This function
@@ -32,7 +32,10 @@ def otel_trace_method(
     """
 
     def decorator(f) -> Callable[..., Coroutine[Any, Any, None]]:
+        """Function decorator."""
+
         async def wrapper(self, *arg, **kwargs) -> None:
+            """Wrapper for the function to be traced."""
             trace_name = (
                 method_to_trace_name(self, *arg, **kwargs)
                 if method_to_trace_name

--- a/synapseclient/core/async_utils.py
+++ b/synapseclient/core/async_utils.py
@@ -1,0 +1,46 @@
+"""This utility class is to hold only any utilities that are needed for async operations."""
+from typing import Any, Callable, Coroutine
+from opentelemetry import trace
+
+
+tracer = trace.get_tracer("synapseclient")
+
+
+def otel_trace_method(
+    method_to_trace_name,
+) -> Callable[..., Callable[..., Coroutine[Any, Any, None]]]:
+    """
+    Decorator to trace a method with OpenTelemetry in an async environment. This function
+    is specifically written to be used on a method within a class.
+
+    This will pass the class instance as the first argument to the method. This allows
+    you to modify the name of the trace to include information about the class instance.
+
+    Example: Decorating a method within a class that will be traced with OpenTelemetry.
+        Setting the trace name:
+
+            @otel_trace_method(method_to_trace_name=lambda self: f"Project_Store: {self.name}")
+            async def store(self):
+
+    Args:
+        method_to_trace_name: A callable that takes the class instance as the first argument
+            and returns a string to be used as the trace name. If this is not provided,
+            the trace name will be set to the method name.
+
+    Returns:
+        A callable decorator that will trace the method with OpenTelemetry.
+    """
+
+    def decorator(f) -> Callable[..., Coroutine[Any, Any, None]]:
+        async def wrapper(self, *arg, **kwargs) -> None:
+            trace_name = (
+                method_to_trace_name(self, *arg, **kwargs)
+                if method_to_trace_name
+                else None
+            )
+            with tracer.start_as_current_span(trace_name or f"Synaspse::{f.__name__}"):
+                await f(self, *arg, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/synapseclient/core/async_utils.py
+++ b/synapseclient/core/async_utils.py
@@ -1,4 +1,4 @@
-"""This utility class is to hold only any utilities that are needed for async operations."""
+"""This utility class is to hold any utilities that are needed for async operations."""
 from typing import Any, Callable, Coroutine
 from opentelemetry import trace
 

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -7,6 +7,7 @@ from synapseclient.models import Annotations
 
 from synapseclient.entity import File as Synapse_File
 from synapseclient import Synapse
+from synapseclient.core.async_utils import otel_trace_method
 
 from typing import Optional, TYPE_CHECKING
 
@@ -159,6 +160,9 @@ class File:
             )
         return self
 
+    @otel_trace_method(
+        method_to_trace_name=lambda self, **kwargs: f"File_Store: {self.path if self.path else self.id}"
+    )
     # TODO: How the parent is stored/referenced needs to be thought through
     async def store(
         self,
@@ -174,47 +178,47 @@ class File:
         Returns:
             The file object.
         """
-        with tracer.start_as_current_span(
-            f"File_Store: {self.path if self.path else self.id}"
-        ):
-            # TODO - We need to add in some validation before the store to verify we have enough
-            # information to store the data
+        # TODO - We need to add in some validation before the store to verify we have enough
+        # information to store the data
 
-            # Call synapse
-            if self.path:
-                loop = asyncio.get_event_loop()
-                synapse_file = Synapse_File(
-                    path=self.path,
-                    name=self.name,
-                    parent=parent.id if parent else self.parent_id,
-                )
-                # TODO: Propogating OTEL context is not working in this case
-                current_context = context.get_current()
-                entity = await loop.run_in_executor(
-                    None,
-                    lambda: Synapse.get_client(synapse_client=synapse_client).store(
-                        obj=synapse_file, opentelemetry_context=current_context
-                    ),
-                )
+        # Call synapse
+        if self.path:
+            loop = asyncio.get_event_loop()
+            synapse_file = Synapse_File(
+                path=self.path,
+                name=self.name,
+                parent=parent.id if parent else self.parent_id,
+            )
+            # TODO: Propogating OTEL context is not working in this case
+            current_context = context.get_current()
+            entity = await loop.run_in_executor(
+                None,
+                lambda: Synapse.get_client(synapse_client=synapse_client).store(
+                    obj=synapse_file, opentelemetry_context=current_context
+                ),
+            )
 
-                self.fill_from_dict(synapse_file=entity, set_annotations=False)
+            self.fill_from_dict(synapse_file=entity, set_annotations=False)
 
-                print(f"Stored file {self.name}, id: {self.id}: {self.path}")
-            elif self.id and not self.etag:
-                # This elif is to handle if only annotations are being stored without
-                # a file path.
-                annotations_to_persist = self.annotations
-                await self.get(synapse_client=synapse_client, download_file=False)
-                self.annotations = annotations_to_persist
+            print(f"Stored file {self.name}, id: {self.id}: {self.path}")
+        elif self.id and not self.etag:
+            # This elif is to handle if only annotations are being stored without
+            # a file path.
+            annotations_to_persist = self.annotations
+            await self.get(synapse_client=synapse_client, download_file=False)
+            self.annotations = annotations_to_persist
 
-            if self.annotations:
-                result = await Annotations(
-                    id=self.id, etag=self.etag, annotations=self.annotations
-                ).store(synapse_client=synapse_client)
-                self.annotations = result.annotations
+        if self.annotations:
+            result = await Annotations(
+                id=self.id, etag=self.etag, annotations=self.annotations
+            ).store(synapse_client=synapse_client)
+            self.annotations = result.annotations
 
-            return self
+        return self
 
+    @otel_trace_method(
+        method_to_trace_name=lambda self, **kwargs: f"File_Get: {self.id}"
+    )
     # TODO: We need to provide all the other options that can be provided here, like collision, follow link ect...
     async def get(
         self,
@@ -232,22 +236,24 @@ class File:
         Returns:
             The file object.
         """
-        with tracer.start_as_current_span(f"File_Get: {self.id}"):
-            loop = asyncio.get_event_loop()
-            current_context = context.get_current()
-            entity = await loop.run_in_executor(
-                None,
-                lambda: Synapse.get_client(synapse_client=synapse_client).get(
-                    entity=self.id,
-                    downloadFile=download_file,
-                    downloadLocation=download_location,
-                    opentelemetry_context=current_context,
-                ),
-            )
+        loop = asyncio.get_event_loop()
+        current_context = context.get_current()
+        entity = await loop.run_in_executor(
+            None,
+            lambda: Synapse.get_client(synapse_client=synapse_client).get(
+                entity=self.id,
+                downloadFile=download_file,
+                downloadLocation=download_location,
+                opentelemetry_context=current_context,
+            ),
+        )
 
-            self.fill_from_dict(synapse_file=entity, set_annotations=True)
-            return self
+        self.fill_from_dict(synapse_file=entity, set_annotations=True)
+        return self
 
+    @otel_trace_method(
+        method_to_trace_name=lambda self, **kwargs: f"File_Get_Provenance: {self.id}"
+    )
     async def delete(self, synapse_client: Optional[Synapse] = None) -> None:
         """Delete the file from Synapse.
 
@@ -257,13 +263,12 @@ class File:
         Returns:
             None
         """
-        with tracer.start_as_current_span(f"File_Delete: {self.id}"):
-            loop = asyncio.get_event_loop()
-            current_context = context.get_current()
-            await loop.run_in_executor(
-                None,
-                lambda: Synapse.get_client(synapse_client=synapse_client).delete(
-                    obj=self.id,
-                    opentelemetry_context=current_context,
-                ),
-            )
+        loop = asyncio.get_event_loop()
+        current_context = context.get_current()
+        await loop.run_in_executor(
+            None,
+            lambda: Synapse.get_client(synapse_client=synapse_client).delete(
+                obj=self.id,
+                opentelemetry_context=current_context,
+            ),
+        )

--- a/synapseclient/models/project.py
+++ b/synapseclient/models/project.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 from synapseclient.models import Folder, File, Annotations
 from synapseclient import Synapse
+from synapseclient.core.async_utils import otel_trace_method
 
 
 tracer = trace.get_tracer("synapseclient")
@@ -157,6 +158,7 @@ class Project:
             )
         return self
 
+    @otel_trace_method(method_to_trace_name=lambda self: f"Project_Store: {self.name}")
     async def store(self, synapse_client: Optional[Synapse] = None) -> "Project":
         """Store project, files, and folders to synapse.
 
@@ -166,66 +168,65 @@ class Project:
         Returns:
             The project object.
         """
+        # Call synapse
+        loop = asyncio.get_event_loop()
+        synapse_project = Synapse_Project(self.name)
+        current_context = context.get_current()
+        entity = await loop.run_in_executor(
+            None,
+            lambda: Synapse.get_client(synapse_client=synapse_client).store(
+                obj=synapse_project, opentelemetry_context=current_context
+            ),
+        )
+        self.fill_from_dict(synapse_project=entity, set_annotations=False)
 
-        with tracer.start_as_current_span(f"Project_Store: {self.name}"):
-            # Call synapse
-            loop = asyncio.get_event_loop()
-            synapse_project = Synapse_Project(self.name)
-            current_context = context.get_current()
-            entity = await loop.run_in_executor(
-                None,
-                lambda: Synapse.get_client(synapse_client=synapse_client).store(
-                    obj=synapse_project, opentelemetry_context=current_context
-                ),
+        tasks = []
+        if self.files:
+            tasks.extend(
+                file.store(parent=self, synapse_client=synapse_client)
+                for file in self.files
             )
-            self.fill_from_dict(synapse_project=entity, set_annotations=False)
 
-            tasks = []
-            if self.files:
-                tasks.extend(
-                    file.store(parent=self, synapse_client=synapse_client)
-                    for file in self.files
+        if self.folders:
+            tasks.extend(
+                folder.store(parent=self, synapse_client=synapse_client)
+                for folder in self.folders
+            )
+
+        if self.annotations:
+            tasks.append(
+                asyncio.create_task(
+                    Annotations(
+                        id=self.id, etag=self.etag, annotations=self.annotations
+                    ).store(synapse_client=synapse_client)
                 )
+            )
 
-            if self.folders:
-                tasks.extend(
-                    folder.store(parent=self, synapse_client=synapse_client)
-                    for folder in self.folders
-                )
+        try:
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            # TODO: Proper exception handling
 
-            if self.annotations:
-                tasks.append(
-                    asyncio.create_task(
-                        Annotations(
-                            id=self.id, etag=self.etag, annotations=self.annotations
-                        ).store(synapse_client=synapse_client)
-                    )
-                )
+            for result in results:
+                if isinstance(result, Folder):
+                    print(f"Stored {result.name}")
+                elif isinstance(result, File):
+                    print(f"Stored {result.name} at: {result.path}")
+                elif isinstance(result, Annotations):
+                    self.annotations = result.annotations
+                    print(f"Stored annotations id: {result.id}, etag: {result.etag}")
+                else:
+                    raise ValueError(f"Unknown type: {type(result)}")
+        except Exception as ex:
+            Synapse.get_client(synapse_client=synapse_client).logger.exception(ex)
+            print("I hit an exception")
 
-            try:
-                results = await asyncio.gather(*tasks, return_exceptions=True)
-                # TODO: Proper exception handling
+        print(f"Saved all files and folders in {self.name}")
 
-                for result in results:
-                    if isinstance(result, Folder):
-                        print(f"Stored {result.name}")
-                    elif isinstance(result, File):
-                        print(f"Stored {result.name} at: {result.path}")
-                    elif isinstance(result, Annotations):
-                        self.annotations = result.annotations
-                        print(
-                            f"Stored annotations id: {result.id}, etag: {result.etag}"
-                        )
-                    else:
-                        raise ValueError(f"Unknown type: {type(result)}")
-            except Exception as ex:
-                Synapse.get_client(synapse_client=synapse_client).logger.exception(ex)
-                print("I hit an exception")
+        return self
 
-            print(f"Saved all files and folders in {self.name}")
-
-            return self
-
+    @otel_trace_method(
+        method_to_trace_name=lambda self: f"Project_Get: ID: {self.id}, Name: {self.name}"
+    )
     async def get(
         self,
         include_children: Optional[bool] = False,
@@ -240,54 +241,52 @@ class Project:
         Returns:
             The project object.
         """
-        with tracer.start_as_current_span(f"Project_Get: {self.id}"):
-            loop = asyncio.get_event_loop()
-            current_context = context.get_current()
-            entity = await loop.run_in_executor(
+        loop = asyncio.get_event_loop()
+        current_context = context.get_current()
+        entity = await loop.run_in_executor(
+            None,
+            lambda: Synapse.get_client(synapse_client=synapse_client).get(
+                entity=self.id,
+                opentelemetry_context=current_context,
+            ),
+        )
+
+        self.fill_from_dict(synapse_project=entity, set_annotations=True)
+        if include_children:
+            children_objects = await loop.run_in_executor(
                 None,
-                lambda: Synapse.get_client(synapse_client=synapse_client).get(
-                    entity=self.id,
+                lambda: Synapse.get_client(synapse_client=synapse_client).getChildren(
+                    parent=self.id,
+                    includeTypes=["folder", "file"],
                     opentelemetry_context=current_context,
                 ),
             )
 
-            self.fill_from_dict(synapse_project=entity, set_annotations=True)
-            if include_children:
-                children_objects = await loop.run_in_executor(
-                    None,
-                    lambda: Synapse.get_client(
-                        synapse_client=synapse_client
-                    ).getChildren(
-                        parent=self.id,
-                        includeTypes=["folder", "file"],
-                        opentelemetry_context=current_context,
-                    ),
-                )
+            folders = []
+            files = []
+            for child in children_objects:
+                if (
+                    "type" in child
+                    and child["type"] == "org.sagebionetworks.repo.model.Folder"
+                ):
+                    folder = Folder().fill_from_dict(synapse_folder=child)
+                    folder.parent_id = self.id
+                    folders.append(folder)
 
-                folders = []
-                files = []
-                for child in children_objects:
-                    if (
-                        "type" in child
-                        and child["type"] == "org.sagebionetworks.repo.model.Folder"
-                    ):
-                        folder = Folder().fill_from_dict(synapse_folder=child)
-                        folder.parent_id = self.id
-                        folders.append(folder)
+                elif (
+                    "type" in child
+                    and child["type"] == "org.sagebionetworks.repo.model.FileEntity"
+                ):
+                    file = File().fill_from_dict(synapse_file=child)
+                    file.parent_id = self.id
+                    files.append(file)
 
-                    elif (
-                        "type" in child
-                        and child["type"] == "org.sagebionetworks.repo.model.FileEntity"
-                    ):
-                        file = File().fill_from_dict(synapse_file=child)
-                        file.parent_id = self.id
-                        files.append(file)
+            self.files.extend(files)
+            self.folders.extend(folders)
 
-                self.files.extend(files)
-                self.folders.extend(folders)
+        return self
 
-            return self
-
+    @otel_trace_method(method_to_trace_name=lambda self: f"Project_Delete: {self.id}")
     async def delete(self, synapse_client: Optional[Synapse] = None) -> None:
         """Delete the project from Synapse.
 
@@ -297,13 +296,12 @@ class Project:
         Returns:
             None
         """
-        with tracer.start_as_current_span(f"Project_Delete: {self.id}"):
-            loop = asyncio.get_event_loop()
-            current_context = context.get_current()
-            await loop.run_in_executor(
-                None,
-                lambda: Synapse.get_client(synapse_client=synapse_client).delete(
-                    obj=self.id,
-                    opentelemetry_context=current_context,
-                ),
-            )
+        loop = asyncio.get_event_loop()
+        current_context = context.get_current()
+        await loop.run_in_executor(
+            None,
+            lambda: Synapse.get_client(synapse_client=synapse_client).delete(
+                obj=self.id,
+                opentelemetry_context=current_context,
+            ),
+        )

--- a/synapseclient/models/project.py
+++ b/synapseclient/models/project.py
@@ -158,7 +158,9 @@ class Project:
             )
         return self
 
-    @otel_trace_method(method_to_trace_name=lambda self: f"Project_Store: {self.name}")
+    @otel_trace_method(
+        method_to_trace_name=lambda self, **kwargs: f"Project_Store: {self.name}"
+    )
     async def store(self, synapse_client: Optional[Synapse] = None) -> "Project":
         """Store project, files, and folders to synapse.
 
@@ -215,7 +217,7 @@ class Project:
                     self.annotations = result.annotations
                     print(f"Stored annotations id: {result.id}, etag: {result.etag}")
                 else:
-                    raise ValueError(f"Unknown type: {type(result)}")
+                    raise ValueError(f"Unknown type: {type(result)}", result)
         except Exception as ex:
             Synapse.get_client(synapse_client=synapse_client).logger.exception(ex)
             print("I hit an exception")
@@ -225,7 +227,7 @@ class Project:
         return self
 
     @otel_trace_method(
-        method_to_trace_name=lambda self: f"Project_Get: ID: {self.id}, Name: {self.name}"
+        method_to_trace_name=lambda self, **kwargs: f"Project_Get: ID: {self.id}, Name: {self.name}"
     )
     async def get(
         self,
@@ -286,7 +288,9 @@ class Project:
 
         return self
 
-    @otel_trace_method(method_to_trace_name=lambda self: f"Project_Delete: {self.id}")
+    @otel_trace_method(
+        method_to_trace_name=lambda self, **kwargs: f"Project_Delete: {self.id}"
+    )
     async def delete(self, synapse_client: Optional[Synapse] = None) -> None:
         """Delete the project from Synapse.
 


### PR DESCRIPTION
Problem:

1. The default OTEL decorator does not work as expected in Async environments. It will only capture when the method is created but not capture the entire execution of the method.
2. We were required to use a context manager in the function leading to more complex code.

Solution:

1. I created a new decorator that will allow us to decorate these class methods. In the future I'll plan to create other decorators for async functions too.

Testing:

1. I verified that the name of the functions were correctly shown:
![image](https://github.com/Sage-Bionetworks/synapsePythonClient/assets/17128019/7b3e4b8c-87e3-4b46-9501-4aceac33c6b6)
![image](https://github.com/Sage-Bionetworks/synapsePythonClient/assets/17128019/25875334-15d2-4495-a564-dd6ecd1c550b)
![image](https://github.com/Sage-Bionetworks/synapsePythonClient/assets/17128019/f707c4e8-d638-452a-ab42-93f5550bc91f)

