### PR TITLE
[SYNPY-1253] Check MD5 before upload to verify change in content

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1632,7 +1632,8 @@ class Synapse(object):
 
                     # Check if we got an MD5 checksum from Synapse and compare it to the local file
                     if (
-                        os.path.isfile(entity["path"])
+                        (entity["synapseStore"] or local_state.get("synapseStore"))
+                        and os.path.isfile(entity["path"])
                         and needs_upload
                         and (
                             md5_stored_in_synapse := local_state.get(

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1636,9 +1636,12 @@ class Synapse(object):
                         and os.path.isfile(entity["path"])
                         and needs_upload
                         and (
-                            md5_stored_in_synapse := local_state.get(
-                                "_file_handle", {}
-                            ).get("contentMd5", None)
+                            md5_stored_in_synapse := (
+                                local_state.get("_file_handle", {}).get(
+                                    "contentMd5", None
+                                )
+                                or (fileHandle or {}).get("contentMd5", None)
+                            )
                         )
                     ):
                         local_file_md5_hex = utils.md5_for_file(

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1631,10 +1631,14 @@ class Synapse(object):
                     )
 
                     # Check if we got an MD5 checksum from Synapse and compare it to the local file
-                    if needs_upload and (
-                        md5_stored_in_synapse := local_state.get(
-                            "_file_handle", {}
-                        ).get("contentMd5", None)
+                    if (
+                        os.path.isfile(entity["path"])
+                        and needs_upload
+                        and (
+                            md5_stored_in_synapse := local_state.get(
+                                "_file_handle", {}
+                            ).get("contentMd5", None)
+                        )
                     ):
                         local_file_md5_hex = utils.md5_for_file(
                             entity["path"]

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1593,6 +1593,7 @@ class Synapse(object):
         # Anything with a path is treated as a cache-able item
         # Only Files are expected in the following logic
         if entity.get("path", False) and not isinstance(obj, Folder):
+            local_file_md5_hex = None
             if "concreteType" not in properties:
                 properties["concreteType"] = File._synapse_entity_type
             # Make sure the path is fully resolved
@@ -1628,6 +1629,18 @@ class Synapse(object):
                     ] or not self.cache.contains(
                         bundle["entity"]["dataFileHandleId"], entity["path"]
                     )
+
+                    # Check if we got an MD5 checksum from Synapse and compare it to the local file
+                    if needs_upload and (
+                        md5_stored_in_synapse := local_state.get(
+                            "_file_handle", {}
+                        ).get("contentMd5", None)
+                    ):
+                        local_file_md5_hex = utils.md5_for_file(
+                            entity["path"]
+                        ).hexdigest()
+                        if md5_stored_in_synapse == local_file_md5_hex:
+                            needs_upload = False
             elif entity.get("dataFileHandleId", None) is not None:
                 needs_upload = False
             else:
@@ -1657,7 +1670,7 @@ class Synapse(object):
                     if (synapseStore or local_state_fh.get("externalURL") is None)
                     else local_state_fh.get("externalURL"),
                     synapseStore=synapseStore,
-                    md5=local_state_fh.get("contentMd5"),
+                    md5=local_file_md5_hex or local_state_fh.get("contentMd5"),
                     file_size=local_state_fh.get("contentSize"),
                     mimetype=local_state_fh.get("contentType"),
                     max_threads=self.max_threads,
@@ -3365,6 +3378,7 @@ class Synapse(object):
         file_path: str,
         storage_location_id: int,
         mimetype: str = None,
+        md5: str = None,
     ) -> Dict[str, Union[str, int]]:
         """
         Create a new FileHandle representing an external object.
@@ -3374,17 +3388,18 @@ class Synapse(object):
             file_path:           The local path of the uploaded file
             storage_location_id: The optional storage location descriptor
             mimetype:            The Mimetype of the file, if known.
+            md5:                 The file's content MD5, if known.
 
         Returns:
             A FileHandle for objects that are stored externally.
         """
         if mimetype is None:
-            mimetype, enc = mimetypes.guess_type(file_path, strict=False)
+            mimetype, _ = mimetypes.guess_type(file_path, strict=False)
         file_handle = {
             "concreteType": concrete_types.EXTERNAL_OBJECT_STORE_FILE_HANDLE,
             "fileKey": s3_file_key,
             "fileName": os.path.basename(file_path),
-            "contentMd5": utils.md5_for_file(file_path).hexdigest(),
+            "contentMd5": md5 or utils.md5_for_file(file_path).hexdigest(),
             "contentSize": os.stat(file_path).st_size,
             "storageLocationId": storage_location_id,
             "contentType": mimetype,
@@ -3404,6 +3419,7 @@ class Synapse(object):
         parent=None,
         storage_location_id=None,
         mimetype=None,
+        md5: str = None,
     ):
         """
         Create an external S3 file handle for e.g. a file that has been uploaded directly to
@@ -3419,6 +3435,7 @@ class Synapse(object):
             storage_location_id: Explicit storage location id to create the file handle in, mutually exclusive
                     with parent
             mimetype: Mimetype of the file, if known
+            md5: MD5 of the file, if known
 
         Raises:
             ValueError: If neither parent nor storage_location_id is specified, or if both are specified.
@@ -3434,14 +3451,14 @@ class Synapse(object):
             storage_location_id = upload_destination["storageLocationId"]
 
         if mimetype is None:
-            mimetype, enc = mimetypes.guess_type(file_path, strict=False)
+            mimetype, _ = mimetypes.guess_type(file_path, strict=False)
 
         file_handle = {
             "concreteType": concrete_types.S3_FILE_HANDLE,
             "key": s3_file_key,
             "bucketName": bucket_name,
             "fileName": os.path.basename(file_path),
-            "contentMd5": utils.md5_for_file(file_path).hexdigest(),
+            "contentMd5": md5 or utils.md5_for_file(file_path).hexdigest(),
             "contentSize": os.stat(file_path).st_size,
             "storageLocationId": storage_location_id,
             "contentType": mimetype,

--- a/synapseclient/core/cache.py
+++ b/synapseclient/core/cache.py
@@ -322,9 +322,9 @@ class Cache:
             # None if there are no unmodified files
             for cached_file_path, cache_map_entry in sorted(
                 cache_map.items(),
-                key=lambda item: item[1]["modified_time"]
-                if isinstance(item[1], dict)
-                else item[1],
+                key=lambda item: (
+                    item[1]["modified_time"] if isinstance(item[1], dict) else item[1]
+                ),
                 reverse=True,
             ):
                 if self._cache_item_unmodified(cache_map_entry, cached_file_path):
@@ -335,7 +335,10 @@ class Cache:
             return None
 
     def add(
-        self, file_handle_id: typing.Union[collections.abc.Mapping, str], path: str
+        self,
+        file_handle_id: typing.Union[collections.abc.Mapping, str],
+        path: str,
+        md5: str = None,
     ) -> dict:
         """
         Add a file to the cache
@@ -353,7 +356,7 @@ class Cache:
                 "modified_time": epoch_time_to_iso(
                     math.floor(_get_modified_time(path))
                 ),
-                "content_md5": utils.md5_for_file(path).hexdigest(),
+                "content_md5": md5 or utils.md5_for_file(path).hexdigest(),
             }
             self._write_cache_map(cache_dir, cache_map)
 

--- a/synapseclient/core/upload/multipart_upload.py
+++ b/synapseclient/core/upload/multipart_upload.py
@@ -445,6 +445,7 @@ def multipart_upload_file(
     preview: bool = True,
     force_restart: bool = False,
     max_threads: int = None,
+    md5: str = None,
 ) -> str:
     """Upload a file to a Synapse upload destination in chunks.
 
@@ -461,6 +462,7 @@ def multipart_upload_file(
                        from scratch, False to try to resume
         max_threads: number of concurrent threads to devote
                      to upload
+        md5: The MD5 of the file. If not provided, it will be calculated.
 
     Returns:
         a File Handle ID
@@ -471,9 +473,9 @@ def multipart_upload_file(
     """
     trace.get_current_span().set_attributes(
         {
-            "synapse.storage_location_id": storage_location_id
-            if storage_location_id is not None
-            else ""
+            "synapse.storage_location_id": (
+                storage_location_id if storage_location_id is not None else ""
+            )
         }
     )
 
@@ -491,7 +493,7 @@ def multipart_upload_file(
         content_type = mime_type or "application/octet-stream"
 
     callback_func = Spinner().print_tick if not syn.silent else None
-    md5_hex = md5_for_file(file_path, callback=callback_func).hexdigest()
+    md5_hex = md5 or md5_for_file(file_path, callback=callback_func).hexdigest()
 
     part_size = _get_part_size(part_size, file_size)
 

--- a/synapseclient/core/upload/upload_functions.py
+++ b/synapseclient/core/upload/upload_functions.py
@@ -71,14 +71,14 @@ def upload_file_handle(
     if path is None:
         raise ValueError("path can not be None")
 
-    if md5 is None:
-        md5 = utils.md5_for_file(path).hexdigest()
-
     # if doing a external file handle with no actual upload
     if not synapseStore:
         return create_external_file_handle(
             syn, path, mimetype=mimetype, md5=md5, file_size=file_size
         )
+
+    if md5 is None:
+        md5 = utils.md5_for_file(path).hexdigest()
 
     # expand the path because past this point an upload is required and some upload functions require an absolute path
     expanded_upload_path = os.path.expandvars(os.path.expanduser(path))

--- a/synapseclient/core/upload/upload_functions.py
+++ b/synapseclient/core/upload/upload_functions.py
@@ -1,7 +1,13 @@
+"""This module handles the various ways that a user can upload a file to Synapse."""
+
+# pylint: disable=protected-access
+import numbers
 import os
 import urllib.parse as urllib_parse
 import uuid
+import collections.abc
 
+from typing import TYPE_CHECKING, Dict, Union
 from synapseclient.core.utils import (
     is_url,
     md5_for_file,
@@ -15,12 +21,16 @@ from synapseclient.core.remote_file_storage_wrappers import S3ClientWrapper, SFT
 from synapseclient.core import sts_transfer
 from synapseclient.core.upload.multipart_upload import multipart_upload_file
 from synapseclient.core.exceptions import SynapseMd5MismatchError
+from synapseclient.core import utils
 from opentelemetry import trace
+
+if TYPE_CHECKING:
+    from synapseclient import Synapse
 
 tracer = trace.get_tracer("synapseclient")
 
 
-def log_upload_message(syn, message):
+def log_upload_message(syn: "Synapse", message: str) -> None:
     # if this upload is in the context of a larger, multi threaded sync upload as indicated by a cumulative progress
     # then we don't print the individual upload messages to the console since they wouldn't be properly interleaved.
     if not cumulative_transfer_progress.is_active():
@@ -29,14 +39,14 @@ def log_upload_message(syn, message):
 
 @tracer.start_as_current_span("upload_functions::upload_file_handle")
 def upload_file_handle(
-    syn,
-    parent_entity,
-    path,
-    synapseStore=True,
-    md5=None,
-    file_size=None,
-    mimetype=None,
-    max_threads=None,
+    syn: "Synapse",
+    parent_entity: Union[str, collections.abc.Mapping, numbers.Number],
+    path: str,
+    synapseStore: bool = True,
+    md5: str = None,
+    file_size: int = None,
+    mimetype: str = None,
+    max_threads: int = None,
 ):
     """
     Uploads the file in the provided path (if necessary) to a storage location based on project settings.
@@ -60,6 +70,9 @@ def upload_file_handle(
     """
     if path is None:
         raise ValueError("path can not be None")
+
+    if md5 is None:
+        md5 = utils.md5_for_file(path).hexdigest()
 
     # if doing a external file handle with no actual upload
     if not synapseStore:
@@ -99,11 +112,12 @@ def upload_file_handle(
         )
 
         return upload_synapse_sts_boto_s3(
-            syn,
-            entity_parent_id,
-            location,
-            expanded_upload_path,
+            syn=syn,
+            parent_id=entity_parent_id,
+            upload_destination=location,
+            local_path=expanded_upload_path,
             mimetype=mimetype,
+            md5=md5,
         )
 
     elif upload_destination_type in (
@@ -130,11 +144,12 @@ def upload_file_handle(
         )
 
         return upload_synapse_s3(
-            syn,
-            expanded_upload_path,
-            location["storageLocationId"],
+            syn=syn,
+            file_path=expanded_upload_path,
+            storageLocationId=location["storageLocationId"],
             mimetype=mimetype,
             max_threads=max_threads,
+            md5=md5,
         )
     # external file handle (sftp)
     elif upload_destination_type == concrete_types.EXTERNAL_UPLOAD_DESTINATION:
@@ -150,7 +165,11 @@ def upload_file_handle(
                 ),
             )
             return upload_external_file_handle_sftp(
-                syn, expanded_upload_path, location["url"], mimetype=mimetype
+                syn=syn,
+                file_path=expanded_upload_path,
+                sftp_url=location["url"],
+                mimetype=mimetype,
+                md5=md5,
             )
         else:
             raise NotImplementedError("Can only handle SFTP upload locations.")
@@ -171,13 +190,14 @@ def upload_file_handle(
             ),
         )
         return upload_client_auth_s3(
-            syn,
-            expanded_upload_path,
-            location["bucket"],
-            location["endpointUrl"],
-            location["keyPrefixUUID"],
-            location["storageLocationId"],
+            syn=syn,
+            file_path=expanded_upload_path,
+            bucket=location["bucket"],
+            endpoint_url=location["endpointUrl"],
+            key_prefix=location["keyPrefixUUID"],
+            storage_location_id=location["storageLocationId"],
             mimetype=mimetype,
+            md5=md5,
         )
     else:  # unknown storage location
         log_upload_message(
@@ -186,11 +206,22 @@ def upload_file_handle(
             % ("!" * 50, location.get("banner", ""), "!" * 50),
         )
         return upload_synapse_s3(
-            syn, expanded_upload_path, None, mimetype=mimetype, max_threads=max_threads
+            syn=syn,
+            file_path=expanded_upload_path,
+            storageLocationId=None,
+            mimetype=mimetype,
+            max_threads=max_threads,
+            md5=md5,
         )
 
 
-def create_external_file_handle(syn, path, mimetype=None, md5=None, file_size=None):
+def create_external_file_handle(
+    syn: "Synapse",
+    path: str,
+    mimetype: str = None,
+    md5: str = None,
+    file_size: int = None,
+) -> Dict[str, Union[str, int]]:
     is_local_file = False  # defaults to false
     url = as_url(os.path.expandvars(os.path.expanduser(path)))
     if is_url(url):
@@ -223,16 +254,18 @@ def create_external_file_handle(syn, path, mimetype=None, md5=None, file_size=No
     return file_handle
 
 
-def upload_external_file_handle_sftp(syn, file_path, sftp_url, mimetype=None):
-    username, password = syn._getUserCredentials(sftp_url)
+def upload_external_file_handle_sftp(
+    syn: "Synapse", file_path: str, sftp_url: str, mimetype: str = None, md5: str = None
+) -> Dict[str, Union[str, int]]:
+    username, password = syn._getUserCredentials(url=sftp_url)
     uploaded_url = SFTPWrapper.upload_file(
         file_path, urllib_parse.unquote(sftp_url), username, password
     )
 
     file_handle = syn._createExternalFileHandle(
-        uploaded_url,
+        externalURL=uploaded_url,
         mimetype=mimetype,
-        md5=md5_for_file(file_path).hexdigest(),
+        md5=md5 or md5_for_file(file_path).hexdigest(),
         fileSize=os.stat(file_path).st_size,
     )
     syn.cache.add(file_handle["id"], file_path)
@@ -240,22 +273,33 @@ def upload_external_file_handle_sftp(syn, file_path, sftp_url, mimetype=None):
 
 
 def upload_synapse_s3(
-    syn, file_path, storageLocationId=None, mimetype=None, max_threads=None
+    syn: "Synapse",
+    file_path: str,
+    storageLocationId=None,
+    mimetype: str = None,
+    max_threads: int = None,
+    md5: str = None,
 ):
     file_handle_id = multipart_upload_file(
-        syn,
-        file_path,
+        syn=syn,
+        file_path=file_path,
         content_type=mimetype,
         storage_location_id=storageLocationId,
         max_threads=max_threads,
+        md5=md5,
     )
-    syn.cache.add(file_handle_id, file_path)
+    syn.cache.add(file_handle_id=file_handle_id, path=file_path, md5=md5)
 
-    return syn._get_file_handle_as_creator(file_handle_id)
+    return syn._get_file_handle_as_creator(fileHandle=file_handle_id)
 
 
 def upload_synapse_sts_boto_s3(
-    syn, parent_id, upload_destination, local_path, mimetype=None
+    syn: "Synapse",
+    parent_id: str,
+    upload_destination,
+    local_path: str,
+    mimetype: str = None,
+    md5: str = None,
 ):
     """
     When uploading to Synapse storage normally the back end will generate a random prefix
@@ -266,11 +310,12 @@ def upload_synapse_sts_boto_s3(
     <https://aws.amazon.com/about-aws/whats-new/2018/07/amazon-s3-announces-increased-request-rate-performance/>
 
     Arguments:
-        syn: _description_
-        parent_id: _description_
-        upload_destination: _description_
-        local_path: _description_
-        mimetype: _description_. Defaults to None.
+        syn: The synapse client
+        parent_id: The synapse ID of the parent.
+        upload_destination: The upload destination
+        local_path: The local path to the file to upload.
+        mimetype: The mimetype is known. Defaults to None.
+        md5: MD5 checksum for the file, if known.
 
     Returns:
         _description_
@@ -285,27 +330,35 @@ def upload_synapse_sts_boto_s3(
 
     def upload_fn(credentials):
         return S3ClientWrapper.upload_file(
-            bucket_name,
-            None,
-            remote_file_key,
-            local_path,
+            bucket=bucket_name,
+            endpoint_url=None,
+            remote_file_key=remote_file_key,
+            upload_file_path=local_path,
             credentials=credentials,
             transfer_config_kwargs={"max_concurrency": syn.max_threads},
         )
 
     sts_transfer.with_boto_sts_credentials(upload_fn, syn, parent_id, "read_write")
     return syn.create_external_s3_file_handle(
-        bucket_name,
-        remote_file_key,
-        local_path,
+        bucket_name=bucket_name,
+        s3_file_key=remote_file_key,
+        file_path=local_path,
         storage_location_id=storage_location_id,
         mimetype=mimetype,
+        md5=md5,
     )
 
 
 def upload_client_auth_s3(
-    syn, file_path, bucket, endpoint_url, key_prefix, storage_location_id, mimetype=None
-):
+    syn: "Synapse",
+    file_path: str,
+    bucket: str,
+    endpoint_url: str,
+    key_prefix: str,
+    storage_location_id: int,
+    mimetype: str = None,
+    md5: str = None,
+) -> Dict[str, Union[str, int]]:
     profile = syn._get_client_authenticated_s3_profile(endpoint_url, bucket)
     file_key = key_prefix + "/" + os.path.basename(file_path)
 
@@ -314,7 +367,11 @@ def upload_client_auth_s3(
     )
 
     file_handle = syn._createExternalObjectStoreFileHandle(
-        file_key, file_path, storage_location_id, mimetype=mimetype
+        s3_file_key=file_key,
+        file_path=file_path,
+        storage_location_id=storage_location_id,
+        mimetype=mimetype,
+        md5=md5,
     )
     syn.cache.add(file_handle["id"], file_path)
 

--- a/synapseclient/core/upload/upload_functions.py
+++ b/synapseclient/core/upload/upload_functions.py
@@ -77,11 +77,11 @@ def upload_file_handle(
             syn, path, mimetype=mimetype, md5=md5, file_size=file_size
         )
 
-    if md5 is None:
-        md5 = utils.md5_for_file(path).hexdigest()
-
     # expand the path because past this point an upload is required and some upload functions require an absolute path
     expanded_upload_path = os.path.expandvars(os.path.expanduser(path))
+
+    if md5 is None and os.path.isfile(expanded_upload_path):
+        md5 = utils.md5_for_file(expanded_upload_path).hexdigest()
 
     entity_parent_id = id_of(parent_entity)
 

--- a/tests/integration/synapseclient/integration_test_Entity.py
+++ b/tests/integration/synapseclient/integration_test_Entity.py
@@ -515,6 +515,12 @@ def test_ExternalFileHandle(syn: Synapse, project: Project):
         == "org.sagebionetworks.repo.model.file.ExternalFileHandle"
     )
     assert fileHandle["externalURL"] == singapore_url
+    file_handle = singapore["_file_handle"]
+    assert file_handle["contentMd5"] is None
+    assert (
+        file_handle["concreteType"]
+        == "org.sagebionetworks.repo.model.file.ExternalFileHandle"
+    )
 
     # The download should occur only on the client side
     singapore = syn.get(singapore, downloadFile=True)
@@ -551,6 +557,12 @@ def test_synapseStore_flag(syn: Synapse, project: Project, schedule_for_cleanup)
     assert bogus.name == file_name
     assert bogus.path == path, "Path: %s\nExpected: %s" % (bogus.path, path)
     assert not bogus.synapseStore
+    file_handle = bogus["_file_handle"]
+    assert file_handle["contentMd5"] is not None
+    assert (
+        file_handle["concreteType"]
+        == "org.sagebionetworks.repo.model.file.ExternalFileHandle"
+    )
 
     # Make sure the test runs on Windows and other OS's
     if path[0].isalpha() and path[1] == ":":
@@ -570,6 +582,13 @@ def test_synapseStore_flag(syn: Synapse, project: Project, schedule_for_cleanup)
     pytest.raises(IOError, syn.get, bogus)
     assert not bogus.synapseStore
 
+    file_handle = bogus["_file_handle"]
+    assert file_handle["contentMd5"] is None
+    assert (
+        file_handle["concreteType"]
+        == "org.sagebionetworks.repo.model.file.ExternalFileHandle"
+    )
+
     # Try a URL
     bogus = File(
         "http://dev-versions.synapse.sagebase.org/synapsePythonClient",
@@ -579,6 +598,13 @@ def test_synapseStore_flag(syn: Synapse, project: Project, schedule_for_cleanup)
     bogus = syn.store(bogus)
     bogus = syn.get(bogus)
     assert not bogus.synapseStore
+
+    file_handle = bogus["_file_handle"]
+    assert file_handle["contentMd5"] is None
+    assert (
+        file_handle["concreteType"]
+        == "org.sagebionetworks.repo.model.file.ExternalFileHandle"
+    )
 
 
 @tracer.start_as_current_span("integration_test_Entity::test_create_or_update_project")

--- a/tests/unit/synapseclient/core/upload/unit_test_upload_functions.py
+++ b/tests/unit/synapseclient/core/upload/unit_test_upload_functions.py
@@ -27,7 +27,9 @@ class TestUploadFileHandle:
         location = {"concreteType": concrete_types.EXTERNAL_S3_UPLOAD_DESTINATION}
         syn._getDefaultUploadDestination.return_value = location
 
-        upload_functions.upload_file_handle(syn, parent_entity, path)
+        upload_functions.upload_file_handle(
+            syn=syn, parent_entity=parent_entity, path=path, md5="fake_md5"
+        )
 
         mock_sts_transfer.is_boto_sts_transfer_enabled.assert_called_once_with(syn)
         mock_sts_transfer.is_storage_location_sts_enabled.assert_called_once_with(
@@ -35,7 +37,12 @@ class TestUploadFileHandle:
         )
         syn._getDefaultUploadDestination.assert_called_once_with(parent_entity)
         mock_upload_synapse_sts_boto_s3.assert_called_once_with(
-            syn, parent_entity, location, path, mimetype=None
+            syn=syn,
+            parent_id=parent_entity,
+            upload_destination=location,
+            local_path=path,
+            mimetype=None,
+            md5="fake_md5",
         )
 
 
@@ -75,17 +82,19 @@ def test_upload_synapse_sts_boto_s3(
     mock_sts_transfer.with_boto_sts_credentials = mock_with_boto_sts_credentials
 
     returned_file_handle = upload_functions.upload_synapse_sts_boto_s3(
-        syn,
-        parent_id,
-        upload_destination,
-        local_path,
+        syn=syn,
+        parent_id=parent_id,
+        upload_destination=upload_destination,
+        local_path=local_path,
+        md5="fake_md5",
     )
     assert returned_file_handle == syn.create_external_s3_file_handle.return_value
     remote_file_key = "/".join([base_key, key_prefix, os.path.basename(local_path)])
     syn.create_external_s3_file_handle.assert_called_once_with(
-        bucket_name,
-        remote_file_key,
-        local_path,
+        bucket_name=bucket_name,
+        s3_file_key=remote_file_key,
+        file_path=local_path,
         storage_location_id=storage_location_id,
         mimetype=None,
+        md5="fake_md5",
     )

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -953,24 +953,30 @@ class TestPrivateUploadExternallyStoringProjects:
             self.syn, "_get_file_handle_as_creator"
         ) as mocked_getFileHandle:
             upload_functions.upload_file_handle(
-                self.syn,
-                test_file["parentId"],
-                test_file["path"],
+                syn=self.syn,
+                parent_entity=test_file["parentId"],
+                path=test_file["path"],
                 max_threads=max_threads,
+                md5="fake_md5",
             )
 
             mock_upload_destination.assert_called_once_with(test_file["parentId"])
             mocked_multipart_upload.assert_called_once_with(
-                self.syn,
-                expected_path_expanded,
+                syn=self.syn,
+                file_path=expected_path_expanded,
                 content_type=None,
                 storage_location_id=expected_storage_location_id,
                 max_threads=max_threads,
+                md5="fake_md5",
             )
             mocked_cache_add.assert_called_once_with(
-                expected_file_handle_id, expected_path_expanded
+                file_handle_id=expected_file_handle_id,
+                path=expected_path_expanded,
+                md5="fake_md5",
             )
-            mocked_getFileHandle.assert_called_once_with(expected_file_handle_id)
+            mocked_getFileHandle.assert_called_once_with(
+                fileHandle=expected_file_handle_id
+            )
             # test
 
 

--- a/tests/unit/synapseutils/unit_test_synapseutils_sync.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_sync.py
@@ -1033,7 +1033,7 @@ class TestSyncUploader:
                 uploader.upload(items)
 
             # it would be aborted with Futures
-            mock_abort.assert_called_once_with([ANY])
+            mock_abort.assert_called_once()
             isinstance(mock_abort.call_args_list[0][0], Future)
 
     @patch("os.path.isfile")

--- a/tests/unit/synapseutils/unit_test_synapseutils_sync.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_sync.py
@@ -1034,7 +1034,9 @@ class TestSyncUploader:
 
             # it would be aborted with Futures
             mock_abort.assert_called_once()
-            isinstance(mock_abort.call_args_list[0][0], Future)
+            assert isinstance(mock_abort.call_args_list[0][0], Future) or isinstance(
+                mock_abort.call_args_list[0][0][0][0], Future
+            )
 
     @patch("os.path.isfile")
     def test_upload(self, mock_os_isfile, syn):


### PR DESCRIPTION
**Problem:**

1. When there is a cache miss we never checked if the content of the file to be uploaded actually changed. As a result we would always upload the file to Synapse.


**Solution:**

1. If we need to upload a file to Synapse and the file already exists in Synapse and we got back an MD5 from Synapse compare the MD5 in Synapse to what the local file is - Is they are the same do not upload the file.

**Testing:**

1. Integration tests around this logic