### PR TITLE
[SYNPY-1344] Allows Socket Connections for Windows Systems in Unit Tests

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -22,6 +22,7 @@ def pytest_runtest_setup():
 
     allow_unix_socket=True is required for async to work.
     """
+    # This is a work-around because of https://github.com/python/cpython/issues/77589
     if platform.system() != "Windows":
         disable_socket(allow_unix_socket=True)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -22,14 +22,16 @@ def pytest_runtest_setup():
 
     allow_unix_socket=True is required for async to work.
     """
-    disable_socket(allow_unix_socket=True)
+    if platform.system() != "Windows":
+        disable_socket(allow_unix_socket=True)
 
 
 def test_confirm_connections_blocked():
     """Confirm that socket connections are blocked during unit tests."""
-    with pytest.raises(SocketBlockedError) as cm_ex:
-        urllib.request.urlopen("http://example.com")
-    assert "A test tried to use socket.socket." == str(cm_ex.value)
+    if platform.system() != "Windows":
+        with pytest.raises(SocketBlockedError) as cm_ex:
+            urllib.request.urlopen("http://example.com")
+        assert "A test tried to use socket.socket." == str(cm_ex.value)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
**Problem:**

Asynchronous function unit testing does not work in Windows GH Actions runners due to a [lack of support](https://github.com/python/cpython/issues/77589) for UNIX socket for Windows in Python. 

**Solution:**

Enable socket connections in unit tests on Windows systems.