### PR TITLE
[SYNPY-1416] File model finishing touches for OOP

### DIFF
--- a/docs/reference/oop/models.md
+++ b/docs/reference/oop/models.md
@@ -26,7 +26,15 @@ the client.
         members:
         - get
         - store
+        - copy
         - delete
+        - from_id
+        - from_path
+        - change_metadata
+::: synapseclient.models.file.FileHandle
+    options:
+      filters:
+      - "!"
 ---
 ::: synapseclient.models.Table
     options:

--- a/docs/scripts/object_orientated_programming_poc/oop_poc_file.py
+++ b/docs/scripts/object_orientated_programming_poc/oop_poc_file.py
@@ -1,19 +1,23 @@
-"""The purpose of this script is to demonstrate how to use the new OOP interface for files.
+"""
+Expects that ~/temp exists and is a directory.
+
+The purpose of this script is to demonstrate how to use the new OOP interface for files.
 The following actions are shown in this script:
 1. Creating a file
-2. Storing a file to a project
-3. Storing a file to a folder
-4. Getting metadata about a file
+2. Storing a file
+3. Storing a file in a sub-folder
+4. Renaming a file
 5. Downloading a file
 6. Deleting a file
+7. Copying a file
+8. Storing an activity to a file
+9. Retrieve an activity from a file
 """
 import asyncio
 import os
 
-from synapseclient.models import (
-    File,
-    Folder,
-)
+from synapseclient.models import File, Folder, Activity, UsedEntity, UsedURL
+from synapseclient.core import utils
 from datetime import date, datetime, timedelta, timezone
 import synapseclient
 
@@ -35,6 +39,15 @@ def create_random_file(
 
 
 async def store_file():
+    # Cleanup synapse for previous runs - Does not delete local files/directories:
+    script_file_folder = Folder(name="file_script_folder", parent_id=PROJECT_ID)
+    if not os.path.exists(os.path.expanduser("~/temp/myNewFolder")):
+        os.mkdir(os.path.expanduser("~/temp/myNewFolder"))
+    # Hack to get the ID as Folder does not support get by name/id yet
+    await script_file_folder.store()
+    await script_file_folder.delete()
+    await script_file_folder.store()
+
     # Creating annotations for my file ==================================================
     annotations_for_my_file = {
         "my_single_key_string": "a",
@@ -52,91 +65,150 @@ async def store_file():
         ],
     }
 
-    name_of_file = "my_file_with_random_data.txt"
+    name_of_file = "file_script_my_file_with_random_data.txt"
     path_to_file = os.path.join(os.path.expanduser("~/temp"), name_of_file)
     create_random_file(path_to_file)
 
-    # Creating and uploading a file to a project =========================================
+    # 1. Creating a file =================================================================
     file = File(
         path=path_to_file,
-        name=name_of_file,
         annotations=annotations_for_my_file,
-        parent_id=PROJECT_ID,
+        parent_id=script_file_folder.id,
         description="This is a file with random data.",
     )
 
+    # 2. Storing a file ==================================================================
     file = await file.store()
 
-    print("File created:")
-    print(file)
+    print(f"File created: ID: {file.id}, Parent ID: {file.parent_id}")
 
-    # Updating and storing an annotation =================================================
-    file_copy = await File(id=file.id).get()
-    file_copy.annotations["my_key_string"] = ["new", "values", "here"]
-    stored_file = await file_copy.store()
-    print("File updated:")
-    print(stored_file)
-
-    # Downloading a file =================================================================
-    downloaded_file_copy = await File(id=file.id).get(
-        download_location=os.path.expanduser("~/temp/myNewFolder")
-    )
-
-    print("Downloaded file:")
-    print(downloaded_file_copy)
-
-    # Get metadata about a file ==========================================================
-    non_downloaded_file_copy = await File(id=file.id).get(
-        download_file=False,
-    )
-
-    print("Metadata about file:")
-    print(non_downloaded_file_copy)
-
-    # Creating and uploading a file to a folder =========================================
-    folder = await Folder(name="my_folder", parent_id=PROJECT_ID).store()
-
-    file = File(
-        path=path_to_file,
-        name=name_of_file,
-        annotations=annotations_for_my_file,
-        parent_id=folder.id,
-        description="This is a file with random data.",
-    )
-
-    file = await file.store()
-
-    print("File created:")
-    print(file)
-
-    downloaded_file_copy = await File(id=file.id).get(
-        download_location=os.path.expanduser("~/temp/myNewFolder")
-    )
-
-    print("Downloaded file:")
-    print(downloaded_file_copy)
-
-    non_downloaded_file_copy = await File(id=file.id).get(
-        download_file=False,
-    )
-
-    print("Metadata about file:")
-    print(non_downloaded_file_copy)
-
-    # Uploading a file and then Deleting a file ==========================================
-    name_of_file = "my_file_with_random_data_to_delete.txt"
+    name_of_file = "file_in_a_sub_folder.txt"
     path_to_file = os.path.join(os.path.expanduser("~/temp"), name_of_file)
     create_random_file(path_to_file)
 
-    file = await File(
-        path=path_to_file,
-        name=name_of_file,
-        annotations=annotations_for_my_file,
-        parent_id=PROJECT_ID,
-        description="This is a file with random data I am going to delete.",
+    # 3. Storing a file to a sub-folder ==================================================
+    script_sub_folder = await Folder(
+        name="file_script_sub_folder", parent_id=script_file_folder.id
     ).store()
+    file_in_a_sub_folder = File(
+        path=path_to_file,
+        annotations=annotations_for_my_file,
+        parent_id=script_sub_folder.id,
+        description="This is a file with random data.",
+    )
+    file_in_a_sub_folder = await file_in_a_sub_folder.store()
 
-    await file.delete()
+    print(
+        f"File created in sub folder: ID: {file_in_a_sub_folder.id}, Parent ID: {file_in_a_sub_folder.parent_id}"
+    )
+
+    # 4. Renaming a file =================================================================
+    name_of_file = "file_script_my_file_to_rename.txt"
+    path_to_file = os.path.join(os.path.expanduser("~/temp"), name_of_file)
+    create_random_file(path_to_file)
+
+    # The name of the entity, and the name of the file is disjointed.
+    # For example, the name of the file is "file_script_my_file_to_rename.txt"
+    # and the name of the entity is "this_name_is_different"
+    file: File = await File(
+        path=path_to_file,
+        name="this_name_is_different",
+        parent_id=script_file_folder.id,
+    ).store()
+    print(f"File created with name: {file.name}")
+    print(f"The path of the file is: {file.path}")
+
+    # You can change the name of the entity without changing the name of the file.
+    file.name = "modified_name_attribute"
+    await file.store()
+    print(f"File renamed to: {file.name}")
+
+    # You can then change the name of the file that would be downloaded like:
+    await file.change_metadata(download_as="new_name_for_downloading.txt")
+    print(f"File download values changed to: {file.file_handle.file_name}")
+
+    # 5. Downloading a file ===============================================================
+    # Downloading a file to a location has a default beahvior of "keep.both"
+    downloaded_file = await File(
+        id=file.id, download_location=os.path.expanduser("~/temp/myNewFolder")
+    ).get()
+    print(f"Downloaded file: {downloaded_file.path}")
+
+    # I can also specify how collisions are handled when downloading a file.
+    # This will replace the file on disk if it already exists and is different (after).
+    path_to_file = downloaded_file.path
+    create_random_file(path_to_file)
+    print(f"Before file md5: {utils.md5_for_file(path_to_file).hexdigest()}")
+    downloaded_file = await File(
+        id=downloaded_file.id,
+        download_location=os.path.expanduser("~/temp/myNewFolder"),
+        if_collision="overwrite.local",
+    ).get()
+    print(f"After file md5: {utils.md5_for_file(path_to_file).hexdigest()}")
+
+    # This will keep the file on disk (before), and no file is downloaded
+    path_to_file = downloaded_file.path
+    create_random_file(path_to_file)
+    print(f"Before file md5: {utils.md5_for_file(path_to_file).hexdigest()}")
+    downloaded_file = await File(
+        id=downloaded_file.id,
+        download_location=os.path.expanduser("~/temp/myNewFolder"),
+        if_collision="keep.local",
+    ).get()
+    print(f"After file md5: {utils.md5_for_file(path_to_file).hexdigest()}")
+
+    # 6. Deleting a file =================================================================
+    # Suppose I have a file that I want to delete.
+    name_of_file = "file_to_delete.txt"
+    path_to_file = os.path.join(os.path.expanduser("~/temp"), name_of_file)
+    create_random_file(path_to_file)
+    file_to_delete = await File(
+        path=path_to_file, parent_id=script_file_folder.id
+    ).store()
+    await file_to_delete.delete()
+
+    # 7. Copying a file ===================================================================
+    print(
+        f"File I am going to copy: ID: {file_in_a_sub_folder.id}, Parent ID: {file_in_a_sub_folder.parent_id}"
+    )
+    new_sub_folder = await Folder(
+        name="sub_sub_folder", parent_id=script_file_folder.id
+    ).store()
+    copied_file_instance = await file_in_a_sub_folder.copy(
+        destination_id=new_sub_folder.id
+    )
+    print(
+        f"File I copied: ID: {copied_file_instance.id}, Parent ID: {copied_file_instance.parent_id}"
+    )
+
+    # 8. Storing an activity to a file =====================================================
+    activity = Activity(
+        name="some_name",
+        description="some_description",
+        used=[
+            UsedURL(name="example", url="https://www.synapse.org/"),
+            UsedEntity(target_id="syn456", target_version_number=1),
+        ],
+        executed=[
+            UsedURL(name="example", url="https://www.synapse.org/"),
+            UsedEntity(target_id="syn789", target_version_number=1),
+        ],
+    )
+
+    name_of_file = "file_with_an_activity.txt"
+    path_to_file = os.path.join(os.path.expanduser("~/temp"), name_of_file)
+    create_random_file(path_to_file)
+    file_with_activity = await File(
+        path=path_to_file, parent_id=script_file_folder.id, activity=activity
+    ).store()
+    print(file_with_activity.activity)
+
+    # 9. When I am retrieving that file later on I can get the activity like =============
+    # By also specifying download_file=False, I can get the activity without downloading the file.
+    new_file_with_activity_instance = await File(
+        id=file_with_activity.id, download_file=False
+    ).get(include_activity=True)
+    print(new_file_with_activity_instance.activity)
 
 
 asyncio.run(store_file())

--- a/docs/scripts/object_orientated_programming_poc/oop_poc_folder.py
+++ b/docs/scripts/object_orientated_programming_poc/oop_poc_folder.py
@@ -1,4 +1,7 @@
-"""The purpose of this script is to demonstrate how to use the new OOP interface for folders.
+"""
+Expects that ~/temp exists and is a directory.
+
+The purpose of this script is to demonstrate how to use the new OOP interface for folders.
 The following actions are shown in this script:
 1. Creating a folder
 2. Storing a folder to a project
@@ -114,6 +117,8 @@ async def store_folder():
     }
 
     for file in folder_copy.files:
+        file.download_file = False
+        await file.get()
         file.annotations = new_annotations
 
     for folder in folder_copy.folders:

--- a/docs/scripts/object_orientated_programming_poc/oop_poc_project.py
+++ b/docs/scripts/object_orientated_programming_poc/oop_poc_project.py
@@ -1,4 +1,7 @@
-"""The purpose of this script is to demonstrate how to use the new OOP interface for projects.
+"""
+Expects that ~/temp exists and is a directory.
+
+The purpose of this script is to demonstrate how to use the new OOP interface for projects.
 The following actions are shown in this script:
 1. Creating a project
 2. Storing a folder to a project
@@ -116,6 +119,8 @@ async def store_project():
     }
 
     for file in project_copy.files:
+        file.download_file = False
+        await file.get()
         file.annotations = new_annotations
 
     for folder in project_copy.folders:

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -1297,3 +1297,11 @@ def run_and_attach_otel_context(
     """
     context.attach(current_context)
     return callable_function()
+
+
+def delete_none_keys(incoming_object: typing.Dict) -> None:
+    """Clean up the incoming object by removing any keys with None values."""
+    if incoming_object:
+        for key in list(incoming_object.keys()):
+            if incoming_object[key] is None:
+                del incoming_object[key]

--- a/synapseclient/entity.py
+++ b/synapseclient/entity.py
@@ -232,7 +232,7 @@ class Entity(collections.abc.MutableMapping):
             "parentId" not in self
             and not isinstance(self, Project)
             and not type(self) == Entity
-        ):
+        ) and "id" not in self:
             raise SynapseMalformedEntityError(
                 "Entities of type %s must have a parentId." % type(self)
             )

--- a/synapseclient/models/__init__.py
+++ b/synapseclient/models/__init__.py
@@ -4,7 +4,7 @@ from synapseclient.models.activity import Activity, UsedURL, UsedEntity
 from synapseclient.models.annotations import (
     Annotations,
 )
-from synapseclient.models.file import File
+from synapseclient.models.file import File, FileHandle
 from synapseclient.models.folder import Folder
 from synapseclient.models.project import Project
 from synapseclient.models.table import (
@@ -27,6 +27,7 @@ __all__ = [
     "UsedURL",
     "UsedEntity",
     "File",
+    "FileHandle",
     "Folder",
     "Project",
     "Annotations",

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -1,5 +1,6 @@
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+import dataclasses
 from datetime import date, datetime
 from typing import Dict, List, Union
 from opentelemetry import trace, context
@@ -9,7 +10,16 @@ from synapseclient.entity import File as Synapse_File
 from synapseclient import Synapse
 from synapseclient.core.async_utils import otel_trace_method
 from synapseclient.models.mixins.access_control import AccessControllable
-from synapseclient.core.utils import run_and_attach_otel_context
+from synapseclient.core.utils import (
+    run_and_attach_otel_context,
+    guess_file_name,
+    delete_none_keys,
+)
+from synapseutils.copy_functions import changeFileMetaData, copy
+from synapseclient.models.services.storable_entity_components import (
+    store_entity_components,
+)
+from synapseclient.core.exceptions import SynapseError
 
 from typing import Optional, TYPE_CHECKING
 
@@ -22,39 +32,168 @@ tracer = trace.get_tracer("synapseclient")
 
 
 @dataclass()
+class FileHandle:
+    """A file handle is a pointer to a file stored in a specific location.
+
+    Attributes:
+        id: The ID of this FileHandle. All references to this FileHandle will use this
+            ID. Synapse will generate this ID when the FileHandle is created.
+        etag: FileHandles are immutable from the perspective of the API. The only field
+            that can be change is the previewId. When a new previewId is set, the
+            etag will change.
+        created_by: The ID Of the user that created this file.
+        created_on: The date when this file was uploaded.
+        modified_on: The date when the file was modified. This is handled by the backend
+            and cannot be modified.
+        concrete_type: This is used to indicate the implementation of this interface.
+            For example, an S3FileHandle should be set to:
+            org.sagebionetworks.repo.model.file.S3FileHandle
+        content_type: Must be: <http://en.wikipedia.org/wiki/Internet_media_type>.
+        content_md5: The file's content MD5.
+        file_name: The short, user visible name for this file.
+        storage_location_id: The optional storage location descriptor.
+        content_size: The size of the file in bytes.
+        status: The status of the file handle as computed by the backend. This value
+            cannot be changed, any file handle that is not AVAILABLE should not be used.
+        bucket_name: The name of the bucket where this file resides.
+        key: The path or resource name for this object.
+        preview_id: If this file has a preview, then this will be the file ID of the preview.
+        is_preview: Whether or not this is a preview of another file.
+        external_url: The URL of the file if it is stored externally.
+    """
+
+    id: Optional[str] = None
+    """The ID of this FileHandle. All references to this FileHandle will use this ID.
+        Synapse will generate this ID when the FileHandle is created."""
+
+    etag: Optional[str] = None
+    """FileHandles are immutable from the perspective of the API. The only field that can
+        be change is the previewId. When a new previewId is set, the etag will change."""
+
+    created_by: Optional[str] = None
+    """The ID Of the user that created this file."""
+
+    created_on: Optional[str] = None
+    """The date when this file was uploaded."""
+
+    modified_on: Optional[str] = None
+    """The date when the file was modified. This is handled by the backend and cannot
+    be modified."""
+
+    concrete_type: Optional[str] = None
+    """This is used to indicate the implementation of this interface. For example,
+    an S3FileHandle should be set to: org.sagebionetworks.repo.model.file.S3FileHandle"""
+
+    content_type: Optional[str] = None
+    """Must be: <http://en.wikipedia.org/wiki/Internet_media_type>."""
+
+    content_md5: Optional[str] = None
+    """The file's content MD5."""
+
+    file_name: Optional[str] = None
+    """The short, user visible name for this file."""
+
+    storage_location_id: Optional[int] = None
+    """The optional storage location descriptor."""
+
+    content_size: Optional[int] = None
+    """The size of the file in bytes."""
+
+    status: Optional[str] = None
+    """The status of the file handle as computed by the backend. This value cannot be
+    changed, any file handle that is not AVAILABLE should not be used."""
+
+    bucket_name: Optional[str] = None
+    """The name of the bucket where this file resides."""
+
+    key: Optional[str] = None
+    """The path or resource name for this object."""
+
+    preview_id: Optional[str] = None
+    """If this file has a preview, then this will be the file ID of the preview."""
+
+    is_preview: Optional[bool] = None
+    """Whether or not this is a preview of another file."""
+
+    external_url: Optional[str] = None
+    """The URL of the file if it is stored externally."""
+
+
+@dataclass()
 class File(AccessControllable):
     """A file within Synapse.
 
     Attributes:
-        id: The unique immutable ID for this file. A new ID will be generated for new Files.
-            Once issued, this ID is guaranteed to never change or be re-issued.
-        name: The name of this entity. Must be 256 characters or less.
-            Names may only contain: letters, numbers, spaces, underscores, hyphens, periods,
-            plus signs, apostrophes, and parentheses.
-        path: The path to the file.
+        id: The unique immutable ID for this file. A new ID will be generated for
+            new Files. Once issued, this ID is guaranteed to never change or be re-issued.
+        name: The name of this entity. Must be 256 characters or less. Names may only
+            contain: letters, numbers, spaces, underscores, hyphens, periods, plus signs,
+            apostrophes, and parentheses. If not specified, the name will be derived from
+            the file name.
+        path: The path to the file on disk.
+        content_type: Used to manually specify Content-type header, for example
+            'application/png' or 'application/json; charset=UTF-8'. If not specified,
+            the content type will be derived from the file extension.
+
+
+            (Create Only)
+            This can be specified only during the initial store of this file.
+            In order to change this after the File has been created use
+            [synapseclient.models.File.change_metadata][].
         description: The description of this file. Must be 1000 characters or less.
-        etag: Synapse employs an Optimistic Concurrency Control (OCC) scheme to handle
-            concurrent updates. Since the E-Tag changes every time an entity is updated it
-            is used to detect when a client's current representation of an entity is out-of-date.
-        created_on: The date this entity was created.
-        modified_on: The date this entity was last modified.
-        created_by: The ID of the user that created this entity.
-        modified_by: The ID of the user that last modified this entity.
-        parent_id: The ID of the Entity that is the parent of this Entity.
-        version_number: Indicates which implementation of Entity this object represents. The value is
-            the fully qualified class name, e.g. org.sagebionetworks.repo.model.FileEntity.
-        version_label: The version label for this entity.
-        version_comment: The version comment for this entity.
-        is_latest_version: If this is the latest version of the object.
-        data_file_handle_id: ID of the file associated with this entity.
-        file_name_override: An optional replacement for the name of the uploaded file. This is distinct
-            from the entity name. If omitted the file will retain its original name.
-        annotations: Additional metadata associated with the folder. The key is the name of your
-            desired annotations. The value is an object containing a list of values
-            (use empty list to represent no values for key) and the value type associated with
-            all values in the list.
+        etag: (Read Only) Synapse employs an Optimistic Concurrency Control (OCC) scheme
+            to handle concurrent updates. Since the E-Tag changes every time an entity is
+            updated it is used to detect when a client's current representation of an
+            entity is out-of-date.
+        created_on: (Read Only) The date this entity was created.
+        modified_on: (Read Only) The date this entity was last modified.
+        created_by: (Read Only) The ID of the user that created this entity.
+        modified_by: (Read Only) The ID of the user that last modified this entity.
+        parent_id: The ID of the Entity that is the parent of this Entity. Setting this
+            to a new value and storing it will move this File under the new parent.
+        version_number: (Read Only) The version number issued to this version on the object.
+        version_label: The version label for this entity
+        version_comment: The version comment for this entity
+        is_latest_version: (Read Only) If this is the latest version of the object.
+        data_file_handle_id: ID of the file associated with this entity. You may define
+            an existing data_file_handle_id to use the existing data_file_handle_id. The
+            creator of the file must also be the owner of the data_file_handle_id to have
+            permission to store the file.
+        file_handle: (Read Only) The file handle associated with this entity.
+        activity: The Activity model represents the main record of Provenance in Synapse.
+            It is analygous to the Activity defined in the
+            [W3C Specification](https://www.w3.org/TR/prov-n/) on Provenance.
+        annotations: Additional metadata associated with the folder. The key is the name
+            of your desired annotations. The value is an object containing a list of
+            values (use empty list to represent no values for key) and the value type
+            associated with all values in the list.
+        create_or_update: (Store only)
+            Indicates whether the method should automatically perform an
+            update if the 'obj' conflicts with an existing Synapse object.
+        force_version: (Store only)
+            Indicates whether the method should increment the version of the
+            object even if nothing has changed.
+        is_restricted: (Store only)
+            If set to true, an email will be sent to the Synapse access control
+            team to start the process of adding terms-of-use or review board approval for
+            this entity. You will be contacted with regards to the specific data being
+            restricted and the requirements of access.
+        synapse_store: (Store only)
+            Whether the File should be uploaded or if only the path should
+            be stored when [synapseclient.models.File.store][] is called.
+        download_file: (Get only) If True the file will be downloaded.
+        download_location: (Get only) The location to download the file to.
+        if_collision: (Get only)
+            Determines how to handle file collisions. Defaults to "keep.both". May be:
 
-
+            - `overwrite.local`
+            - `keep.local`
+            - `keep.both`
+        synapse_container_limit: (Get only)
+            A Synanpse ID used to limit the search in Synapse if
+            file is specified as a local file. That is, if the file is stored in multiple
+            locations in Synapse only the ones in the specified folder/project will be
+            returned.
     """
 
     id: Optional[str] = None
@@ -62,40 +201,58 @@ class File(AccessControllable):
     Once issued, this ID is guaranteed to never change or be re-issued."""
 
     name: Optional[str] = None
-    """The name of this entity. Must be 256 characters or less.
+    """
+    The name of this entity. Must be 256 characters or less.
     Names may only contain: letters, numbers, spaces, underscores, hyphens, periods,
-    plus signs, apostrophes, and parentheses."""
+    plus signs, apostrophes, and parentheses. If not specified, the name will be
+    derived from the file name.
+    """
 
     path: Optional[str] = None
-    # TODO - Should a file also have a folder, or a method that figures out the folder class?
+    """The path to the file on disk."""
 
-    # TODO: Description doesn't seem to be working properly
+    content_type: Optional[str] = None
+    """
+    Used to manually specify Content-type header, for example 'application/png'
+    or 'application/json; charset=UTF-8'. If not specified, the content type will be
+    derived from the file extension.
+
+
+    (Create Only)
+    This can be specified only during the initial store of this file. In order to change
+    this after the File has been created use
+    [synapseclient.models.File.change_metadata][].
+    """
+
     description: Optional[str] = None
     """The description of this file. Must be 1000 characters or less."""
 
     etag: Optional[str] = None
-    """Synapse employs an Optimistic Concurrency Control (OCC) scheme to handle
+    """
+    (Read Only)
+    Synapse employs an Optimistic Concurrency Control (OCC) scheme to handle
     concurrent updates. Since the E-Tag changes every time an entity is updated it
-    is used to detect when a client's current representation of an entity is out-of-date."""
+    is used to detect when a client's current representation of an entity is out-of-date.
+    """
 
     created_on: Optional[str] = None
-    """The date this entity was created."""
+    """(Read Only) The date this entity was created."""
 
     modified_on: Optional[str] = None
-    """The date this entity was last modified."""
+    """(Read Only) The date this entity was last modified."""
 
     created_by: Optional[str] = None
-    """The ID of the user that created this entity."""
+    """(Read Only) The ID of the user that created this entity."""
 
     modified_by: Optional[str] = None
-    """The ID of the user that last modified this entity."""
+    """(Read Only) The ID of the user that last modified this entity."""
 
     parent_id: Optional[str] = None
-    """The ID of the Entity that is the parent of this Entity."""
+    """The ID of the Entity that is the parent of this Entity. Setting this to a new
+    value and storing it will move this File under the new parent."""
 
     version_number: Optional[int] = None
-    """Indicates which implementation of Entity this object represents. The value is
-    the fully qualified class name, e.g. org.sagebionetworks.repo.model.FileEntity."""
+    """(Read Only) The version number issued to this version on the object."""
 
     version_label: Optional[str] = None
     """The version label for this entity"""
@@ -104,19 +261,23 @@ class File(AccessControllable):
     """The version comment for this entity"""
 
     is_latest_version: Optional[bool] = False
-    """If this is the latest version of the object."""
+    """(Read Only) If this is the latest version of the object."""
 
     data_file_handle_id: Optional[str] = None
-    """ID of the file associated with this entity."""
+    """
+    ID of the file associated with this entity. You may define an existing
+    data_file_handle_id to use the existing data_file_handle_id. The creator of the
+    file must also be the owner of the data_file_handle_id to have permission to
+    store the file.
+    """
 
-    file_name_override: Optional[str] = None
-    """An optional replacement for the name of the uploaded file. This is distinct
-    from the entity name. If omitted the file will retain its original name."""
+    file_handle: Optional[FileHandle] = None
+    """(Read Only) The file handle associated with this entity."""
 
     activity: Optional[Activity] = None
     """The Activity model represents the main record of Provenance in Synapse.  It is
     analygous to the Activity defined in the
-    [W3C Specification](https://www.w3.org/TR/prov-n/) on Provenance. """
+    [W3C Specification](https://www.w3.org/TR/prov-n/) on Provenance."""
 
     annotations: Optional[
         Dict[
@@ -134,14 +295,97 @@ class File(AccessControllable):
     """Additional metadata associated with the folder. The key is the name of your
     desired annotations. The value is an object containing a list of values
     (use empty list to represent no values for key) and the value type associated with
-    all values in the list."""
+    all values in the list. To remove all annotations set this to an empty dict `{}`."""
 
-    # TODO: We need to provide functionality for folks to store the file in Synapse, but
-    # TODO: Not upload the file.
+    create_or_update: bool = field(default=True, repr=False)
+    """
+    (Store only)
+
+    Indicates whether the method should automatically perform an update if the file
+    conflicts with an existing Synapse object.
+    """
+
+    force_version: bool = field(default=True, repr=False)
+    """
+    (Store only)
+
+    Indicates whether the method should increment the version of the object even if
+    nothing has changed.
+    """
+
+    is_restricted: bool = field(default=False, repr=False)
+    """
+    (Store only)
+
+    If set to true, an email will be sent to the Synapse access control team to start the
+    process of adding terms-of-use or review board approval for this entity.
+    You will be contacted with regards to the specific data being restricted and the
+    requirements of access.
+    """
+
+    synapse_store: bool = field(default=True, repr=False)
+    """
+    (Store only)
+
+    Whether the File should be uploaded or if only the path should be stored when
+    [synapseclient.models.File.store][] is called.
+    """
+
+    download_file: bool = field(default=True, repr=False)
+    """
+    (Get only)
+
+    If True the file will be downloaded."""
+
+    download_location: str = field(default=None, repr=False)
+    """
+    (Get only)
+
+    The location to download the file to."""
+
+    if_collision: str = field(default="keep.both", repr=False)
+    """
+    (Get only)
+
+    Determines how to handle file collisions. Defaults to "keep.both".
+            May be
+
+            - `overwrite.local`
+            - `keep.local`
+            - `keep.both`
+    """
+
+    synapse_container_limit: Optional[str] = field(default=None, repr=False)
+    """A Synanpse ID used to limit the search in Synapse if file is specified as a local
+    file. That is, if the file is stored in multiple locations in Synapse only the
+    ones in the specified folder/project will be returned."""
+
+    _last_persistent_instance: Optional["File"] = field(default=None, repr=False)
+    """The last persistent instance of this object. This is used to determine if the
+    object has been changed and needs to be updated in Synapse."""
+
+    def _set_last_persistent_instance(self) -> None:
+        """Stash the last time this object interacted with Synapse. This is used to
+        determine if the object has been changed and needs to be updated in Synapse."""
+        del self._last_persistent_instance
+        self._last_persistent_instance = dataclasses.replace(self)
+        self._last_persistent_instance.activity = (
+            dataclasses.replace(self.activity) if self.activity else None
+        )
 
     def fill_from_dict(
-        self, synapse_file: Synapse_File, set_annotations: bool = True
+        self, synapse_file: Union[Synapse_File, Dict], set_annotations: bool = True
     ) -> "File":
+        """
+        Converts a response from the REST API into this dataclass.
+
+        Arguments:
+            synapse_file: The response from the REST API.
+            set_annotations: Whether to set the annotations from the response.
+
+        Returns:
+            The File object.
+        """
         self.id = synapse_file.get("id", None)
         self.name = synapse_file.get("name", None)
         self.path = synapse_file.get("path", None)
@@ -155,9 +399,33 @@ class File(AccessControllable):
         self.version_number = synapse_file.get("versionNumber", None)
         self.version_label = synapse_file.get("versionLabel", None)
         self.version_comment = synapse_file.get("versionComment", None)
-        self.is_latest_version = synapse_file.get("isLatestVersion", None)
+        self.is_latest_version = synapse_file.get("isLatestVersion", False)
         self.data_file_handle_id = synapse_file.get("dataFileHandleId", None)
-        self.file_name_override = synapse_file.get("fileNameOverride", None)
+        synapse_file_handle = synapse_file.get("_file_handle", None)
+        if synapse_file_handle:
+            file_handle = self.file_handle or FileHandle()
+            self.file_handle = file_handle
+            file_handle.id = synapse_file_handle.get("id", None)
+            file_handle.etag = synapse_file_handle.get("etag", None)
+            file_handle.created_by = synapse_file_handle.get("createdBy", None)
+            file_handle.created_on = synapse_file_handle.get("createdOn", None)
+            file_handle.modified_on = synapse_file_handle.get("modifiedOn", None)
+            file_handle.concrete_type = synapse_file_handle.get("concreteType", None)
+            self.content_type = synapse_file_handle.get("contentType", None)
+            file_handle.content_type = synapse_file_handle.get("contentType", None)
+            file_handle.content_md5 = synapse_file_handle.get("contentMd5", None)
+            file_handle.file_name = synapse_file_handle.get("fileName", None)
+            file_handle.storage_location_id = synapse_file_handle.get(
+                "storageLocationId", None
+            )
+            file_handle.content_size = synapse_file_handle.get("contentSize", None)
+            file_handle.status = synapse_file_handle.get("status", None)
+            file_handle.bucket_name = synapse_file_handle.get("bucketName", None)
+            file_handle.key = synapse_file_handle.get("key", None)
+            file_handle.preview_id = synapse_file_handle.get("previewId", None)
+            file_handle.is_preview = synapse_file_handle.get("isPreview", None)
+            file_handle.external_url = synapse_file_handle.get("externalURL", None)
+
         if set_annotations:
             self.annotations = Annotations.from_dict(
                 synapse_file.get("annotations", None)
@@ -167,7 +435,6 @@ class File(AccessControllable):
     @otel_trace_method(
         method_to_trace_name=lambda self, **kwargs: f"File_Store: {self.path if self.path else self.id}"
     )
-    # TODO: How the parent is stored/referenced needs to be thought through
     async def store(
         self,
         parent: Optional[Union["Folder", "Project"]] = None,
@@ -176,132 +443,324 @@ class File(AccessControllable):
         """Store the file in Synapse.
 
         Arguments:
-            parent: The parent folder or project to store the file in.
-            synapse_client: If not passed in or None this will use the last client from the `.login()` method.
+            parent: The parent folder or project to store the file in. May also be
+                specified in the File object. If both are provided the parent passed
+                into `store` will take precedence.
+            synapse_client: If not passed in or None this will use the last client from
+                the `.login()` method.
 
         Returns:
             The file object.
+
+
+        Example: Using this function
+            File with the ID `syn123` at path `path/to/file.txt`:
+
+                file_instance = await File(id="syn123", path="path/to/file.txt").store()
+
+            File at the path `path/to/file.txt` and a parent folder with the ID `syn456`:
+
+                file_instance = await File(path="path/to/file.txt", parent_id="syn456").store()
+
+            File at the path `path/to/file.txt` and a parent folder with the ID `syn456`:
+
+                file_instance = await File(path="path/to/file.txt").store(parent=Folder(id="syn456"))
+
+            Rename a file (Does not update the file on disk or the name of the downloaded file):
+
+                file_instance = await File(id="syn123", download_file=False).get()
+                print(file_instance.name)  ## prints, e.g., "my_file.txt"
+                file_instance.name = "my_new_name_file.txt"
+                await file_instance.store()
+
+            Rename a file, and the name of the file as downloaded (Does not update the file on disk):
+
+                file_instance = await File(id="syn123", download_file=False).get()
+                print(file_instance.name)  ## prints, e.g., "my_file.txt"
+                file_instance.name = "my_new_name_file.txt"
+                await file_instance.store()
+                await file_instance.change_metadata(download_as="my_new_name_file.txt")
+
         """
-        # TODO - We need to add in some validation before the store to verify we have enough
-        # information to store the data
-
-        # Call synapse
-        if self.path:
-            loop = asyncio.get_event_loop()
-            synapse_file = Synapse_File(
-                path=self.path,
-                name=self.name,
-                parent=parent.id if parent else self.parent_id,
-            )
-            # TODO: Propogating OTEL context is not working in this case
-            current_context = context.get_current()
-            entity = await loop.run_in_executor(
-                None,
-                lambda: run_and_attach_otel_context(
-                    lambda: Synapse.get_client(synapse_client=synapse_client).store(
-                        obj=synapse_file
-                    ),
-                    current_context,
-                ),
+        if not (
+            self.id is not None
+            and (self.path is not None or self.data_file_handle_id is not None)
+        ) and not (
+            self.path is not None
+            and (parent.id if parent else self.parent_id) is not None
+        ):
+            raise ValueError(
+                "The file must have an (ID with a (path or `data_file_handle_id`)), or a "
+                "(path with a (`parent_id` or parent with an id)) to store."
             )
 
-            self.fill_from_dict(synapse_file=entity, set_annotations=False)
-
-            print(f"Stored file {self.name}, id: {self.id}: {self.path}")
-        elif self.id and not self.etag:
-            # This elif is to handle if only annotations are being stored without
-            # a file path.
-            annotations_to_persist = self.annotations
-            await self.get(synapse_client=synapse_client, download_file=False)
-            self.annotations = annotations_to_persist
-
-        tasks = []
-
-        if self.annotations:
-            tasks.append(
-                asyncio.create_task(
-                    Annotations(
-                        id=self.id, etag=self.etag, annotations=self.annotations
-                    ).store(synapse_client=synapse_client)
-                )
-            )
-
-        if self.activity:
-            tasks.append(
-                asyncio.create_task(
-                    self.activity.store(parent=self, synapse_client=synapse_client)
-                )
-            )
-
-        try:
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-
-            # TODO: Proper exception handling
-            for result in results:
-                if isinstance(result, Activity):
-                    self.activity = result
-                elif isinstance(result, Annotations):
-                    self.annotations = result.annotations
-                    print(f"Stored annotations id: {result.id}, etag: {result.etag}")
-                else:
-                    if isinstance(result, BaseException):
-                        raise result
-                    raise ValueError(f"Unknown type: {type(result)}", result)
-        except Exception as ex:
-            Synapse.get_client(synapse_client=synapse_client).logger.exception(ex)
-            print("I hit an exception")
-
-        return self
-
-    @otel_trace_method(
-        method_to_trace_name=lambda self, **kwargs: f"File_Get: {self.id}"
-    )
-    # TODO: We need to provide all the other options that can be provided here, like collision, follow link ect...
-    async def get(
-        self,
-        download_file: Optional[bool] = True,
-        download_location: Optional[str] = None,
-        synapse_client: Optional[Synapse] = None,
-    ) -> "File":
-        """Get the file metadata from Synapse.
-
-        Arguments:
-            download_file: If True the file will be downloaded.
-            download_location: The location to download the file to.
-            synapse_client: If not passed in or None this will use the last client from the `.login()` method.
-
-        Returns:
-            The file object.
-        """
         loop = asyncio.get_event_loop()
+        synapse_file = Synapse_File(
+            id=self.id,
+            path=self.path,
+            description=self.description,
+            etag=self.etag,
+            name=self.name or (guess_file_name(self.path) if self.path else None),
+            parent=parent.id if parent else self.parent_id,
+            contentType=self.content_type,
+            dataFileHandleId=self.data_file_handle_id,
+            synapseStore=self.synapse_store,
+            modifiedOn=self.modified_on,
+            versionLabel=self.version_label,
+            versionNumber=self.version_number,
+            versionComment=self.version_comment,
+        )
+        delete_none_keys(synapse_file)
         current_context = context.get_current()
         entity = await loop.run_in_executor(
             None,
             lambda: run_and_attach_otel_context(
-                lambda: Synapse.get_client(synapse_client=synapse_client).get(
+                lambda: Synapse.get_client(synapse_client=synapse_client).store(
+                    obj=synapse_file,
+                    createOrUpdate=self.create_or_update,
+                    forceVersion=self.force_version,
+                    isRestricted=self.is_restricted,
+                    set_annotations=False,
+                ),
+                current_context,
+            ),
+        )
+
+        self.fill_from_dict(synapse_file=entity, set_annotations=False)
+
+        re_read_required = await store_entity_components(
+            root_resource=self, synapse_client=synapse_client
+        )
+        if re_read_required:
+            before_download_file = self.download_file
+            self.download_file = False
+            await self.get(
+                synapse_client=synapse_client,
+            )
+            self.download_file = before_download_file
+
+        self._set_last_persistent_instance()
+
+        Synapse.get_client(synapse_client=synapse_client).logger.debug(
+            f"Stored File {self.name}, id: {self.id}: {self.path}"
+        )
+        return self
+
+    @otel_trace_method(
+        method_to_trace_name=lambda self, **kwargs: f"File_Change_Metadata: {self.id}"
+    )
+    async def change_metadata(
+        self,
+        download_as: Optional[str] = None,
+        content_type: Optional[str] = None,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "File":
+        """
+        Change File Entity metadata for properties that are immutable after creation
+        through the store method.
+
+        Arguments:
+            download_as: Specify filename to change the filename of a filehandle.
+            content_type: Specify content type to change the content type of a filehandle.
+            synapse_client: If not passed in or None this will use the last client from the `.login()` method.
+
+        Returns:
+            The file object.
+
+        Example: Using this function
+            Can be used to change the filename or the file content-type without downloading:
+
+            file_entity = await File(id="syn123").get()
+            print(os.path.basename(file_entity.path))  ## prints, e.g., "my_file.txt"
+            file_entity = file_entity.change_metadata(download_as="my_new_name_file.txt", content_type="text/plain")
+
+        Raises:
+            ValueError: If the file does not have an ID to change metadata.
+        """
+        if not self.id:
+            raise ValueError("The file must have an ID to change metadata.")
+
+        loop = asyncio.get_event_loop()
+
+        current_context = context.get_current()
+        syn = Synapse.get_client(synapse_client=synapse_client)
+        entity = await loop.run_in_executor(
+            None,
+            lambda: run_and_attach_otel_context(
+                lambda: changeFileMetaData(
+                    syn=syn,
                     entity=self.id,
-                    downloadFile=download_file,
-                    downloadLocation=download_location,
+                    downloadAs=download_as,
+                    contentType=content_type,
+                    forceVersion=self.force_version,
                 ),
                 current_context,
             ),
         )
 
         self.fill_from_dict(synapse_file=entity, set_annotations=True)
+        self._set_last_persistent_instance()
+        Synapse.get_client(synapse_client=synapse_client).logger.debug(
+            f"Change metadata for file {self.name}, id: {self.id}: {self.path}"
+        )
         return self
 
     @otel_trace_method(
-        method_to_trace_name=lambda self, **kwargs: f"File_Get_Provenance: {self.id}"
+        method_to_trace_name=lambda self, **kwargs: f"File_Get: {self.id}, {self.path}"
+    )
+    async def get(
+        self,
+        include_activity: bool = False,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "File":
+        """
+        Get the file from Synapse. You may retrieve a File entity by either:
+
+        - id
+        - path
+
+
+        If you specify both, the `id` will take precedence.
+
+
+        If you specify the `path` and the file is stored in multiple locations in Synapse
+        only the first one found will be returned. The other matching files will be
+        printed to the console.
+
+
+        You may also specify a `version_number` to get a specific version of the file.
+
+        Arguments:
+            include_activity: If True the activity will be included in the file if it exists.
+            synapse_client: If not passed in or None this will use the last client from
+                the `.login()` method.
+
+        Returns:
+            The file object.
+
+        Raises:
+            ValueError: If the file does not have an ID or path to get.
+
+
+        Example: Using this function
+            Assuming you have a file with the ID "syn123":
+
+                file_instance = await File(id="syn123").get()
+
+            Assuming you have a file at the path "path/to/file.txt":
+
+                file_instance = await File(path="path/to/file.txt").get()
+        """
+        if not self.id and not self.path:
+            raise ValueError("The file must have an ID or path to get.")
+
+        loop = asyncio.get_event_loop()
+        current_context = context.get_current()
+        entity = await loop.run_in_executor(
+            None,
+            lambda: run_and_attach_otel_context(
+                lambda: Synapse.get_client(synapse_client=synapse_client).get(
+                    entity=self.id or self.path,
+                    version=self.version_number,
+                    ifcollision=self.if_collision,
+                    limitSearch=self.synapse_container_limit,
+                    downloadFile=self.download_file,
+                    downloadLocation=self.download_location,
+                ),
+                current_context,
+            ),
+        )
+
+        self.fill_from_dict(synapse_file=entity, set_annotations=True)
+
+        if include_activity:
+            self.activity = await Activity.from_parent(
+                parent=self, synapse_client=synapse_client
+            )
+
+        self._set_last_persistent_instance()
+        Synapse.get_client(synapse_client=synapse_client).logger.debug(
+            f"Got file {self.name}, id: {self.id}, path: {self.path}"
+        )
+        return self
+
+    @classmethod
+    async def from_id(
+        cls,
+        synapse_id: str,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "File":
+        """Wrapper for [synapseclient.models.File.get][].
+
+        Arguments:
+            synapse_id: The ID of the file in Synapse.
+            synapse_client: If not passed in or None this will use the last client from the `.login()` method.
+
+        Returns:
+            The file object.
+
+        Example: Using this function
+            Assuming you have a file with the ID "syn123":
+
+                file_instance = await File.from_id(synapse_id="syn123")
+        """
+        return await cls(id=synapse_id).get(
+            synapse_client=synapse_client,
+        )
+
+    @classmethod
+    async def from_path(
+        cls,
+        path: str,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "File":
+        """Get the file from Synapse. If the path of the file matches multiple files
+        within Synapse the first one found will be returned. The other matching
+        files will be printed to the console.
+
+
+        Wrapper for [synapseclient.models.File.get][].
+
+        Arguments:
+            path: The path to the file on disk.
+            synapse_client: If not passed in or None this will use the last client from the `.login()` method.
+
+        Returns:
+            The file object.
+
+        Example: Using this function
+            Assuming you have a file at the path "path/to/file.txt":
+
+                file_instance = await File.from_path(path="path/to/file.txt")
+        """
+        return await cls(path=path).get(
+            synapse_client=synapse_client,
+        )
+
+    @otel_trace_method(
+        method_to_trace_name=lambda self, **kwargs: f"File_Delete: {self.id}"
     )
     async def delete(self, synapse_client: Optional[Synapse] = None) -> None:
         """Delete the file from Synapse.
 
         Arguments:
-            synapse_client: If not passed in or None this will use the last client from the `.login()` method.
+            synapse_client: If not passed in or None this will use the last client from
+                the `.login()` method.
 
         Returns:
             None
+
+        Raises:
+            ValueError: If the file does not have an ID to delete.
+
+        Example: Using this function
+            Assuming you have a file with the ID "syn123":
+
+                await File(id="syn123").delete()
         """
+        if not self.id:
+            raise ValueError("The file must have an ID to delete.")
+
         loop = asyncio.get_event_loop()
         current_context = context.get_current()
         await loop.run_in_executor(
@@ -313,3 +772,82 @@ class File(AccessControllable):
                 current_context,
             ),
         )
+        Synapse.get_client(synapse_client=synapse_client).logger.debug(
+            f"Deleted file {self.id}"
+        )
+
+    @otel_trace_method(
+        method_to_trace_name=lambda self, **kwargs: f"File_Change_Metadata: {self.id}"
+    )
+    async def copy(
+        self,
+        destination_id: str,
+        update_existing: bool = False,
+        copy_annotations: bool = True,
+        copy_activity: Union[str, None] = "traceback",
+        synapse_client: Optional[Synapse] = None,
+    ) -> "File":
+        """
+        Copy the file to another Synpase location. Defaults to the latest version of the
+        file, or the version_number specified in the instance.
+
+        Arguments:
+            destination_id: Synapse ID of a folder/project that the copied entity is being copied to
+            update_existing: When the destination has a file that has the same name,
+                users can choose to update that file.
+            copy_annotations: True to copy the annotations.
+            copy_activity: Has three options to set the activity of the copied file:
+
+                    - traceback: Creates a copy of the source files Activity.
+                    - existing: Link to the source file's original Activity (if it exists)
+                    - None: No activity is set
+            synapse_client: If not passed in or None this will use the last client from the `.login()` method.
+
+        Returns:
+            The copied file object.
+
+        Example: Using this function
+            Assuming you have a file with the ID "syn123" and you want to copy it to a folder with the ID "syn456":
+
+                new_file_instance = await File(id="syn123").copy(destination_id="syn456")
+
+            Copy the file but do not persist annotations of activity:
+
+                new_file_instance = await File(id="syn123").copy(destination_id="syn456", copy_annotations=False, copy_activity=None)
+
+        Raises:
+            ValueError: If the file does not have an ID and destination_id to copy.
+        """
+        if not self.id:
+            raise ValueError("The file must have an ID and destination_id to copy.")
+
+        loop = asyncio.get_event_loop()
+
+        current_context = context.get_current()
+        syn = Synapse.get_client(synapse_client=synapse_client)
+        source_and_destination = await loop.run_in_executor(
+            None,
+            lambda: run_and_attach_otel_context(
+                lambda: copy(
+                    syn=syn,
+                    entity=self.id,
+                    destinationId=destination_id,
+                    skipCopyAnnotations=not copy_annotations,
+                    updateExisting=update_existing,
+                    setProvenance=copy_activity,
+                ),
+                current_context,
+            ),
+        )
+
+        destination_id = source_and_destination.get(self.id, None)
+        if not destination_id:
+            raise SynapseError("Failed to copy file.")
+        file_copy = await File(id=destination_id, download_file=False).get(
+            synapse_client=synapse_client
+        )
+        file_copy.download_file = True
+        Synapse.get_client(synapse_client=synapse_client).logger.debug(
+            f"Copied from file {self.id} to {destination_id}"
+        )
+        return file_copy

--- a/synapseclient/models/folder.py
+++ b/synapseclient/models/folder.py
@@ -11,6 +11,9 @@ from synapseclient.models import File, Annotations
 from synapseclient.core.async_utils import otel_trace_method
 from synapseclient.core.utils import run_and_attach_otel_context
 from synapseclient.models.mixins.access_control import AccessControllable
+from synapseclient.models.services.storable_entity_components import (
+    store_entity_components,
+)
 
 if TYPE_CHECKING:
     from synapseclient.models import Project
@@ -101,7 +104,7 @@ class Folder(AccessControllable):
     """Additional metadata associated with the folder. The key is the name of your
     desired annotations. The value is an object containing a list of values
     (use empty list to represent no values for key) and the value type associated with
-    all values in the list."""
+    all values in the list. To remove all annotations set this to an empty dict `{}`."""
 
     # def __post_init__(self):
     #     # TODO - What is the best way to enforce this, basically we need a minimum amount
@@ -166,49 +169,11 @@ class Folder(AccessControllable):
 
         self.fill_from_dict(synapse_folder=entity, set_annotations=False)
 
-        tasks = []
-        if self.files:
-            tasks.extend(
-                file.store(parent=self, synapse_client=synapse_client)
-                for file in self.files
-            )
+        await store_entity_components(root_resource=self, synapse_client=synapse_client)
 
-        if self.folders:
-            tasks.extend(
-                folder.store(parent=self, synapse_client=synapse_client)
-                for folder in self.folders
-            )
-
-        if self.annotations:
-            tasks.append(
-                asyncio.create_task(
-                    Annotations(
-                        id=self.id, etag=self.etag, annotations=self.annotations
-                    ).store(synapse_client=synapse_client)
-                )
-            )
-
-        try:
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-
-            # TODO: Proper exception handling
-            for result in results:
-                if isinstance(result, Folder):
-                    print(f"Stored {result.name}")
-                elif isinstance(result, File):
-                    print(f"Stored {result.name} at: {result.path}")
-                elif isinstance(result, Annotations):
-                    self.annotations = result.annotations
-                    print(f"Stored annotations id: {result.id}, etag: {result.etag}")
-                else:
-                    if isinstance(result, BaseException):
-                        raise result
-                    raise ValueError(f"Unknown type: {type(result)}", result)
-        except Exception as ex:
-            Synapse.get_client(synapse_client=synapse_client).logger.exception(ex)
-            print("I hit an exception")
-
-        print(f"Saved all files and folders in {self.name}")
+        Synapse.get_client(synapse_client=synapse_client).logger.debug(
+            f"Saved Folder: {self.name}, parent: {self.parent_id}"
+        )
 
         return self
 

--- a/synapseclient/models/project.py
+++ b/synapseclient/models/project.py
@@ -13,6 +13,9 @@ from synapseclient.models.mixins.access_control import AccessControllable
 from synapseclient import Synapse
 from synapseclient.core.async_utils import otel_trace_method
 from synapseclient.core.utils import run_and_attach_otel_context
+from synapseclient.models.services.storable_entity_components import (
+    store_entity_components,
+)
 
 
 tracer = trace.get_tracer("synapseclient")
@@ -53,6 +56,15 @@ class Project(AccessControllable):
     Example: Creating a project
         This example shows how to create a project
 
+            from synapseclient.models import Project, File
+            import synapseclient
+
+            synapseclient.login()
+
+            my_annotations = {
+                "my_single_key_string": "a",
+                "my_key_string": ["b", "a", "c"],
+            }
             project = Project(
                 name="bfauble_my_new_project_for_testing",
                 annotations=my_annotations,
@@ -133,11 +145,22 @@ class Project(AccessControllable):
     """Additional metadata associated with the folder. The key is the name of your
     desired annotations. The value is an object containing a list of values
     (use empty list to represent no values for key) and the value type associated with
-    all values in the list."""
+    all values in the list. To remove all annotations set this to an empty dict `{}`."""
 
     def fill_from_dict(
-        self, synapse_project: Synapse_Project, set_annotations: bool = True
+        self,
+        synapse_project: Union[Synapse_Project, Dict],
+        set_annotations: bool = True,
     ) -> "Project":
+        """
+        Converts a response from the REST API into this dataclass.
+
+        Arguments:
+            synapse_project: The response from the REST API.
+
+        Returns:
+            The Project object.
+        """
         self.id = synapse_project.get("id", None)
         self.name = synapse_project.get("name", None)
         self.description = synapse_project.get("description", None)
@@ -157,7 +180,8 @@ class Project(AccessControllable):
         method_to_trace_name=lambda self, **kwargs: f"Project_Store: {self.name}"
     )
     async def store(self, synapse_client: Optional[Synapse] = None) -> "Project":
-        """Store project, files, and folders to synapse.
+        """
+        Store project, files, and folders to synapse.
 
         Arguments:
             synapse_client: If not passed in or None this will use the last client from the `.login()` method.
@@ -180,49 +204,11 @@ class Project(AccessControllable):
         )
         self.fill_from_dict(synapse_project=entity, set_annotations=False)
 
-        tasks = []
-        if self.files:
-            tasks.extend(
-                file.store(parent=self, synapse_client=synapse_client)
-                for file in self.files
-            )
+        await store_entity_components(root_resource=self, synapse_client=synapse_client)
 
-        if self.folders:
-            tasks.extend(
-                folder.store(parent=self, synapse_client=synapse_client)
-                for folder in self.folders
-            )
-
-        if self.annotations:
-            tasks.append(
-                asyncio.create_task(
-                    Annotations(
-                        id=self.id, etag=self.etag, annotations=self.annotations
-                    ).store(synapse_client=synapse_client)
-                )
-            )
-
-        try:
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-            # TODO: Proper exception handling
-
-            for result in results:
-                if isinstance(result, Folder):
-                    print(f"Stored {result.name}")
-                elif isinstance(result, File):
-                    print(f"Stored {result.name} at: {result.path}")
-                elif isinstance(result, Annotations):
-                    self.annotations = result.annotations
-                    print(f"Stored annotations id: {result.id}, etag: {result.etag}")
-                else:
-                    if isinstance(result, BaseException):
-                        raise result
-                    raise ValueError(f"Unknown type: {type(result)}", result)
-        except Exception as ex:
-            Synapse.get_client(synapse_client=synapse_client).logger.exception(ex)
-            print("I hit an exception")
-
-        print(f"Saved all files and folders in {self.name}")
+        Synapse.get_client(synapse_client=synapse_client).logger.debug(
+            f"Saved Project {self.name}"
+        )
 
         return self
 
@@ -285,6 +271,9 @@ class Project(AccessControllable):
                     "type" in child
                     and child["type"] == "org.sagebionetworks.repo.model.FileEntity"
                 ):
+                    # TODO: This child only contains a small slice of data, in order to
+                    # save the file again we need to call `.get()` on the file.
+                    # Perhaps we should not return this as a full File object?
                     file = File().fill_from_dict(synapse_file=child)
                     file.parent_id = self.id
                     files.append(file)

--- a/synapseclient/models/services/storable_entity_components.py
+++ b/synapseclient/models/services/storable_entity_components.py
@@ -1,0 +1,143 @@
+import asyncio
+from typing import Union, TYPE_CHECKING, Optional
+from synapseclient import Synapse
+from synapseclient.models import Annotations
+
+if TYPE_CHECKING:
+    from synapseclient.models import File, Folder, Project, Table
+
+
+async def store_entity_components(
+    root_resource: Union["File", "Folder", "Project", "Table"],
+    synapse_client: Optional[Synapse] = None,
+) -> bool:
+    """
+    Function to store ancillary components of an entity to synapse. This function will
+    execute the stores in parallel.
+
+    This is responsible for storing the annotations, activity, files and folders of a
+    resource to synapse.
+
+
+    Arguments:
+        root_resource: The root resource to store objects on.
+        synapse_client: If not passed in or None this will use the last client from the `.login()` method.
+
+    Returns:
+        If a read from Synapse is required to retireve the current state of the entity.
+    """
+    re_read_required = False
+    # pylint: disable=protected-access
+    last_persistent_instance = (
+        root_resource._last_persistent_instance
+        if hasattr(root_resource, "_last_persistent_instance")
+        else None
+    )
+    tasks = []
+
+    if hasattr(root_resource, "files") and root_resource.files is not None:
+        for file in root_resource.files:
+            tasks.append(
+                asyncio.create_task(
+                    file.store(parent=root_resource, synapse_client=synapse_client)
+                )
+            )
+
+    if hasattr(root_resource, "folders") and root_resource.folders is not None:
+        for folder in root_resource.folders:
+            tasks.append(
+                asyncio.create_task(
+                    folder.store(parent=root_resource, synapse_client=synapse_client)
+                )
+            )
+
+    if (
+        hasattr(root_resource, "annotations")
+        and root_resource.annotations is not None
+        and (
+            last_persistent_instance is None
+            or last_persistent_instance.annotations != root_resource.annotations
+        )
+    ):
+        tasks.append(
+            asyncio.create_task(
+                Annotations(
+                    id=root_resource.id,
+                    etag=root_resource.etag,
+                    annotations=root_resource.annotations,
+                ).store(synapse_client=synapse_client)
+            )
+        )
+
+    try:
+        for task in asyncio.as_completed(tasks):
+            result = await task
+            if isinstance(result, Annotations):
+                root_resource.annotations = result.annotations
+                root_resource.etag = result.etag
+            elif result.__class__.__name__ == "Folder":
+                pass
+            elif result.__class__.__name__ == "File":
+                pass
+            else:
+                if isinstance(result, BaseException):
+                    Synapse.get_client(synapse_client=synapse_client).logger.exception(
+                        result
+                    )
+                    raise result
+                raise ValueError(f"Unknown type: {type(result)}", result)
+    except Exception as ex:
+        Synapse.get_client(synapse_client=synapse_client).logger.exception(ex)
+        raise ex
+
+    re_read_required = await _store_activity(
+        root_resource, synapse_client=synapse_client
+    )
+
+    return re_read_required
+
+
+async def _store_activity(
+    root_resource: Union["File", "Folder", "Project", "Table"],
+    synapse_client: Optional[Synapse] = None,
+) -> bool:
+    """
+    Function to store ancillary activity of an entity to synapse. This function is split
+    off from the main store_entity_components function because of 2 reasons:
+    1) It is not possible to concurrently store annotations and activity because both
+        intend that the latest etag is used to store the entity.
+    2) The activity endpoints do not return the etag of the entity, so the etag of the
+        entity has to be retrieved later on with another GET request.
+
+    Jira: https://sagebionetworks.jira.com/browse/PLFM-8251 has been created to review
+    this logic.
+
+    Arguments:
+        root_resource: The root resource to store objects on.
+        synapse_client: If not passed in or None this will use the last client from the `.login()` method.
+
+    Returns:
+        If a read from Synapse is required to retireve the current state of the entity.
+    """
+    # pylint: disable=protected-access
+    last_persistent_instance = (
+        root_resource._last_persistent_instance
+        if hasattr(root_resource, "_last_persistent_instance")
+        else None
+    )
+
+    if (
+        hasattr(root_resource, "activity")
+        and root_resource.activity is not None
+        and (
+            last_persistent_instance is None
+            or last_persistent_instance.activity != root_resource.activity
+        )
+    ):
+        result = await root_resource.activity.store(
+            parent=root_resource, synapse_client=synapse_client
+        )
+
+        root_resource.activity = result
+        return True
+    return False

--- a/synapseclient/models/table.py
+++ b/synapseclient/models/table.py
@@ -601,7 +601,13 @@ class Table(AccessControllable):
 
         self.fill_from_dict(synapse_table=entity, set_annotations=False)
 
-        await store_entity_components(root_resource=self, synapse_client=synapse_client)
+        re_read_required = await store_entity_components(
+            root_resource=self, synapse_client=synapse_client
+        )
+        if re_read_required:
+            await self.get(
+                synapse_client=synapse_client,
+            )
 
         return self
 

--- a/synapseclient/models/table.py
+++ b/synapseclient/models/table.py
@@ -19,6 +19,9 @@ from synapseclient.models import Annotations, Activity
 from synapseclient.core.async_utils import otel_trace_method
 from synapseclient.core.utils import run_and_attach_otel_context
 from synapseclient.models.mixins.access_control import AccessControllable
+from synapseclient.models.services.storable_entity_components import (
+    store_entity_components,
+)
 from opentelemetry import trace, context
 
 
@@ -444,7 +447,7 @@ class Table(AccessControllable):
     """Additional metadata associated with the table. The key is the name of your
     desired annotations. The value is an object containing a list of values
     (use empty list to represent no values for key) and the value type associated with
-    all values in the list."""
+    all values in the list. To remove all annotations set this to an empty dict `{}`."""
 
     def fill_from_dict(
         self, synapse_table: Synapse_Table, set_annotations: bool = True
@@ -598,40 +601,8 @@ class Table(AccessControllable):
 
         self.fill_from_dict(synapse_table=entity, set_annotations=False)
 
-        tasks = []
-        if self.annotations:
-            tasks.append(
-                asyncio.create_task(
-                    Annotations(
-                        id=self.id, etag=self.etag, annotations=self.annotations
-                    ).store(synapse_client=synapse_client)
-                )
-            )
+        await store_entity_components(root_resource=self, synapse_client=synapse_client)
 
-        if self.activity:
-            tasks.append(
-                asyncio.create_task(
-                    self.activity.store(parent=self, synapse_client=synapse_client)
-                )
-            )
-        try:
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-
-            # TODO: Proper exception handling
-            for result in results:
-                if isinstance(result, Activity):
-                    self.activity = result
-                    print(f"Stored activity id: {result.id}, etag: {result.etag}")
-                elif isinstance(result, Annotations):
-                    self.annotations = result.annotations
-                    print(f"Stored annotations id: {result.id}, etag: {result.etag}")
-                else:
-                    if isinstance(result, BaseException):
-                        raise result
-                    raise ValueError(f"Unknown type: {type(result)}", result)
-        except Exception as ex:
-            Synapse.get_client(synapse_client=synapse_client).logger.exception(ex)
-            print("I hit an exception")
         return self
 
     @otel_trace_method(

--- a/tests/integration/synapseclient/models/test_file.py
+++ b/tests/integration/synapseclient/models/test_file.py
@@ -1,0 +1,1178 @@
+"""Integration tests for the synapseclient.models.File class."""
+import os
+import asyncio
+from unittest.mock import patch
+import uuid
+
+from typing import Callable
+import pytest
+
+from synapseclient import Synapse
+from synapseclient.core import utils
+from synapseclient.core.exceptions import SynapseHTTPError
+
+from synapseclient.models import (
+    Project,
+    Folder,
+    File,
+    Activity,
+    UsedURL,
+    UsedEntity,
+)
+
+
+class TestFileStore:
+    """Tests for the synapseclient.models.File.store method."""
+
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    @pytest.fixture(autouse=True, scope="function")
+    def file(self, schedule_for_cleanup: Callable[..., None]) -> None:
+        filename = utils.make_bogus_data_file(1)
+        schedule_for_cleanup(filename)
+        return File(
+            path=filename,
+            description="This is an example file.",
+            content_type="text/plain",
+            version_comment="My version comment",
+            version_label=str(uuid.uuid4()),
+        )
+
+    @pytest.mark.asyncio
+    async def test_store_in_project(self, project_model: Project, file: File) -> None:
+        # GIVEN a file
+        file.name = str(uuid.uuid4())
+
+        # WHEN I store the file
+        file_copy_object = await file.store(parent=project_model)
+        self.schedule_for_cleanup(file.id)
+
+        # THEN I expect the file to be stored
+        assert file.id is not None
+        assert file_copy_object.id is not None
+        assert file_copy_object == file
+        assert file.parent_id == project_model.id
+        assert file.content_type == "text/plain"
+        assert file.version_comment == "My version comment"
+        assert file.version_label is not None
+        assert file.version_number == 1
+        assert file.created_by is not None
+        assert file.created_on is not None
+        assert file.modified_by is not None
+        assert file.modified_on is not None
+        assert file.data_file_handle_id is not None
+        assert file.file_handle is not None
+        assert file.file_handle.id is not None
+        assert file.file_handle.etag is not None
+        assert file.file_handle.created_by is not None
+        assert file.file_handle.created_on is not None
+        assert file.file_handle.modified_on is not None
+        assert file.file_handle.concrete_type is not None
+        assert file.file_handle.content_type is not None
+        assert file.file_handle.content_md5 is not None
+        assert file.file_handle.file_name is not None
+        assert file.file_handle.storage_location_id is not None
+        assert file.file_handle.content_size is not None
+        assert file.file_handle.status is not None
+        assert file.file_handle.bucket_name is not None
+        assert file.file_handle.key is not None
+        assert file.file_handle.external_url is None
+
+    @pytest.mark.asyncio
+    async def test_store_in_folder(self, project_model: Project, file: File) -> None:
+        # GIVEN a file
+        file.name = str(uuid.uuid4())
+
+        # AND a folder to store the file in
+        folder = await Folder(
+            name=str(uuid.uuid4()), parent_id=project_model.id
+        ).store()
+        self.schedule_for_cleanup(folder.id)
+
+        # WHEN I store the file
+        file_copy_object = await file.store(parent=folder)
+        self.schedule_for_cleanup(file.id)
+
+        # THEN I expect the file to be stored
+        assert file.id is not None
+        assert file_copy_object.id is not None
+        assert file_copy_object == file
+        assert file.parent_id == folder.id
+        assert file.content_type == "text/plain"
+        assert file.version_comment == "My version comment"
+        assert file.version_label is not None
+        assert file.version_number == 1
+        assert file.created_by is not None
+        assert file.created_on is not None
+        assert file.modified_by is not None
+        assert file.modified_on is not None
+        assert file.data_file_handle_id is not None
+        assert file.file_handle is not None
+        assert file.file_handle.id is not None
+        assert file.file_handle.etag is not None
+        assert file.file_handle.created_by is not None
+        assert file.file_handle.created_on is not None
+        assert file.file_handle.modified_on is not None
+        assert file.file_handle.concrete_type is not None
+        assert file.file_handle.content_type is not None
+        assert file.file_handle.content_md5 is not None
+        assert file.file_handle.file_name is not None
+        assert file.file_handle.storage_location_id is not None
+        assert file.file_handle.content_size is not None
+        assert file.file_handle.status is not None
+        assert file.file_handle.bucket_name is not None
+        assert file.file_handle.key is not None
+        assert file.file_handle.external_url is None
+
+    @pytest.mark.asyncio
+    async def test_store_multiple_files(self, project_model: Project) -> None:
+        # GIVEN a file
+        filename = utils.make_bogus_data_file(1)
+        self.schedule_for_cleanup(filename)
+        file_1 = File(
+            path=filename,
+            description="This is an example file.",
+            content_type="text/plain",
+            version_comment="My version comment",
+            version_label=str(uuid.uuid4()),
+        )
+
+        # AND a second file
+        filename = utils.make_bogus_data_file(1)
+        self.schedule_for_cleanup(filename)
+        file_2 = File(
+            path=filename,
+            description="This is an example file.",
+            content_type="text/plain",
+            version_comment="My version comment",
+            version_label=str(uuid.uuid4()),
+        )
+
+        # WHEN I store both the file
+        files = await asyncio.gather(
+            *[file_1.store(parent=project_model), file_2.store(parent=project_model)]
+        )
+        for file in files:
+            self.schedule_for_cleanup(file.id)
+
+            # THEN I expect the files to be stored
+            assert file.id is not None
+            assert file == file_1 or file == file_2
+            assert file.parent_id == project_model.id
+            assert file.content_type == "text/plain"
+            assert file.version_comment == "My version comment"
+            assert file.version_label is not None
+            assert file.version_number == 1
+            assert file.created_by is not None
+            assert file.created_on is not None
+            assert file.modified_by is not None
+            assert file.modified_on is not None
+            assert file.data_file_handle_id is not None
+            assert file.file_handle is not None
+            assert file.file_handle.id is not None
+            assert file.file_handle.etag is not None
+            assert file.file_handle.created_by is not None
+            assert file.file_handle.created_on is not None
+            assert file.file_handle.modified_on is not None
+            assert file.file_handle.concrete_type is not None
+            assert file.file_handle.content_type is not None
+            assert file.file_handle.content_md5 is not None
+            assert file.file_handle.file_name is not None
+            assert file.file_handle.storage_location_id is not None
+            assert file.file_handle.content_size is not None
+            assert file.file_handle.status is not None
+            assert file.file_handle.bucket_name is not None
+            assert file.file_handle.key is not None
+            assert file.file_handle.external_url is None
+
+    @pytest.mark.asyncio
+    async def test_store_change_filename(
+        self, project_model: Project, file: File
+    ) -> None:
+        # GIVEN a file
+        file.name = str(uuid.uuid4())
+        file.parent_id = project_model.id
+
+        # WHEN I store the file
+        file = await file.store()
+        self.schedule_for_cleanup(file.id)
+        before_etag = file.etag
+
+        # AND I change the filename
+        changed_file_name = str(uuid.uuid4())
+        file.name = changed_file_name
+
+        # AND I store the file again
+        file = await file.store()
+
+        # THEN I expect the file to be changed
+        assert file.name == changed_file_name
+        assert before_etag is not None
+        assert file.etag is not None
+        assert before_etag != file.etag
+
+    @pytest.mark.asyncio
+    async def test_store_move_file(self, project_model: Project, file: File) -> None:
+        # GIVEN a file
+        file.name = str(uuid.uuid4())
+        file.parent_id = project_model.id
+
+        # AND a folder to store the file in
+        folder = await Folder(
+            name=str(uuid.uuid4()), parent_id=project_model.id
+        ).store()
+        self.schedule_for_cleanup(folder.id)
+
+        # WHEN I store the file in the project
+        file = await file.store()
+        self.schedule_for_cleanup(file.id)
+        assert file.parent_id == project_model.id
+        before_file_id = file.id
+
+        # AND I store the file under a new parent
+        file = await file.store(parent=folder)
+
+        # THEN I expect the file to have been moved
+        assert file.parent_id == folder.id
+
+        # AND the file does not have an updated ID
+        assert before_file_id == file.id
+
+    @pytest.mark.asyncio
+    async def test_store_same_data_file_handle_id(self, project_model: Project) -> None:
+        # GIVEN a file
+        filename = utils.make_bogus_data_file(1)
+        self.schedule_for_cleanup(filename)
+        file_1 = await File(
+            path=filename,
+            description="This is an example file.",
+            content_type="text/plain",
+            version_comment="My version comment",
+            version_label=str(uuid.uuid4()),
+        ).store(parent=project_model)
+
+        # AND a second file
+        filename = utils.make_bogus_data_file(1)
+        self.schedule_for_cleanup(filename)
+        file_2 = await File(
+            path=filename,
+            description="This is an example file.",
+            content_type="text/plain",
+            version_comment="My version comment",
+            version_label=str(uuid.uuid4()),
+        ).store(parent=project_model)
+        assert file_1.data_file_handle_id is not None
+        assert file_2.data_file_handle_id is not None
+        assert file_1.data_file_handle_id != file_2.data_file_handle_id
+        file_2_etag = file_2.etag
+
+        # WHEN I store the data_file_handle_id onto the second file
+        file_2.data_file_handle_id = file_1.data_file_handle_id
+        await file_2.store()
+
+        # THEN I expect the file handles to match
+        assert file_2_etag != file_2.etag
+        assert (await file_1.get()).file_handle == file_2.file_handle
+
+    @pytest.mark.asyncio
+    async def test_store_updated_file(self, project_model: Project) -> None:
+        # GIVEN a file
+        filename = utils.make_bogus_data_file(1)
+        self.schedule_for_cleanup(filename)
+        file = await File(
+            path=filename,
+            description="This is an example file.",
+            content_type="text/plain",
+            version_comment="My version comment",
+            version_label=str(uuid.uuid4()),
+        ).store(parent=project_model)
+        before_etag = file.etag
+        before_id = file.id
+        before_file_handle_id = file.file_handle.id
+
+        # WHEN I update the file
+        filename = utils.make_bogus_data_file(1)
+        self.schedule_for_cleanup(filename)
+        file.path = filename
+        await file.store()
+
+        # THEN I expect the file to be updated
+        assert before_etag is not None
+        assert file.etag is not None
+        assert before_etag != file.etag
+        assert before_id == file.id
+        assert before_file_handle_id is not None
+        assert file.file_handle.id is not None
+        assert before_file_handle_id != file.file_handle.id
+
+    @pytest.mark.asyncio
+    async def test_store_and_get_activity(
+        self, project_model: Project, file: File
+    ) -> None:
+        # GIVEN an activity
+        activity = Activity(
+            name="some_name",
+            description="some_description",
+            used=[
+                UsedURL(name="example", url="https://www.synapse.org/"),
+                UsedEntity(target_id="syn456", target_version_number=1),
+            ],
+            executed=[
+                UsedURL(name="example", url="https://www.synapse.org/"),
+                UsedEntity(target_id="syn789", target_version_number=1),
+            ],
+        )
+
+        # AND a file with the activity
+        file.name = str(uuid.uuid4())
+        file.activity = activity
+
+        # WHEN I store the file
+        file = await file.store(parent=project_model)
+        self.schedule_for_cleanup(file.id)
+
+        # AND I get the file with the activity
+        file_copy = await File(id=file.id, download_file=False).get(
+            include_activity=True
+        )
+
+        # THEN I expect that the activity is returned
+        assert file_copy.activity is not None
+        assert file_copy.activity.name == "some_name"
+        assert file_copy.activity.description == "some_description"
+        assert file_copy.activity.used[0].name == "example"
+        assert file_copy.activity.used[0].url == "https://www.synapse.org/"
+        assert file_copy.activity.used[1].target_id == "syn456"
+        assert file_copy.activity.used[1].target_version_number == 1
+        assert file_copy.activity.executed[0].name == "example"
+        assert file_copy.activity.executed[0].url == "https://www.synapse.org/"
+        assert file_copy.activity.executed[1].target_id == "syn789"
+        assert file_copy.activity.executed[1].target_version_number == 1
+
+        # WHEN I get the file without the activity flag
+        file_copy_2 = await File(id=file.id, download_file=False).get()
+
+        # THEN I expect that the activity is not returned
+        assert file_copy_2.activity is None
+
+    @pytest.mark.asyncio
+    async def test_store_annotations(self, project_model: Project, file: File) -> None:
+        # GIVEN an annotation
+        annotations_for_my_file = {
+            "my_single_key_string": "a",
+            "my_key_string": ["b", "a", "c"],
+            "my_key_bool": [False, False, False],
+            "my_key_double": [1.2, 3.4, 5.6],
+            "my_key_long": [1, 2, 3],
+        }
+
+        # AND a file with the annotation
+        file.name = str(uuid.uuid4())
+        file.annotations = annotations_for_my_file
+
+        # WHEN I store the file
+        file = await file.store(parent=project_model)
+        self.schedule_for_cleanup(file.id)
+
+        # THEN I expect the file annotations to have been stored
+        assert file.annotations.keys() == annotations_for_my_file.keys()
+        assert file.annotations["my_single_key_string"] == ["a"]
+        assert file.annotations["my_key_string"] == ["b", "a", "c"]
+        assert file.annotations["my_key_bool"] == [False, False, False]
+        assert file.annotations["my_key_double"] == [1.2, 3.4, 5.6]
+        assert file.annotations["my_key_long"] == [1, 2, 3]
+
+        # WHEN I update the annotations and store the file again
+        file.annotations["my_key_string"] = ["new", "values", "here"]
+        await file.store()
+
+        # THEN I expect the file annotations to have been updated
+        assert file.annotations.keys() == annotations_for_my_file.keys()
+        assert file.annotations["my_single_key_string"] == ["a"]
+        assert file.annotations["my_key_string"] == ["new", "values", "here"]
+        assert file.annotations["my_key_bool"] == [False, False, False]
+        assert file.annotations["my_key_double"] == [1.2, 3.4, 5.6]
+        assert file.annotations["my_key_long"] == [1, 2, 3]
+
+    @pytest.mark.asyncio
+    async def test_store_without_upload(
+        self, project_model: Project, file: File
+    ) -> None:
+        # GIVEN a file
+        file.name = str(uuid.uuid4())
+
+        # AND the file is not to be uploaded
+        file.synapse_store = False
+
+        # WHEN I store the file
+        file = await file.store(parent=project_model)
+        self.schedule_for_cleanup(file.id)
+
+        # THEN I expect the file to be stored as an external file
+        assert file.id is not None
+        assert file.parent_id == project_model.id
+        assert file.content_type == "text/plain"
+        assert file.version_comment == "My version comment"
+        assert file.version_label is not None
+        assert file.version_number == 1
+        assert file.created_by is not None
+        assert file.created_on is not None
+        assert file.modified_by is not None
+        assert file.modified_on is not None
+        assert file.data_file_handle_id is not None
+        assert file.file_handle is not None
+        assert file.file_handle.id is not None
+        assert file.file_handle.etag is not None
+        assert file.file_handle.created_by is not None
+        assert file.file_handle.created_on is not None
+        assert file.file_handle.modified_on is not None
+        assert (
+            file.file_handle.concrete_type
+            == "org.sagebionetworks.repo.model.file.ExternalFileHandle"
+        )
+        assert file.file_handle.content_type == "text/plain"
+        assert file.file_handle.content_md5 is not None
+        assert file.file_handle.file_name is not None
+        assert file.file_handle.content_size is not None
+        assert file.file_handle.status is not None
+        assert file.file_handle.bucket_name is None
+        assert file.file_handle.key is None
+
+    @pytest.mark.asyncio
+    async def test_store_conflict_with_existing_object(
+        self, project_model: Project, file: File
+    ) -> None:
+        # GIVEN a file
+        file.name = str(uuid.uuid4())
+
+        # WHEN I store the file
+        file_copy_object = await file.store(parent=project_model)
+        self.schedule_for_cleanup(file.id)
+
+        # THEN I expect the file to be stored
+        assert file.id is not None
+        assert file_copy_object.id is not None
+        assert file_copy_object == file
+        assert file.parent_id == project_model.id
+        assert file.content_type == "text/plain"
+        assert file.version_comment == "My version comment"
+        assert file.version_label is not None
+        assert file.version_number == 1
+        assert file.created_by is not None
+        assert file.created_on is not None
+        assert file.modified_by is not None
+        assert file.modified_on is not None
+        assert file.data_file_handle_id is not None
+        assert file.file_handle is not None
+        assert file.file_handle.id is not None
+        assert file.file_handle.etag is not None
+        assert file.file_handle.created_by is not None
+        assert file.file_handle.created_on is not None
+        assert file.file_handle.modified_on is not None
+        assert file.file_handle.concrete_type is not None
+        assert file.file_handle.content_type is not None
+        assert file.file_handle.content_md5 is not None
+        assert file.file_handle.file_name is not None
+        assert file.file_handle.storage_location_id is not None
+        assert file.file_handle.content_size is not None
+        assert file.file_handle.status is not None
+        assert file.file_handle.bucket_name is not None
+        assert file.file_handle.key is not None
+        assert file.file_handle.external_url is None
+
+        # WHEN I store a file with the same properties
+        filename = utils.make_bogus_data_file(1)
+        self.schedule_for_cleanup(filename)
+        new_file = File(
+            path=filename,
+            parent_id=project_model.id,
+            name=file.name,
+            create_or_update=False,
+        )
+
+        # THEN I expect a SynapseHTTPError to be raised
+        with pytest.raises(SynapseHTTPError) as e:
+            await new_file.store()
+
+        assert (
+            str(e.value)
+            == f"409 Client Error: \nAn entity with the name: {file.name} already exists with a parentId: {project_model.id}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_store_force_version(
+        self, project_model: Project, file: File
+    ) -> None:
+        # GIVEN a file
+        file.name = str(uuid.uuid4())
+
+        # WHEN I store the file
+        await file.store(parent=project_model)
+        self.schedule_for_cleanup(file.id)
+
+        # THEN I expect the file to be stored
+        assert file.id is not None
+        assert file.version_number == 1
+
+        # WHEN I store the file again with force_version=False
+        file.force_version = False
+        await file.store()
+
+        # THEN the version should not be updated
+        assert file.version_number == 1
+
+        # WHEN I store the file again with force_version=True
+        file.force_version = True
+        await file.store()
+
+        # THEN the version should be updated
+        assert file.version_number == 2
+
+    @pytest.mark.asyncio
+    async def test_store_is_restricted(
+        self, project_model: Project, file: File
+    ) -> None:
+        """Tests that setting is_restricted is calling the correct Synapse method. We are
+        not testing the actual behavior of the method, only that it is called with the
+        correct arguments. We do not want to actually restrict the file in Synapse as it
+        would send an email to our ACT team."""
+        # GIVEN a file
+        file.name = str(uuid.uuid4())
+
+        # AND the file is restricted
+        file.is_restricted = True
+
+        with patch.object(
+            self.syn,
+            "_createAccessRequirementIfNone",
+            return_value=(None),
+        ) as mocked_client_call:
+            # WHEN I store the file
+            await file.store(parent=project_model)
+            self.schedule_for_cleanup(file.id)
+
+            # THEN I expect the file to be restricted
+            mocked_client_call.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_store_and_get_with_activity(
+        self, project_model: Project, file: File
+    ) -> None:
+        # GIVEN a file
+        file.name = str(uuid.uuid4())
+
+        # AND an activity
+        activity = Activity(
+            name="some_name",
+            description="some_description",
+            used=[
+                UsedURL(name="example", url="https://www.synapse.org/"),
+                UsedEntity(target_id="syn456", target_version_number=1),
+            ],
+            executed=[
+                UsedURL(name="example", url="https://www.synapse.org/"),
+                UsedEntity(target_id="syn789", target_version_number=1),
+            ],
+        )
+        file.activity = activity
+
+        # WHEN I store the file
+        file_copy_object = await file.store(parent=project_model)
+        self.schedule_for_cleanup(file.id)
+
+        # THEN I expect the file to be stored
+        assert file.id is not None
+        assert file_copy_object.id is not None
+        assert file_copy_object == file
+        assert file.parent_id == project_model.id
+        assert file.content_type == "text/plain"
+        assert file.version_comment == "My version comment"
+        assert file.version_label is not None
+        assert file.version_number == 1
+        assert file.created_by is not None
+        assert file.created_on is not None
+        assert file.modified_by is not None
+        assert file.modified_on is not None
+        assert file.data_file_handle_id is not None
+        assert file.file_handle is not None
+        assert file.file_handle.id is not None
+        assert file.file_handle.etag is not None
+        assert file.file_handle.created_by is not None
+        assert file.file_handle.created_on is not None
+        assert file.file_handle.modified_on is not None
+        assert file.file_handle.concrete_type is not None
+        assert file.file_handle.content_type is not None
+        assert file.file_handle.content_md5 is not None
+        assert file.file_handle.file_name is not None
+        assert file.file_handle.storage_location_id is not None
+        assert file.file_handle.content_size is not None
+        assert file.file_handle.status is not None
+        assert file.file_handle.bucket_name is not None
+        assert file.file_handle.key is not None
+        assert file.file_handle.external_url is None
+
+
+class TestChangeMetadata:
+    """Tests for the synapseclient.models.File.change_metadata method."""
+
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    @pytest.fixture(autouse=True, scope="function")
+    def file(
+        self, schedule_for_cleanup: Callable[..., None], project_model: Project
+    ) -> None:
+        filename = utils.make_bogus_data_file(1)
+        schedule_for_cleanup(filename)
+        file = asyncio.run(
+            File(
+                path=filename,
+                description="This is an example file.",
+                content_type="text/plain",
+                version_comment="My version comment",
+                version_label=str(uuid.uuid4()),
+                parent_id=project_model.id,
+            ).store()
+        )
+        schedule_for_cleanup(file.id)
+        return file
+
+    @pytest.mark.asyncio
+    async def test_change_content_type_and_download(self, file: File) -> None:
+        # GIVEN a file stored in synapse
+        assert file.id is not None
+        assert file.name is not None
+        assert file.content_type == "text/plain"
+        current_filename = file.name
+
+        # WHEN I change the files metadata
+        new_filename = f"my_new_file_name_{str(uuid.uuid4())}.txt"
+        await file.change_metadata(download_as=new_filename, content_type="text/json")
+
+        # THEN I expect the file download name to have been updated
+        assert file.file_handle.file_name == new_filename
+        assert file.name == current_filename
+        assert file.content_type == "text/json"
+        file_copy = await File(id=file.id, download_file=False).get()
+        assert file_copy.file_handle.file_name == new_filename
+        assert file_copy.name == current_filename
+        assert file_copy.content_type == "text/json"
+
+    @pytest.mark.asyncio
+    async def test_change_content_type_and_download_and_name(self, file: File) -> None:
+        # GIVEN a file stored in synapse
+        assert file.id is not None
+        assert file.name is not None
+        assert file.content_type == "text/plain"
+
+        # WHEN I change the files metadata
+        new_filename = f"my_new_file_name_{str(uuid.uuid4())}.txt"
+        await file.change_metadata(download_as=new_filename, content_type="text/json")
+
+        # AND I change the name of the file entity
+        file.name = new_filename
+        await file.store()
+
+        # THEN I expect the file download name and entity name to have been updated
+        assert file.file_handle.file_name == new_filename
+        assert file.name == new_filename
+        assert file.content_type == "text/json"
+        file_copy = await File(id=file.id, download_file=False).get()
+        assert file_copy.file_handle.file_name == new_filename
+        assert file_copy.name == new_filename
+        assert file_copy.content_type == "text/json"
+
+
+class TestFrom:
+    """Tests for the synapseclient.models.File.from_id and
+    synapseclient.models.File.from_path method."""
+
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    @pytest.fixture(autouse=True, scope="function")
+    def file(
+        self, schedule_for_cleanup: Callable[..., None], project_model: Project
+    ) -> File:
+        filename = utils.make_bogus_data_file(1)
+        schedule_for_cleanup(filename)
+        file = asyncio.run(
+            File(
+                path=filename,
+                description="This is an example file.",
+                content_type="text/plain",
+                version_comment="My version comment",
+                version_label=str(uuid.uuid4()),
+                parent_id=project_model.id,
+            ).store()
+        )
+        schedule_for_cleanup(file.id)
+        return file
+
+    @pytest.mark.asyncio
+    async def test_from_id(self, file: File) -> None:
+        # GIVEN a file stored in synapse
+        assert file.id is not None
+
+        # WHEN I get the file by id
+        file_copy = await File.from_id(file.id)
+
+        # THEN I expect the file to be returned
+        assert file_copy == file
+
+    @pytest.mark.asyncio
+    async def test_from_path(self, file: File) -> None:
+        # GIVEN a file stored in synapse
+        assert file.id is not None
+        assert file.path is not None
+
+        # WHEN I get the file by path
+        file_copy = await File.from_path(file.path)
+
+        # THEN I expect the file to be returned
+        assert file_copy == file
+
+
+class TestDelete:
+    """Tests for the synapseclient.models.File.delete method."""
+
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    @pytest.fixture(autouse=True, scope="function")
+    def file(
+        self, schedule_for_cleanup: Callable[..., None], project_model: Project
+    ) -> File:
+        filename = utils.make_bogus_data_file(1)
+        schedule_for_cleanup(filename)
+        file = asyncio.run(
+            File(
+                path=filename,
+                description="This is an example file.",
+                content_type="text/plain",
+                version_comment="My version comment",
+                version_label=str(uuid.uuid4()),
+                parent_id=project_model.id,
+            ).store()
+        )
+        schedule_for_cleanup(file.id)
+        return file
+
+    @pytest.mark.asyncio
+    async def test_delete(self, file: File) -> None:
+        # GIVEN a file stored in synapse
+        assert file.id is not None
+
+        # WHEN I delete the file
+        await file.delete()
+
+        # THEN I expect the file to be deleted
+        with pytest.raises(SynapseHTTPError) as e:
+            await file.get()
+        assert str(e.value) == f"404 Client Error: \nEntity {file.id} is in trash can."
+
+
+class TestGet:
+    """Tests for the synapseclient.models.File.get method."""
+
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    @pytest.fixture(autouse=True, scope="function")
+    def file(
+        self, schedule_for_cleanup: Callable[..., None], project_model: Project
+    ) -> File:
+        filename = utils.make_bogus_data_file(1)
+        schedule_for_cleanup(filename)
+        file = asyncio.run(
+            File(
+                path=filename,
+                description="This is an example file.",
+                content_type="text/plain",
+                version_comment="My version comment",
+                version_label=str(uuid.uuid4()),
+                parent_id=project_model.id,
+            ).store()
+        )
+        schedule_for_cleanup(file.id)
+        return file
+
+    @pytest.mark.asyncio
+    async def test_get_by_path(self, file: File) -> None:
+        # GIVEN a file stored in synapse
+        assert file.id is not None
+        assert file.path is not None
+
+        # WHEN I get the file by path
+        file_copy = await File(path=file.path).get()
+
+        # THEN I expect the file to be returned
+        assert file_copy == file
+
+    @pytest.mark.asyncio
+    async def test_get_by_id(self, file: File) -> None:
+        # GIVEN a file stored in synapse
+        assert file.id is not None
+
+        # WHEN I get the file by id
+        file_copy = await File(id=file.id).get()
+
+        # THEN I expect the file to be returned
+        assert file_copy == file
+
+    @pytest.mark.asyncio
+    async def test_get_previous_version(self, file: File) -> None:
+        # GIVEN a file stored in synapse
+        assert file.id is not None
+        assert file.version_number == 1
+
+        # WHEN I update the file
+        await file.store()
+
+        # AND I get the file by version
+        file_copy = await File(id=file.id, version_number=1).get()
+
+        # THEN I expect the file to be returned
+        assert file_copy.id == file.id
+        assert file_copy.version_number == 1
+
+    @pytest.mark.asyncio
+    async def test_get_keep_both_for_matching_filenames(self, file: File) -> None:
+        # GIVEN a file stored in synapse
+        assert file.id is not None
+        assert file.path is not None
+        assert file.name is not None
+
+        # AND I store a second file in another location
+        filename = utils.make_bogus_data_file(1)
+        folder = Folder(parent_id=file.parent_id, name=str(uuid.uuid4()))
+        await folder.store()
+        file_2 = await File(
+            path=filename,
+            name=file.name,
+            description="This is an example file.",
+            content_type="text/plain",
+            version_comment="My version comment",
+            version_label=str(uuid.uuid4()),
+            parent_id=folder.id,
+        ).store()
+        self.schedule_for_cleanup(file_2.id)
+
+        # AND I change the download name of the second file to the first file
+        await file_2.change_metadata(download_as=file.name)
+
+        # WHEN I get the file with the default collision of `keep.both`
+        file_2 = await File(id=file_2.id, download_location="/tmp").get()
+
+        # THEN I expect both files to exist
+        assert file.path != file_2.path
+        assert os.path.exists(file.path)
+        assert os.path.exists(file_2.path)
+
+        base_name, extension = os.path.splitext(os.path.basename(file.path))
+        expected_path_2 = os.path.join(
+            os.path.dirname(file.path), f"{base_name}(1){extension}"
+        )
+
+        # AND the second file to have a different path
+        assert file_2.path == expected_path_2
+
+    @pytest.mark.asyncio
+    async def test_get_overwrite_local_for_matching_filenames(self, file: File) -> None:
+        # GIVEN a file stored in synapse
+        assert file.id is not None
+        assert file.path is not None
+        assert file.name is not None
+        file_1_md5 = utils.md5_for_file(file.path).hexdigest()
+
+        # AND I store a second file in another location
+        filename = utils.make_bogus_data_file(1)
+        file_2_md5 = utils.md5_for_file(filename).hexdigest()
+        folder = Folder(parent_id=file.parent_id, name=str(uuid.uuid4()))
+        await folder.store()
+        file_2 = await File(
+            path=filename,
+            name=file.name,
+            description="This is an example file.",
+            content_type="text/plain",
+            version_comment="My version comment",
+            version_label=str(uuid.uuid4()),
+            parent_id=folder.id,
+        ).store()
+        self.schedule_for_cleanup(file_2.id)
+
+        # AND I change the download name of the second file to the first file
+        await file_2.change_metadata(download_as=file.name)
+
+        # WHEN I get the file with the default collision of `keep.both`
+        file_2 = await File(
+            id=file_2.id, download_location="/tmp", if_collision="overwrite.local"
+        ).get()
+
+        # THEN I expect only the newer file to exist
+        assert os.path.exists(file_2.path)
+        assert file_1_md5 != file_2_md5
+        assert utils.md5_for_file(file_2.path).hexdigest() == file_2_md5
+
+    @pytest.mark.asyncio
+    async def test_get_keep_local_for_matching_filenames(self, file: File) -> None:
+        # GIVEN a file stored in synapse
+        assert file.id is not None
+        assert file.path is not None
+        assert file.name is not None
+        file_1_md5 = utils.md5_for_file(file.path).hexdigest()
+
+        # AND I store a second file in another location
+        filename = utils.make_bogus_data_file(1)
+        file_2_md5 = utils.md5_for_file(filename).hexdigest()
+        folder = Folder(parent_id=file.parent_id, name=str(uuid.uuid4()))
+        await folder.store()
+        file_2 = await File(
+            path=filename,
+            name=file.name,
+            description="This is an example file.",
+            content_type="text/plain",
+            version_comment="My version comment",
+            version_label=str(uuid.uuid4()),
+            parent_id=folder.id,
+        ).store()
+        self.schedule_for_cleanup(file_2.id)
+
+        # AND I change the download name of the second file to the first file
+        await file_2.change_metadata(download_as=file.name)
+
+        # WHEN I get the file with the default collision of `keep.both`
+        file_2 = await File(
+            id=file_2.id, download_location="/tmp", if_collision="keep.local"
+        ).get()
+
+        # THEN I expect only the newer file to exist
+        assert file_2.path is None
+        assert os.path.exists(file.path)
+        assert file_1_md5 != file_2_md5
+        assert utils.md5_for_file(file.path).hexdigest() == file_1_md5
+
+    @pytest.mark.asyncio
+    async def test_get_by_path_limit_search(self, file: File) -> None:
+        # GIVEN a file stored in synapse
+        assert file.id is not None
+        assert file.path is not None
+
+        # AND I store a copy of the file in a folder
+        folder = Folder(parent_id=file.parent_id, name=str(uuid.uuid4()))
+        await folder.store()
+        self.schedule_for_cleanup(folder.id)
+        file_copy = await file.copy(destination_id=folder.id)
+
+        # WHEN I get the file by path and limit the search to the folder
+        file_by_path = await File(
+            path=file.path, synapse_container_limit=folder.id, download_file=False
+        ).get()
+
+        # THEN I expect the file in the folder to be returned
+        assert file_by_path.id == file_copy.id
+
+        # WHEN I get the file by path and limit the search to the project
+        file_by_path = await File(
+            path=file.path, synapse_container_limit=file.parent_id, download_file=False
+        ).get()
+
+        # THEN I expect the file at the project level to be returned
+        assert file.id == file_by_path.id
+
+
+class TestCopy:
+    """Tests for the synapseclient.models.File.copy method."""
+
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    @pytest.fixture(autouse=True, scope="function")
+    def file(
+        self, schedule_for_cleanup: Callable[..., None], project_model: Project
+    ) -> File:
+        filename = utils.make_bogus_data_file(1)
+        schedule_for_cleanup(filename)
+        file = asyncio.run(
+            File(
+                path=filename,
+                description="This is an example file.",
+                content_type="text/plain",
+                version_comment="My version comment",
+                version_label=str(uuid.uuid4()),
+                parent_id=project_model.id,
+            ).store()
+        )
+        schedule_for_cleanup(file.id)
+        return file
+
+    @pytest.mark.asyncio
+    async def test_copy_same_path(self, file: File) -> None:
+        # GIVEN a file stored in synapse
+        assert file.id is not None
+        assert file.path is not None
+
+        # AND I store a copy of the file in a folder
+        folder = Folder(parent_id=file.parent_id, name=str(uuid.uuid4()))
+        await folder.store()
+        self.schedule_for_cleanup(folder.id)
+        file_copy = await file.copy(destination_id=folder.id)
+
+        # WHEN I get both files by ID:
+        file_1 = await File(id=file.id, download_file=False).get()
+        file_2 = await File(id=file_copy.id, download_file=False).get()
+
+        # THEN I expect the paths to be the same file
+        assert file_1.path == file_2.path
+
+    @pytest.mark.asyncio
+    async def test_copy_annotations_and_activity(self, file: File) -> None:
+        # GIVEN a file stored in synapse
+        assert file.id is not None
+        assert file.path is not None
+
+        # AND I store activites and annotations on the file
+        activity = Activity(
+            name="some_name",
+            description="some_description",
+            used=[
+                UsedURL(name="example", url="https://www.synapse.org/"),
+                UsedEntity(target_id="syn456", target_version_number=1),
+            ],
+            executed=[
+                UsedURL(name="example", url="https://www.synapse.org/"),
+                UsedEntity(target_id="syn789", target_version_number=1),
+            ],
+        )
+        annotations_for_my_file = {
+            "my_single_key_string": "a",
+            "my_key_string": ["b", "a", "c"],
+            "my_key_bool": [False, False, False],
+            "my_key_double": [1.2, 3.4, 5.6],
+            "my_key_long": [1, 2, 3],
+        }
+        file.activity = activity
+        file.annotations = annotations_for_my_file
+        await file.store()
+
+        # AND I store a copy of the file in a folder
+        folder = Folder(parent_id=file.parent_id, name=str(uuid.uuid4()))
+        await folder.store()
+        self.schedule_for_cleanup(folder.id)
+        file_copy = await file.copy(destination_id=folder.id)
+
+        # WHEN I get both files by ID:
+        file_1 = await File(id=file.id, download_file=False).get()
+        file_2 = await File(id=file_copy.id, download_file=False).get()
+
+        # THEN I expect the activities and annotations to be the same
+        assert file_1.annotations == file_2.annotations
+        assert file_1.activity == file_2.activity
+
+    @pytest.mark.asyncio
+    async def test_copy_activity_only(self, file: File) -> None:
+        # GIVEN a file stored in synapse
+        assert file.id is not None
+        assert file.path is not None
+
+        # AND I store activites and annotations on the file
+        activity = Activity(
+            name="some_name",
+            description="some_description",
+            used=[
+                UsedURL(name="example", url="https://www.synapse.org/"),
+                UsedEntity(target_id="syn456", target_version_number=1),
+            ],
+            executed=[
+                UsedURL(name="example", url="https://www.synapse.org/"),
+                UsedEntity(target_id="syn789", target_version_number=1),
+            ],
+        )
+        annotations_for_my_file = {
+            "my_single_key_string": "a",
+            "my_key_string": ["b", "a", "c"],
+            "my_key_bool": [False, False, False],
+            "my_key_double": [1.2, 3.4, 5.6],
+            "my_key_long": [1, 2, 3],
+        }
+        file.activity = activity
+        file.annotations = annotations_for_my_file
+        await file.store()
+
+        # AND I store a copy of the file in a folder
+        folder = Folder(parent_id=file.parent_id, name=str(uuid.uuid4()))
+        await folder.store()
+        self.schedule_for_cleanup(folder.id)
+        file_copy = await file.copy(destination_id=folder.id, copy_annotations=False)
+
+        # WHEN I get both files by ID:
+        file_1 = await File(id=file.id, download_file=False).get()
+        file_2 = await File(id=file_copy.id, download_file=False).get()
+
+        # THEN I expect the activities to be the same and annotations on the second to be None
+        assert file_1.annotations != file_2.annotations
+        assert file_2.annotations is None
+        assert file_1.activity == file_2.activity
+
+    @pytest.mark.asyncio
+    async def test_copy_with_no_activity_or_annotations(self, file: File) -> None:
+        # GIVEN a file stored in synapse
+        assert file.id is not None
+        assert file.path is not None
+
+        # AND I store activites and annotations on the file
+        activity = Activity(
+            name="some_name",
+            description="some_description",
+            used=[
+                UsedURL(name="example", url="https://www.synapse.org/"),
+                UsedEntity(target_id="syn456", target_version_number=1),
+            ],
+            executed=[
+                UsedURL(name="example", url="https://www.synapse.org/"),
+                UsedEntity(target_id="syn789", target_version_number=1),
+            ],
+        )
+        annotations_for_my_file = {
+            "my_single_key_string": "a",
+            "my_key_string": ["b", "a", "c"],
+            "my_key_bool": [False, False, False],
+            "my_key_double": [1.2, 3.4, 5.6],
+            "my_key_long": [1, 2, 3],
+        }
+        file.activity = activity
+        file.annotations = annotations_for_my_file
+        await file.store()
+
+        # AND I store a copy of the file in a folder
+        folder = Folder(parent_id=file.parent_id, name=str(uuid.uuid4()))
+        await folder.store()
+        self.schedule_for_cleanup(folder.id)
+        file_copy = await file.copy(
+            destination_id=folder.id, copy_annotations=False, copy_activity=None
+        )
+
+        # WHEN I get both files by ID:
+        file_1 = await File(id=file.id, download_file=False).get(include_activity=True)
+        file_2 = await File(id=file_copy.id, download_file=False).get(
+            include_activity=True
+        )
+
+        # THEN I expect the activities to be the same and annotations on the second to be None
+        assert file_1.annotations != file_2.annotations
+        assert file_1.activity != file_2.activity
+        assert file_2.annotations is None
+        assert file_2.activity is None

--- a/tests/unit/synapseclient/models/unit_test_file.py
+++ b/tests/unit/synapseclient/models/unit_test_file.py
@@ -1,0 +1,830 @@
+from unittest.mock import patch
+import pytest
+from synapseclient.models import Activity, UsedURL, File, Project
+from synapseclient import File as Synapse_File
+
+
+class TestFile:
+    @pytest.fixture(autouse=True, scope="function")
+    def init_syn(self, syn):
+        self.syn = syn
+
+    def get_example_synapse_file_output(self) -> Synapse_File:
+        return Synapse_File(
+            id="syn123",
+            name="example_file",
+            path="~/example_file.txt",
+            description="This is an example file.",
+            etag="etag_value",
+            createdOn="createdOn_value",
+            modifiedOn="modifiedOn_value",
+            createdBy="createdBy_value",
+            modifiedBy="modifiedBy_value",
+            parentId="parent_id_value",
+            versionNumber=1,
+            versionLabel="v1",
+            versionComment="This is version 1.",
+            dataFileHandleId="dataFileHandleId_value",
+            _file_handle={
+                "id": "file_handle_id_value",
+                "etag": "file_handle_etag_value",
+                "createdBy": "file_handle_createdBy_value",
+                "createdOn": "file_handle_createdOn_value",
+                "modifiedOn": "file_handle_modifiedOn_value",
+                "concreteType": "file_handle_concreteType_value",
+                "contentType": "file_handle_contentType_value",
+                "contentMd5": "file_handle_contentMd5_value",
+                "fileName": "file_handle_fileName_value",
+                "storageLocationId": "file_handle_storageLocationId_value",
+                "contentSize": 123,
+                "status": "file_handle_status_value",
+                "bucketName": "file_handle_bucketName_value",
+                "key": "file_handle_key_value",
+                "previewId": "file_handle_previewId_value",
+                "isPreview": True,
+                "externalURL": "file_handle_externalURL_value",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_fill_from_dict(self) -> None:
+        # GIVEN an example Synapse File `get_example_synapse_file_output`
+        # WHEN I call `fill_from_dict` with the example Synapse File
+        file_output = File().fill_from_dict(self.get_example_synapse_file_output())
+
+        # THEN the File object should be filled with the example Synapse File
+        assert file_output.id == "syn123"
+        assert file_output.name == "example_file"
+        assert file_output.path == "~/example_file.txt"
+        assert file_output.description == "This is an example file."
+        assert file_output.etag == "etag_value"
+        assert file_output.created_on == "createdOn_value"
+        assert file_output.modified_on == "modifiedOn_value"
+        assert file_output.created_by == "createdBy_value"
+        assert file_output.modified_by == "modifiedBy_value"
+        assert file_output.parent_id == "parent_id_value"
+        assert file_output.version_number == 1
+        assert file_output.version_label == "v1"
+        assert file_output.version_comment == "This is version 1."
+        assert file_output.data_file_handle_id == "dataFileHandleId_value"
+        assert file_output.file_handle.id == "file_handle_id_value"
+        assert file_output.file_handle.etag == "file_handle_etag_value"
+        assert file_output.file_handle.created_by == "file_handle_createdBy_value"
+        assert file_output.file_handle.created_on == "file_handle_createdOn_value"
+        assert file_output.file_handle.modified_on == "file_handle_modifiedOn_value"
+        assert file_output.file_handle.concrete_type == "file_handle_concreteType_value"
+        assert file_output.file_handle.content_type == "file_handle_contentType_value"
+        assert file_output.file_handle.content_md5 == "file_handle_contentMd5_value"
+        assert file_output.file_handle.file_name == "file_handle_fileName_value"
+        assert (
+            file_output.file_handle.storage_location_id
+            == "file_handle_storageLocationId_value"
+        )
+        assert file_output.file_handle.content_size == 123
+        assert file_output.file_handle.status == "file_handle_status_value"
+        assert file_output.file_handle.bucket_name == "file_handle_bucketName_value"
+        assert file_output.file_handle.key == "file_handle_key_value"
+        assert file_output.file_handle.preview_id == "file_handle_previewId_value"
+        assert file_output.file_handle.is_preview
+        assert file_output.file_handle.external_url == "file_handle_externalURL_value"
+
+    @pytest.mark.asyncio
+    async def test_store_with_id_and_path(self) -> None:
+        # GIVEN an example file
+        file = File(id="syn123", path="~/example_file.txt")
+
+        # WHEN I store the example file
+        with patch.object(
+            self.syn,
+            "store",
+            return_value=(self.get_example_synapse_file_output()),
+        ) as mocked_client_call:
+            result = await file.store()
+
+            # THEN we should call the method with this data
+            mocked_client_call.assert_called_once_with(
+                obj=Synapse_File(id="syn123", path="~/example_file.txt"),
+                createOrUpdate=file.create_or_update,
+                forceVersion=file.force_version,
+                isRestricted=file.is_restricted,
+                set_annotations=False,
+            )
+
+            # THEN the file should be stored
+            assert result.id == "syn123"
+            assert result.name == "example_file"
+            assert result.path == "~/example_file.txt"
+            assert result.description == "This is an example file."
+            assert result.etag == "etag_value"
+            assert result.created_on == "createdOn_value"
+            assert result.modified_on == "modifiedOn_value"
+            assert result.created_by == "createdBy_value"
+            assert result.modified_by == "modifiedBy_value"
+            assert result.parent_id == "parent_id_value"
+            assert result.version_number == 1
+            assert result.version_label == "v1"
+            assert result.version_comment == "This is version 1."
+            assert result.data_file_handle_id == "dataFileHandleId_value"
+            assert result.file_handle.id == "file_handle_id_value"
+            assert result.file_handle.etag == "file_handle_etag_value"
+            assert result.file_handle.created_by == "file_handle_createdBy_value"
+            assert result.file_handle.created_on == "file_handle_createdOn_value"
+            assert result.file_handle.modified_on == "file_handle_modifiedOn_value"
+            assert result.file_handle.concrete_type == "file_handle_concreteType_value"
+            assert result.file_handle.content_type == "file_handle_contentType_value"
+            assert result.file_handle.content_md5 == "file_handle_contentMd5_value"
+            assert result.file_handle.file_name == "file_handle_fileName_value"
+            assert (
+                result.file_handle.storage_location_id
+                == "file_handle_storageLocationId_value"
+            )
+            assert result.file_handle.content_size == 123
+            assert result.file_handle.status == "file_handle_status_value"
+            assert result.file_handle.bucket_name == "file_handle_bucketName_value"
+            assert result.file_handle.key == "file_handle_key_value"
+            assert result.file_handle.preview_id == "file_handle_previewId_value"
+            assert result.file_handle.is_preview
+            assert result.file_handle.external_url == "file_handle_externalURL_value"
+
+    @pytest.mark.asyncio
+    async def test_store_with_id_and_file_handle(self) -> None:
+        # GIVEN an example file
+        file = File(id="syn123", data_file_handle_id="dataFileHandleId_value")
+
+        # WHEN I store the example file
+        with patch.object(
+            self.syn,
+            "store",
+            return_value=(self.get_example_synapse_file_output()),
+        ) as mocked_client_call:
+            result = await file.store()
+
+            # THEN we should call the method with this data
+            mocked_client_call.assert_called_once_with(
+                obj=Synapse_File(
+                    id="syn123", dataFileHandleId="dataFileHandleId_value"
+                ),
+                createOrUpdate=file.create_or_update,
+                forceVersion=file.force_version,
+                isRestricted=file.is_restricted,
+                set_annotations=False,
+            )
+
+            # THEN the file should be stored
+            assert result.id == "syn123"
+            assert result.name == "example_file"
+            assert result.path == "~/example_file.txt"
+            assert result.description == "This is an example file."
+            assert result.etag == "etag_value"
+            assert result.created_on == "createdOn_value"
+            assert result.modified_on == "modifiedOn_value"
+            assert result.created_by == "createdBy_value"
+            assert result.modified_by == "modifiedBy_value"
+            assert result.parent_id == "parent_id_value"
+            assert result.version_number == 1
+            assert result.version_label == "v1"
+            assert result.version_comment == "This is version 1."
+            assert result.data_file_handle_id == "dataFileHandleId_value"
+            assert result.file_handle.id == "file_handle_id_value"
+            assert result.file_handle.etag == "file_handle_etag_value"
+            assert result.file_handle.created_by == "file_handle_createdBy_value"
+            assert result.file_handle.created_on == "file_handle_createdOn_value"
+            assert result.file_handle.modified_on == "file_handle_modifiedOn_value"
+            assert result.file_handle.concrete_type == "file_handle_concreteType_value"
+            assert result.file_handle.content_type == "file_handle_contentType_value"
+            assert result.file_handle.content_md5 == "file_handle_contentMd5_value"
+            assert result.file_handle.file_name == "file_handle_fileName_value"
+            assert (
+                result.file_handle.storage_location_id
+                == "file_handle_storageLocationId_value"
+            )
+            assert result.file_handle.content_size == 123
+            assert result.file_handle.status == "file_handle_status_value"
+            assert result.file_handle.bucket_name == "file_handle_bucketName_value"
+            assert result.file_handle.key == "file_handle_key_value"
+            assert result.file_handle.preview_id == "file_handle_previewId_value"
+            assert result.file_handle.is_preview
+            assert result.file_handle.external_url == "file_handle_externalURL_value"
+
+    @pytest.mark.asyncio
+    async def test_store_with_parent_and_path(self) -> None:
+        # GIVEN an example file
+        file = File(path="~/example_file.txt")
+
+        # WHEN I store the example file
+        with patch.object(
+            self.syn,
+            "store",
+            return_value=(self.get_example_synapse_file_output()),
+        ) as mocked_client_call:
+            result = await file.store(parent=Project(id="syn999"))
+
+            # THEN we should call the method with this data
+            mocked_client_call.assert_called_once_with(
+                obj=Synapse_File(path="~/example_file.txt", parentId="syn999"),
+                createOrUpdate=file.create_or_update,
+                forceVersion=file.force_version,
+                isRestricted=file.is_restricted,
+                set_annotations=False,
+            )
+
+            # THEN the file should be stored
+            assert result.id == "syn123"
+            assert result.name == "example_file"
+            assert result.path == "~/example_file.txt"
+            assert result.description == "This is an example file."
+            assert result.etag == "etag_value"
+            assert result.created_on == "createdOn_value"
+            assert result.modified_on == "modifiedOn_value"
+            assert result.created_by == "createdBy_value"
+            assert result.modified_by == "modifiedBy_value"
+            assert result.parent_id == "parent_id_value"
+            assert result.version_number == 1
+            assert result.version_label == "v1"
+            assert result.version_comment == "This is version 1."
+            assert result.data_file_handle_id == "dataFileHandleId_value"
+            assert result.file_handle.id == "file_handle_id_value"
+            assert result.file_handle.etag == "file_handle_etag_value"
+            assert result.file_handle.created_by == "file_handle_createdBy_value"
+            assert result.file_handle.created_on == "file_handle_createdOn_value"
+            assert result.file_handle.modified_on == "file_handle_modifiedOn_value"
+            assert result.file_handle.concrete_type == "file_handle_concreteType_value"
+            assert result.file_handle.content_type == "file_handle_contentType_value"
+            assert result.file_handle.content_md5 == "file_handle_contentMd5_value"
+            assert result.file_handle.file_name == "file_handle_fileName_value"
+            assert (
+                result.file_handle.storage_location_id
+                == "file_handle_storageLocationId_value"
+            )
+            assert result.file_handle.content_size == 123
+            assert result.file_handle.status == "file_handle_status_value"
+            assert result.file_handle.bucket_name == "file_handle_bucketName_value"
+            assert result.file_handle.key == "file_handle_key_value"
+            assert result.file_handle.preview_id == "file_handle_previewId_value"
+            assert result.file_handle.is_preview
+            assert result.file_handle.external_url == "file_handle_externalURL_value"
+
+    @pytest.mark.asyncio
+    async def test_store_with_parent_id_and_path(self) -> None:
+        # GIVEN an example file
+        file = File(path="~/example_file.txt", parent_id="syn999")
+
+        # WHEN I store the example file
+        with patch.object(
+            self.syn,
+            "store",
+            return_value=(self.get_example_synapse_file_output()),
+        ) as mocked_client_call:
+            result = await file.store()
+
+            # THEN we should call the method with this data
+            mocked_client_call.assert_called_once_with(
+                obj=Synapse_File(path="~/example_file.txt", parentId="syn999"),
+                createOrUpdate=file.create_or_update,
+                forceVersion=file.force_version,
+                isRestricted=file.is_restricted,
+                set_annotations=False,
+            )
+
+            # THEN the file should be stored
+            assert result.id == "syn123"
+            assert result.name == "example_file"
+            assert result.path == "~/example_file.txt"
+            assert result.description == "This is an example file."
+            assert result.etag == "etag_value"
+            assert result.created_on == "createdOn_value"
+            assert result.modified_on == "modifiedOn_value"
+            assert result.created_by == "createdBy_value"
+            assert result.modified_by == "modifiedBy_value"
+            assert result.parent_id == "parent_id_value"
+            assert result.version_number == 1
+            assert result.version_label == "v1"
+            assert result.version_comment == "This is version 1."
+            assert result.data_file_handle_id == "dataFileHandleId_value"
+            assert result.file_handle.id == "file_handle_id_value"
+            assert result.file_handle.etag == "file_handle_etag_value"
+            assert result.file_handle.created_by == "file_handle_createdBy_value"
+            assert result.file_handle.created_on == "file_handle_createdOn_value"
+            assert result.file_handle.modified_on == "file_handle_modifiedOn_value"
+            assert result.file_handle.concrete_type == "file_handle_concreteType_value"
+            assert result.file_handle.content_type == "file_handle_contentType_value"
+            assert result.file_handle.content_md5 == "file_handle_contentMd5_value"
+            assert result.file_handle.file_name == "file_handle_fileName_value"
+            assert (
+                result.file_handle.storage_location_id
+                == "file_handle_storageLocationId_value"
+            )
+            assert result.file_handle.content_size == 123
+            assert result.file_handle.status == "file_handle_status_value"
+            assert result.file_handle.bucket_name == "file_handle_bucketName_value"
+            assert result.file_handle.key == "file_handle_key_value"
+            assert result.file_handle.preview_id == "file_handle_previewId_value"
+            assert result.file_handle.is_preview
+            assert result.file_handle.external_url == "file_handle_externalURL_value"
+
+    @pytest.mark.asyncio
+    async def test_store_with_components(self) -> None:
+        # GIVEN an example file
+        file = File(
+            path="~/example_file.txt",
+            parent_id="syn999",
+            annotations={"key": "value"},
+            activity=Activity(
+                name="My Activity",
+                executed=[
+                    UsedURL(name="Used URL", url="https://www.synapse.org/"),
+                ],
+            ),
+        )
+
+        # WHEN I store the example file
+        with patch.object(
+            self.syn,
+            "store",
+            return_value=(self.get_example_synapse_file_output()),
+        ) as mocked_client_call, patch(
+            "synapseclient.models.file.store_entity_components",
+            return_value=True,
+        ) as mocked_store_entity_components, patch.object(
+            file,
+            "get",
+        ) as mocked_get:
+            result = await file.store()
+
+            # THEN we should call the method with this data
+            mocked_client_call.assert_called_once_with(
+                obj=Synapse_File(path="~/example_file.txt", parentId="syn999"),
+                createOrUpdate=file.create_or_update,
+                forceVersion=file.force_version,
+                isRestricted=file.is_restricted,
+                set_annotations=False,
+            )
+
+            # AND we should store the components
+            mocked_store_entity_components.assert_called_once()
+
+            # AND we should get the file
+            mocked_get.assert_called_once()
+
+            # THEN the file should be stored
+            assert result.id == "syn123"
+            assert result.name == "example_file"
+            assert result.path == "~/example_file.txt"
+            assert result.description == "This is an example file."
+            assert result.etag == "etag_value"
+            assert result.created_on == "createdOn_value"
+            assert result.modified_on == "modifiedOn_value"
+            assert result.created_by == "createdBy_value"
+            assert result.modified_by == "modifiedBy_value"
+            assert result.parent_id == "parent_id_value"
+            assert result.version_number == 1
+            assert result.version_label == "v1"
+            assert result.version_comment == "This is version 1."
+            assert result.data_file_handle_id == "dataFileHandleId_value"
+            assert result.file_handle.id == "file_handle_id_value"
+            assert result.file_handle.etag == "file_handle_etag_value"
+            assert result.file_handle.created_by == "file_handle_createdBy_value"
+            assert result.file_handle.created_on == "file_handle_createdOn_value"
+            assert result.file_handle.modified_on == "file_handle_modifiedOn_value"
+            assert result.file_handle.concrete_type == "file_handle_concreteType_value"
+            assert result.file_handle.content_type == "file_handle_contentType_value"
+            assert result.file_handle.content_md5 == "file_handle_contentMd5_value"
+            assert result.file_handle.file_name == "file_handle_fileName_value"
+            assert (
+                result.file_handle.storage_location_id
+                == "file_handle_storageLocationId_value"
+            )
+            assert result.file_handle.content_size == 123
+            assert result.file_handle.status == "file_handle_status_value"
+            assert result.file_handle.bucket_name == "file_handle_bucketName_value"
+            assert result.file_handle.key == "file_handle_key_value"
+            assert result.file_handle.preview_id == "file_handle_previewId_value"
+            assert result.file_handle.is_preview
+            assert result.file_handle.external_url == "file_handle_externalURL_value"
+
+    @pytest.mark.asyncio
+    async def test_store_id_with_no_path_or_file_handle(self) -> None:
+        # GIVEN an example file
+        file = File(id="syn123")
+
+        # WHEN I get the file
+        with pytest.raises(ValueError) as e:
+            await file.store()
+
+        # THEN we should get an error
+        assert (
+            str(e.value)
+            == "The file must have an (ID with a (path or `data_file_handle_id`)), or "
+            "a (path with a (`parent_id` or parent with an id)) to store."
+        )
+
+    @pytest.mark.asyncio
+    async def test_store_path_with_no_id(self) -> None:
+        # GIVEN an example file
+        file = File(path="~/example_file.txt")
+
+        # WHEN I get the file
+        with pytest.raises(ValueError) as e:
+            await file.store()
+
+        # THEN we should get an error
+        assert (
+            str(e.value)
+            == "The file must have an (ID with a (path or `data_file_handle_id`)), or "
+            "a (path with a (`parent_id` or parent with an id)) to store."
+        )
+
+    @pytest.mark.asyncio
+    async def test_store_id_with_parent_id(self) -> None:
+        # GIVEN an example file
+        file = File(id="syn123", parent_id="syn999")
+
+        # WHEN I get the file
+        with pytest.raises(ValueError) as e:
+            await file.store()
+
+        # THEN we should get an error
+        assert (
+            str(e.value)
+            == "The file must have an (ID with a (path or `data_file_handle_id`)), or "
+            "a (path with a (`parent_id` or parent with an id)) to store."
+        )
+
+    @pytest.mark.asyncio
+    async def test_store_id_with_parent(self) -> None:
+        # GIVEN an example file
+        file = File(id="syn123")
+
+        # WHEN I get the file
+        with pytest.raises(ValueError) as e:
+            await file.store(parent=Project(id="syn999"))
+
+        # THEN we should get an error
+        assert (
+            str(e.value)
+            == "The file must have an (ID with a (path or `data_file_handle_id`)), or "
+            "a (path with a (`parent_id` or parent with an id)) to store."
+        )
+
+    @pytest.mark.asyncio
+    async def test_change_file_metadata(self) -> None:
+        # GIVEN an example file
+        file = File(
+            id="syn123",
+        )
+
+        # WHEN I change the metadata on the example file
+        with patch(
+            "synapseclient.models.file.changeFileMetaData",
+            return_value=(self.get_example_synapse_file_output()),
+        ) as mocked_change_meta_data:
+            result = await file.change_metadata(
+                download_as="modified_file.txt", content_type="text/plain"
+            )
+
+            # THEN we should call the method with this data
+            mocked_change_meta_data.assert_called_once_with(
+                syn=self.syn,
+                entity="syn123",
+                downloadAs="modified_file.txt",
+                contentType="text/plain",
+                forceVersion=True,
+            )
+
+            # THEN the file should be updated with the mock return
+            assert result.id == "syn123"
+            assert result.name == "example_file"
+            assert result.path == "~/example_file.txt"
+            assert result.description == "This is an example file."
+            assert result.etag == "etag_value"
+            assert result.created_on == "createdOn_value"
+            assert result.modified_on == "modifiedOn_value"
+            assert result.created_by == "createdBy_value"
+            assert result.modified_by == "modifiedBy_value"
+            assert result.parent_id == "parent_id_value"
+            assert result.version_number == 1
+            assert result.version_label == "v1"
+            assert result.version_comment == "This is version 1."
+            assert result.data_file_handle_id == "dataFileHandleId_value"
+            assert result.file_handle.id == "file_handle_id_value"
+            assert result.file_handle.etag == "file_handle_etag_value"
+            assert result.file_handle.created_by == "file_handle_createdBy_value"
+            assert result.file_handle.created_on == "file_handle_createdOn_value"
+            assert result.file_handle.modified_on == "file_handle_modifiedOn_value"
+            assert result.file_handle.concrete_type == "file_handle_concreteType_value"
+            assert result.file_handle.content_type == "file_handle_contentType_value"
+            assert result.file_handle.content_md5 == "file_handle_contentMd5_value"
+            assert result.file_handle.file_name == "file_handle_fileName_value"
+            assert (
+                result.file_handle.storage_location_id
+                == "file_handle_storageLocationId_value"
+            )
+            assert result.file_handle.content_size == 123
+            assert result.file_handle.status == "file_handle_status_value"
+            assert result.file_handle.bucket_name == "file_handle_bucketName_value"
+            assert result.file_handle.key == "file_handle_key_value"
+            assert result.file_handle.preview_id == "file_handle_previewId_value"
+            assert result.file_handle.is_preview
+            assert result.file_handle.external_url == "file_handle_externalURL_value"
+
+    @pytest.mark.asyncio
+    async def test_change_file_metadata_missing_id(self) -> None:
+        # GIVEN an example file
+        file = File()
+
+        # WHEN I change the metadata on the example file
+        with pytest.raises(ValueError) as e:
+            await file.change_metadata()
+
+        # THEN we should get an error
+        assert str(e.value) == "The file must have an ID to change metadata."
+
+    @pytest.mark.asyncio
+    async def test_get_with_id(self) -> None:
+        # GIVEN an example file
+        file = File(
+            id="syn123",
+        )
+
+        # WHEN I get the example file
+        with patch.object(
+            self.syn,
+            "get",
+            return_value=(self.get_example_synapse_file_output()),
+        ) as mocked_client_call:
+            result = await file.get()
+
+            # THEN we should call the method with this data
+            mocked_client_call.assert_called_once_with(
+                entity="syn123",
+                version=None,
+                ifcollision=file.if_collision,
+                limitSearch=file.synapse_container_limit,
+                downloadFile=file.download_file,
+                downloadLocation=file.download_location,
+            )
+
+            # THEN the file should be stored
+            assert result.id == "syn123"
+            assert result.name == "example_file"
+            assert result.path == "~/example_file.txt"
+            assert result.description == "This is an example file."
+            assert result.etag == "etag_value"
+            assert result.created_on == "createdOn_value"
+            assert result.modified_on == "modifiedOn_value"
+            assert result.created_by == "createdBy_value"
+            assert result.modified_by == "modifiedBy_value"
+            assert result.parent_id == "parent_id_value"
+            assert result.version_number == 1
+            assert result.version_label == "v1"
+            assert result.version_comment == "This is version 1."
+            assert result.data_file_handle_id == "dataFileHandleId_value"
+            assert result.file_handle.id == "file_handle_id_value"
+            assert result.file_handle.etag == "file_handle_etag_value"
+            assert result.file_handle.created_by == "file_handle_createdBy_value"
+            assert result.file_handle.created_on == "file_handle_createdOn_value"
+            assert result.file_handle.modified_on == "file_handle_modifiedOn_value"
+            assert result.file_handle.concrete_type == "file_handle_concreteType_value"
+            assert result.file_handle.content_type == "file_handle_contentType_value"
+            assert result.file_handle.content_md5 == "file_handle_contentMd5_value"
+            assert result.file_handle.file_name == "file_handle_fileName_value"
+            assert (
+                result.file_handle.storage_location_id
+                == "file_handle_storageLocationId_value"
+            )
+            assert result.file_handle.content_size == 123
+            assert result.file_handle.status == "file_handle_status_value"
+            assert result.file_handle.bucket_name == "file_handle_bucketName_value"
+            assert result.file_handle.key == "file_handle_key_value"
+            assert result.file_handle.preview_id == "file_handle_previewId_value"
+            assert result.file_handle.is_preview
+            assert result.file_handle.external_url == "file_handle_externalURL_value"
+
+    @pytest.mark.asyncio
+    async def test_get_with_path(self) -> None:
+        # GIVEN an example file
+        file = File(
+            path="~/example_file.txt",
+        )
+
+        # WHEN I get the example file
+        with patch.object(
+            self.syn,
+            "get",
+            return_value=(self.get_example_synapse_file_output()),
+        ) as mocked_client_call:
+            result = await file.get()
+
+            # THEN we should call the method with this data
+            mocked_client_call.assert_called_once_with(
+                entity="~/example_file.txt",
+                version=None,
+                ifcollision=file.if_collision,
+                limitSearch=file.synapse_container_limit,
+                downloadFile=file.download_file,
+                downloadLocation=file.download_location,
+            )
+
+            # THEN the file should be stored
+            assert result.id == "syn123"
+            assert result.name == "example_file"
+            assert result.path == "~/example_file.txt"
+            assert result.description == "This is an example file."
+            assert result.etag == "etag_value"
+            assert result.created_on == "createdOn_value"
+            assert result.modified_on == "modifiedOn_value"
+            assert result.created_by == "createdBy_value"
+            assert result.modified_by == "modifiedBy_value"
+            assert result.parent_id == "parent_id_value"
+            assert result.version_number == 1
+            assert result.version_label == "v1"
+            assert result.version_comment == "This is version 1."
+            assert result.data_file_handle_id == "dataFileHandleId_value"
+            assert result.file_handle.id == "file_handle_id_value"
+            assert result.file_handle.etag == "file_handle_etag_value"
+            assert result.file_handle.created_by == "file_handle_createdBy_value"
+            assert result.file_handle.created_on == "file_handle_createdOn_value"
+            assert result.file_handle.modified_on == "file_handle_modifiedOn_value"
+            assert result.file_handle.concrete_type == "file_handle_concreteType_value"
+            assert result.file_handle.content_type == "file_handle_contentType_value"
+            assert result.file_handle.content_md5 == "file_handle_contentMd5_value"
+            assert result.file_handle.file_name == "file_handle_fileName_value"
+            assert (
+                result.file_handle.storage_location_id
+                == "file_handle_storageLocationId_value"
+            )
+            assert result.file_handle.content_size == 123
+            assert result.file_handle.status == "file_handle_status_value"
+            assert result.file_handle.bucket_name == "file_handle_bucketName_value"
+            assert result.file_handle.key == "file_handle_key_value"
+            assert result.file_handle.preview_id == "file_handle_previewId_value"
+            assert result.file_handle.is_preview
+            assert result.file_handle.external_url == "file_handle_externalURL_value"
+
+    @pytest.mark.asyncio
+    async def test_from_path(self) -> None:
+        # GIVEN an example path
+        path = "~/example_file.txt"
+
+        # AND a default File
+        default_file = File()
+
+        # WHEN I get the example file
+        with patch.object(
+            self.syn,
+            "get",
+            return_value=(self.get_example_synapse_file_output()),
+        ) as mocked_client_call:
+            result = await File.from_path(path=path)
+
+            # THEN we should call the method with this data
+            mocked_client_call.assert_called_once_with(
+                entity="~/example_file.txt",
+                version=None,
+                ifcollision=default_file.if_collision,
+                limitSearch=default_file.synapse_container_limit,
+                downloadFile=default_file.download_file,
+                downloadLocation=default_file.download_location,
+            )
+
+            # THEN the file should be stored
+            assert result.id == "syn123"
+            assert result.name == "example_file"
+            assert result.path == "~/example_file.txt"
+            assert result.description == "This is an example file."
+            assert result.etag == "etag_value"
+            assert result.created_on == "createdOn_value"
+            assert result.modified_on == "modifiedOn_value"
+            assert result.created_by == "createdBy_value"
+            assert result.modified_by == "modifiedBy_value"
+            assert result.parent_id == "parent_id_value"
+            assert result.version_number == 1
+            assert result.version_label == "v1"
+            assert result.version_comment == "This is version 1."
+            assert result.data_file_handle_id == "dataFileHandleId_value"
+            assert result.file_handle.id == "file_handle_id_value"
+            assert result.file_handle.etag == "file_handle_etag_value"
+            assert result.file_handle.created_by == "file_handle_createdBy_value"
+            assert result.file_handle.created_on == "file_handle_createdOn_value"
+            assert result.file_handle.modified_on == "file_handle_modifiedOn_value"
+            assert result.file_handle.concrete_type == "file_handle_concreteType_value"
+            assert result.file_handle.content_type == "file_handle_contentType_value"
+            assert result.file_handle.content_md5 == "file_handle_contentMd5_value"
+            assert result.file_handle.file_name == "file_handle_fileName_value"
+            assert (
+                result.file_handle.storage_location_id
+                == "file_handle_storageLocationId_value"
+            )
+            assert result.file_handle.content_size == 123
+            assert result.file_handle.status == "file_handle_status_value"
+            assert result.file_handle.bucket_name == "file_handle_bucketName_value"
+            assert result.file_handle.key == "file_handle_key_value"
+            assert result.file_handle.preview_id == "file_handle_previewId_value"
+            assert result.file_handle.is_preview
+            assert result.file_handle.external_url == "file_handle_externalURL_value"
+
+    @pytest.mark.asyncio
+    async def test_from_id(self) -> None:
+        # GIVEN an example id
+        synapse_id = "syn123"
+
+        # AND a default File
+        default_file = File()
+
+        # WHEN I get the example file
+        with patch.object(
+            self.syn,
+            "get",
+            return_value=(self.get_example_synapse_file_output()),
+        ) as mocked_client_call:
+            result = await File.from_id(synapse_id=synapse_id)
+
+            # THEN we should call the method with this data
+            mocked_client_call.assert_called_once_with(
+                entity="syn123",
+                version=None,
+                ifcollision=default_file.if_collision,
+                limitSearch=default_file.synapse_container_limit,
+                downloadFile=default_file.download_file,
+                downloadLocation=default_file.download_location,
+            )
+
+            # THEN the file should be stored
+            assert result.id == "syn123"
+            assert result.name == "example_file"
+            assert result.path == "~/example_file.txt"
+            assert result.description == "This is an example file."
+            assert result.etag == "etag_value"
+            assert result.created_on == "createdOn_value"
+            assert result.modified_on == "modifiedOn_value"
+            assert result.created_by == "createdBy_value"
+            assert result.modified_by == "modifiedBy_value"
+            assert result.parent_id == "parent_id_value"
+            assert result.version_number == 1
+            assert result.version_label == "v1"
+            assert result.version_comment == "This is version 1."
+            assert result.data_file_handle_id == "dataFileHandleId_value"
+            assert result.file_handle.id == "file_handle_id_value"
+            assert result.file_handle.etag == "file_handle_etag_value"
+            assert result.file_handle.created_by == "file_handle_createdBy_value"
+            assert result.file_handle.created_on == "file_handle_createdOn_value"
+            assert result.file_handle.modified_on == "file_handle_modifiedOn_value"
+            assert result.file_handle.concrete_type == "file_handle_concreteType_value"
+            assert result.file_handle.content_type == "file_handle_contentType_value"
+            assert result.file_handle.content_md5 == "file_handle_contentMd5_value"
+            assert result.file_handle.file_name == "file_handle_fileName_value"
+            assert (
+                result.file_handle.storage_location_id
+                == "file_handle_storageLocationId_value"
+            )
+            assert result.file_handle.content_size == 123
+            assert result.file_handle.status == "file_handle_status_value"
+            assert result.file_handle.bucket_name == "file_handle_bucketName_value"
+            assert result.file_handle.key == "file_handle_key_value"
+            assert result.file_handle.preview_id == "file_handle_previewId_value"
+            assert result.file_handle.is_preview
+            assert result.file_handle.external_url == "file_handle_externalURL_value"
+
+    @pytest.mark.asyncio
+    async def test_get_missing_id_and_path(self) -> None:
+        # GIVEN an example file
+        file = File()
+
+        # WHEN I get the file
+        with pytest.raises(ValueError) as e:
+            await file.get()
+
+        # THEN we should get an error
+        assert str(e.value) == "The file must have an ID or path to get."
+
+    @pytest.mark.asyncio
+    async def test_delete(self) -> None:
+        # GIVEN an example file
+        file = File(
+            id="syn123",
+        )
+
+        # WHEN I get the example file
+        with patch.object(
+            self.syn,
+            "delete",
+            return_value=(None),
+        ) as mocked_client_call:
+            await file.delete()
+
+            # THEN we should call the method with this data
+            mocked_client_call.assert_called_once_with(
+                obj="syn123",
+            )
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_id(self) -> None:
+        # GIVEN an example file
+        file = File()
+
+        # WHEN I get the file
+        with pytest.raises(ValueError) as e:
+            await file.delete()
+
+        # THEN we should get an error
+        assert str(e.value) == "The file must have an ID to delete."


### PR DESCRIPTION
**Problem:**

1. File model was not complete
2. A file could not be stored in Synapse unless you specified the Parent ID, even if the ID of the file was known

**Solution:**

1. Adding in the various flags for get and store that modify how they function
3. Adding in a copy function
4. Adding in a change_metadata function
5. Adding in guard conditions in several areas
6. Updating the order in which we are concurrently saving Annotations and Activities to reflect the issue noted in https://sagebionetworks.jira.com/browse/PLFM-8251
7. Updating the File script
8. Adding in logic to the client.py to allow storing a file if storing with the ID of the file

**Testing:**

1. Unit/integration testing
2. File script provided