### PR TITLE
[SYNPY-1443] Correct which fields are merged if there is a change

### DIFF
--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -1355,19 +1355,20 @@ def merge_dataclass_entities(
     # Convert dataclasses to dictionaries
     destination_dict = asdict(destination)
     source_dict = asdict(source)
+    modified_items = {}
 
     # Update destination_dict with source_dict, keeping destination's values in case of conflicts
     for key, value in source_dict.items():
         if key not in destination_dict or destination_dict[key] is None:
-            destination_dict[key] = value
+            modified_items[key] = value
         elif key == "annotations":
-            destination_dict[key] = {
+            modified_items[key] = {
                 **(value or {}),
                 **destination_dict[key],
             }
 
     # Update destination's fields with the merged dictionary
-    for key, value in destination_dict.items():
+    for key, value in modified_items.items():
         setattr(destination, key, value)
     destination._last_persistent_instance = source._last_persistent_instance
     return destination

--- a/synapseclient/models/folder.py
+++ b/synapseclient/models/folder.py
@@ -60,6 +60,16 @@ class Folder(FolderSynchronousProtocol, AccessControllable, StorableContainer):
             values (use empty list to represent no values for key) and the value type
             associated with all values in the list.  To remove all annotations set this
             to an empty dict `{}`.
+        create_or_update: (Store only) Indicates whether the method should
+            automatically perform an update if the resource conflicts with an existing
+            Synapse object. When True this means that any changes to the resource will
+            be non-destructive.
+
+            This boolean is ignored if you've already stored or retrieved the resource
+            from Synapse for this instance at least once. Any changes to the resource
+            will be destructive in this case. For example if you want to delete the
+            content for a field you will need to call `.get()` and then modify the
+            field.
     """
 
     id: Optional[str] = None

--- a/synapseclient/models/project.py
+++ b/synapseclient/models/project.py
@@ -56,6 +56,18 @@ class Project(ProjectSynchronousProtocol, AccessControllable, StorableContainer)
             values (use empty list to represent no values for key) and the value type
             associated with all values in the list.  To remove all annotations set this
             to an empty dict `{}`.
+        create_or_update: (Store only) Indicates whether the method should
+            automatically perform an update if the resource conflicts with an existing
+            Synapse object. When True this means that any changes to the resource will
+            be non-destructive.
+
+            This boolean is ignored if you've already stored or retrieved the resource
+            from Synapse for this instance at least once. Any changes to the resource
+            will be destructive in this case. For example if you want to delete the
+            content for a field you will need to call `.get()` and then modify the
+            field.
+        parent_id: The parent ID of the project. In practice projects do not have a
+            parent, but this is required for the inner workings of Synapse.
 
     Example: Creating a project
         This example shows how to create a project

--- a/tests/integration/synapseclient/models/async/test_project_async.py
+++ b/tests/integration/synapseclient/models/async/test_project_async.py
@@ -96,6 +96,51 @@ class TestProjectStore:
         assert file.path is not None
 
     @pytest.mark.asyncio
+    async def test_store_project_with_folder_in_file_on_project_that_already_exists(
+        self, file: File, project: Project
+    ) -> None:
+        # GIVEN that the project is already stored in Synapse
+        project_copy = await Project(name=project.name).store_async()
+        assert project_copy.id is not None
+
+        # AND a Folder under the project instance that didn't interact with Synapse
+        folder = Folder(name=str(uuid.uuid4()))
+        project.folders.append(folder)
+
+        # AND a File on the folder
+        folder.files.append(file)
+
+        # WHEN I store the Project on Synapse
+        stored_project = await project.store_async()
+        self.schedule_for_cleanup(project.id)
+
+        # THEN I expect the stored Project to have the expected properties
+        assert stored_project.id is not None
+        assert stored_project.name is not None
+        assert stored_project.parent_id is not None
+        assert stored_project.description is not None
+        assert stored_project.etag is not None
+        assert stored_project.created_on is not None
+        assert stored_project.modified_on is not None
+        assert stored_project.created_by is not None
+        assert stored_project.modified_by is not None
+        assert len(stored_project.folders) == 1
+        assert stored_project.files == []
+        assert stored_project.folders == [folder]
+        assert stored_project.annotations is None
+
+        # AND I expect the Folder to be stored in Synapse
+        assert folder.id is not None
+        assert folder.name is not None
+        assert folder.parent_id == stored_project.id
+
+        # AND I expect the File to be stored on Synapse
+        assert file.id is not None
+        assert file.name is not None
+        assert file.parent_id == folder.id
+        assert file.path is not None
+
+    @pytest.mark.asyncio
     async def test_store_project_with_multiple_files(self, project: Project) -> None:
         # GIVEN multiple files in a project
         files = []

--- a/tests/integration/synapseclient/models/synchronous/test_project.py
+++ b/tests/integration/synapseclient/models/synchronous/test_project.py
@@ -93,6 +93,50 @@ class TestProjectStore:
         assert file.parent_id == stored_project.id
         assert file.path is not None
 
+    def test_store_project_with_folder_in_file_on_project_that_already_exists(
+        self, file: File, project: Project
+    ) -> None:
+        # GIVEN that the project is already stored in Synapse
+        project_copy = Project(name=project.name).store()
+        assert project_copy.id is not None
+
+        # AND a Folder under the project instance that didn't interact with Synapse
+        folder = Folder(name=str(uuid.uuid4()))
+        project.folders.append(folder)
+
+        # AND a File on the folder
+        folder.files.append(file)
+
+        # WHEN I store the Project on Synapse
+        stored_project = project.store()
+        self.schedule_for_cleanup(project.id)
+
+        # THEN I expect the stored Project to have the expected properties
+        assert stored_project.id is not None
+        assert stored_project.name is not None
+        assert stored_project.parent_id is not None
+        assert stored_project.description is not None
+        assert stored_project.etag is not None
+        assert stored_project.created_on is not None
+        assert stored_project.modified_on is not None
+        assert stored_project.created_by is not None
+        assert stored_project.modified_by is not None
+        assert len(stored_project.folders) == 1
+        assert stored_project.files == []
+        assert stored_project.folders == [folder]
+        assert stored_project.annotations is None
+
+        # AND I expect the Folder to be stored in Synapse
+        assert folder.id is not None
+        assert folder.name is not None
+        assert folder.parent_id == stored_project.id
+
+        # AND I expect the File to be stored on Synapse
+        assert file.id is not None
+        assert file.name is not None
+        assert file.parent_id == folder.id
+        assert file.path is not None
+
     def test_store_project_with_multiple_files(self, project: Project) -> None:
         # GIVEN multiple files in a project
         files = []


### PR DESCRIPTION
**Problem:**

1. The usage of `asdict` was converting the folder/file dataclasses to a dict on the Project class - This pevented further code from calling methods on the Folder/File class.
```
  File "/home/bfauble/BryansGreatWorkspace/synapsePythonClient/synapseclient/models/project.py", line 308, in store_async
    await store_entity_components(
  File "/home/bfauble/BryansGreatWorkspace/synapsePythonClient/synapseclient/models/services/storable_entity_components.py", line 80, in store_entity_components
    folder.store_async(
AttributeError: 'dict' object has no attribute 'store_async'
```

**Solution:**

1. Only apply changes for modified items. We are not retrieving any dataclasses during the `get_async` calls [during this line](https://github.com/Sage-Bionetworks/synapsePythonClient/blob/SYNPY-1443-store-before-get-for-containers/synapseclient/models/project.py#L288) besides `self` - So we won't run into issues where a dataclass is getting replaced by a dict.
2. If we are to retrieve dataclasses during the `get_async` calls we'll need to make a small modification to this code to ensure the merge occurs in that dataclass (recursively) and is converted back into the correct class instance. I will take ownership of this problem when we need to cross that bridge.

**Testing:**

1. Verified the broken script works as expected:
```
import synapseclient
from synapseclient.models import Project, Folder, File

syn = synapseclient.login()
file_for_demo = "/home/bfauble/temp/my_file_with_random_data.txt"
my_project_name = "My Super Cool Project"


my_project = Project(name=my_project_name)

my_folder = Folder(name="my folder")

my_file = File(path=file_for_demo)

my_folder.files.append(my_file)

my_project.folders.append(my_folder)

my_project.store()
```

1. Integration test around this logic