### PR TITLE
[SYNPY-1398] Correct broken docstring

### DIFF
--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -361,9 +361,9 @@ def get_synid_and_version(
 
     Returns:
         A tuple containing the synapse ID and version number,
-        where the version number may be an integer or None if
-        the input object does not contain a versonNumber or
-        .version notation (if string).
+            where the version number may be an integer or None if
+            the input object does not contain a versonNumber or
+            .version notation (if string).
 
     Example: Get synID and version from string object
         Extract the synID and version number of the entity string ID


### PR DESCRIPTION
Problem:
```
Traceback (most recent call last):
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/mkdocs/livereload/__init__.py", line 193, in _build_loop
    func()
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/mkdocs/commands/serve.py", line 67, in builder
    build(config, live_server=None if is_clean else server, dirty=is_dirty)
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/mkdocs/commands/build.py", line 322, in build
    _populate_page(file.page, config, files, dirty)
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/mkdocs/commands/build.py", line 175, in _populate_page
    page.render(config, files)
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/mkdocs/structure/pages.py", line 271, in render
    self.content = md.convert(self.markdown)
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/markdown/core.py", line 357, in convert
    root = self.parser.parseDocument(self.lines).getroot()
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/markdown/blockparser.py", line 117, in parseDocument
    self.parseChunk(self.root, '\n'.join(lines))
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/markdown/blockparser.py", line 136, in parseChunk
    self.parseBlocks(parent, text.split('\n\n'))
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/markdown/blockparser.py", line 158, in parseBlocks
    if processor.run(parent, blocks) is not False:
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/mkdocstrings/extension.py", line 124, in run
    html, handler, data = self._process_block(identifier, block, heading_level)
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/mkdocstrings/extension.py", line 220, in _process_block
    rendered = handler.render(data, options)
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/mkdocstrings_handlers/python/handler.py", line 355, in render
    return template.render(
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/jinja2/environment.py", line 1301, in render
    self.environment.handle_exception()
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/mkdocstrings_handlers/python/templates/material/module.html", line 1, in top-level template code
    {% extends "_base/module.html" %}
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/mkdocstrings_handlers/python/templates/material/_base/module.html", line 58, in top-level template code
    {% block contents scoped %}
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/mkdocstrings_handlers/python/templates/material/_base/module.html", line 65, in block 'contents'
    {% block children scoped %}
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/mkdocstrings_handlers/python/templates/material/_base/module.html", line 68, in block 'children'
    {% include "children.html" with context %}
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/mkdocstrings_handlers/python/templates/material/children.html", line 1, in top-level template code
    {% extends "_base/children.html" %}
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/mkdocstrings_handlers/python/templates/material/_base/children.html", line 76, in top-level template code
    {% include function|get_template with context %}
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/mkdocstrings_handlers/python/templates/material/function.html", line 1, in top-level template code
    {% extends "_base/function.html" %}
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/mkdocstrings_handlers/python/templates/material/_base/function.html", line 73, in top-level template code
    {% block contents scoped %}
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/mkdocstrings_handlers/python/templates/material/_base/function.html", line 74, in block 'contents'
    {% block docstring scoped %}
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/mkdocstrings_handlers/python/templates/material/_base/function.html", line 74, in block 'docstring'
    {% block docstring scoped %}
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/jinja2/environment.py", line 485, in getattr
    return getattr(obj, attribute)
  File "/home/bfauble/.pyenv/versions/3.8.18/lib/python3.8/functools.py", line 967, in __get__
    val = self.func(instance)
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/griffe/dataclasses.py", line 119, in parsed
    return self.parse()
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/griffe/dataclasses.py", line 136, in parse
    return parse(self, parser or self.parser, **(options or self.parser_options))
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/griffe/docstrings/parsers.py", line 41, in parse
    return parsers[parser](docstring, **options)  # type: ignore[operator]
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/griffe/docstrings/google.py", line 809, in parse
    section, offset = reader(docstring, offset=offset + 1, **options)  # type: ignore[operator]
  File "/home/bfauble/.local/share/virtualenvs/synapsePythonClient-17ZKsCr2/lib/python3.8/site-packages/griffe/docstrings/google.py", line 474, in _read_returns_section
    annotation = annotation.slice.elements[index]
IndexError: list index out of range
ERROR   -  [12:33:04] An error happened during the rebuild. The server will appear stuck until build errors are resolved.
```

Solution:
Correct indent

Testing:
Doc page can now be displayed locally