### PR TITLE
[SYNPY-1344] Set client in conftest since login is not used in unit tests

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -46,4 +46,5 @@ def syn():
     """
     syn = Synapse(debug=False, skip_checks=True)
     syn.logger = logging.getLogger(SILENT_LOGGER_NAME)
+    Synapse.set_client(syn)
     return syn


### PR DESCRIPTION
**Problem:**

1. The `synapse_client` parameter in the Synapse class is only initialized when using `login` - Which is ok for integration tests and normal operations, however, because we are not using `login` for unit tests I need to manually set the parameter

**Solution:**
Set the client in the `conftest.py` for unit tests

**Testing:**
Unit tests Brad/Bryan are developing