### PR TITLE
[SYNPY-1419] Httpx async client

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
           path: |
             ${{ steps.get-dependencies.outputs.site_packages_loc }}
             ${{ steps.get-dependencies.outputs.site_bin_dir }}
-          key: ${{ runner.os }}-${{ matrix.python }}-build-${{ env.cache-name }}-${{ hashFiles('setup.py') }}-v10
+          key: ${{ runner.os }}-${{ matrix.python }}-build-${{ env.cache-name }}-${{ hashFiles('setup.py') }}-v11
 
       - name: Install py-dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true'

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "anyio": {
+            "hashes": [
+                "sha256:048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8",
+                "sha256:f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.3.0"
+        },
         "backoff": {
             "hashes": [
                 "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba",
@@ -136,6 +144,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.2.14"
         },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14",
+                "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.2.0"
+        },
         "googleapis-common-protos": {
             "hashes": [
                 "sha256:4750113612205514f9f6aa4cb00d523a94f3e8c06c5ad2fee466387dc4875f07",
@@ -143,6 +159,30 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==1.62.0"
+        },
+        "h11": {
+            "hashes": [
+                "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d",
+                "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.14.0"
+        },
+        "httpcore": {
+            "hashes": [
+                "sha256:ac418c1db41bade2ad53ae2f3834a3a0f5ae76b56cf5aa497d2d033384fc7d73",
+                "sha256:cb2839ccfcba0d2d3c1131d3c3e26dfc327326fbe7a5dc0dbfe9f6c9151bb022"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.0.4"
+        },
+        "httpx": {
+            "hashes": [
+                "sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5",
+                "sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.27.0"
         },
         "idna": {
             "hashes": [
@@ -241,6 +281,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.31.0"
         },
+        "sniffio": {
+            "hashes": [
+                "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2",
+                "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.1"
+        },
         "synapseclient": {
             "editable": true,
             "markers": "python_version >= '3.8'",
@@ -248,11 +296,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783",
-                "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"
+                "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
+                "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.9.0"
+            "version": "==4.10.0"
         },
         "urllib3": {
             "hashes": [
@@ -348,6 +396,22 @@
         }
     },
     "develop": {
+        "anyio": {
+            "hashes": [
+                "sha256:048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8",
+                "sha256:f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.3.0"
+        },
+        "astunparse": {
+            "hashes": [
+                "sha256:5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872",
+                "sha256:c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8"
+            ],
+            "markers": "python_version < '3.9'",
+            "version": "==1.6.3"
+        },
         "attrs": {
             "hashes": [
                 "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30",
@@ -434,18 +498,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:0d382baac02ba4ead82230f34ba377fbf5f6481321dca911e6664b752d79b682",
-                "sha256:eb5d84c2127ffddf8e7f4dd6f9084f86cb18dca8416fb5d6bea278298cf8d84c"
+                "sha256:300888f0c1b6f32f27f85a9aa876f50f46514ec619647af7e4d20db74d339714",
+                "sha256:b26928f9a21cf3649cea20a59061340f3294c6e7785ceb6e1a953eb8010dc3ba"
             ],
-            "version": "==1.34.46"
+            "version": "==1.34.56"
         },
         "botocore": {
             "hashes": [
-                "sha256:21a6c391c6b4869aed66bc888b8e6d54581b343514cfe97dbe71ede12026c3cc",
-                "sha256:f54330ba1e8ce31489a4e09b4ba8afbf84be01bbc48dbb31d44897fb7657f7ad"
+                "sha256:bffeb71ab21d47d4ecf947d9bdb2fbd1b0bbd0c27742cea7cf0b77b701c41d9f",
+                "sha256:fff66e22a5589c2d58fba57d1d95c334ce771895e831f80365f6cff6453285ec"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.46"
+            "version": "==1.34.56"
         },
         "certifi": {
             "hashes": [
@@ -638,99 +702,99 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:006d220ba2e1a45f1de083d5022d4955abb0aedd78904cd5a779b955b019ec73",
-                "sha256:06fe398145a2e91edaf1ab4eee66149c6776c6b25b136f4a86fcbbb09512fd10",
-                "sha256:175f56572f25e1e1201d2b3e07b71ca4d201bf0b9cb8fad3f1dfae6a4188de86",
-                "sha256:18cac867950943fe93d6cd56a67eb7dcd2d4a781a40f4c1e25d6f1ed98721a55",
-                "sha256:1a5ee18e3a8d766075ce9314ed1cb695414bae67df6a4b0805f5137d93d6f1cb",
-                "sha256:20a875bfd8c282985c4720c32aa05056f77a68e6d8bbc5fe8632c5860ee0b49b",
-                "sha256:2412e98e70f16243be41d20836abd5f3f32edef07cbf8f407f1b6e1ceae783ac",
-                "sha256:2599972b21911111114100d362aea9e70a88b258400672626efa2b9e2179609c",
-                "sha256:2ed37e16cf35c8d6e0b430254574b8edd242a367a1b1531bd1adc99c6a5e00fe",
-                "sha256:32b4ab7e6c924f945cbae5392832e93e4ceb81483fd6dc4aa8fb1a97b9d3e0e1",
-                "sha256:34423abbaad70fea9d0164add189eabaea679068ebdf693baa5c02d03e7db244",
-                "sha256:3507427d83fa961cbd73f11140f4a5ce84208d31756f7238d6257b2d3d868405",
-                "sha256:3733545eb294e5ad274abe131d1e7e7de4ba17a144505c12feca48803fea5f64",
-                "sha256:3ff5bdb08d8938d336ce4088ca1a1e4b6c8cd3bef8bb3a4c0eb2f37406e49643",
-                "sha256:3ff7f92ae5a456101ca8f48387fd3c56eb96353588e686286f50633a611afc95",
-                "sha256:42a9e754aa250fe61f0f99986399cec086d7e7a01dd82fd863a20af34cbce962",
-                "sha256:51593a1f05c39332f623d64d910445fdec3d2ac2d96b37ce7f331882d5678ddf",
-                "sha256:5b11f9c6587668e495cc7365f85c93bed34c3a81f9f08b0920b87a89acc13469",
-                "sha256:69f1665165ba2fe7614e2f0c1aed71e14d83510bf67e2ee13df467d1c08bf1e8",
-                "sha256:78cdcbf7b9cb83fe047ee09298e25b1cd1636824067166dc97ad0543b079d22f",
-                "sha256:7df95fdd1432a5d2675ce630fef5f239939e2b3610fe2f2b5bf21fa505256fa3",
-                "sha256:81a5fb41b0d24447a47543b749adc34d45a2cf77b48ca74e5bf3de60a7bd9edc",
-                "sha256:840456cb1067dc350af9080298c7c2cfdddcedc1cb1e0b30dceecdaf7be1a2d3",
-                "sha256:8562ca91e8c40864942615b1d0b12289d3e745e6b2da901d133f52f2d510a1e3",
-                "sha256:861d75402269ffda0b33af94694b8e0703563116b04c681b1832903fac8fd647",
-                "sha256:8b98c89db1b150d851a7840142d60d01d07677a18f0f46836e691c38134ed18b",
-                "sha256:a178b7b1ac0f1530bb28d2e51f88c0bab3e5949835851a60dda80bff6052510c",
-                "sha256:a8ddbd158e069dded57738ea69b9744525181e99974c899b39f75b2b29a624e2",
-                "sha256:ac4bab32f396b03ebecfcf2971668da9275b3bb5f81b3b6ba96622f4ef3f6e17",
-                "sha256:ac9e95cefcf044c98d4e2c829cd0669918585755dd9a92e28a1a7012322d0a95",
-                "sha256:adbdfcda2469d188d79771d5696dc54fab98a16d2ef7e0875013b5f56a251047",
-                "sha256:b3c8bbb95a699c80a167478478efe5e09ad31680931ec280bf2087905e3b95ec",
-                "sha256:b3f2b1eb229f23c82898eedfc3296137cf1f16bb145ceab3edfd17cbde273fb7",
-                "sha256:b4ae777bebaed89e3a7e80c4a03fac434a98a8abb5251b2a957d38fe3fd30088",
-                "sha256:b953275d4edfab6cc0ed7139fa773dfb89e81fee1569a932f6020ce7c6da0e8f",
-                "sha256:bf54c3e089179d9d23900e3efc86d46e4431188d9a657f345410eecdd0151f50",
-                "sha256:bf711d517e21fb5bc429f5c4308fbc430a8585ff2a43e88540264ae87871e36a",
-                "sha256:c00e54f0bd258ab25e7f731ca1d5144b0bf7bec0051abccd2bdcff65fa3262c9",
-                "sha256:c11ca2df2206a4e3e4c4567f52594637392ed05d7c7fb73b4ea1c658ba560265",
-                "sha256:c5f9683be6a5b19cd776ee4e2f2ffb411424819c69afab6b2db3a0a364ec6642",
-                "sha256:cf89ab85027427d351f1de918aff4b43f4eb5f33aff6835ed30322a86ac29c9e",
-                "sha256:d1b750a8409bec61caa7824bfd64a8074b6d2d420433f64c161a8335796c7c6b",
-                "sha256:d779a48fac416387dd5673fc5b2d6bd903ed903faaa3247dc1865c65eaa5a93e",
-                "sha256:d9a1ef0f173e1a19738f154fb3644f90d0ada56fe6c9b422f992b04266c55d5a",
-                "sha256:ddb79414c15c6f03f56cc68fa06994f047cf20207c31b5dad3f6bab54a0f66ef",
-                "sha256:ef00d31b7569ed3cb2036f26565f1984b9fc08541731ce01012b02a4c238bf03",
-                "sha256:f40ac873045db4fd98a6f40387d242bde2708a3f8167bd967ccd43ad46394ba2",
-                "sha256:f593a4a90118d99014517c2679e04a4ef5aee2d81aa05c26c734d271065efcb6",
-                "sha256:f5df76c58977bc35a49515b2fbba84a1d952ff0ec784a4070334dfbec28a2def",
-                "sha256:f72cdd2586f9a769570d4b5714a3837b3a59a53b096bb954f1811f6a0afad305",
-                "sha256:f8e845d894e39fb53834da826078f6dc1a933b32b1478cf437007367efaf6f6a",
-                "sha256:fe6e43c8b510719b48af7db9631b5fbac910ade4bd90e6378c85ac5ac706382c"
+                "sha256:0209a6369ccce576b43bb227dc8322d8ef9e323d089c6f3f26a597b09cb4d2aa",
+                "sha256:062b0a75d9261e2f9c6d071753f7eef0fc9caf3a2c82d36d76667ba7b6470003",
+                "sha256:0842571634f39016a6c03e9d4aba502be652a6e4455fadb73cd3a3a49173e38f",
+                "sha256:16bae383a9cc5abab9bb05c10a3e5a52e0a788325dc9ba8499e821885928968c",
+                "sha256:18c7320695c949de11a351742ee001849912fd57e62a706d83dfc1581897fa2e",
+                "sha256:18d90523ce7553dd0b7e23cbb28865db23cddfd683a38fb224115f7826de78d0",
+                "sha256:1bf25fbca0c8d121a3e92a2a0555c7e5bc981aee5c3fdaf4bb7809f410f696b9",
+                "sha256:276f6077a5c61447a48d133ed13e759c09e62aff0dc84274a68dc18660104d52",
+                "sha256:280459f0a03cecbe8800786cdc23067a8fc64c0bd51dc614008d9c36e1659d7e",
+                "sha256:28ca2098939eabab044ad68850aac8f8db6bf0b29bc7f2887d05889b17346454",
+                "sha256:2c854ce44e1ee31bda4e318af1dbcfc929026d12c5ed030095ad98197eeeaed0",
+                "sha256:35eb581efdacf7b7422af677b92170da4ef34500467381e805944a3201df2079",
+                "sha256:37389611ba54fd6d278fde86eb2c013c8e50232e38f5c68235d09d0a3f8aa352",
+                "sha256:3b253094dbe1b431d3a4ac2f053b6d7ede2664ac559705a704f621742e034f1f",
+                "sha256:3b2eccb883368f9e972e216c7b4c7c06cabda925b5f06dde0650281cb7666a30",
+                "sha256:451f433ad901b3bb00184d83fd83d135fb682d780b38af7944c9faeecb1e0bfe",
+                "sha256:489763b2d037b164846ebac0cbd368b8a4ca56385c4090807ff9fad817de4113",
+                "sha256:4af154d617c875b52651dd8dd17a31270c495082f3d55f6128e7629658d63765",
+                "sha256:506edb1dd49e13a2d4cac6a5173317b82a23c9d6e8df63efb4f0380de0fbccbc",
+                "sha256:6679060424faa9c11808598504c3ab472de4531c571ab2befa32f4971835788e",
+                "sha256:69b9f6f66c0af29642e73a520b6fed25ff9fd69a25975ebe6acb297234eda501",
+                "sha256:6c00cdc8fa4e50e1cc1f941a7f2e3e0f26cb2a1233c9696f26963ff58445bac7",
+                "sha256:6c0cdedd3500e0511eac1517bf560149764b7d8e65cb800d8bf1c63ebf39edd2",
+                "sha256:708a3369dcf055c00ddeeaa2b20f0dd1ce664eeabde6623e516c5228b753654f",
+                "sha256:718187eeb9849fc6cc23e0d9b092bc2348821c5e1a901c9f8975df0bc785bfd4",
+                "sha256:767b35c3a246bcb55b8044fd3a43b8cd553dd1f9f2c1eeb87a302b1f8daa0524",
+                "sha256:77fbfc5720cceac9c200054b9fab50cb2a7d79660609200ab83f5db96162d20c",
+                "sha256:7cbde573904625509a3f37b6fecea974e363460b556a627c60dc2f47e2fffa51",
+                "sha256:8249b1c7334be8f8c3abcaaa996e1e4927b0e5a23b65f5bf6cfe3180d8ca7840",
+                "sha256:8580b827d4746d47294c0e0b92854c85a92c2227927433998f0d3320ae8a71b6",
+                "sha256:8640f1fde5e1b8e3439fe482cdc2b0bb6c329f4bb161927c28d2e8879c6029ee",
+                "sha256:9a9babb9466fe1da12417a4aed923e90124a534736de6201794a3aea9d98484e",
+                "sha256:a78ed23b08e8ab524551f52953a8a05d61c3a760781762aac49f8de6eede8c45",
+                "sha256:abbbd8093c5229c72d4c2926afaee0e6e3140de69d5dcd918b2921f2f0c8baba",
+                "sha256:ae7f19afe0cce50039e2c782bff379c7e347cba335429678450b8fe81c4ef96d",
+                "sha256:b3ec74cfef2d985e145baae90d9b1b32f85e1741b04cd967aaf9cfa84c1334f3",
+                "sha256:b51bfc348925e92a9bd9b2e48dad13431b57011fd1038f08316e6bf1df107d10",
+                "sha256:b9a4a8dd3dcf4cbd3165737358e4d7dfbd9d59902ad11e3b15eebb6393b0446e",
+                "sha256:ba3a8aaed13770e970b3df46980cb068d1c24af1a1968b7818b69af8c4347efb",
+                "sha256:c0524de3ff096e15fcbfe8f056fdb4ea0bf497d584454f344d59fce069d3e6e9",
+                "sha256:c0a120238dd71c68484f02562f6d446d736adcc6ca0993712289b102705a9a3a",
+                "sha256:cbbe5e739d45a52f3200a771c6d2c7acf89eb2524890a4a3aa1a7fa0695d2a47",
+                "sha256:ce8c50520f57ec57aa21a63ea4f325c7b657386b3f02ccaedeccf9ebe27686e1",
+                "sha256:cf30900aa1ba595312ae41978b95e256e419d8a823af79ce670835409fc02ad3",
+                "sha256:d25b937a5d9ffa857d41be042b4238dd61db888533b53bc76dc082cb5a15e914",
+                "sha256:d6cdecaedea1ea9e033d8adf6a0ab11107b49571bbb9737175444cea6eb72328",
+                "sha256:dec9de46a33cf2dd87a5254af095a409ea3bf952d85ad339751e7de6d962cde6",
+                "sha256:ebe7c9e67a2d15fa97b77ea6571ce5e1e1f6b0db71d1d5e96f8d2bf134303c1d",
+                "sha256:ee866acc0861caebb4f2ab79f0b94dbfbdbfadc19f82e6e9c93930f74e11d7a0",
+                "sha256:f6a09b360d67e589236a44f0c39218a8efba2593b6abdccc300a8862cffc2f94",
+                "sha256:fcc66e222cf4c719fe7722a403888b1f5e1682d1679bd780e2b26c18bb648cdc",
+                "sha256:fd6545d97c98a192c5ac995d21c894b581f1fd14cf389be90724d21808b657e2"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==7.4.2"
+            "version": "==7.4.3"
         },
         "cryptography": {
             "hashes": [
-                "sha256:01911714117642a3f1792c7f376db572aadadbafcd8d75bb527166009c9f1d1b",
-                "sha256:0e89f7b84f421c56e7ff69f11c441ebda73b8a8e6488d322ef71746224c20fce",
-                "sha256:12d341bd42cdb7d4937b0cabbdf2a94f949413ac4504904d0cdbdce4a22cbf88",
-                "sha256:15a1fb843c48b4a604663fa30af60818cd28f895572386e5f9b8a665874c26e7",
-                "sha256:1cdcdbd117681c88d717437ada72bdd5be9de117f96e3f4d50dab3f59fd9ab20",
-                "sha256:1df6fcbf60560d2113b5ed90f072dc0b108d64750d4cbd46a21ec882c7aefce9",
-                "sha256:3c6048f217533d89f2f8f4f0fe3044bf0b2090453b7b73d0b77db47b80af8dff",
-                "sha256:3e970a2119507d0b104f0a8e281521ad28fc26f2820687b3436b8c9a5fcf20d1",
-                "sha256:44a64043f743485925d3bcac548d05df0f9bb445c5fcca6681889c7c3ab12764",
-                "sha256:4e36685cb634af55e0677d435d425043967ac2f3790ec652b2b88ad03b85c27b",
-                "sha256:5f8907fcf57392cd917892ae83708761c6ff3c37a8e835d7246ff0ad251d9298",
-                "sha256:69b22ab6506a3fe483d67d1ed878e1602bdd5912a134e6202c1ec672233241c1",
-                "sha256:6bfadd884e7280df24d26f2186e4e07556a05d37393b0f220a840b083dc6a824",
-                "sha256:6d0fbe73728c44ca3a241eff9aefe6496ab2656d6e7a4ea2459865f2e8613257",
-                "sha256:6ffb03d419edcab93b4b19c22ee80c007fb2d708429cecebf1dd3258956a563a",
-                "sha256:810bcf151caefc03e51a3d61e53335cd5c7316c0a105cc695f0959f2c638b129",
-                "sha256:831a4b37accef30cccd34fcb916a5d7b5be3cbbe27268a02832c3e450aea39cb",
-                "sha256:887623fe0d70f48ab3f5e4dbf234986b1329a64c066d719432d0698522749929",
-                "sha256:a0298bdc6e98ca21382afe914c642620370ce0470a01e1bef6dd9b5354c36854",
-                "sha256:a1327f280c824ff7885bdeef8578f74690e9079267c1c8bd7dc5cc5aa065ae52",
-                "sha256:c1f25b252d2c87088abc8bbc4f1ecbf7c919e05508a7e8628e6875c40bc70923",
-                "sha256:c3a5cbc620e1e17009f30dd34cb0d85c987afd21c41a74352d1719be33380885",
-                "sha256:ce8613beaffc7c14f091497346ef117c1798c202b01153a8cc7b8e2ebaaf41c0",
-                "sha256:d2a27aca5597c8a71abbe10209184e1a8e91c1fd470b5070a2ea60cafec35bcd",
-                "sha256:dad9c385ba8ee025bb0d856714f71d7840020fe176ae0229de618f14dae7a6e2",
-                "sha256:db4b65b02f59035037fde0998974d84244a64c3265bdef32a827ab9b63d61b18",
-                "sha256:e09469a2cec88fb7b078e16d4adec594414397e8879a4341c6ace96013463d5b",
-                "sha256:e53dc41cda40b248ebc40b83b31516487f7db95ab8ceac1f042626bc43a2f992",
-                "sha256:f1e85a178384bf19e36779d91ff35c7617c885da487d689b05c1366f9933ad74",
-                "sha256:f47be41843200f7faec0683ad751e5ef11b9a56a220d57f300376cd8aba81660",
-                "sha256:fb0cef872d8193e487fc6bdb08559c3aa41b659a7d9be48b2e10747f47863925",
-                "sha256:ffc73996c4fca3d2b6c1c8c12bfd3ad00def8621da24f547626bf06441400449"
+                "sha256:0270572b8bd2c833c3981724b8ee9747b3ec96f699a9665470018594301439ee",
+                "sha256:111a0d8553afcf8eb02a4fea6ca4f59d48ddb34497aa8706a6cf536f1a5ec576",
+                "sha256:16a48c23a62a2f4a285699dba2e4ff2d1cff3115b9df052cdd976a18856d8e3d",
+                "sha256:1b95b98b0d2af784078fa69f637135e3c317091b615cd0905f8b8a087e86fa30",
+                "sha256:1f71c10d1e88467126f0efd484bd44bca5e14c664ec2ede64c32f20875c0d413",
+                "sha256:2424ff4c4ac7f6b8177b53c17ed5d8fa74ae5955656867f5a8affaca36a27abb",
+                "sha256:2bce03af1ce5a5567ab89bd90d11e7bbdff56b8af3acbbec1faded8f44cb06da",
+                "sha256:329906dcc7b20ff3cad13c069a78124ed8247adcac44b10bea1130e36caae0b4",
+                "sha256:37dd623507659e08be98eec89323469e8c7b4c1407c85112634ae3dbdb926fdd",
+                "sha256:3eaafe47ec0d0ffcc9349e1708be2aaea4c6dd4978d76bf6eb0cb2c13636c6fc",
+                "sha256:5e6275c09d2badf57aea3afa80d975444f4be8d3bc58f7f80d2a484c6f9485c8",
+                "sha256:6fe07eec95dfd477eb9530aef5bead34fec819b3aaf6c5bd6d20565da607bfe1",
+                "sha256:7367d7b2eca6513681127ebad53b2582911d1736dc2ffc19f2c3ae49997496bc",
+                "sha256:7cde5f38e614f55e28d831754e8a3bacf9ace5d1566235e39d91b35502d6936e",
+                "sha256:9481ffe3cf013b71b2428b905c4f7a9a4f76ec03065b05ff499bb5682a8d9ad8",
+                "sha256:98d8dc6d012b82287f2c3d26ce1d2dd130ec200c8679b6213b3c73c08b2b7940",
+                "sha256:a011a644f6d7d03736214d38832e030d8268bcff4a41f728e6030325fea3e400",
+                "sha256:a2913c5375154b6ef2e91c10b5720ea6e21007412f6437504ffea2109b5a33d7",
+                "sha256:a30596bae9403a342c978fb47d9b0ee277699fa53bbafad14706af51fe543d16",
+                "sha256:b03c2ae5d2f0fc05f9a2c0c997e1bc18c8229f392234e8a0194f202169ccd278",
+                "sha256:b6cd2203306b63e41acdf39aa93b86fb566049aeb6dc489b70e34bcd07adca74",
+                "sha256:b7ffe927ee6531c78f81aa17e684e2ff617daeba7f189f911065b2ea2d526dec",
+                "sha256:b8cac287fafc4ad485b8a9b67d0ee80c66bf3574f655d3b97ef2e1082360faf1",
+                "sha256:ba334e6e4b1d92442b75ddacc615c5476d4ad55cc29b15d590cc6b86efa487e2",
+                "sha256:ba3e4a42397c25b7ff88cdec6e2a16c2be18720f317506ee25210f6d31925f9c",
+                "sha256:c41fb5e6a5fe9ebcd58ca3abfeb51dffb5d83d6775405305bfa8715b76521922",
+                "sha256:cd2030f6650c089aeb304cf093f3244d34745ce0cfcc39f20c6fbfe030102e2a",
+                "sha256:cd65d75953847815962c84a4654a84850b2bb4aed3f26fadcc1c13892e1e29f6",
+                "sha256:e4985a790f921508f36f81831817cbc03b102d643b5fcb81cd33df3fa291a1a1",
+                "sha256:e807b3188f9eb0eaa7bbb579b462c5ace579f1cedb28107ce8b48a9f7ad3679e",
+                "sha256:f12764b8fffc7a123f641d7d049d382b73f96a34117e0b637b80643169cec8ac",
+                "sha256:f8837fe1d6ac4a8052a9a8ddab256bc006242696f03368a4009be7ee3075cdb7"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==42.0.4"
+            "version": "==42.0.5"
         },
         "deprecated": {
             "hashes": [
@@ -746,6 +810,14 @@
                 "sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64"
             ],
             "version": "==0.3.8"
+        },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14",
+                "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.2.0"
         },
         "execnet": {
             "hashes": [
@@ -793,11 +865,35 @@
         },
         "griffe": {
             "hashes": [
-                "sha256:5b8c023f366fe273e762131fe4bfd141ea56c09b3cb825aa92d06a82681cfd93",
-                "sha256:66c48a62e2ce5784b6940e603300fcfb807b6f099b94e7f753f1841661fd5c7c"
+                "sha256:27b4610f1ba6e5d039e9f0a2c97232e13463df75e53cb1833e0679f3377b9de2",
+                "sha256:9edcfa9f57f4d9c5fcc6d5ce067c67a685b7101a21a7d11848ce0437368e474c"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.40.1"
+            "version": "==0.41.3"
+        },
+        "h11": {
+            "hashes": [
+                "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d",
+                "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.14.0"
+        },
+        "httpcore": {
+            "hashes": [
+                "sha256:ac418c1db41bade2ad53ae2f3834a3a0f5ae76b56cf5aa497d2d033384fc7d73",
+                "sha256:cb2839ccfcba0d2d3c1131d3c3e26dfc327326fbe7a5dc0dbfe9f6c9151bb022"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.0.4"
+        },
+        "httpx": {
+            "hashes": [
+                "sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5",
+                "sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.27.0"
         },
         "identify": {
             "hashes": [
@@ -952,18 +1048,18 @@
         },
         "mkdocs-autorefs": {
             "hashes": [
-                "sha256:7930fcb8ac1249f10e683967aeaddc0af49d90702af111a5e390e8b20b3d97ff",
-                "sha256:9a5054a94c08d28855cfab967ada10ed5be76e2bfad642302a610b252c3274c0"
+                "sha256:aacdfae1ab197780fb7a2dac92ad8a3d8f7ca8049a9cbe56a4218cd52e8da570",
+                "sha256:f684edf847eced40b570b57846b15f0bf57fb93ac2c510450775dcf16accb971"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.5.0"
+            "version": "==1.0.1"
         },
         "mkdocs-material": {
             "hashes": [
-                "sha256:3c6c46b57d2ee3c8890e6e0406e68b6863cf65768f0f436990a742702d198442",
-                "sha256:6ad626dbb31070ebbaedff813323a16a406629620e04b96458f16e6e9c7008fe"
+                "sha256:5f69cef6a8aaa4050b812f72b1094fda3d079b9a51cf27a247244c03ec455e97",
+                "sha256:d6f0c269f015e48c76291cdc79efb70f7b33bbbf42d649cfe475522ebee61b1f"
             ],
-            "version": "==9.5.10"
+            "version": "==9.5.12"
         },
         "mkdocs-material-extensions": {
             "hashes": [
@@ -982,10 +1078,10 @@
         },
         "mkdocstrings": {
             "hashes": [
-                "sha256:222b1165be41257b494a9d29b14135d2b7ca43f38161d5b10caae03b87bd4f7e",
-                "sha256:f4908560c10f587326d8f5165d1908817b2e280bbf707607f601c996366a2264"
+                "sha256:b4206f9a2ca8a648e222d5a0ca1d36ba7dee53c88732818de183b536f9042b5d",
+                "sha256:cc83f9a1c8724fc1be3c2fa071dd73d91ce902ef6a79710249ec8d0ee1064401"
             ],
-            "version": "==0.24.0"
+            "version": "==0.24.1"
         },
         "mkdocstrings-python": {
             "hashes": [
@@ -1262,11 +1358,11 @@
         },
         "pymdown-extensions": {
             "hashes": [
-                "sha256:6ca215bc57bc12bf32b414887a68b810637d039124ed9b2e5bd3325cbb2c050c",
-                "sha256:c0d64d5cf62566f59e6b2b690a4095c931107c250a8c8e1351c1de5f6b036deb"
+                "sha256:c70e146bdd83c744ffc766b4671999796aba18842b268510a329f7f64700d584",
+                "sha256:f5cc7000d7ff0d1ce9395d216017fa4df3dde800afb1fb72d1c7d3fd35e710f4"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==10.7"
+            "version": "==10.7.1"
         },
         "pynacl": {
             "hashes": [
@@ -1352,11 +1448,11 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.8.2"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==2.9.0.post0"
         },
         "pytz": {
             "hashes": [
@@ -1547,19 +1643,27 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:850894c4195f09c4ed30dba56213bf7c3f21d86ed6bdaafb5df5972593bfc401",
-                "sha256:c054629b81b946d63a9c6e732bc8b2513a7c3ea645f11d0139a2191d735c60c6"
+                "sha256:02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56",
+                "sha256:5c0806c7d9af348e6dd3777b4f4dbb42c7ad85b190104837488eab9a7c945cf8"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==69.1.0"
+            "version": "==69.1.1"
         },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
+        },
+        "sniffio": {
+            "hashes": [
+                "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2",
+                "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.1"
         },
         "synapseclient": {
             "editable": true,
@@ -1578,7 +1682,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
         },
         "tomli": {
@@ -1591,11 +1695,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783",
-                "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"
+                "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
+                "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.9.0"
+            "version": "==4.10.0"
         },
         "tzdata": {
             "hashes": [
@@ -1615,11 +1719,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:4238949c5ffe6876362d9c0180fc6c3a824a7b12b80604eeb8085f2ed7460de3",
-                "sha256:bf51c0d9c7dd63ea8e44086fa1e4fb1093a31e963b86959257378aef020e1f1b"
+                "sha256:961c026ac520bac5f69acb8ea063e8a4f071bcc9457b9c1f28f6b085c511583a",
+                "sha256:e08e13ecdca7a0bd53798f356d5831434afa5b07b93f0abdf0797b7a06ffe197"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==20.25.0"
+            "version": "==20.25.1"
         },
         "watchdog": {
             "hashes": [
@@ -1655,6 +1759,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==4.0.0"
+        },
+        "wheel": {
+            "hashes": [
+                "sha256:177f9c9b0d45c47873b619f5b650346d632cdc35fb5e4d25058e09c9e581433d",
+                "sha256:c45be39f7882c9d34243236f2d63cbd58039e360f85d0913425fbd7ceea617a8"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.42.0"
         },
         "wrapt": {
             "hashes": [

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -80,6 +80,10 @@ those memebrs. We are roughly grouping these for similar functionality. -->
         - restPOST
         - restPUT
         - restDELETE
+        - rest_get_async
+        - rest_post_async
+        - rest_put_async
+        - rest_delete_async
 
 ## More information
 

--- a/docs/reference/rest_apis.md
+++ b/docs/reference/rest_apis.md
@@ -1,0 +1,16 @@
+# Rest APIs
+
+This section is for super users / developers only.
+These functions are subject to change as they are internal development
+functions. Use at your own risk.
+
+
+The functions provided in these documents are generally direct representations of the
+Synapse REST API. They're used within the Synapse Python Client to interact with the
+Synapse servers. These will eventually be removed from the Synapse Python Client in
+favor of an auto-generated client derived from the
+[Synapse Open API Spec](https://rest-docs.synapse.org/rest/openapi/openapispecification.json).
+
+
+::: synapseclient.api.entity_bundle_services_v2
+::: synapseclient.api.annotations

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
     - Exceptions: reference/exceptions.md
     - Permissions: reference/permissions.md
     - Core: reference/core.md
+    - REST Apis: reference/rest_apis.md
     - Experimental:
       - Object-Orientated Models: reference/oop/models.md
       - Async Object-Orientated Models: reference/oop/models_async.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ install_requires =
     opentelemetry-sdk~=1.21.0
     opentelemetry-exporter-otlp-proto-http~=1.21.0
     nest-asyncio~=1.6.0
+    httpx~=0.27.0
 tests_require =
     pytest>=6.0.0,<7.0
     pytest-mock>=3.0,<4.0

--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -1,7 +1,17 @@
 # These are all of the models that are used by the Synapse client.
 from .annotations import set_annotations
+from .entity_bundle_services_v2 import (
+    get_entity_id_bundle2,
+    get_entity_id_version_bundle2,
+    post_entity_bundle2_create,
+    put_entity_id_bundle2,
+)
 
 
 __all__ = [
     "set_annotations",
+    "get_entity_id_bundle2",
+    "get_entity_id_version_bundle2",
+    "post_entity_bundle2_create",
+    "put_entity_id_bundle2",
 ]

--- a/synapseclient/api/entity_bundle_services_v2.py
+++ b/synapseclient/api/entity_bundle_services_v2.py
@@ -1,0 +1,136 @@
+"""This module is responsible for exposing the services defined at:
+<https://rest-docs.synapse.org/rest/#org.sagebionetworks.repo.web.controller.EntityBundleV2Controller>
+"""
+
+import json
+from typing import Any, Dict, Optional
+
+from synapseclient import Synapse
+
+
+async def get_entity_id_bundle2(
+    entity_id: str,
+    request: Optional[Dict[str, bool]] = None,
+    synapse_client: Optional[Synapse] = None,
+) -> Dict[str, Any]:
+    """
+    Arguments:
+        entity_id: The ID of the entity to which the bundle belongs
+        request: The request for the bundle matching
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/entitybundle/v2/EntityBundleRequest.html>.
+            If not passed in or None, the default request will be used:
+
+            - includeEntity: True
+            - includeAnnotations: True
+            - includeFileHandles: True
+            - includeRestrictionInformation: True
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        The requested entity bundle matching
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/entitybundle/v2/EntityBundle.html>
+    """
+    if not request:
+        request = {
+            "includeEntity": True,
+            "includeAnnotations": True,
+            "includeFileHandles": True,
+            "includeRestrictionInformation": True,
+        }
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_post_async(
+        uri=f"/entity/{entity_id}/bundle2",
+        body=json.dumps(request),
+    )
+
+
+async def get_entity_id_version_bundle2(
+    entity_id: str,
+    version: int,
+    request: Optional[Dict[str, bool]] = None,
+    synapse_client: Optional[Synapse] = None,
+) -> Dict[str, Any]:
+    """
+    Arguments:
+        entity_id: The ID of the entity to which the bundle belongs
+        version: The version of the entity to which the bundle belongs
+        request: The request for the bundle matching
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/entitybundle/v2/EntityBundleRequest.html>.
+            If not passed in or None, the default request will be used:
+
+            - includeEntity: True
+            - includeAnnotations: True
+            - includeFileHandles: True
+            - includeRestrictionInformation: True
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        The requested entity bundle matching
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/entitybundle/v2/EntityBundle.html>
+    """
+    if not request:
+        request = {
+            "includeEntity": True,
+            "includeAnnotations": True,
+            "includeFileHandles": True,
+            "includeRestrictionInformation": True,
+        }
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_post_async(
+        uri=f"/entity/{entity_id}/version/{version}/bundle2",
+        body=json.dumps(request),
+    )
+
+
+async def post_entity_bundle2_create(
+    request: Dict[str, Any],
+    generated_by: Optional[str] = None,
+    synapse_client: Optional[Synapse] = None,
+) -> Dict[str, Any]:
+    """
+    Arguments:
+        request: The request for the bundle matching
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/entitybundle/v2/EntityBundleCreate.html>
+        generated_by: The ID of the activity to associate with the entity.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        The requested entity bundle matching
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/entitybundle/v2/EntityBundle.html>
+    """
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_post_async(
+        uri="/entity/bundle2/create"
+        + (f"?generatedBy={generated_by}" if generated_by else ""),
+        body=json.dumps(request),
+    )
+
+
+async def put_entity_id_bundle2(
+    entity_id: str,
+    request: Dict[str, Any],
+    generated_by: Optional[str] = None,
+    synapse_client: Optional[Synapse] = None,
+) -> Dict[str, Any]:
+    """
+    Arguments:
+        entity_id: The ID of the entity to which the bundle belongs.
+        request: The request for the bundle matching
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/entitybundle/v2/EntityBundleCreate.html>
+        generated_by: The ID of the activity to associate with the entity.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        The requested entity bundle matching
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/entitybundle/v2/EntityBundle.html>
+    """
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_put_async(
+        uri=f"/entity/{entity_id}/bundle2"
+        + (f"?generatedBy={generated_by}" if generated_by else ""),
+        body=json.dumps(request),
+    )

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -6198,8 +6198,8 @@ class Synapse(object):
 
     async def rest_post_async(
         self,
-        uri,
-        body,
+        uri: str,
+        body: Any = None,
         endpoint: str = None,
         headers: httpx.Headers = None,
         retry_policy: Dict[str, Any] = {},
@@ -6240,10 +6240,10 @@ class Synapse(object):
 
     async def rest_put_async(
         self,
-        uri,
-        body=None,
-        endpoint=None,
-        headers=None,
+        uri: str,
+        body: Any = None,
+        endpoint: str = None,
+        headers: httpx.Headers = None,
         retry_policy: Dict[str, Any] = {},
         requests_session_async_synapse: httpx.AsyncClient = None,
         **kwargs,
@@ -6282,9 +6282,9 @@ class Synapse(object):
 
     async def rest_delete_async(
         self,
-        uri,
-        endpoint=None,
-        headers=None,
+        uri: str,
+        endpoint: str = None,
+        headers: httpx.Headers = None,
         retryPolicy: Dict[str, Any] = {},
         requests_session_async_synapse: httpx.AsyncClient = None,
         **kwargs,

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -6130,7 +6130,7 @@ class Synapse(object):
             response = await with_retry_async(
                 lambda: requests_method_fn(
                     uri,
-                    data=data,
+                    content=data,
                     headers=headers,
                     auth=auth,
                     **kwargs,

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -6067,15 +6067,15 @@ class Synapse(object):
         return defaults
 
     def _build_retry_policy_async(
-        self, retryPolicy: Dict[str, Any] = {}
+        self, retry_policy: Dict[str, Any] = {}
     ) -> Dict[str, Any]:
         """Returns a retry policy to be passed onto _with_retry_async."""
 
         defaults = dict(STANDARD_RETRY_ASYNC_PARAMS)
-        defaults.update(retryPolicy)
+        defaults.update(retry_policy)
         return defaults
 
-    def _return_rest_body(self, response):
+    def _return_rest_body(self, response) -> Union[Dict[str, Any], str]:
         """Returns either a dictionary or a string depending on the 'content-type' of the response."""
         trace.get_current_span().set_attributes(
             {"http.response.status_code": response.status_code}
@@ -6094,7 +6094,7 @@ class Synapse(object):
         retry_policy: Dict[str, Any],
         requests_session_async_synapse: httpx.AsyncClient,
         **kwargs,
-    ):
+    ) -> Union[httpx.Response, None]:
         """
         Sends an HTTP request to the Synapse server.
 
@@ -6161,7 +6161,7 @@ class Synapse(object):
         retry_policy: Dict[str, Any] = {},
         requests_session_async_synapse: httpx.AsyncClient = None,
         **kwargs,
-    ):
+    ) -> Union[Dict[str, Any], str, None]:
         """
         Sends an HTTP GET request to the Synapse server.
 
@@ -6205,7 +6205,7 @@ class Synapse(object):
         retry_policy: Dict[str, Any] = {},
         requests_session_async_synapse: httpx.AsyncClient = None,
         **kwargs,
-    ):
+    ) -> Union[Dict[str, Any], str]:
         """
         Sends an HTTP POST request to the Synapse server.
 
@@ -6247,7 +6247,7 @@ class Synapse(object):
         retry_policy: Dict[str, Any] = {},
         requests_session_async_synapse: httpx.AsyncClient = None,
         **kwargs,
-    ):
+    ) -> Union[Dict[str, Any], str]:
         """
         Sends an HTTP PUT request to the Synapse server.
 
@@ -6285,7 +6285,7 @@ class Synapse(object):
         uri: str,
         endpoint: str = None,
         headers: httpx.Headers = None,
-        retryPolicy: Dict[str, Any] = {},
+        retry_policy: Dict[str, Any] = {},
         requests_session_async_synapse: httpx.AsyncClient = None,
         **kwargs,
     ) -> None:
@@ -6311,7 +6311,7 @@ class Synapse(object):
                 None,
                 endpoint,
                 headers,
-                retryPolicy,
+                retry_policy,
                 requests_session_async_synapse,
                 **kwargs,
             )

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -6106,7 +6106,7 @@ class Synapse(object):
             endpoint: Server endpoint, defaults to self.repoEndpoint
             headers: Dictionary of headers to use.
             retry_policy: A retry policy that matches the arguments of
-                [synapseclient.core.retry#with_retry_async][].
+                [synapseclient.core.retry.with_retry_async][].
             requests_session_async_synapse: The async client to use when making this
                 specific call.
             kwargs: Any other arguments taken by a
@@ -6170,7 +6170,7 @@ class Synapse(object):
             endpoint: Server endpoint, defaults to self.repoEndpoint
             headers: Dictionary of headers to use.
             retry_policy: A retry policy that matches the arguments of
-                [synapseclient.core.retry#with_retry_async][].
+                [synapseclient.core.retry.with_retry_async][].
             requests_session_async_synapse: The async client to use when making this
                 specific call.
             kwargs: Any other arguments taken by a
@@ -6215,7 +6215,7 @@ class Synapse(object):
             body: The payload to be delivered
             headers: Dictionary of headers to use.
             retry_policy: A retry policy that matches the arguments of
-                [synapseclient.core.retry#with_retry_async][].
+                [synapseclient.core.retry.with_retry_async][].
             requests_session_async_synapse: The async client to use when making this
                 specific call.
             kwargs: Any other arguments taken by a
@@ -6257,7 +6257,7 @@ class Synapse(object):
             endpoint: Server endpoint, defaults to self.repoEndpoint
             headers: Dictionary of headers to use.
             retry_policy: A retry policy that matches the arguments of
-                [synapseclient.core.retry#with_retry_async][].
+                [synapseclient.core.retry.with_retry_async][].
             requests_session_async_synapse: The async client to use when making this
                 specific call.
             kwargs: Any other arguments taken by a
@@ -6297,7 +6297,7 @@ class Synapse(object):
             endpoint: Server endpoint, defaults to self.repoEndpoint
             headers: Dictionary of headers to use.
             retry_policy: A retry policy that matches the arguments of
-                [synapseclient.core.retry#with_retry_async][].
+                [synapseclient.core.retry.with_retry_async][].
             requests_session_async_synapse: The async client to use when making this
                 specific call
             kwargs: Any other arguments taken by a [request](https://www.python-httpx.org/api/) method

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -5835,7 +5835,9 @@ class Synapse(object):
         """
 
         try:
-            exceptions._raise_for_status_httpx(response, verbose=self.debug)
+            exceptions._raise_for_status_httpx(
+                response=response, verbose=self.debug, logger=self.logger
+            )
         except exceptions.SynapseHTTPError as ex:
             # if we get a unauthenticated or forbidden error and the user is not logged in
             # then we raise it as an authentication error.

--- a/synapseclient/core/exceptions.py
+++ b/synapseclient/core/exceptions.py
@@ -1,3 +1,6 @@
+from typing import Union
+
+import httpx
 import requests
 
 from synapseclient.core import utils
@@ -64,6 +67,22 @@ class SynapseUploadFailedException(SynapseError):
     """Raised when an upload failed. Should be chained to a cause Exception"""
 
     pass
+
+
+def _get_message(response: httpx.Response) -> Union[str, None]:
+    """Extracts the message body or a response object by checking for a json response
+    and returning the reason otherwise getting body.
+    """
+    try:
+        if utils.is_json(response.headers.get("content-type", None)):
+            json = response.json()
+            return json.get("reason", None)
+        else:
+            # if the response is not JSON, return the text content
+            return response.text
+    except (AttributeError, ValueError):
+        # The response can be truncated. In which case, the message cannot be retrieved.
+        return None
 
 
 def _raise_for_status(response, verbose=False):
@@ -145,6 +164,105 @@ def _raise_for_status(response, verbose=False):
                 )
                 message += "\n>>> Headers: %s" % response.request.headers
                 message += "\n>>> Body: %s" % response.request.body
+            except:  # noqa
+                message += "\nCould not append all request info"
+
+            try:
+                # Append the response received
+                message += "\n\n>>>>>> Response <<<<<<\n%s" % str(response)
+                message += "\n>>> Headers: %s" % response.headers
+                message += "\n>>> Body: %s\n\n" % response.text
+            except:  # noqa
+                message += "\nCould not append all response info"
+
+        raise SynapseHTTPError(message, response=response)
+
+
+def _raise_for_status_httpx(response: httpx.Response, verbose: bool = False) -> None:
+    """
+    Replacement for requests.response.raise_for_status().
+    Catches and wraps any Synapse-specific HTTP errors with appropriate text with the
+    HTTPX library in mind.
+
+    Arguments:
+        response: The response object from the HTTPX request.
+        verbose: If True, the request and response information will be appended to the
+            error message.
+    """
+
+    message = None
+
+    # TODO: Add more meaningful Synapse-specific messages to each error code
+    # TODO: For some status codes, throw other types of exceptions
+    if 400 <= response.status_code < 500:
+        # TODOs:
+        # 400: 'bad_request'
+        # 401: 'unauthorized'
+        # 402: 'payment_required'
+        # 403: 'forbidden'
+        # 404: 'not_found'
+        # 405: 'method_not_allowed'
+        # 406: 'not_acceptable'
+        # 407: 'proxy_authentication_required'
+        # 408: 'request_timeout'
+        # 409: 'conflict'
+        # 410: 'gone'
+        # 411: 'length_required'
+        # 412: 'precondition_failed'
+        # 413: 'request_entity_too_large'
+        # 414: 'request_uri_too_large'
+        # 415: 'unsupported_media_type'
+        # 416: 'requested_range_not_satisfiable'
+        # 417: 'expectation_failed'
+        # 418: 'im_a_teapot'
+        # 422: 'unprocessable_entity'
+        # 423: 'locked'
+        # 424: 'failed_dependency'
+        # 425: 'unordered_collection'
+        # 426: 'upgrade_required'
+        # 428: 'precondition_required'
+        # 429: 'too_many_requests'
+        # 431: 'header_fields_too_large'
+        # 444: 'no_response'
+        # 449: 'retry_with'
+        # 450: 'blocked_by_windows_parental_controls'
+        # 451: 'unavailable_for_legal_reasons'
+        # 499: 'client_closed_request'
+        message = "%s Client Error: %s" % (response.status_code, _get_message(response))
+
+    elif 500 <= response.status_code < 600:
+        # TODOs:
+        # 500: 'internal_server_error'
+        # 501: 'not_implemented'
+        # 502: 'bad_gateway'
+        # 503: 'service_unavailable'
+        # 504: 'gateway_timeout'
+        # 505: 'http_version_not_supported'
+        # 506: 'variant_also_negotiates'
+        # 507: 'insufficient_storage'
+        # 509: 'bandwidth_limit_exceeded'
+        # 510: 'not_extended'
+        message = "%s Server Error: %s" % (response.status_code, _get_message(response))
+
+    if message is not None:
+        # Append the server's JSON error message
+        if (
+            utils.is_json(response.headers.get("content-type", None))
+            and "reason" in response.json()
+        ):
+            message += "\n%s" % response.json()["reason"]
+        else:
+            message += "\n%s" % response.text
+
+        if verbose:
+            try:
+                # Append the request sent
+                message += "\n\n>>>>>> Request <<<<<<\n%s %s" % (
+                    response.request.url,
+                    response.request.method,
+                )
+                message += "\n>>> Headers: %s" % response.request.headers
+                message += "\n>>> Body: %s" % response.request.content
             except:  # noqa
                 message += "\nCould not append all request info"
 

--- a/synapseclient/core/exceptions.py
+++ b/synapseclient/core/exceptions.py
@@ -233,7 +233,8 @@ def _raise_for_status_httpx(
         # 450: 'blocked_by_windows_parental_controls'
         # 451: 'unavailable_for_legal_reasons'
         # 499: 'client_closed_request'
-        message = f"{response.status_code} {CLIENT_ERROR}"
+        message_body = _get_message(response, logger)
+        message = f"{response.status_code} {CLIENT_ERROR} {message_body}"
 
     elif 500 <= response.status_code < 600:
         # TODOs:
@@ -247,7 +248,8 @@ def _raise_for_status_httpx(
         # 507: 'insufficient_storage'
         # 509: 'bandwidth_limit_exceeded'
         # 510: 'not_extended'
-        message = f"{response.status_code} {SERVER_ERROR}"
+        message_body = _get_message(response, logger)
+        message = f"{response.status_code} {SERVER_ERROR} {message_body}"
 
     if message is not None:
         if verbose:
@@ -264,7 +266,7 @@ def _raise_for_status_httpx(
                 # Append the response received
                 message += f"\n\n{RESPONSE_PREFIX}\n{str(response)}"
                 message += f"\n{HEADERS_PREFIX}{response.headers}"
-                message += f"\n{BODY_PREFIX}{_get_message(response, logger)}\n\n"
+                message += f"\n{BODY_PREFIX}{message_body}\n\n"
             except Exception:  # noqa
                 logger.exception(UNABLE_TO_APPEND_RESPONSE)
                 message += f"\n{UNABLE_TO_APPEND_RESPONSE}"

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -230,7 +230,7 @@ async def with_retry_async(
     retry_status_codes: typing.List[int] = None,
     expected_status_codes: typing.List[int] = None,
     retry_errors: typing.List[str] = None,
-    retry_exceptions: typing.List[Exception] = None,
+    retry_exceptions: typing.List[typing.Union[Exception, str]] = None,
     retry_base_wait: float = DEFAULT_BASE_WAIT_ASYNC,
     retry_wait_random_lower: float = DEFAULT_WAIT_RANDOM_LOWER_ASYNC,
     retry_wait_random_upper: float = DEFAULT_WAIT_RANDOM_UPPER_ASYNC,

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -6,9 +6,11 @@ i.e. for certain status codes, connection errors, and/or connection exceptions.
 
 """
 
+import asyncio
 import random
 import sys
 import logging
+import typing
 from opentelemetry import trace
 
 from synapseclient.core.logging_setup import (
@@ -18,10 +20,21 @@ from synapseclient.core.logging_setup import (
 from synapseclient.core.utils import is_json
 from synapseclient.core.dozer import doze
 
+# All of these constants are in seconds
 DEFAULT_RETRIES = 3
 DEFAULT_WAIT = 1
 DEFAULT_BACK_OFF = 2
 DEFAULT_MAX_WAIT = 30
+
+
+DEFAULT_BASE_WAIT_ASYNC = 0.001
+
+DEFAULT_WAIT_RANDOM_LOWER_ASYNC = 0.01
+DEFAULT_WAIT_RANDOM_UPPER_ASYNC = 0.1
+
+DEFAULT_BACK_OFF_FACTOR_ASYNC = 2
+DEFAULT_MAX_BACK_OFF_ASYNC = 10
+DEFAULT_MAX_WAIT_BEFORE_FAIL_ASYNC = 20 * 60
 
 DEFAULT_RETRY_STATUS_CODES = [429, 500, 502, 503, 504]
 
@@ -178,6 +191,197 @@ def with_retry(
                 "retries have run out. re-raising the exception", exc_info=True
             )
             raise exc
+        return response
+
+
+def calculate_exponential_backoff(
+    retries: int,
+    base_wait: float,
+    wait_random_lower: float,
+    wait_random_upper: float,
+    back_off_factor: float,
+    max_back_off: float,
+) -> float:
+    """
+    Handle calculating the exponential backoff.
+
+    Arguments:
+        retries: The number of retries that have been attempted
+        base_wait: The base wait time
+        wait_random_lower: The lower bound of the random wait time
+        wait_random_upper: The upper bound of the random wait time
+        back_off_factor: The factor to increase the wait time by for each retry
+        max_back_off: The maximum wait time
+
+    Returns:
+        The total wait time
+    """
+    random_jitter = random.uniform(wait_random_lower, wait_random_upper)
+    time_to_wait = min(
+        (base_wait * (back_off_factor**retries)) + random_jitter,
+        max_back_off,
+    )
+    return time_to_wait
+
+
+async def with_retry_async(
+    function,
+    verbose: bool = False,
+    retry_status_codes: typing.List[int] = None,
+    expected_status_codes: typing.List[int] = None,
+    retry_errors: typing.List[str] = None,
+    retry_exceptions: typing.List[Exception] = None,
+    retry_base_wait: float = DEFAULT_BASE_WAIT_ASYNC,
+    retry_wait_random_lower: float = DEFAULT_WAIT_RANDOM_LOWER_ASYNC,
+    retry_wait_random_upper: float = DEFAULT_WAIT_RANDOM_UPPER_ASYNC,
+    retry_back_off_factor: float = DEFAULT_BACK_OFF_FACTOR_ASYNC,
+    retry_max_back_off: float = DEFAULT_MAX_BACK_OFF_ASYNC,
+    retry_max_wait_before_failure: float = DEFAULT_MAX_WAIT_BEFORE_FAIL_ASYNC,
+):
+    """
+    Retries the given function under certain conditions. This is created such that it
+    will retry an unbounded number of times until the maximum wait time is reached. The
+    backoff is calculated using an exponential backoff algorithm with a random jitter.
+    The maximum backoff inbetween retries is capped at `retry_max_back_off`.
+
+    Arguments:
+        verbose: Whether to log debug messages
+        function: A function with no arguments. If arguments are needed, use a lambda
+            (see example).
+        retry_status_codes: What status codes to retry upon in the case of a
+            SynapseHTTPError.
+        expected_status_codes: If specified responses with any other status codes result
+            in a retry.
+        retry_errors: What reasons to retry upon, if
+            `function().response.json()['reason']` exists.
+        retry_exceptions: What types of exceptions, specified as strings or Exception
+            classes, to retry upon.
+        retry_base_wait: The base wait time inbetween retries.
+        retry_wait_random_lower: The lower bound of the random wait time.
+        retry_wait_random_upper: The upper bound of the random wait time.
+        retry_back_off_factor: The factor to increase the wait time by for each retry.
+        retry_max_back_off: The maximum wait time.
+        retry_max_wait_before_failure: The maximum wait time before failure.
+
+    Example: Using with_retry
+        Using ``with_retry_async`` to consolidate inputs into a list.
+
+            from synapseclient.core.retry import with_retry_async
+
+            def foo(a, b, c): return [a, b, c]
+            result = await with_retry_async(lambda: foo("1", "2", "3"))
+    """
+    if not retry_status_codes:
+        retry_status_codes = [429, 500, 502, 503, 504]
+    if not expected_status_codes:
+        expected_status_codes = []
+    if not retry_errors:
+        retry_errors = []
+    if not retry_exceptions:
+        retry_exceptions = []
+
+    if verbose:
+        logger = logging.getLogger(DEBUG_LOGGER_NAME)
+    else:
+        logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+
+    # Retry until we succeed or run past the maximum wait time
+    total_wait = 0
+    retries = -1
+    while True:
+        caught_exception = None
+        caught_exception_info = None
+        retry = False
+        response = None
+
+        try:
+            response = await function()
+        except Exception as ex:
+            caught_exception = ex
+            caught_exception_info = sys.exc_info()
+            logger.debug("calling %s resulted in an Exception", function)
+            if hasattr(ex, "response"):
+                response = ex.response
+
+        # Check if we got a retry-able HTTP error
+        if response is not None and hasattr(response, "status_code"):
+            if (
+                expected_status_codes
+                and response.status_code not in expected_status_codes
+            ) or (retry_status_codes and response.status_code in retry_status_codes):
+                retry = True
+
+            elif response.status_code not in range(200, 299):
+                # For all other non 200 messages look for retryable errors in the body or reason field
+                response_message = _get_message(response)
+                if any(
+                    [msg.lower() in response_message.lower() for msg in retry_errors]
+                ):
+                    retry = True
+                # special case for message throttling
+                elif (
+                    "Please slow down.  You may send a maximum of 10 message"
+                    in response_message
+                ):
+                    retry = True
+
+        # Check if we got a retry-able exception
+        if (
+            not retry
+            and caught_exception is not None
+            and (
+                caught_exception.__class__.__name__ in retry_exceptions
+                or caught_exception.__class__ in retry_exceptions
+                or any(
+                    [
+                        msg.lower() in str(caught_exception_info[1]).lower()
+                        for msg in retry_errors
+                    ]
+                )
+            )
+        ):
+            retry = True
+
+        # Wait then retry
+        retries += 1
+
+        if total_wait < retry_max_wait_before_failure and retry:
+            if response is not None:
+                response_message = _get_message(response)
+                logger.debug(
+                    "retrying on status code: %s - %s%s%s - %s",
+                    str(response.status_code),
+                    response.request.url.host,
+                    response.request.url.path,
+                    (
+                        f"?{response.request.url.params}"
+                        if response.request.url.params
+                        else ""
+                    ),
+                    response_message,
+                )
+            elif caught_exception is not None:
+                logger.debug("retrying exception: %s", str(caught_exception))
+
+            with tracer.start_as_current_span("Synapse::retry_wait"):
+                backoff_wait = calculate_exponential_backoff(
+                    retries=retries,
+                    base_wait=retry_base_wait,
+                    wait_random_lower=retry_wait_random_lower,
+                    wait_random_upper=retry_wait_random_upper,
+                    back_off_factor=retry_back_off_factor,
+                    max_back_off=retry_max_back_off,
+                )
+                total_wait += backoff_wait
+                await asyncio.sleep(backoff_wait)
+                continue
+
+        # Out of retries, re-raise the exception or return the response
+        if caught_exception_info is not None and caught_exception_info[0] is not None:
+            logger.debug(
+                "retries have run out. re-raising the exception", exc_info=True
+            )
+            raise caught_exception
         return response
 
 

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -410,15 +410,13 @@ def _log_for_retry(
 ) -> None:
     if response is not None:
         response_message = _get_message(response)
-        url_param_part = (
-            f"?{response.request.url.params}" if response.request.url.params else ""
-        )
+        url_message_part = ""
 
-        url_message_part = (
-            f"{response.request.url.host}{response.request.url.path}{url_param_part}"
-            if hasattr(response, "request") and hasattr(response.request, "url")
-            else ""
-        )
+        if hasattr(response, "request") and hasattr(response.request, "url"):
+            url_param_part = (
+                f"?{response.request.url.params}" if response.request.url.params else ""
+            )
+            url_message_part = f"{response.request.url.host}{response.request.url.path}{url_param_part}"
         logger.debug(
             "retrying on status code: %s - %s - %s",
             str(response.status_code),

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -268,7 +268,7 @@ async def with_retry_async(
 
             from synapseclient.core.retry import with_retry_async
 
-            def foo(a, b, c): return [a, b, c]
+            async def foo(a, b, c): return [a, b, c]
             result = await with_retry_async(lambda: foo("1", "2", "3"))
     """
     if not retry_status_codes:

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -337,7 +337,12 @@ async def with_retry_async(
         # Out of retries, re-raise the exception or return the response
         if caught_exception_info is not None and caught_exception_info[0] is not None:
             logger.debug(
-                "retries have run out. re-raising the exception", exc_info=True
+                (
+                    "Retries have run out. re-raising the exception: %s"
+                    if retry
+                    else "Rasing the exception: %s"
+                ),
+                str(caught_exception_info[0]),
             )
             raise caught_exception
         return response

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -319,7 +319,7 @@ async def with_retry_async(
                 ):
                     retry = True
                 # special case for message throttling
-                elif (
+                elif response_message and (
                     "Please slow down.  You may send a maximum of 10 message"
                     in response_message
                 ):
@@ -348,16 +348,16 @@ async def with_retry_async(
         if total_wait < retry_max_wait_before_failure and retry:
             if response is not None:
                 response_message = _get_message(response)
+                url_message_part = (
+                    f"{response.request.url.host}{response.request.url.path}"
+                    f"{f'?{response.request.url.params}' if response.request.url.params else ''}"
+                    if hasattr(response, "request") and hasattr(response.request, "url")
+                    else ""
+                )
                 logger.debug(
-                    "retrying on status code: %s - %s%s%s - %s",
+                    "retrying on status code: %s - %s - %s",
                     str(response.status_code),
-                    response.request.url.host,
-                    response.request.url.path,
-                    (
-                        f"?{response.request.url.params}"
-                        if response.request.url.params
-                        else ""
-                    ),
+                    url_message_part,
                     response_message,
                 )
             elif caught_exception is not None:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -32,6 +32,21 @@ pytest session level fixtures shared by all integration tests.
 
 
 @pytest.fixture(scope="session")
+def event_loop(request):
+    """
+    Redefine the event loop to support session/module-scoped fixtures;
+    see https://github.com/pytest-dev/pytest-asyncio/issues/371
+    """
+    policy = asyncio.get_event_loop_policy()
+    loop = policy.new_event_loop()
+
+    try:
+        yield loop
+    finally:
+        loop.close()
+
+
+@pytest.fixture(scope="session")
 @tracer.start_as_current_span("conftest::syn")
 def syn() -> Synapse:
     """

--- a/tests/integration/synapseclient/integration_test.py
+++ b/tests/integration/synapseclient/integration_test.py
@@ -35,6 +35,7 @@ tracer = trace.get_tracer("synapseclient")
 
 FILE_NAME_PREFIX = "fooUploadFileEntity"
 FILE_DESCRIPTION = "A test file entity"
+NEW_DESCRIPTION = "new description"
 
 
 @tracer.start_as_current_span("integration_test::test_login")
@@ -1283,7 +1284,7 @@ class TestAsyncRestInterfaces:
 
         # WHEN I updated a field on the entity
         assert entity_bundle["entity"]["description"] == FILE_DESCRIPTION
-        entity_bundle["entity"]["description"] = "new description"
+        entity_bundle["entity"]["description"] = NEW_DESCRIPTION
 
         # AND I PUT the updated entity back to Synapse
         updated_entity_bundle = await self.syn.rest_put_async(
@@ -1292,7 +1293,7 @@ class TestAsyncRestInterfaces:
         )
 
         # THEN I expect the updated entity to have been stored to synapse
-        assert updated_entity_bundle["entity"]["description"] == "new description"
+        assert updated_entity_bundle["entity"]["description"] == NEW_DESCRIPTION
 
         # AND getting the entity again from synapse should return the updated entity
         entity_bundle_copy = await self.syn.rest_post_async(
@@ -1303,7 +1304,7 @@ class TestAsyncRestInterfaces:
                 }
             ),
         )
-        assert entity_bundle_copy["entity"]["description"] == "new description"
+        assert entity_bundle_copy["entity"]["description"] == NEW_DESCRIPTION
 
     @pytest.mark.asyncio
     async def test_rest_delete_async(self, project: Project) -> None:

--- a/tests/integration/synapseclient/integration_test.py
+++ b/tests/integration/synapseclient/integration_test.py
@@ -1337,7 +1337,4 @@ class TestAsyncRestInterfaces:
         except SynapseHTTPError as ex:
             # THEN I expect that nothing is found as it is in the trash can
             assert ex.response.status_code == 404
-            assert (
-                f"404 Client Error: Entity {entity.id} is in trash can.\nEntity "
-                f"{entity.id} is in trash can." in str(ex)
-            )
+            assert f"404 Client Error: Entity {entity.id} is in trash can." in str(ex)

--- a/tests/unit/synapseclient/core/unit_test_retry.py
+++ b/tests/unit/synapseclient/core/unit_test_retry.py
@@ -1,10 +1,10 @@
-from requests import Response
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from unittest.mock import MagicMock
+from requests import Response
 
-from synapseclient.core.retry import with_retry
 from synapseclient.core.exceptions import SynapseError
+from synapseclient.core.retry import with_retry, with_retry_async
 
 
 def test_with_retry():
@@ -42,8 +42,8 @@ def test_with_retry():
     response.status_code.__eq__.side_effect = lambda x: x == 500
     response.headers.__contains__.reset_mock()
     response.headers.__contains__.side_effect = lambda x: x == "content-type"
-    response.headers.get.side_effect = (
-        lambda x, default_value: "application/json" if x == "content-type" else None
+    response.headers.get.side_effect = lambda x, default_value: (
+        "application/json" if x == "content-type" else None
     )
     response.json.return_value = {"reason": retryErrorMessages[0]}
     with_retry(function, **retryParams)
@@ -124,3 +124,128 @@ def test_with_retry__no_status_code():
 
     response = with_retry(fn, retry_exceptions=[ValueError])
     assert 2 == response
+
+
+class TestAsyncRetry:
+    """Unit tests for the with_retry_async function."""
+
+    @pytest.mark.asyncio
+    async def test_with_retry(self) -> None:
+        retry_params = {"retry_max_wait_before_failure": 1}
+        response = AsyncMock()
+        function = AsyncMock()
+        function.return_value = response
+
+        # -- No failures --
+        response.status_code.__eq__.side_effect = lambda x: x == 250
+        await with_retry_async(function, verbose=True, **retry_params)
+        assert function.call_count == 1
+
+        # -- Always fail --
+        response.status_code.__eq__.side_effect = lambda x: x == 503
+        await with_retry_async(function, verbose=True, **retry_params)
+        assert function.call_count > 5
+
+        # -- Fail then succeed --
+        thirdTimes = [3, 2, 1]
+
+        def the_charm(x):
+            if x == 503:
+                count = thirdTimes.pop()
+                return count != 3
+            return x == 503
+
+        response.status_code.__eq__.side_effect = the_charm
+        await with_retry_async(function, verbose=True, **retry_params)
+        assert function.call_count > 8
+
+        # -- Retry with an error message --
+        retry_error_messages = ["Foo"]
+        retry_params["retry_errors"] = retry_error_messages
+        response.status_code.__eq__.side_effect = lambda x: x == 500
+        response.headers.__contains__.reset_mock()
+        response.headers.__contains__.side_effect = lambda x: x == "content-type"
+        response.headers.get.side_effect = lambda x, default_value: (
+            "application/json" if x == "content-type" else None
+        )
+        response.json.return_value = {"reason": retry_error_messages[0]}
+        await with_retry_async(function, **retry_params)
+        assert response.headers.get.called
+        assert function.call_count > 12
+
+        # -- Propagate an error up --
+        print("Expect a SynapseError: Bar")
+
+        def foo():
+            raise SynapseError("Bar")
+
+        function.side_effect = foo
+        with pytest.raises(SynapseError) as ex_cm:
+            await with_retry_async(function, **retry_params)
+        assert "Bar" in str(ex_cm.value)
+        assert function.call_count > 13
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "values",
+        (
+            None,
+            [],
+            tuple(),
+        ),
+    )
+    async def test_with_retry__empty_status_codes(self, values) -> None:
+        """Verify that passing some Falsey values for the various sequence args is ok"""
+        response = AsyncMock(spec=Response)
+        response.status_code = 200
+
+        fn = AsyncMock()
+        fn.return_value = response
+
+        # no unexpected exceptions etc should be raised
+        returned_response = await with_retry_async(
+            fn,
+            retry_status_codes=values,
+            expected_status_codes=values,
+            retry_exceptions=values,
+            retry_errors=values,
+        )
+        assert returned_response == response
+
+    @pytest.mark.asyncio
+    async def test_with_retry__expected_status_code(self) -> None:
+        """Verify using retry expected_status_codes"""
+
+        non_matching_response = AsyncMock(spec=Response)
+        non_matching_response.status_code = 200
+
+        matching_response = AsyncMock(spec=Response)
+        matching_response.status_code = 201
+
+        fn = AsyncMock()
+        fn.side_effect = [
+            non_matching_response,
+            matching_response,
+        ]
+
+        response = await with_retry_async(fn, expected_status_codes=[201])
+        assert response == matching_response
+
+    @pytest.mark.asyncio
+    async def test_with_retry__no_status_code(self) -> None:
+        """Verify that with_retry can also be used on any function
+        even whose return values don't have status_codes.
+        In that case just for its exception retrying
+        and back off capabiliies."""
+
+        x = 0
+
+        async def fn():
+            nonlocal x
+            x += 1
+            if x < 2:
+                raise ValueError("not yet")
+            return x
+
+        response = await with_retry_async(fn, retry_exceptions=[ValueError])
+        assert 2 == response


### PR DESCRIPTION
**Problem:**

1. The default requests library does not contain any async interfaces
2. The back-off was not sufficient and the retry logic needs some TLC

**Solution:**

1. Adding the HTTPX dependency
3. Creating 2 new async client instances in Synapse that can be used to interact with Synapse or the Storage Providers
4. Creating a new API class with async interfaces that work directly with the the [EntityBundleV2Controller](https://rest-docs.synapse.org/rest/#org.sagebionetworks.repo.web.controller.EntityBundleV2Controller)
5. I re-wrote our exponential back-off logic to follow: 1ms + random(10ms-100ms). The 1ms is exponentially backed off by a factor of 2 for each retry and the random is not touched.
6. Updated retry logic to not fail based on the number of retries, instead fail after a certain amount of time has elapsed.

**Testing:**

1. Integration/Unit tests
2. Manual testing with these scripts:

**Creating and then deleting a folder**
```
import asyncio
import uuid

import synapseclient
from synapseclient.api import post_entity_bundle2_create


syn = synapseclient.Synapse(debug=True)
syn.login()


async def execute_create_then_delete_folder():
    folder_entity = {
        "entity": {
            "concreteType": "org.sagebionetworks.repo.model.Folder",
            "name": "test_folder_" + str(uuid.uuid4()),
            "parentId": "syn53972896",
        }
    }
    result = await post_entity_bundle2_create(request=folder_entity)
    print(result)

    await syn.rest_delete_async(uri=f"/entity/{result['entity']['id']}")
    await syn.rest_get_async(uri=f"/entity/{result['entity']['id']}")


asyncio.run(execute_create_then_delete_folder())
```

**Creating a folder**
```
import asyncio
import uuid

import synapseclient
from synapseclient.api import post_entity_bundle2_create


syn = synapseclient.Synapse(debug=True)
syn.login()


async def execute_create_folder():
    folder_entity = {
        "entity": {
            "concreteType": "org.sagebionetworks.repo.model.Folder",
            "name": "test_folder_" + str(uuid.uuid4()),
            "parentId": "syn53972896",
        }
    }
    result = await post_entity_bundle2_create(request=folder_entity)
    print(result)


asyncio.run(execute_create_folder())
```

**Getting a specific version of a file**
```
import asyncio

import synapseclient
from synapseclient.api import get_entity_id_version_bundle2


syn = synapseclient.Synapse(debug=True)
syn.login()


async def execute_get_with_id_and_version():
    synapse_id = "syn53604544"
    result = await get_entity_id_version_bundle2(entity_id=synapse_id, version=2)
    print(result)


asyncio.run(execute_get_with_id_and_version())
```

**Updating an entity by the /bundle2 endpoints**
```
import asyncio
import uuid

import synapseclient
from synapseclient.api import get_entity_id_bundle2, put_entity_id_bundle2
from synapseclient.annotations import _convert_to_annotations_list


syn = synapseclient.Synapse(debug=True)
syn.login()


async def execute_put():
    synapse_id = "syn53666147"
    result = await get_entity_id_bundle2(entity_id=synapse_id)
    print(result)

    print("\n\n\n\n\n")
    result["entity"]["description"] = str(uuid.uuid4())
    result["entity"]["versionNumber"] = result["entity"]["versionNumber"] + 1
    result["entity"]["versionLabel"] = str(result["entity"]["versionNumber"])
    synapse_annotations = _convert_to_annotations_list(
        {**result["annotations"]["annotations"], "asdf": [str(uuid.uuid4())]}
    )

    result["annotations"]["annotations"] = synapse_annotations

    put_result = await put_entity_id_bundle2(entity_id=synapse_id, request=result)

    print(put_result)


asyncio.run(execute_put())
```


I verified in several cases that the backoff was working as expected via console logs. I also verified several exceptions were being logged to the console based on the error:

HTTP 429:
```
2024-03-07 09:33:09,610 [retry:342 - DEBUG]: retrying on status code: 429 - repo-prod.prod.sagebase.org/repo/v1/entity/syn53666136/bundle2 - Too many concurrent requests. Allowed 3 concurrent connections at any time
```

HTTP 404:
```
Traceback (most recent call last):
  File "/home/bfauble/.pyenv/versions/3.8.18/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/bfauble/.pyenv/versions/3.8.18/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/bfauble/.vscode-server/extensions/ms-python.python-2024.2.1/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 39, in <module>
    cli.main()
  File "/home/bfauble/.vscode-server/extensions/ms-python.python-2024.2.1/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 430, in main
    run()
  File "/home/bfauble/.vscode-server/extensions/ms-python.python-2024.2.1/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 284, in run_file
    runpy.run_path(target, run_name="__main__")
  File "/home/bfauble/.vscode-server/extensions/ms-python.python-2024.2.1/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 321, in run_path
    return _run_module_code(code, init_globals, run_name,
  File "/home/bfauble/.vscode-server/extensions/ms-python.python-2024.2.1/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 135, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/home/bfauble/.vscode-server/extensions/ms-python.python-2024.2.1/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 124, in _run_code
    exec(code, run_globals)
  File "/home/bfauble/BryansGreatWorkspace/synapsePythonClient/junk/execute_get_bundle_async.py", line 62, in <module>
    asyncio.run(execute_gets())
  File "/home/bfauble/.pyenv/versions/3.8.18/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/home/bfauble/.pyenv/versions/3.8.18/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/home/bfauble/BryansGreatWorkspace/synapsePythonClient/junk/execute_get_bundle_async.py", line 43, in execute_gets
    result = await get_entity_id_bundle2(
  File "/home/bfauble/BryansGreatWorkspace/synapsePythonClient/synapseclient/api/entity_bundle_services_v2.py", line 29, in get_entity_id_bundle2
    return await client.rest_post_async(
  File "/home/bfauble/BryansGreatWorkspace/synapsePythonClient/synapseclient/client.py", line 6211, in rest_post_async
    response = await self._rest_call_async(
  File "/home/bfauble/BryansGreatWorkspace/synapsePythonClient/synapseclient/client.py", line 6143, in _rest_call_async
    self._handle_httpx_synapse_http_error(response)
  File "/home/bfauble/BryansGreatWorkspace/synapsePythonClient/synapseclient/client.py", line 5834, in _handle_httpx_synapse_http_error
    exceptions._raise_for_status_httpx(response, verbose=self.debug)
  File "/home/bfauble/BryansGreatWorkspace/synapsePythonClient/synapseclient/core/exceptions.py", line 277, in _raise_for_status_httpx
    raise SynapseHTTPError(message, response=response)
synapseclient.core.exceptions.SynapseHTTPError: 404 Client Error: Resource: 'syn536661362' does not exist
Resource: 'syn536661362' does not exist

>>>>>> Request <<<<<<
https://repo-prod.prod.sagebase.org/repo/v1/entity/syn536661362/bundle2 POST
>>> Headers: Headers({'host': 'repo-prod.prod.sagebase.org', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'content-type': 'application/json; charset=UTF-8', 'accept': 'application/json; charset=UTF-8', 'user-agent': 'synapseclient/4.1.1 python-requests/2.31.0', 'content-length': '118', 'authorization': '[secure]'})
>>> Body: b'{"includeEntity": true, "includeAnnotations": true, "includeFileHandles": true, "includeRestrictionInformation": true}'

>>>>>> Response <<<<<<
<Response [404 ]>
>>> Headers: Headers({'date': 'Thu, 07 Mar 2024 16:51:27 GMT', 'content-type': 'application/json;charset=UTF-8', 'content-length': '122', 'connection': 'keep-alive', 'server': '34 f6e676 27, 1647 57 c616 4796f6 e6 3712 0295. f6 5702 66f657 e6 4602 f657 27 02 3756, 3627 5647e2.', 'x-xss-protection': '1;mode=block', 'x-content-type-options': 'nosniff', 'access-control-allow-origin': '*', 'strict-transport-security': 'max-age=31536000', 'set-cookie': 'sessionID=367181e0-07c4-40c0-be70-04079e227e77; HttpOnly', 'vary': 'Accept-Encoding,User-Agent', 'content-encoding': 'gzip', 'x-frame-options': 'SAMEORIGIN'})
>>> Body: {"concreteType":"org.sagebionetworks.repo.model.ErrorResponse","reason":"Resource: 'syn536661362' does not exist"}
```

HTTP 404 in trash:
```
2024-03-07 11:45:38,701 [client:6189 - ERROR]: Error in rest_get_async
Traceback (most recent call last):
  File "/home/bfauble/BryansGreatWorkspace/synapsePythonClient/synapseclient/client.py", line 6177, in rest_get_async
    response = await self._rest_call_async(
  File "/home/bfauble/BryansGreatWorkspace/synapsePythonClient/synapseclient/client.py", line 6145, in _rest_call_async
    self._handle_httpx_synapse_http_error(response)
  File "/home/bfauble/BryansGreatWorkspace/synapsePythonClient/synapseclient/client.py", line 5833, in _handle_httpx_synapse_http_error
    exceptions._raise_for_status_httpx(response, verbose=self.debug)
  File "/home/bfauble/BryansGreatWorkspace/synapsePythonClient/synapseclient/core/exceptions.py", line 277, in _raise_for_status_httpx
    raise SynapseHTTPError(message, response=response)
synapseclient.core.exceptions.SynapseHTTPError: 404 Client Error: Entity syn53972940 is in trash can.
Entity syn53972940 is in trash can.

>>>>>> Request <<<<<<
https://repo-prod.prod.sagebase.org/repo/v1/entity/syn53972940 GET
>>> Headers: Headers({'host': 'repo-prod.prod.sagebase.org', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'content-type': 'application/json; charset=UTF-8', 'accept': 'application/json; charset=UTF-8', 'user-agent': 'synapseclient/4.1.1 python-requests/2.31.0', 'cookie': 'sessionID=0af536fc-19b2-4257-a535-2f848f46cfc0', 'authorization': '[secure]'})
>>> Body: b''

>>>>>> Response <<<<<<
<Response [404 ]>
>>> Headers: Headers({'date': 'Thu, 07 Mar 2024 18:45:33 GMT', 'content-type': 'application/json;charset=UTF-8', 'transfer-encoding': 'chunked', 'connection': 'keep-alive', 'server': '34 f6e676 27, 1647 57 c616 4796f6 e6 3712 0295. f6 5702 66f657 e6 4602 f657 27 02 3756, 3627 5647e2.', 'x-xss-protection': '1;mode=block', 'x-content-type-options': 'nosniff', 'access-control-allow-origin': '*', 'strict-transport-security': 'max-age=31536000', 'vary': 'Accept-Encoding,User-Agent', 'content-encoding': 'gzip', 'x-frame-options': 'SAMEORIGIN'})
>>> Body: {"concreteType":"org.sagebionetworks.repo.model.ErrorResponse","reason":"Entity syn53972940 is in trash can."}
```


