### PR TITLE
[SYNPY-448] allow changing Synapse name in changeFileMetaData

### DIFF
--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -577,7 +577,8 @@ class File(AccessControllable):
             name: Specify filename to change the filename of a file.
             download_as: Specify filename to change the filename of a filehandle.
             content_type: Specify content type to change the content type of a filehandle.
-            synapse_client: If not passed in or None this will use the last client from the `.login()` method.
+            synapse_client: If not passed in or None this will use the last client from
+                the `.login()` method.
 
         Returns:
             The file object.
@@ -585,9 +586,11 @@ class File(AccessControllable):
         Example: Using this function
             Can be used to change the filename, the filename when the file is downloaded, or the file content-type without downloading:
 
-            file_entity = await File(id="syn123").get()
-            print(os.path.basename(file_entity.path))  ## prints, e.g., "my_file.txt"
-            file_entity = file_entity.change_metadata(name="my_new_name_file.txt", download_as="my_new_downloadAs_name_file.txt", content_type="text/plain")
+                file_entity = await File(id="syn123").get()
+                print(os.path.basename(file_entity.path))  ## prints, e.g., "my_file.txt"
+                file_entity = file_entity.change_metadata(name="my_new_name_file.txt", download_as="my_new_downloadAs_name_file.txt", content_type="text/plain")
+                print(os.path.basename(file_entity.path))  ## prints, "my_new_downloadAs_name_file.txt"
+                print(file_entity.name) ## prints, "my_new_name_file.txt"
 
         Raises:
             ValueError: If the file does not have an ID to change metadata.

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -567,6 +567,7 @@ class File(AccessControllable):
     )
     async def change_metadata(
         self,
+        name: Optional[str] = None,
         download_as: Optional[str] = None,
         content_type: Optional[str] = None,
         synapse_client: Optional[Synapse] = None,
@@ -576,6 +577,7 @@ class File(AccessControllable):
         through the store method.
 
         Arguments:
+            name: Specify filename to change the filename of a file.
             download_as: Specify filename to change the filename of a filehandle.
             content_type: Specify content type to change the content type of a filehandle.
             synapse_client: If not passed in or None this will use the last client from the `.login()` method.
@@ -584,11 +586,11 @@ class File(AccessControllable):
             The file object.
 
         Example: Using this function
-            Can be used to change the filename or the file content-type without downloading:
+            Can be used to change the filename, the filename when the file is downloaded, or the file content-type without downloading:
 
             file_entity = await File(id="syn123").get()
             print(os.path.basename(file_entity.path))  ## prints, e.g., "my_file.txt"
-            file_entity = file_entity.change_metadata(download_as="my_new_name_file.txt", content_type="text/plain")
+            file_entity = file_entity.change_metadata(name = "my_new_name_file.txt", download_as="my_new_downloadAs_name_file.txt", content_type="text/plain")
 
         Raises:
             ValueError: If the file does not have an ID to change metadata.
@@ -606,6 +608,7 @@ class File(AccessControllable):
                 lambda: changeFileMetaData(
                     syn=syn,
                     entity=self.id,
+                    name=name,
                     downloadAs=download_as,
                     contentType=content_type,
                     forceVersion=self.force_version,

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -486,16 +486,13 @@ class File(AccessControllable):
 
                 file_instance = await File(id="syn123", download_file=False).get()
                 print(file_instance.name)  ## prints, e.g., "my_file.txt"
-                file_instance.name = "my_new_name_file.txt"
-                await file_instance.store()
+                await file_instance.change_metadata(name="my_new_name_file.txt")
 
             Rename a file, and the name of the file as downloaded (Does not update the file on disk):
 
                 file_instance = await File(id="syn123", download_file=False).get()
                 print(file_instance.name)  ## prints, e.g., "my_file.txt"
-                file_instance.name = "my_new_name_file.txt"
-                await file_instance.store()
-                await file_instance.change_metadata(download_as="my_new_name_file.txt")
+                await file_instance.change_metadata(name="my_new_name_file.txt", download_as="my_new_name_file.txt")
 
         """
         if not (
@@ -590,7 +587,7 @@ class File(AccessControllable):
 
             file_entity = await File(id="syn123").get()
             print(os.path.basename(file_entity.path))  ## prints, e.g., "my_file.txt"
-            file_entity = file_entity.change_metadata(name = "my_new_name_file.txt", download_as="my_new_downloadAs_name_file.txt", content_type="text/plain")
+            file_entity = file_entity.change_metadata(name="my_new_name_file.txt", download_as="my_new_downloadAs_name_file.txt", content_type="text/plain")
 
         Raises:
             ValueError: If the file does not have an ID to change metadata.

--- a/synapseutils/copy_functions.py
+++ b/synapseutils/copy_functions.py
@@ -264,7 +264,7 @@ def changeFileMetaData(
 
             file_entity = syn.get(synid)
             print(os.path.basename(file_entity.path))  ## prints, e.g., "my_file.txt"
-            file_entity = synapseutils.changeFileMetaData(syn, file_entity, "my_new_name_file.txt", "my_new_downloadAs_name_file.txt")
+            file_entity = synapseutils.changeFileMetaData(syn=syn, entity=file_entity, downloadAs="my_new_downloadAs_name_file.txt", name="my_new_name_file.txt")
             print(os.path.basename(file_entity.path))  ## prints, "my_new_downloadAs_name_file.txt"
             print(file_entity.name) ## prints, "my_new_name_file.txt"
     """

--- a/synapseutils/copy_functions.py
+++ b/synapseutils/copy_functions.py
@@ -239,10 +239,10 @@ def _copy_cached_file_handles(cache: Cache, copiedFileHandles: dict) -> None:
 def changeFileMetaData(
     syn: synapseclient.Synapse,
     entity: typing.Union[str, Entity],
-    name: str = None,
     downloadAs: str = None,
     contentType: str = None,
     forceVersion: bool = True,
+    name: str = None,
 ) -> Entity:
     """
     Change File Entity metadata like the download as name.
@@ -250,11 +250,11 @@ def changeFileMetaData(
     Arguments:
         syn: A Synapse object with user's login, e.g. syn = synapseclient.login()
         entity: Synapse entity Id or object.
-        name: Specify filename to change the filename of the file.
         downloadAs: Specify filename to change the filename of a filehandle.
         contentType: Specify content type to change the content type of a filehandle.
         forceVersion: Indicates whether the method should increment the version of
                         the object even if nothing has changed. Defaults to True.
+        name: Specify filename to change the filename of the file.
 
     Returns:
         Synapse Entity
@@ -262,9 +262,11 @@ def changeFileMetaData(
     Example: Using this function
         Can be used to change the filename, the filename when the file is downloaded, or the file content-type without downloading:
 
-        file_entity = syn.get(synid)
-        print(os.path.basename(file_entity.path))  ## prints, e.g., "my_file.txt"
-        file_entity = synapseutils.changeFileMetaData(syn, file_entity, "my_new_name_file.txt", "my_new_downloadAs_name_file.txt")
+            file_entity = syn.get(synid)
+            print(os.path.basename(file_entity.path))  ## prints, e.g., "my_file.txt"
+            file_entity = synapseutils.changeFileMetaData(syn, file_entity, "my_new_name_file.txt", "my_new_downloadAs_name_file.txt")
+            print(os.path.basename(file_entity.path))  ## prints, "my_new_downloadAs_name_file.txt"
+            print(file_entity.name) ## prints, "my_new_name_file.txt"
     """
     ent = syn.get(entity, downloadFile=False)
     fileResult = syn._getFileHandleDownload(ent.dataFileHandleId, ent.id)

--- a/synapseutils/copy_functions.py
+++ b/synapseutils/copy_functions.py
@@ -239,6 +239,7 @@ def _copy_cached_file_handles(cache: Cache, copiedFileHandles: dict) -> None:
 def changeFileMetaData(
     syn: synapseclient.Synapse,
     entity: typing.Union[str, Entity],
+    name: str = None,
     downloadAs: str = None,
     contentType: str = None,
     forceVersion: bool = True,
@@ -249,8 +250,9 @@ def changeFileMetaData(
     Arguments:
         syn: A Synapse object with user's login, e.g. syn = synapseclient.login()
         entity: Synapse entity Id or object.
-        contentType: Specify content type to change the content type of a filehandle.
+        name: Specify filename to change the filename of the file.
         downloadAs: Specify filename to change the filename of a filehandle.
+        contentType: Specify content type to change the content type of a filehandle.
         forceVersion: Indicates whether the method should increment the version of
                         the object even if nothing has changed. Defaults to True.
 
@@ -258,11 +260,11 @@ def changeFileMetaData(
         Synapse Entity
 
     Example: Using this function
-        Can be used to change the filename or the file content-type without downloading:
+        Can be used to change the filename, the filename when the file is downloaded, or the file content-type without downloading:
 
         file_entity = syn.get(synid)
         print(os.path.basename(file_entity.path))  ## prints, e.g., "my_file.txt"
-        file_entity = synapseutils.changeFileMetaData(syn, file_entity, "my_new_name_file.txt")
+        file_entity = synapseutils.changeFileMetaData(syn, file_entity, "my_new_name_file.txt", "my_new_downloadAs_name_file.txt")
     """
     ent = syn.get(entity, downloadFile=False)
     fileResult = syn._getFileHandleDownload(ent.dataFileHandleId, ent.id)
@@ -285,6 +287,7 @@ def changeFileMetaData(
             % (copyResult["failureCode"], copyResult["originalFileHandleId"])
         )
     ent.dataFileHandleId = copyResult["newFileHandle"]["id"]
+    ent.name = ent.name if name is None else name
     ent = syn.store(ent, forceVersion=forceVersion)
     return ent
 

--- a/tests/unit/synapseclient/models/unit_test_file.py
+++ b/tests/unit/synapseclient/models/unit_test_file.py
@@ -479,13 +479,16 @@ class TestFile:
             return_value=(self.get_example_synapse_file_output()),
         ) as mocked_change_meta_data:
             result = await file.change_metadata(
-                download_as="modified_file.txt", content_type="text/plain"
+                name="modified_file.txt",
+                download_as="modified_file.txt",
+                content_type="text/plain",
             )
 
             # THEN we should call the method with this data
             mocked_change_meta_data.assert_called_once_with(
                 syn=self.syn,
                 entity="syn123",
+                name="modified_file.txt",
                 downloadAs="modified_file.txt",
                 contentType="text/plain",
                 forceVersion=True,


### PR DESCRIPTION
Problem:

Python client doesn't allow changing Synapse name for file metadata 

Solution:

Add a name argument to change_metadata in file.py and changeFileMetaData function in synapseutils

Testing:

Integration and unit testing are included in this PR