### PR TITLE
DRAFT: [SYNPY-1420] Re-write uploads to mix async, multi-threading, and multi-processing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
           path: |
             ${{ steps.get-dependencies.outputs.site_packages_loc }}
             ${{ steps.get-dependencies.outputs.site_bin_dir }}
-          key: ${{ runner.os }}-${{ matrix.python }}-build-${{ env.cache-name }}-${{ hashFiles('setup.py') }}-v11
+          key: ${{ runner.os }}-${{ matrix.python }}-build-${{ env.cache-name }}-${{ hashFiles('setup.py') }}-v12
 
       - name: Install py-dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
@@ -117,7 +117,10 @@ jobs:
         if: ${{ steps.secret-check.outputs.secrets_available == 'true' && steps.secret-check.outputs.synapse_pat_available == 'true' && !(startsWith(matrix.os, 'windows')) }}
         shell: bash
         run: |
-          echo "run_opentelemetry=true" >> $GITHUB_OUTPUT;
+          # Leave disabled during normal integration test runs - Enable when we want to
+          # collect the data.
+          # echo "run_opentelemetry=true" >> $GITHUB_OUTPUT;
+          echo "run_opentelemetry=false" >> $GITHUB_OUTPUT;
 
           # AWS CLI is pre-installed on github hosted runners - Commented out for GH runs
             # curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
@@ -181,7 +184,7 @@ jobs:
           export EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY="${{secrets.EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY}}"
           if [ ${{ steps.otel-check.outputs.run_opentelemetry }} == "true" ]; then
             # Set to 'otlp' to enable OpenTelemetry
-            export SYNAPSE_OTEL_INTEGRATION_TEST_EXPORTER="none"
+            export SYNAPSE_OTEL_INTEGRATION_TEST_EXPORTER="otlp"
           fi
 
           # use loadscope to avoid issues running tests concurrently that share scoped fixtures

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -24,6 +24,14 @@
             "markers": "python_version >= '3.8'",
             "version": "==4.3.0"
         },
+        "asyncio-atexit": {
+            "hashes": [
+                "sha256:1d0c71544b8ee2c484d322844ee72c0875dde6f250c0ed5b6993592ab9f7d436",
+                "sha256:d93d5f7d5633a534abd521ce2896ed0fbe8de170bb1e65ec871d1c20eac9d376"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.1"
+        },
         "backoff": {
             "hashes": [
                 "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba",
@@ -154,11 +162,11 @@
         },
         "googleapis-common-protos": {
             "hashes": [
-                "sha256:4750113612205514f9f6aa4cb00d523a94f3e8c06c5ad2fee466387dc4875f07",
-                "sha256:83f0ece9f94e5672cced82f592d2a5edf527a96ed1794f0bab36d5735c996277"
+                "sha256:17ad01b11d5f1d0171c06d3ba5c04c54474e883b66b949722b4938ee2694ef4e",
+                "sha256:ae45f75702f7c08b541f750854a678bd8f534a1a6bace6afe975f1d0a82d6632"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.62.0"
+            "version": "==1.63.0"
         },
         "h11": {
             "hashes": [
@@ -412,6 +420,14 @@
             "markers": "python_version < '3.9'",
             "version": "==1.6.3"
         },
+        "asyncio-atexit": {
+            "hashes": [
+                "sha256:1d0c71544b8ee2c484d322844ee72c0875dde6f250c0ed5b6993592ab9f7d436",
+                "sha256:d93d5f7d5633a534abd521ce2896ed0fbe8de170bb1e65ec871d1c20eac9d376"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.1"
+        },
         "attrs": {
             "hashes": [
                 "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30",
@@ -498,18 +514,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:300888f0c1b6f32f27f85a9aa876f50f46514ec619647af7e4d20db74d339714",
-                "sha256:b26928f9a21cf3649cea20a59061340f3294c6e7785ceb6e1a953eb8010dc3ba"
+                "sha256:199f11518b370e2ec1f6d5ec0c647eca967b6eb2cf6a332d9fc01a2144ea3690",
+                "sha256:f78f30f4d6b1d5839ec20da9ffe0f3b36c1b404a415d208459a0b88c202a05e9"
             ],
-            "version": "==1.34.56"
+            "version": "==1.34.60"
         },
         "botocore": {
             "hashes": [
-                "sha256:bffeb71ab21d47d4ecf947d9bdb2fbd1b0bbd0c27742cea7cf0b77b701c41d9f",
-                "sha256:fff66e22a5589c2d58fba57d1d95c334ce771895e831f80365f6cff6453285ec"
+                "sha256:4101494f0b692c95c592cba2719a61854e1c2923d89c60eaddf0e0d986442562",
+                "sha256:6e5317aab5dea19579e7c33528d53761bfb02f3fac5da2de01d1686a25f116a5"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.56"
+            "version": "==1.34.60"
         },
         "certifi": {
             "hashes": [
@@ -857,19 +873,19 @@
         },
         "googleapis-common-protos": {
             "hashes": [
-                "sha256:4750113612205514f9f6aa4cb00d523a94f3e8c06c5ad2fee466387dc4875f07",
-                "sha256:83f0ece9f94e5672cced82f592d2a5edf527a96ed1794f0bab36d5735c996277"
+                "sha256:17ad01b11d5f1d0171c06d3ba5c04c54474e883b66b949722b4938ee2694ef4e",
+                "sha256:ae45f75702f7c08b541f750854a678bd8f534a1a6bace6afe975f1d0a82d6632"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.62.0"
+            "version": "==1.63.0"
         },
         "griffe": {
             "hashes": [
-                "sha256:27b4610f1ba6e5d039e9f0a2c97232e13463df75e53cb1833e0679f3377b9de2",
-                "sha256:9edcfa9f57f4d9c5fcc6d5ce067c67a685b7101a21a7d11848ce0437368e474c"
+                "sha256:384df6b802a60f70e65fdb7e83f5b27e2da869a12eac85b25b55250012dbc263",
+                "sha256:fb83ee602701ffdf99c9a6bf5f0a5a3bd877364b3bffb2c451dc8fbd9645b0cf"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.41.3"
+            "version": "==0.42.0"
         },
         "h11": {
             "hashes": [
@@ -1056,10 +1072,10 @@
         },
         "mkdocs-material": {
             "hashes": [
-                "sha256:5f69cef6a8aaa4050b812f72b1094fda3d079b9a51cf27a247244c03ec455e97",
-                "sha256:d6f0c269f015e48c76291cdc79efb70f7b33bbbf42d649cfe475522ebee61b1f"
+                "sha256:5cbe17fee4e3b4980c8420a04cc762d8dc052ef1e10532abd4fce88e5ea9ce6a",
+                "sha256:d8e4caae576312a88fd2609b81cf43d233cdbe36860d67a68702b018b425bd87"
             ],
-            "version": "==9.5.12"
+            "version": "==9.5.13"
         },
         "mkdocs-material-extensions": {
             "hashes": [
@@ -1198,11 +1214,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5",
-                "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"
+                "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
+                "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==23.2"
+            "version": "==24.0"
         },
         "paginate": {
             "hashes": [
@@ -1762,11 +1778,11 @@
         },
         "wheel": {
             "hashes": [
-                "sha256:177f9c9b0d45c47873b619f5b650346d632cdc35fb5e4d25058e09c9e581433d",
-                "sha256:c45be39f7882c9d34243236f2d63cbd58039e360f85d0913425fbd7ceea617a8"
+                "sha256:465ef92c69fa5c5da2d1cf8ac40559a8c940886afcef87dcf14b9470862f1d85",
+                "sha256:55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==0.42.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==0.43.0"
         },
         "wrapt": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -302,6 +302,14 @@
             "markers": "python_version >= '3.8'",
             "path": "."
         },
+        "tqdm": {
+            "hashes": [
+                "sha256:1ee4f8a893eb9bef51c6e35730cebf234d5d0b6bd112b0271e10ed7c24a02bd9",
+                "sha256:6cd52cdf0fef0e0f543299cfc96fec90d7b8a7e88745f411ec33eb44d5ed3531"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.66.2"
+        },
         "typing-extensions": {
             "hashes": [
                 "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
@@ -396,11 +404,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31",
-                "sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"
+                "sha256:206f5a15f2af3dbaee80769fb7dc6f249695e940acca08dfb2a4769fe61e538b",
+                "sha256:2884ed22e7d8961de1c9a05142eb69a247f120291bc0206a00a7642f09b5b715"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.17.0"
+            "version": "==3.18.1"
         }
     },
     "develop": {
@@ -514,18 +522,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:199f11518b370e2ec1f6d5ec0c647eca967b6eb2cf6a332d9fc01a2144ea3690",
-                "sha256:f78f30f4d6b1d5839ec20da9ffe0f3b36c1b404a415d208459a0b88c202a05e9"
+                "sha256:617174f9051b564a57fb1079186ad15db6519ab3bb0d1fb22cb54767b0c4f46e",
+                "sha256:e14f3866f6f372aadc5457ff9a052a45d9e2dd93466122ba86cdd5351cfeafaf"
             ],
-            "version": "==1.34.60"
+            "version": "==1.34.63"
         },
         "botocore": {
             "hashes": [
-                "sha256:4101494f0b692c95c592cba2719a61854e1c2923d89c60eaddf0e0d986442562",
-                "sha256:6e5317aab5dea19579e7c33528d53761bfb02f3fac5da2de01d1686a25f116a5"
+                "sha256:2237743fc3ed68319bc358b451e7c13a02110242b1522b839806fd64fcee45fb",
+                "sha256:8a6cbc3a5c5988725c00815f8f7f6baf81980b19d9a2ee414b031e726759dba9"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.60"
+            "version": "==1.34.63"
         },
         "certifi": {
             "hashes": [
@@ -718,61 +726,61 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:0209a6369ccce576b43bb227dc8322d8ef9e323d089c6f3f26a597b09cb4d2aa",
-                "sha256:062b0a75d9261e2f9c6d071753f7eef0fc9caf3a2c82d36d76667ba7b6470003",
-                "sha256:0842571634f39016a6c03e9d4aba502be652a6e4455fadb73cd3a3a49173e38f",
-                "sha256:16bae383a9cc5abab9bb05c10a3e5a52e0a788325dc9ba8499e821885928968c",
-                "sha256:18c7320695c949de11a351742ee001849912fd57e62a706d83dfc1581897fa2e",
-                "sha256:18d90523ce7553dd0b7e23cbb28865db23cddfd683a38fb224115f7826de78d0",
-                "sha256:1bf25fbca0c8d121a3e92a2a0555c7e5bc981aee5c3fdaf4bb7809f410f696b9",
-                "sha256:276f6077a5c61447a48d133ed13e759c09e62aff0dc84274a68dc18660104d52",
-                "sha256:280459f0a03cecbe8800786cdc23067a8fc64c0bd51dc614008d9c36e1659d7e",
-                "sha256:28ca2098939eabab044ad68850aac8f8db6bf0b29bc7f2887d05889b17346454",
-                "sha256:2c854ce44e1ee31bda4e318af1dbcfc929026d12c5ed030095ad98197eeeaed0",
-                "sha256:35eb581efdacf7b7422af677b92170da4ef34500467381e805944a3201df2079",
-                "sha256:37389611ba54fd6d278fde86eb2c013c8e50232e38f5c68235d09d0a3f8aa352",
-                "sha256:3b253094dbe1b431d3a4ac2f053b6d7ede2664ac559705a704f621742e034f1f",
-                "sha256:3b2eccb883368f9e972e216c7b4c7c06cabda925b5f06dde0650281cb7666a30",
-                "sha256:451f433ad901b3bb00184d83fd83d135fb682d780b38af7944c9faeecb1e0bfe",
-                "sha256:489763b2d037b164846ebac0cbd368b8a4ca56385c4090807ff9fad817de4113",
-                "sha256:4af154d617c875b52651dd8dd17a31270c495082f3d55f6128e7629658d63765",
-                "sha256:506edb1dd49e13a2d4cac6a5173317b82a23c9d6e8df63efb4f0380de0fbccbc",
-                "sha256:6679060424faa9c11808598504c3ab472de4531c571ab2befa32f4971835788e",
-                "sha256:69b9f6f66c0af29642e73a520b6fed25ff9fd69a25975ebe6acb297234eda501",
-                "sha256:6c00cdc8fa4e50e1cc1f941a7f2e3e0f26cb2a1233c9696f26963ff58445bac7",
-                "sha256:6c0cdedd3500e0511eac1517bf560149764b7d8e65cb800d8bf1c63ebf39edd2",
-                "sha256:708a3369dcf055c00ddeeaa2b20f0dd1ce664eeabde6623e516c5228b753654f",
-                "sha256:718187eeb9849fc6cc23e0d9b092bc2348821c5e1a901c9f8975df0bc785bfd4",
-                "sha256:767b35c3a246bcb55b8044fd3a43b8cd553dd1f9f2c1eeb87a302b1f8daa0524",
-                "sha256:77fbfc5720cceac9c200054b9fab50cb2a7d79660609200ab83f5db96162d20c",
-                "sha256:7cbde573904625509a3f37b6fecea974e363460b556a627c60dc2f47e2fffa51",
-                "sha256:8249b1c7334be8f8c3abcaaa996e1e4927b0e5a23b65f5bf6cfe3180d8ca7840",
-                "sha256:8580b827d4746d47294c0e0b92854c85a92c2227927433998f0d3320ae8a71b6",
-                "sha256:8640f1fde5e1b8e3439fe482cdc2b0bb6c329f4bb161927c28d2e8879c6029ee",
-                "sha256:9a9babb9466fe1da12417a4aed923e90124a534736de6201794a3aea9d98484e",
-                "sha256:a78ed23b08e8ab524551f52953a8a05d61c3a760781762aac49f8de6eede8c45",
-                "sha256:abbbd8093c5229c72d4c2926afaee0e6e3140de69d5dcd918b2921f2f0c8baba",
-                "sha256:ae7f19afe0cce50039e2c782bff379c7e347cba335429678450b8fe81c4ef96d",
-                "sha256:b3ec74cfef2d985e145baae90d9b1b32f85e1741b04cd967aaf9cfa84c1334f3",
-                "sha256:b51bfc348925e92a9bd9b2e48dad13431b57011fd1038f08316e6bf1df107d10",
-                "sha256:b9a4a8dd3dcf4cbd3165737358e4d7dfbd9d59902ad11e3b15eebb6393b0446e",
-                "sha256:ba3a8aaed13770e970b3df46980cb068d1c24af1a1968b7818b69af8c4347efb",
-                "sha256:c0524de3ff096e15fcbfe8f056fdb4ea0bf497d584454f344d59fce069d3e6e9",
-                "sha256:c0a120238dd71c68484f02562f6d446d736adcc6ca0993712289b102705a9a3a",
-                "sha256:cbbe5e739d45a52f3200a771c6d2c7acf89eb2524890a4a3aa1a7fa0695d2a47",
-                "sha256:ce8c50520f57ec57aa21a63ea4f325c7b657386b3f02ccaedeccf9ebe27686e1",
-                "sha256:cf30900aa1ba595312ae41978b95e256e419d8a823af79ce670835409fc02ad3",
-                "sha256:d25b937a5d9ffa857d41be042b4238dd61db888533b53bc76dc082cb5a15e914",
-                "sha256:d6cdecaedea1ea9e033d8adf6a0ab11107b49571bbb9737175444cea6eb72328",
-                "sha256:dec9de46a33cf2dd87a5254af095a409ea3bf952d85ad339751e7de6d962cde6",
-                "sha256:ebe7c9e67a2d15fa97b77ea6571ce5e1e1f6b0db71d1d5e96f8d2bf134303c1d",
-                "sha256:ee866acc0861caebb4f2ab79f0b94dbfbdbfadc19f82e6e9c93930f74e11d7a0",
-                "sha256:f6a09b360d67e589236a44f0c39218a8efba2593b6abdccc300a8862cffc2f94",
-                "sha256:fcc66e222cf4c719fe7722a403888b1f5e1682d1679bd780e2b26c18bb648cdc",
-                "sha256:fd6545d97c98a192c5ac995d21c894b581f1fd14cf389be90724d21808b657e2"
+                "sha256:00838a35b882694afda09f85e469c96367daa3f3f2b097d846a7216993d37f4c",
+                "sha256:0513b9508b93da4e1716744ef6ebc507aff016ba115ffe8ecff744d1322a7b63",
+                "sha256:09c3255458533cb76ef55da8cc49ffab9e33f083739c8bd4f58e79fecfe288f7",
+                "sha256:09ef9199ed6653989ebbcaacc9b62b514bb63ea2f90256e71fea3ed74bd8ff6f",
+                "sha256:09fa497a8ab37784fbb20ab699c246053ac294d13fc7eb40ec007a5043ec91f8",
+                "sha256:0f9f50e7ef2a71e2fae92774c99170eb8304e3fdf9c8c3c7ae9bab3e7229c5cf",
+                "sha256:137eb07173141545e07403cca94ab625cc1cc6bc4c1e97b6e3846270e7e1fea0",
+                "sha256:1f384c3cc76aeedce208643697fb3e8437604b512255de6d18dae3f27655a384",
+                "sha256:201bef2eea65e0e9c56343115ba3814e896afe6d36ffd37bab783261db430f76",
+                "sha256:38dd60d7bf242c4ed5b38e094baf6401faa114fc09e9e6632374388a404f98e7",
+                "sha256:3b799445b9f7ee8bf299cfaed6f5b226c0037b74886a4e11515e569b36fe310d",
+                "sha256:3ea79bb50e805cd6ac058dfa3b5c8f6c040cb87fe83de10845857f5535d1db70",
+                "sha256:40209e141059b9370a2657c9b15607815359ab3ef9918f0196b6fccce8d3230f",
+                "sha256:41c9c5f3de16b903b610d09650e5e27adbfa7f500302718c9ffd1c12cf9d6818",
+                "sha256:54eb8d1bf7cacfbf2a3186019bcf01d11c666bd495ed18717162f7eb1e9dd00b",
+                "sha256:598825b51b81c808cb6f078dcb972f96af96b078faa47af7dfcdf282835baa8d",
+                "sha256:5fc1de20b2d4a061b3df27ab9b7c7111e9a710f10dc2b84d33a4ab25065994ec",
+                "sha256:623512f8ba53c422fcfb2ce68362c97945095b864cda94a92edbaf5994201083",
+                "sha256:690db6517f09336559dc0b5f55342df62370a48f5469fabf502db2c6d1cffcd2",
+                "sha256:69eb372f7e2ece89f14751fbcbe470295d73ed41ecd37ca36ed2eb47512a6ab9",
+                "sha256:73bfb9c09951125d06ee473bed216e2c3742f530fc5acc1383883125de76d9cd",
+                "sha256:742a76a12aa45b44d236815d282b03cfb1de3b4323f3e4ec933acfae08e54ade",
+                "sha256:7c95949560050d04d46b919301826525597f07b33beba6187d04fa64d47ac82e",
+                "sha256:8130a2aa2acb8788e0b56938786c33c7c98562697bf9f4c7d6e8e5e3a0501e4a",
+                "sha256:8a2b2b78c78293782fd3767d53e6474582f62443d0504b1554370bde86cc8227",
+                "sha256:8ce1415194b4a6bd0cdcc3a1dfbf58b63f910dcb7330fe15bdff542c56949f87",
+                "sha256:9ca28a302acb19b6af89e90f33ee3e1906961f94b54ea37de6737b7ca9d8827c",
+                "sha256:a4cdc86d54b5da0df6d3d3a2f0b710949286094c3a6700c21e9015932b81447e",
+                "sha256:aa5b1c1bfc28384f1f53b69a023d789f72b2e0ab1b3787aae16992a7ca21056c",
+                "sha256:aadacf9a2f407a4688d700e4ebab33a7e2e408f2ca04dbf4aef17585389eff3e",
+                "sha256:ae71e7ddb7a413dd60052e90528f2f65270aad4b509563af6d03d53e979feafd",
+                "sha256:b14706df8b2de49869ae03a5ccbc211f4041750cd4a66f698df89d44f4bd30ec",
+                "sha256:b1a93009cb80730c9bca5d6d4665494b725b6e8e157c1cb7f2db5b4b122ea562",
+                "sha256:b2991665420a803495e0b90a79233c1433d6ed77ef282e8e152a324bbbc5e0c8",
+                "sha256:b2c5edc4ac10a7ef6605a966c58929ec6c1bd0917fb8c15cb3363f65aa40e677",
+                "sha256:b4d33f418f46362995f1e9d4f3a35a1b6322cb959c31d88ae56b0298e1c22357",
+                "sha256:b91cbc4b195444e7e258ba27ac33769c41b94967919f10037e6355e998af255c",
+                "sha256:c74880fc64d4958159fbd537a091d2a585448a8f8508bf248d72112723974cbd",
+                "sha256:c901df83d097649e257e803be22592aedfd5182f07b3cc87d640bbb9afd50f49",
+                "sha256:cac99918c7bba15302a2d81f0312c08054a3359eaa1929c7e4b26ebe41e9b286",
+                "sha256:cc4f1358cb0c78edef3ed237ef2c86056206bb8d9140e73b6b89fbcfcbdd40e1",
+                "sha256:ccd341521be3d1b3daeb41960ae94a5e87abe2f46f17224ba5d6f2b8398016cf",
+                "sha256:ce4b94265ca988c3f8e479e741693d143026632672e3ff924f25fab50518dd51",
+                "sha256:cf271892d13e43bc2b51e6908ec9a6a5094a4df1d8af0bfc360088ee6c684409",
+                "sha256:d5ae728ff3b5401cc320d792866987e7e7e880e6ebd24433b70a33b643bb0384",
+                "sha256:d71eec7d83298f1af3326ce0ff1d0ea83c7cb98f72b577097f9083b20bdaf05e",
+                "sha256:d898fe162d26929b5960e4e138651f7427048e72c853607f2b200909794ed978",
+                "sha256:d89d7b2974cae412400e88f35d86af72208e1ede1a541954af5d944a8ba46c57",
+                "sha256:dfa8fe35a0bb90382837b238fff375de15f0dcdb9ae68ff85f7a63649c98527e",
+                "sha256:e0be5efd5127542ef31f165de269f77560d6cdef525fffa446de6f7e9186cfb2",
+                "sha256:fdfafb32984684eb03c2d83e1e51f64f0906b11e64482df3c5db936ce3839d48",
+                "sha256:ff7687ca3d7028d8a5f0ebae95a6e4827c5616b31a4ee1192bdfde697db110d4"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==7.4.3"
+            "version": "==7.4.4"
         },
         "cryptography": {
             "hashes": [
@@ -1101,10 +1109,10 @@
         },
         "mkdocstrings-python": {
             "hashes": [
-                "sha256:1488bddf50ee42c07d9a488dddc197f8e8999c2899687043ec5dd1643d057192",
-                "sha256:4209970cc90bec194568682a535848a8d8489516c6ed4adbe58bbc67b699ca9d"
+                "sha256:6e1a442367cf75d30cf69774cbb1ad02aebec58bfff26087439df4955efecfde",
+                "sha256:fad27d7314b4ec9c0359a187b477fb94c65ef561fdae941dca1b717c59aae96f"
             ],
-            "version": "==1.8.0"
+            "version": "==1.9.0"
         },
         "mypy-extensions": {
             "hashes": [
@@ -1651,19 +1659,19 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:3cdb40f5cfa6966e812209d0994f2a4709b561c88e90cf00c2696d2df4e56b2e",
-                "sha256:d0c8bbf672d5eebbe4e57945e23b972d963f07d82f661cabf678a5c88831595b"
+                "sha256:5683916b4c724f799e600f41dd9e10a9ff19871bf87623cc8f491cb4f5fa0a19",
+                "sha256:ceb252b11bcf87080fb7850a224fb6e05c8a776bab8f2b64b7f25b969464839d"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.10.0"
+            "version": "==0.10.1"
         },
         "setuptools": {
             "hashes": [
-                "sha256:02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56",
-                "sha256:5c0806c7d9af348e6dd3777b4f4dbb42c7ad85b190104837488eab9a7c945cf8"
+                "sha256:0ff4183f8f42cd8fa3acea16c45205521a4ef28f73c6391d8a25e92893134f2e",
+                "sha256:c21c49fb1042386df081cb5d86759792ab89efca84cf114889191cd09aacc80c"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==69.1.1"
+            "version": "==69.2.0"
         },
         "six": {
             "hashes": [
@@ -1708,6 +1716,14 @@
             ],
             "markers": "python_version < '3.11'",
             "version": "==2.0.1"
+        },
+        "tqdm": {
+            "hashes": [
+                "sha256:1ee4f8a893eb9bef51c6e35730cebf234d5d0b6bd112b0271e10ed7c24a02bd9",
+                "sha256:6cd52cdf0fef0e0f543299cfc96fec90d7b8a7e88745f411ec33eb44d5ed3531"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.66.2"
         },
         "typing-extensions": {
             "hashes": [
@@ -1862,11 +1878,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31",
-                "sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"
+                "sha256:206f5a15f2af3dbaee80769fb7dc6f249695e940acca08dfb2a4769fe61e538b",
+                "sha256:2884ed22e7d8961de1c9a05142eb69a247f120291bc0206a00a7642f09b5b715"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.17.0"
+            "version": "==3.18.1"
         }
     }
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ install_requires =
     opentelemetry-sdk~=1.21.0
     opentelemetry-exporter-otlp-proto-http~=1.21.0
     nest-asyncio~=1.6.0
+    asyncio-atexit~=1.0.1
     httpx~=0.27.0
 tests_require =
     pytest>=6.0.0,<7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ install_requires =
     nest-asyncio~=1.6.0
     asyncio-atexit~=1.0.1
     httpx~=0.27.0
+    tqdm>=4.66.2,<5.0
 tests_require =
     pytest>=6.0.0,<7.0
     pytest-mock>=3.0,<4.0

--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -23,6 +23,7 @@ from .file_services import (
     put_file_multipart_add,
     put_file_multipart_complete,
     post_file_multipart_presigned_urls_async,
+    put_file_multipart_add_async,
 )
 
 __all__ = [
@@ -43,6 +44,7 @@ __all__ = [
     "post_external_filehandle",
     "post_file_multipart_presigned_urls",
     "post_file_multipart_presigned_urls_async",
+    "put_file_multipart_add_async",
     # entity_services
     "get_entity",
     "put_entity",

--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -12,6 +12,7 @@ from .entity_services import (
     get_upload_destination_location,
     post_entity,
     put_entity,
+    create_access_requirements_if_none,
 )
 from .file_services import (
     get_file_handle,
@@ -51,4 +52,5 @@ __all__ = [
     "post_entity",
     "get_upload_destination",
     "get_upload_destination_location",
+    "create_access_requirements_if_none",
 ]

--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -22,6 +22,7 @@ from .file_services import (
     post_file_multipart_presigned_urls,
     put_file_multipart_add,
     put_file_multipart_complete,
+    post_file_multipart_presigned_urls_async,
 )
 
 __all__ = [
@@ -41,6 +42,7 @@ __all__ = [
     "get_file_handle",
     "post_external_filehandle",
     "post_file_multipart_presigned_urls",
+    "post_file_multipart_presigned_urls_async",
     # entity_services
     "get_entity",
     "put_entity",

--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -6,12 +6,45 @@ from .entity_bundle_services_v2 import (
     post_entity_bundle2_create,
     put_entity_id_bundle2,
 )
+from .file_services import (
+    post_file_multipart,
+    put_file_multipart_add,
+    put_file_multipart_complete,
+    post_file_multipart_presigned_urls,
+    post_external_object_store_filehandle,
+    post_external_s3_file_handle,
+    get_file_handle,
+    post_external_filehandle,
+)
+from .entity_services import (
+    get_upload_destination,
+    get_entity,
+    put_entity,
+    post_entity,
+    get_upload_destination_location,
+)
 
 
 __all__ = [
+    # annotations
     "set_annotations",
     "get_entity_id_bundle2",
     "get_entity_id_version_bundle2",
     "post_entity_bundle2_create",
     "put_entity_id_bundle2",
+    # file_services
+    "post_file_multipart",
+    "put_file_multipart_add",
+    "put_file_multipart_complete",
+    "post_file_multipart_presigned_urls",
+    "post_external_object_store_filehandle",
+    "post_external_s3_file_handle",
+    "get_file_handle",
+    "post_external_filehandle",
+    # entity_services
+    "get_entity",
+    "put_entity",
+    "post_entity",
+    "get_upload_destination",
+    "get_upload_destination_location",
 ]

--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -6,24 +6,23 @@ from .entity_bundle_services_v2 import (
     post_entity_bundle2_create,
     put_entity_id_bundle2,
 )
+from .entity_services import (
+    get_entity,
+    get_upload_destination,
+    get_upload_destination_location,
+    post_entity,
+    put_entity,
+)
 from .file_services import (
-    post_file_multipart,
-    put_file_multipart_add,
-    put_file_multipart_complete,
-    post_file_multipart_presigned_urls,
-    post_external_object_store_filehandle,
-    post_external_s3_file_handle,
     get_file_handle,
     post_external_filehandle,
+    post_external_object_store_filehandle,
+    post_external_s3_file_handle,
+    post_file_multipart,
+    post_file_multipart_presigned_urls,
+    put_file_multipart_add,
+    put_file_multipart_complete,
 )
-from .entity_services import (
-    get_upload_destination,
-    get_entity,
-    put_entity,
-    post_entity,
-    get_upload_destination_location,
-)
-
 
 __all__ = [
     # annotations
@@ -41,6 +40,7 @@ __all__ = [
     "post_external_s3_file_handle",
     "get_file_handle",
     "post_external_filehandle",
+    "post_file_multipart_presigned_urls",
     # entity_services
     "get_entity",
     "put_entity",

--- a/synapseclient/api/entity_services.py
+++ b/synapseclient/api/entity_services.py
@@ -1,0 +1,130 @@
+"""This module is responsible for exposing the services defined at:
+<https://rest-docs.synapse.org/rest/#org.sagebionetworks.repo.web.controller.EntityController>
+"""
+
+import json
+from typing import Any, Dict, Optional, Union
+
+from synapseclient import Synapse
+
+
+async def post_entity(
+    request: Dict[str, Any],
+    generated_by: Optional[str] = None,
+    synapse_client: Optional[Synapse] = None,
+) -> Dict[str, Any]:
+    """
+    Arguments:
+        request: The request for the entity matching
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/Entity.html>
+        generated_by: The ID of the activity to associate with the entity.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        The requested entity matching
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/Entity.html>
+    """
+    client = Synapse.get_client(synapse_client=synapse_client)
+    params = {}
+    if generated_by:
+        params["generatedBy"] = generated_by
+    return await client.rest_post_async(
+        uri="/entity", body=json.dumps(request), params=params
+    )
+
+
+async def put_entity(
+    entity_id: str,
+    request: Dict[str, Any],
+    new_version: bool = False,
+    generated_by: Optional[str] = None,
+    synapse_client: Optional[Synapse] = None,
+) -> Dict[str, Any]:
+    """
+    Arguments:
+        entity_id: The ID of the entity to update.
+        request: The request for the entity matching
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/Entity.html>
+        generated_by: The ID of the activity to associate with the entity.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        The requested entity bundle matching
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/Entity.html>
+    """
+    client = Synapse.get_client(synapse_client=synapse_client)
+    params = {}
+    if generated_by:
+        params["generatedBy"] = generated_by
+    if new_version:
+        params["newVersion"] = "true"
+    return await client.rest_put_async(
+        uri=f"/entity/{entity_id}", body=json.dumps(request), params=params
+    )
+
+
+async def get_entity(
+    entity_id: str,
+    synapse_client: Optional[Synapse] = None,
+) -> Dict[str, Any]:
+    """
+    Arguments:
+        entity_id: The ID of the entity.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        The requested entity bundle matching
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/Entity.html>
+    """
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_get_async(
+        uri=f"/entity/{entity_id}",
+    )
+
+
+async def get_upload_destination(
+    entity_id: str, synapse_client: Optional[Synapse] = None
+) -> Dict[str, Union[str, int]]:
+    """
+    <https://rest-docs.synapse.org/rest/GET/entity/id/uploadDestination.html>
+
+    Arguments:
+        entity_id: The ID of the entity.
+        endpoint: Server endpoint to call to.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        The upload destination.
+        <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/UploadDestination.html>
+    """
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_get_async(
+        uri=f"/entity/{entity_id}/uploadDestination",
+        endpoint=client.fileHandleEndpoint,
+    )
+
+
+async def get_upload_destination_location(
+    entity_id: str, location: str, synapse_client: Optional[Synapse] = None
+) -> Dict[str, Union[str, int]]:
+    """
+    <https://rest-docs.synapse.org/rest/GET/entity/id/uploadDestination/storageLocationId.html>
+
+    Arguments:
+        entity_id: The ID of the entity.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        The upload destination.
+        <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/UploadDestination.html>
+    """
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_get_async(
+        uri=f"/entity/{entity_id}/uploadDestination/{location}",
+        endpoint=client.fileHandleEndpoint,
+    )

--- a/synapseclient/api/file_services.py
+++ b/synapseclient/api/file_services.py
@@ -44,7 +44,7 @@ async def post_file_multipart(
     )
 
 
-async def put_file_multipart_add(
+async def put_file_multipart_add_async(
     upload_id: str,
     part_number: int,
     md5_hex: str,
@@ -75,6 +75,37 @@ async def put_file_multipart_add(
     )
 
 
+def put_file_multipart_add(
+    upload_id: str,
+    part_number: int,
+    md5_hex: str,
+    endpoint: str,
+    synapse_client: Optional[Synapse] = None,
+) -> Dict[str, Any]:
+    """
+    <https://rest-docs.synapse.org/rest/PUT/file/multipart/uploadId/add/partNumber.html>
+
+    Arguments:
+        upload_id: The unique identifier of the file upload.
+        part_number: The part number to add. Must be a number between 1 and 10,000.
+        md5_hex: The MD5 of the uploaded part represented as a hexadecimal string. If
+            the provided MD5 does not match the MD5 of the uploaded part, the add
+            will fail.
+        endpoint: Server endpoint to call to
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        Object matching
+        <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/AddPartResponse.html>
+    """
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return client.restPUT(
+        f"/file/multipart/{upload_id}/add/{part_number}?partMD5Hex={md5_hex}",
+        endpoint=endpoint,
+    )
+
+
 async def put_file_multipart_complete(
     upload_id: str,
     endpoint: str,
@@ -100,7 +131,7 @@ async def put_file_multipart_complete(
     )
 
 
-async def post_file_multipart_presigned_urls(
+async def post_file_multipart_presigned_urls_async(
     upload_id: str,
     part_numbers: List[int],
     synapse_client: Optional[Synapse] = None,
@@ -126,6 +157,38 @@ async def post_file_multipart_presigned_urls(
 
     client = Synapse.get_client(synapse_client=synapse_client)
     return await client.rest_post_async(
+        uri,
+        json.dumps(body),
+        endpoint=client.fileHandleEndpoint,
+    )
+
+
+def post_file_multipart_presigned_urls(
+    upload_id: str,
+    part_numbers: List[int],
+    synapse_client: Optional[Synapse] = None,
+) -> Dict[str, Any]:
+    """
+    <https://rest-docs.synapse.org/rest/PUT/file/multipart/uploadId/add/partNumber.html>
+
+    Arguments:
+        upload_id: The unique identifier of the file upload.
+        part_numbers: The part numbers to get pre-signed URLs for.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        Object matching
+        <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/AddPartResponse.html>
+    """
+    uri = f"/file/multipart/{upload_id}/presigned/url/batch"
+    body = {
+        "uploadId": upload_id,
+        "partNumbers": part_numbers,
+    }
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return client.restPOST(
         uri,
         json.dumps(body),
         endpoint=client.fileHandleEndpoint,

--- a/synapseclient/api/file_services.py
+++ b/synapseclient/api/file_services.py
@@ -48,7 +48,6 @@ async def put_file_multipart_add_async(
     upload_id: str,
     part_number: int,
     md5_hex: str,
-    endpoint: str,
     synapse_client: Optional[Synapse] = None,
 ) -> Dict[str, Any]:
     """
@@ -60,7 +59,6 @@ async def put_file_multipart_add_async(
         md5_hex: The MD5 of the uploaded part represented as a hexadecimal string. If
             the provided MD5 does not match the MD5 of the uploaded part, the add
             will fail.
-        endpoint: Server endpoint to call to
         synapse_client: If not passed in or None this will use the last client from
             the `.login()` method.
 
@@ -71,7 +69,7 @@ async def put_file_multipart_add_async(
     client = Synapse.get_client(synapse_client=synapse_client)
     return await client.rest_put_async(
         f"/file/multipart/{upload_id}/add/{part_number}?partMD5Hex={md5_hex}",
-        endpoint=endpoint,
+        endpoint=client.fileHandleEndpoint,
     )
 
 

--- a/synapseclient/api/file_services.py
+++ b/synapseclient/api/file_services.py
@@ -1,0 +1,315 @@
+"""This module is responsible for exposing the services defined at:
+<https://rest-docs.synapse.org/rest/#org.sagebionetworks.repo.web.controller.EntityController>
+"""
+
+import json
+import mimetypes
+import os
+from typing import Any, Dict, Optional, List, Union
+
+from synapseclient import Synapse
+from synapseclient.core import utils
+from synapseclient.core.constants import concrete_types
+from synapseclient.api.entity_services import get_upload_destination
+
+
+async def post_file_multipart(
+    upload_request_payload: Dict[str, Any],
+    force_restart: bool,
+    endpoint: str,
+    synapse_client: Optional[Synapse] = None,
+) -> Dict[str, Any]:
+    """
+    <https://rest-docs.synapse.org/rest/POST/file/multipart.html>
+
+    Arguments:
+        upload_request_payload: The request matching
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/MultipartRequest.html>
+        force_restart: Optional parameter. When True, any upload state for the given
+            file will be cleared and a new upload will be started.
+        endpoint: Server endpoint to call to.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        The requested multipart upload status matching
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/MultipartUploadStatus.html>
+    """
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_post_async(
+        f"/file/multipart?forceRestart={str(force_restart).lower()}",
+        json.dumps(upload_request_payload),
+        endpoint=endpoint,
+    )
+
+
+async def put_file_multipart_add(
+    upload_id: str,
+    part_number: int,
+    md5_hex: str,
+    endpoint: str,
+    synapse_client: Optional[Synapse] = None,
+) -> Dict[str, Any]:
+    """
+    <https://rest-docs.synapse.org/rest/PUT/file/multipart/uploadId/add/partNumber.html>
+
+    Arguments:
+        upload_id: The unique identifier of the file upload.
+        part_number: The part number to add. Must be a number between 1 and 10,000.
+        md5_hex: The MD5 of the uploaded part represented as a hexadecimal string. If
+            the provided MD5 does not match the MD5 of the uploaded part, the add
+            will fail.
+        endpoint: Server endpoint to call to
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        Object matching
+        <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/AddPartResponse.html>
+    """
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_put_async(
+        f"/file/multipart/{upload_id}/add/{part_number}?partMD5Hex={md5_hex}",
+        endpoint=endpoint,
+    )
+
+
+async def put_file_multipart_complete(
+    upload_id: str,
+    endpoint: str,
+    synapse_client: Optional[Synapse] = None,
+) -> Dict[str, Any]:
+    """
+    <https://rest-docs.synapse.org/rest/PUT/file/multipart/uploadId/complete.html>
+
+    Arguments:
+        upload_id: The unique identifier of the file upload.
+        endpoint: Server endpoint to call to.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        Object matching
+        <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/MultipartUploadStatus.html>
+    """
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_put_async(
+        f"/file/multipart/{upload_id}/complete",
+        endpoint=endpoint,
+    )
+
+
+async def post_file_multipart_presigned_urls(
+    upload_id: str,
+    part_numbers: List[int],
+    synapse_client: Optional[Synapse] = None,
+) -> Dict[str, Any]:
+    """
+    <https://rest-docs.synapse.org/rest/PUT/file/multipart/uploadId/add/partNumber.html>
+
+    Arguments:
+        upload_id: The unique identifier of the file upload.
+        part_numbers: The part numbers to get pre-signed URLs for.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        Object matching
+        <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/AddPartResponse.html>
+    """
+    uri = f"/file/multipart/{upload_id}/presigned/url/batch"
+    body = {
+        "uploadId": upload_id,
+        "partNumbers": part_numbers,
+    }
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_post_async(
+        uri,
+        json.dumps(body),
+        endpoint=client.fileHandleEndpoint,
+    )
+
+
+async def post_external_object_store_filehandle(
+    s3_file_key: str,
+    file_path: str,
+    storage_location_id: int,
+    mimetype: str = None,
+    md5: str = None,
+    synapse_client: Optional[Synapse] = None,
+) -> Dict[str, Union[str, int]]:
+    """
+    Create a new FileHandle representing an external object.
+    <https://rest-docs.synapse.org/rest/POST/externalFileHandle.html>
+
+    Arguments:
+        s3_file_key:         S3 key of the uploaded object
+        file_path:           The local path of the uploaded file
+        storage_location_id: The optional storage location descriptor
+        mimetype:            The Mimetype of the file, if known.
+        md5:                 The file's content MD5, if known.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        A FileHandle for objects that are stored externally.
+        <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/ExternalFileHandleInterface.html>
+    """
+    client = Synapse.get_client(synapse_client=synapse_client)
+    if mimetype is None:
+        mimetype, _ = mimetypes.guess_type(file_path, strict=False)
+    file_handle = {
+        "concreteType": concrete_types.EXTERNAL_OBJECT_STORE_FILE_HANDLE,
+        "fileKey": s3_file_key,
+        "fileName": os.path.basename(file_path),
+        "contentMd5": md5 or utils.md5_for_file(file_path).hexdigest(),
+        "contentSize": os.stat(file_path).st_size,
+        "storageLocationId": storage_location_id,
+        "contentType": mimetype,
+    }
+
+    return await client.rest_post_async(
+        "/externalFileHandle", json.dumps(file_handle), client.fileHandleEndpoint
+    )
+
+
+async def post_external_filehandle(
+    external_url: str,
+    mimetype: str = None,
+    md5: str = None,
+    file_size: int = None,
+    synapse_client: Optional[Synapse] = None,
+) -> Dict[str, Union[str, int]]:
+    """
+    Create a new FileHandle representing an external object.
+    <https://rest-docs.synapse.org/rest/POST/externalFileHandle.html>
+
+    Arguments:
+        externalURL:  An external URL
+        mimetype:     The Mimetype of the file, if known.
+        md5:          The file's content MD5.
+        file_size:    The size of the file in bytes.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        A FileHandle for objects that are stored externally.
+        <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/ExternalFileHandleInterface.html>
+    """
+    client = Synapse.get_client(synapse_client=synapse_client)
+    file_name = external_url.split("/")[-1]
+    external_url = utils.as_url(external_url)
+    file_handle = {
+        "concreteType": concrete_types.EXTERNAL_FILE_HANDLE,
+        "fileName": file_name,
+        "externalURL": external_url,
+        "contentMd5": md5,
+        "contentSize": file_size,
+    }
+    if mimetype is None:
+        (mimetype, _) = mimetypes.guess_type(external_url, strict=False)
+    if mimetype is not None:
+        file_handle["contentType"] = mimetype
+    return await client.rest_post_async(
+        "/externalFileHandle", json.dumps(file_handle), client.fileHandleEndpoint
+    )
+
+
+async def post_external_s3_file_handle(
+    bucket_name: str,
+    s3_file_key: str,
+    file_path: str,
+    parent: str = None,
+    storage_location_id: str = None,
+    mimetype: str = None,
+    md5: str = None,
+    synapse_client: Optional[Synapse] = None,
+) -> Dict[str, Union[str, int, bool]]:
+    """
+    Create an external S3 file handle for e.g. a file that has been uploaded directly to
+    an external S3 storage location.
+
+    <https://rest-docs.synapse.org/rest/POST/externalFileHandle/s3.html>
+
+    Arguments:
+        bucket_name: Name of the S3 bucket
+        s3_file_key: S3 key of the uploaded object
+        file_path: Local path of the uploaded file
+        parent: Parent entity to create the file handle in, the file handle will be
+            created in the default storage location of the parent. Mutually exclusive
+            with storage_location_id
+        storage_location_id: Explicit storage location id to create the file handle in,
+            mutually exclusive with parent
+        mimetype: Mimetype of the file, if known
+        md5: MD5 of the file, if known
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        The created file handle.
+        <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/S3FileHandle.html>
+
+    Raises:
+        ValueError: If neither parent nor storage_location_id is specified, or if
+            both are specified.
+    """
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    if storage_location_id:
+        if parent:
+            raise ValueError("Pass parent or storage_location_id, not both")
+    elif not parent:
+        raise ValueError("One of parent or storage_location_id is required")
+    else:
+        upload_destination = await get_upload_destination(
+            entity_id=parent, synapse_client=client
+        )
+        storage_location_id = upload_destination["storageLocationId"]
+
+    if mimetype is None:
+        mimetype, _ = mimetypes.guess_type(file_path, strict=False)
+
+    file_handle = {
+        "concreteType": concrete_types.S3_FILE_HANDLE,
+        "key": s3_file_key,
+        "bucketName": bucket_name,
+        "fileName": os.path.basename(file_path),
+        "contentMd5": md5 or utils.md5_for_file(file_path).hexdigest(),
+        "contentSize": os.stat(file_path).st_size,
+        "storageLocationId": storage_location_id,
+        "contentType": mimetype,
+    }
+
+    return await client.rest_post_async(
+        "/externalFileHandle/s3",
+        json.dumps(file_handle),
+        endpoint=client.fileHandleEndpoint,
+    )
+
+
+async def get_file_handle(
+    file_handle_id: Dict[str, Union[str, int]], synapse_client: Optional[Synapse] = None
+) -> Dict[str, Union[str, int]]:
+    """
+    Retrieve a fileHandle from the fileHandle service.
+    Note: You must be the creator of the filehandle to use this method.
+    Otherwise, an 403-Forbidden error will be raised.
+
+    <https://rest-docs.synapse.org/rest/GET/fileHandle/handleId.html>
+
+    Arguments:
+        file_handle_id: The ID of the file handle to look up.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        A file handle retrieved from the file handle service.
+        <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/FileHandle.html>
+    """
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    return await client.rest_get_async(
+        f"/fileHandle/{file_handle_id}", endpoint=client.fileHandleEndpoint
+    )

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -109,7 +109,7 @@ from synapseclient.core.utils import (
 )
 from synapseclient.core.retry import (
     with_retry,
-    with_retry_async,
+    with_retry_time_based_async,
     DEFAULT_RETRY_STATUS_CODES,
     RETRYABLE_CONNECTION_ERRORS,
     RETRYABLE_CONNECTION_EXCEPTIONS,
@@ -397,7 +397,7 @@ class Synapse(object):
 
         def close_pool() -> None:
             """Close pool when event loop exits"""
-            self._thread_executor.shutdown()
+            self._thread_executor.shutdown(wait=True)
             del self._thread_executor
 
         self._thread_executor = get_executor(thread_count=self.max_threads)
@@ -417,7 +417,7 @@ class Synapse(object):
 
         def close_pool() -> None:
             """Close pool when event loop exits"""
-            self._process_executor.shutdown()
+            self._process_executor.shutdown(wait=True)
             del self._process_executor
 
         self._process_executor = ProcessPoolExecutor()
@@ -473,7 +473,6 @@ class Synapse(object):
 
     @property
     def max_threads(self) -> int:
-        print(f"max_threads: {self._max_threads}")
         return self._max_threads
 
     @max_threads.setter
@@ -6204,7 +6203,7 @@ class Synapse(object):
         auth = kwargs.pop("auth", self.credentials)
         requests_method_fn = getattr(requests_session, method)
         if data:
-            response = await with_retry_async(
+            response = await with_retry_time_based_async(
                 lambda: requests_method_fn(
                     uri,
                     content=data,
@@ -6216,7 +6215,7 @@ class Synapse(object):
                 **retry_policy,
             )
         else:
-            response = await with_retry_async(
+            response = await with_retry_time_based_async(
                 lambda: requests_method_fn(
                     uri,
                     headers=headers,

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -261,6 +261,7 @@ class Synapse(object):
         silent: bool = None,
         requests_session_async_synapse: httpx.AsyncClient = None,
         requests_session_async_storage: httpx.AsyncClient = None,
+        requests_session_storage: httpx.Client = None,
     ) -> "Synapse":
         """
         Initialize Synapse object
@@ -290,6 +291,9 @@ class Synapse(object):
         self._requests_session_async_synapse = requests_session_async_synapse
 
         self._requests_session_async_storage = requests_session_async_storage
+
+        httpx_timeout = httpx.Timeout(70)
+        self._requests_session_storage = httpx.Client(timeout=httpx_timeout)
 
         cache_root_dir = (
             cache.CACHE_ROOT_DIR if cache_root_dir is None else cache_root_dir

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -31,6 +31,7 @@ import zipfile
 import httpx
 
 from deprecated import deprecated
+from concurrent.futures import ProcessPoolExecutor
 
 import synapseclient
 from .annotations import (
@@ -347,6 +348,7 @@ class Synapse(object):
         # TODO: Need to determine the best practices to close the executor, ie:
         # >> executor.shutdown
         self._executor = get_executor(thread_count=self.max_threads)
+        self._process_executor = ProcessPoolExecutor()
         self.use_boto_sts_transfers = transfer_config["use_boto_sts"]
 
     def _get_requests_session_async_synapse(self) -> httpx.AsyncClient:
@@ -6269,8 +6271,8 @@ class Synapse(object):
 
         Arguments:
             uri: URI on which get is performed
-            endpoint: Server endpoint, defaults to self.repoEndpoint
             body: The payload to be delivered
+            endpoint: Server endpoint, defaults to self.repoEndpoint
             headers: Dictionary of headers to use.
             retry_policy: A retry policy that matches the arguments of
                 [synapseclient.core.retry.with_retry_async][].

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -341,7 +341,7 @@ async def with_retry_async(
                 (
                     "Retries have run out. re-raising the exception: %s"
                     if retry
-                    else "Rasing the exception: %s"
+                    else "Raising the exception: %s"
                 ),
                 str(caught_exception_info[0]),
             )
@@ -464,7 +464,7 @@ def with_retry_non_async(
                 (
                     "Retries have run out. re-raising the exception: %s"
                     if retry
-                    else "Rasing the exception: %s"
+                    else "Raising the exception: %s"
                 ),
                 str(caught_exception_info[0]),
             )

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -226,7 +226,7 @@ def calculate_exponential_backoff(
     return time_to_wait
 
 
-async def with_retry_async(
+async def with_retry_time_based_async(
     function,
     verbose: bool = False,
     retry_status_codes: typing.List[int] = None,
@@ -266,12 +266,12 @@ async def with_retry_async(
         retry_max_wait_before_failure: The maximum wait time before failure.
 
     Example: Using with_retry
-        Using ``with_retry_async`` to consolidate inputs into a list.
+        Using ``with_retry_time_based_async`` to consolidate inputs into a list.
 
-            from synapseclient.core.retry import with_retry_async
+            from synapseclient.core.retry import with_retry_time_based_async
 
             async def foo(a, b, c): return [a, b, c]
-            result = await with_retry_async(lambda: foo("1", "2", "3"))
+            result = await with_retry_time_based_async(lambda: foo("1", "2", "3"))
     """
     if not retry_status_codes:
         retry_status_codes = [429, 500, 502, 503, 504]
@@ -349,7 +349,7 @@ async def with_retry_async(
         return response
 
 
-def with_retry_non_async(
+def with_retry_time_based(
     function,
     verbose: bool = False,
     retry_status_codes: typing.List[int] = None,
@@ -389,12 +389,12 @@ def with_retry_non_async(
         retry_max_wait_before_failure: The maximum wait time before failure.
 
     Example: Using with_retry
-        Using ``with_retry_async`` to consolidate inputs into a list.
+        Using ``with_retry_time_based`` to consolidate inputs into a list.
 
-            from synapseclient.core.retry import with_retry_async
+            from synapseclient.core.retry import with_retry_time_based
 
             async def foo(a, b, c): return [a, b, c]
-            result = await with_retry_async(lambda: foo("1", "2", "3"))
+            result = with_retry_time_based(lambda: foo("1", "2", "3"))
     """
     if not retry_status_codes:
         retry_status_codes = [429, 500, 502, 503, 504]

--- a/synapseclient/core/sts_transfer.py
+++ b/synapseclient/core/sts_transfer.py
@@ -5,8 +5,11 @@ import importlib
 import os
 import threading
 import platform
-
+from typing import TYPE_CHECKING
 from synapseclient.core.utils import iso_to_datetime, snake_case
+
+if TYPE_CHECKING:
+    from synapseclient import Synapse
 
 try:
     boto3 = importlib.import_module("boto3")
@@ -253,6 +256,39 @@ def is_storage_location_sts_enabled(syn, entity_id, location):
         destination = syn.restGET(
             f"/entity/{entity_id}/uploadDestination/{location}",
             endpoint=syn.fileHandleEndpoint,
+        )
+
+    return destination.get("stsEnabled", False)
+
+
+async def is_storage_location_sts_enabled_async(
+    syn: "Synapse", entity_id: str, location: str
+) -> bool:
+    """
+    Returns whether the given storage location is enabled for STS.
+
+    Arguments:
+        syn:       A [Synapse][synapseclient.Synapse] object
+        entity_id: The ID of synapse entity whose storage location we want to check for sts access
+        location:  A storage location ID or a dictionary representing the location UploadDestination
+
+    Returns:
+        True if STS if enabled for the location, False otherwise
+    """
+    if not location:
+        return False
+
+    if isinstance(location, collections.abc.Mapping):
+        # looks like this is already an upload destination dict
+        destination = location
+
+    else:
+        # Lazy import to avoid circular imports
+        from synapseclient.api.entity_services import get_upload_destination_location
+
+        # otherwise treat it as a storage location id,
+        destination = await get_upload_destination_location(
+            entity_id=entity_id, location=location, synapse_client=syn
         )
 
     return destination.get("stsEnabled", False)

--- a/synapseclient/core/upload/multipart_upload_async.py
+++ b/synapseclient/core/upload/multipart_upload_async.py
@@ -34,7 +34,7 @@ from synapseclient.core.exceptions import (
     _raise_for_status,
 )
 from synapseclient.core.retry import with_retry_non_async
-from synapseclient.core.utils import MB, Spinner, md5_fn, md5_for_file_multithreading
+from synapseclient.core.utils import MB, Spinner, md5_fn, md5_for_file_multiprocessing
 
 if TYPE_CHECKING:
     from synapseclient import Synapse
@@ -460,10 +460,10 @@ async def multipart_upload_file_async(
 
         callback_func = Spinner().print_tick if not syn.silent else None
         md5_hex = md5 or (
-            await md5_for_file_multithreading(
+            await md5_for_file_multiprocessing(
                 filename=file_path,
                 callback=callback_func,
-                thread_pool_executor=syn._executor,
+                process_pool_executor=syn._process_executor,
             )
         )
 

--- a/synapseclient/core/upload/multipart_upload_async.py
+++ b/synapseclient/core/upload/multipart_upload_async.py
@@ -1,0 +1,660 @@
+"""Implements the client side of
+Synapse's [Multipart File Upload API](https://rest-docs.synapse.org/rest/index.html#org.sagebionetworks.file.controller.UploadController), which provides a
+robust means of uploading large files (into the 10s of GiB). End users should not need to call any of the methods under
+[UploadAttempt][synapseclient.core.upload.multipart_upload.UploadAttempt] directly.
+
+"""
+
+import asyncio
+import math
+import mimetypes
+import os
+import re
+import time
+from typing import TYPE_CHECKING, List, Mapping
+
+import httpx
+import requests
+from opentelemetry import trace
+
+from synapseclient.core.constants import concrete_types
+from synapseclient.core.exceptions import (
+    SynapseHTTPError,
+    SynapseUploadAbortedException,
+    SynapseUploadFailedException,
+    _raise_for_status,
+)
+from synapseclient.core.retry import with_retry_async
+from synapseclient.core.utils import MB, Spinner, md5_fn, md5_for_file
+from synapseclient.api import (
+    post_file_multipart,
+    put_file_multipart_add,
+    put_file_multipart_complete,
+    post_file_multipart_presigned_urls,
+)
+
+if TYPE_CHECKING:
+    from synapseclient import Synapse
+
+# AWS limits
+MAX_NUMBER_OF_PARTS = 10000
+MIN_PART_SIZE = 5 * MB
+
+# ancient tribal knowledge
+DEFAULT_PART_SIZE = 8 * MB
+MAX_RETRIES = 30
+
+
+tracer = trace.get_tracer("synapseclient")
+
+
+class UploadAttemptAsync:
+    """
+    Used to handle multi-threaded operations for uploading one or parts of a file.
+    """
+
+    def __init__(
+        self,
+        syn: "Synapse",
+        dest_file_name: str,
+        upload_request_payload,
+        part_request_body_provider_fn,
+        md5_fn,
+        force_restart: bool,
+        storage_str: str = None,
+    ):
+        self._syn = syn
+        self._dest_file_name = dest_file_name
+        self._part_size = upload_request_payload["partSizeBytes"]
+
+        self._upload_request_payload = upload_request_payload
+
+        self._part_request_body_provider_fn = part_request_body_provider_fn
+        self._md5_fn = md5_fn
+
+        self._force_restart = force_restart
+
+        self._lock = asyncio.Lock()
+
+        self._storage_str = storage_str
+
+        # populated later
+        self._upload_id: str = None
+        self._pre_signed_part_urls: Mapping[int, str] = None
+
+    @classmethod
+    def _get_remaining_part_numbers(cls, upload_status):
+        part_numbers = []
+        parts_state = upload_status["partsState"]
+
+        # parts are 1-based
+        for i, part_status in enumerate(parts_state, 1):
+            if part_status == "0":
+                part_numbers.append(i)
+
+        return len(parts_state), part_numbers
+
+    def _is_copy(self):
+        # is this a copy or upload request
+        return (
+            self._upload_request_payload.get("concreteType")
+            == concrete_types.MULTIPART_UPLOAD_COPY_REQUEST
+        )
+
+    async def _fetch_pre_signed_part_urls(
+        self,
+        upload_id: str,
+        part_numbers: List[int],
+    ) -> Mapping[int, str]:
+        with tracer.start_as_current_span(
+            "UploadAttemptAsync::_fetch_pre_signed_part_urls"
+        ):
+            response = await post_file_multipart_presigned_urls(
+                upload_id=upload_id,
+                part_numbers=part_numbers,
+                synapse_client=self._syn,
+            )
+
+            part_urls = {}
+            for part in response["partPresignedUrls"]:
+                part_urls[part["partNumber"]] = (
+                    part["uploadPresignedUrl"],
+                    part.get("signedHeaders", {}),
+                )
+
+            return part_urls
+
+    async def _refresh_pre_signed_part_urls(
+        self,
+        part_number: int,
+        expired_url: str,
+    ):
+        """Refresh all unfetched presigned urls, and return the refreshed
+        url for the given part number. If an existing expired_url is passed
+        and the url for the given part has already changed that new url
+        will be returned without a refresh (i.e. it is assumed that another
+        thread has already refreshed the url since the passed url expired).
+
+        Arguments:
+            part_number: the part number whose refreshed url should
+                         be returned
+            expired_url: the url that was detected as expired triggering
+                         this refresh
+        Returns:
+            refreshed URL
+
+        """
+        with tracer.start_as_current_span(
+            "UploadAttemptAsync::_refresh_pre_signed_part_urls"
+        ):
+            async with self._lock:
+                current_url = self._pre_signed_part_urls[part_number]
+                if current_url != expired_url:
+                    # if the url has already changed since the given url
+                    # was detected as expired we can assume that another
+                    # thread already refreshed the url and can avoid the extra
+                    # fetch.
+                    refreshed_url = current_url
+                else:
+                    self._pre_signed_part_urls = await self._fetch_pre_signed_part_urls(
+                        self._upload_id,
+                        list(self._pre_signed_part_urls.keys()),
+                    )
+
+                    refreshed_url = self._pre_signed_part_urls[part_number]
+
+            return refreshed_url
+
+    async def _handle_part(self, part_number):
+        with tracer.start_as_current_span("UploadAttempt::_handle_part"):
+            part_url, signed_headers = self._pre_signed_part_urls.get(part_number)
+
+            session: httpx.AsyncClient = self._syn._get_requests_session_async_storage()
+
+            # obtain the body (i.e. the upload bytes) for the given part number.
+            body = (
+                self._part_request_body_provider_fn(part_number)
+                if self._part_request_body_provider_fn
+                else None
+            )
+            part_size = len(body) if body else 0
+            self._syn.logger.debug(f"Uploading part {part_number} of size {part_size}")
+            if body is None:
+                raise ValueError(f"No body for part {part_number}")
+            for retry in range(2):
+                try:
+                    # use our backoff mechanism here, we have encountered 500s on puts to AWS signed urls
+                    response = await with_retry_async(
+                        lambda: session.put(
+                            url=part_url,
+                            content=body,  # noqa: F821
+                            headers=signed_headers,
+                        ),
+                        retry_exceptions=[requests.exceptions.ConnectionError],
+                    )
+                    try:
+                        _raise_for_status(response)
+                    except Exception as ex:
+                        raise ex
+
+                    # completed upload part to s3 successfully
+                    break
+
+                except SynapseHTTPError as ex:
+                    if ex.response.status_code == 403 and retry < 1:
+                        # we interpret this to mean our pre_signed url expired.
+                        self._syn.logger.debug(
+                            f"The pre-signed upload URL for part {part_number} has expired."
+                            "Refreshing urls and retrying.\n"
+                        )
+
+                        # we refresh all the urls and obtain this part's
+                        # specific url for the retry
+                        with tracer.start_as_current_span(
+                            "UploadAttempt::refresh_pre_signed_part_urls"
+                        ):
+                            (
+                                part_url,
+                                signed_headers,
+                            ) = await self._refresh_pre_signed_part_urls(
+                                part_number,
+                                part_url,
+                            )
+
+                    else:
+                        raise
+
+            md5_hex = self._md5_fn(body, response)
+            del response
+            del body
+
+            # now tell synapse that we uploaded that part successfully
+            await put_file_multipart_add(
+                upload_id=self._upload_id,
+                part_number=part_number,
+                md5_hex=md5_hex,
+                endpoint=self._syn.fileHandleEndpoint,
+                synapse_client=self._syn,
+            )
+
+            # # remove so future batch pre_signed url fetches will exclude this part
+            async with self._lock:
+                del self._pre_signed_part_urls[part_number]
+
+            return part_number, part_size
+
+    async def _upload_parts(self, part_count, remaining_part_numbers):
+        with tracer.start_as_current_span("UploadAttempt::_upload_parts"):
+            time_upload_started = time.time()
+            completed_part_count = part_count - len(remaining_part_numbers)
+            file_size = self._upload_request_payload.get("fileSizeBytes")
+
+            self._pre_signed_part_urls = await self._fetch_pre_signed_part_urls(
+                self._upload_id,
+                remaining_part_numbers,
+            )
+
+            futures = []
+
+            for part_number in remaining_part_numbers:
+                futures.append(
+                    asyncio.create_task(self._handle_part(part_number=part_number))
+                )
+
+            if not self._is_copy():
+                # we won't have bytes to measure during a copy so the byte oriented progress bar is not useful
+                progress = previously_transferred = min(
+                    completed_part_count * self._part_size,
+                    file_size,
+                )
+
+                self._syn._print_transfer_progress(
+                    progress,
+                    file_size,
+                    prefix=self._storage_str if self._storage_str else "Uploading",
+                    postfix=self._dest_file_name,
+                    previouslyTransferred=previously_transferred,
+                )
+
+            for result in asyncio.as_completed(futures):
+                try:
+                    _, part_size = await result
+
+                    if part_size and not self._is_copy():
+                        progress += part_size
+                        self._syn._print_transfer_progress(
+                            min(progress, file_size),
+                            file_size,
+                            prefix=(
+                                self._storage_str if self._storage_str else "Uploading"
+                            ),
+                            postfix=self._dest_file_name,
+                            dt=time.time() - time_upload_started,
+                            previouslyTransferred=previously_transferred,
+                        )
+                    del result
+                    del _
+                    del part_size
+                except (Exception, KeyboardInterrupt) as cause:
+                    # wait for all threads to complete before
+                    # raising the exception, we don't want to return
+                    # control while there are still threads from this
+                    # upload attempt running
+                    # await asyncio.wait(futures)
+                    for future in futures:
+                        future.cancel()
+                    await asyncio.gather(*futures)
+
+                    if isinstance(cause, KeyboardInterrupt):
+                        raise SynapseUploadAbortedException(
+                            "User interrupted upload"
+                        ) from cause
+                    raise SynapseUploadFailedException("Part upload failed") from cause
+
+    async def _complete_upload(self):
+        with tracer.start_as_current_span("UploadAttempt::_complete_upload"):
+            upload_status_response = await put_file_multipart_complete(
+                upload_id=self._upload_id,
+                endpoint=self._syn.fileHandleEndpoint,
+                synapse_client=self._syn,
+            )
+
+            upload_state = upload_status_response.get("state")
+            if upload_state != "COMPLETED":
+                # at this point we think successfully uploaded all the parts
+                # but the upload status isn't complete, we'll throw an error
+                # and let a subsequent attempt try to reconcile
+                raise SynapseUploadFailedException(
+                    f"Upload status has an unexpected state {upload_state}"
+                )
+
+            return upload_status_response
+
+    async def __call__(self):
+        with tracer.start_as_current_span("UploadAttempt::__call__"):
+            upload_status_response = await post_file_multipart(
+                upload_request_payload=self._upload_request_payload,
+                force_restart=self._force_restart,
+                endpoint=self._syn.fileHandleEndpoint,
+                synapse_client=self._syn,
+            )
+            upload_state = upload_status_response.get("state")
+
+            if upload_state != "COMPLETED":
+                self._upload_id = upload_status_response["uploadId"]
+                part_count, remaining_part_numbers = self._get_remaining_part_numbers(
+                    upload_status_response
+                )
+
+                # if no remaining part numbers then all the parts have been
+                # uploaded but the upload has not been marked complete.
+                if remaining_part_numbers:
+                    await self._upload_parts(part_count, remaining_part_numbers)
+                upload_status_response = await self._complete_upload()
+
+            return upload_status_response
+
+
+async def multipart_upload_file_async(
+    syn,
+    file_path: str,
+    dest_file_name: str = None,
+    content_type: str = None,
+    part_size: int = None,
+    storage_location_id: str = None,
+    preview: bool = True,
+    force_restart: bool = False,
+    md5: str = None,
+    storage_str: str = None,
+) -> str:
+    """Upload a file to a Synapse upload destination in chunks.
+
+    Arguments:
+        syn: a Synapse object
+        file_path: the file to upload
+        dest_file_name: upload as a different filename
+        content_type: Refers to the Content-Type of the API request.
+        part_size: Number of bytes per part. Minimum is 5MiB (5 * 1024 * 1024 bytes).
+        storage_location_id: an id indicating where the file should be
+                             stored. Retrieved from Synapse's UploadDestination
+        preview: True to generate a preview
+        force_restart: True to restart a previously initiated upload
+                       from scratch, False to try to resume
+        md5: The MD5 of the file. If not provided, it will be calculated.
+        storage_str: Optional string to append to the upload message
+
+    Returns:
+        a File Handle ID
+
+    Keyword arguments are passed down to
+    [_multipart_upload()][synapseclient.core.upload.multipart_upload._multipart_upload].
+
+    """
+    with tracer.start_as_current_span("multipart_upload::multipart_upload_file"):
+        trace.get_current_span().set_attributes(
+            {
+                "synapse.storage_location_id": (
+                    storage_location_id if storage_location_id is not None else ""
+                )
+            }
+        )
+
+        if not os.path.exists(file_path):
+            raise IOError(f'File "{file_path}" not found.')
+        if os.path.isdir(file_path):
+            raise IOError(f'File "{file_path}" is a directory.')
+
+        file_size = os.path.getsize(file_path)
+        if not dest_file_name:
+            dest_file_name = os.path.basename(file_path)
+
+        if content_type is None:
+            mime_type, _ = mimetypes.guess_type(file_path, strict=False)
+            content_type = mime_type or "application/octet-stream"
+
+        callback_func = Spinner().print_tick if not syn.silent else None
+        md5_hex = md5 or md5_for_file(file_path, callback=callback_func).hexdigest()
+
+        part_size = _get_part_size(part_size, file_size)
+
+        upload_request = {
+            "concreteType": concrete_types.MULTIPART_UPLOAD_REQUEST,
+            "contentType": content_type,
+            "contentMD5Hex": md5_hex,
+            "fileName": dest_file_name,
+            "fileSizeBytes": file_size,
+            "generatePreview": preview,
+            "partSizeBytes": part_size,
+            "storageLocationId": storage_location_id,
+        }
+
+        def part_fn(part_number):
+            return _get_file_chunk(file_path, part_number, part_size)
+
+        return await _multipart_upload_async(
+            syn,
+            dest_file_name,
+            upload_request,
+            part_fn,
+            md5_fn,
+            force_restart=force_restart,
+            storage_str=storage_str,
+        )
+
+
+async def _multipart_upload_async(
+    syn,
+    dest_file_name,
+    upload_request,
+    part_fn,
+    md5_fn,
+    force_restart: bool = False,
+    storage_str: str = None,
+):
+    """Calls upon an [UploadAttempt][synapseclient.core.upload.multipart_upload.UploadAttempt]
+    object to initiate and/or retry a multipart file upload or copy. This function is wrapped by
+    [multipart_upload_file][synapseclient.core.upload.multipart_upload.multipart_upload_file],
+    [multipart_upload_string][synapseclient.core.upload.multipart_upload.multipart_upload_string], and
+    [multipart_copy][synapseclient.core.upload.multipart_upload.multipart_copy].
+    Retries cannot exceed 7 retries per call.
+
+    Arguments:
+        syn: A Synapse object
+        dest_file_name: upload as a different filename
+        upload_request: A dictionary object with the user-fed logistical
+                        details of the upload/copy request.
+        part_fn: Function to calculate the partSize of each part
+        md5_fn: Function to calculate the MD5 of the file-like object
+        storage_str: Optional string to append to the upload message
+
+    Returns:
+        A File Handle ID
+
+    """
+    with tracer.start_as_current_span("multipart_upload::_multipart_upload_async"):
+        retry = 0
+        while True:
+            try:
+                upload_status_response = await UploadAttemptAsync(
+                    syn,
+                    dest_file_name,
+                    upload_request,
+                    part_fn,
+                    md5_fn,
+                    # only force_restart the first time through (if requested).
+                    # a retry after a caught exception will not restart the upload
+                    # from scratch.
+                    force_restart and retry == 0,
+                    storage_str=storage_str,
+                )()
+
+                # success
+                return upload_status_response["resultFileHandleId"]
+
+            except SynapseUploadFailedException:
+                if retry < MAX_RETRIES:
+                    retry += 1
+                else:
+                    raise
+
+
+def _get_file_chunk(file_path, part_number, chunk_size):
+    """Read the nth chunk from the file."""
+    with open(file_path, "rb") as f:
+        f.seek((part_number - 1) * chunk_size)
+        return f.read(chunk_size)
+
+
+def _get_data_chunk(data, part_number, chunk_size):
+    """Return the nth chunk of a buffer."""
+    return data[((part_number - 1) * chunk_size) : part_number * chunk_size]
+
+
+def _get_part_size(part_size, file_size):
+    part_size = part_size or DEFAULT_PART_SIZE
+
+    # can't exceed the maximum allowed num parts
+    part_size = max(
+        part_size, MIN_PART_SIZE, int(math.ceil(file_size / MAX_NUMBER_OF_PARTS))
+    )
+    return part_size
+
+
+@tracer.start_as_current_span("multipart_upload::multipart_upload_string")
+async def multipart_upload_string_async(
+    syn,
+    text: str,
+    dest_file_name: str = None,
+    part_size: int = None,
+    content_type: str = None,
+    storage_location_id: str = None,
+    preview: bool = True,
+    force_restart: bool = False,
+):
+    """Upload a file to a Synapse upload destination in chunks.
+
+    Arguments:
+        syn: a Synapse object
+        text: a string to upload as a file.
+        dest_file_name: upload as a different filename
+        content_type: Refers to the Content-Type of the API request.
+        part_size: number of bytes per part. Minimum 5MB.
+        storage_location_id: an id indicating where the file should be
+                             stored. Retrieved from Synapse's UploadDestination
+        preview: True to generate a preview
+        force_restart: True to restart a previously initiated upload
+                       from scratch, False to try to resume
+
+    Returns:
+        a File Handle ID
+
+    Keyword arguments are passed down to
+    [_multipart_upload()][synapseclient.core.upload.multipart_upload._multipart_upload].
+
+    """
+    data = text.encode("utf-8")
+    file_size = len(data)
+    md5_hex = md5_fn(data, None)
+
+    if not dest_file_name:
+        dest_file_name = "message.txt"
+
+    if not content_type:
+        content_type = "text/plain; charset=utf-8"
+
+    part_size = _get_part_size(part_size, file_size)
+
+    upload_request = {
+        "concreteType": concrete_types.MULTIPART_UPLOAD_REQUEST,
+        "contentType": content_type,
+        "contentMD5Hex": md5_hex,
+        "fileName": dest_file_name,
+        "fileSizeBytes": file_size,
+        "generatePreview": preview,
+        "partSizeBytes": part_size,
+        "storageLocationId": storage_location_id,
+    }
+
+    def part_fn(part_number):
+        return _get_data_chunk(data, part_number, part_size)
+
+    part_size = _get_part_size(part_size, file_size)
+    return await _multipart_upload_async(
+        syn,
+        dest_file_name,
+        upload_request,
+        part_fn,
+        md5_fn,
+        force_restart=force_restart,
+    )
+
+
+@tracer.start_as_current_span("multipart_upload::multipart_copy")
+async def multipart_copy_async(
+    syn,
+    source_file_handle_association,
+    dest_file_name: str = None,
+    part_size: int = None,
+    storage_location_id: str = None,
+    preview: bool = True,
+    force_restart: bool = False,
+):
+    """Makes a
+    [Multipart Upload Copy Request](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/MultipartUploadCopyRequest.html).
+    This request performs a copy of an existing file handle without data transfer from the client.
+
+    Arguments:
+        syn: A Synapse object
+        source_file_handle_association: Describes an association of a FileHandle with another object.
+        dest_file_name: The name of the file to be uploaded.
+        part_size: The size that each part will be (in bytes).
+        storage_location_id: The identifier of the storage location where this file should be copied to.
+                             The user must be the owner of the storage location.
+        preview: True to generate a preview of the data.
+        force_restart: True to restart a previously initiated upload from scratch, False to try to resume.
+
+    Returns:
+        a File Handle ID
+
+    Keyword arguments are passed down to
+    [_multipart_upload()][synapseclient.core.upload.multipart_upload._multipart_upload].
+
+    """
+    part_size = part_size or DEFAULT_PART_SIZE
+
+    upload_request = {
+        "concreteType": concrete_types.MULTIPART_UPLOAD_COPY_REQUEST,
+        "fileName": dest_file_name,
+        "generatePreview": preview,
+        "partSizeBytes": part_size,
+        "sourceFileHandleAssociation": source_file_handle_association,
+        "storageLocationId": storage_location_id,
+    }
+
+    def part_request_body_provider_fn(_) -> None:
+        # for an upload copy there are no bytes
+        return None
+
+    def md5_fn(_, response) -> str:
+        # for a multipart copy we use the md5 returned by the UploadPartCopy command
+        # when we add the part to the Synapse upload
+
+        # we extract the md5 from the <ETag> element in the response.
+        # use lookahead and lookbehind to find the opening and closing ETag elements but
+        # do not include those in the match, thus the entire matched string (group 0) will be
+        # what was between those elements.
+        md5_hex = re.search(
+            "(?<=<ETag>).*?(?=<\\/ETag>)", (response.content.decode("utf-8"))
+        ).group(0)
+
+        # remove quotes found in the ETag to get at the normalized ETag
+        return md5_hex.replace("&quot;", "").replace('"', "")
+
+    return _multipart_upload_async(
+        syn,
+        dest_file_name,
+        upload_request,
+        part_request_body_provider_fn,
+        md5_fn,
+        force_restart=force_restart,
+    )

--- a/synapseclient/core/upload/upload_functions_async.py
+++ b/synapseclient/core/upload/upload_functions_async.py
@@ -1,0 +1,387 @@
+"""This module handles the various ways that a user can upload a file to Synapse."""
+
+# pylint: disable=protected-access
+import asyncio
+import collections.abc
+import numbers
+import os
+import urllib.parse as urllib_parse
+import uuid
+from typing import TYPE_CHECKING, Dict, Union
+
+from opentelemetry import trace
+
+from synapseclient.api import (
+    post_external_object_store_filehandle,
+    post_external_s3_file_handle,
+    get_file_handle,
+    post_external_filehandle,
+    get_upload_destination,
+)
+from synapseclient.core import cumulative_transfer_progress, sts_transfer, utils
+from synapseclient.core.constants import concrete_types
+from synapseclient.core.exceptions import SynapseMd5MismatchError
+from synapseclient.core.remote_file_storage_wrappers import S3ClientWrapper, SFTPWrapper
+from synapseclient.core.upload.multipart_upload_async import multipart_upload_file_async
+from synapseclient.core.utils import (
+    as_url,
+    file_url_to_path,
+    id_of,
+    is_url,
+    md5_for_file,
+)
+
+if TYPE_CHECKING:
+    from synapseclient import Synapse
+
+tracer = trace.get_tracer("synapseclient")
+
+
+def log_upload_message(syn: "Synapse", message: str) -> None:
+    # if this upload is in the context of a larger, multi threaded sync upload as indicated by a cumulative progress
+    # then we don't print the individual upload messages to the console since they wouldn't be properly interleaved.
+    if not cumulative_transfer_progress.is_active():
+        syn.logger.info(message)
+
+
+@tracer.start_as_current_span("upload_functions::upload_file_handle")
+async def upload_file_handle(
+    syn: "Synapse",
+    parent_entity: Union[str, collections.abc.Mapping, numbers.Number],
+    path: str,
+    synapse_store: bool = True,
+    md5: str = None,
+    file_size: int = None,
+    mimetype: str = None,
+):
+    """
+    Uploads the file in the provided path (if necessary) to a storage location based on project settings.
+    Returns a new FileHandle as a dict to represent the stored file.
+
+    Arguments:
+        parent_entity: Entity object or id of the parent entity.
+        path:          The file path to the file being uploaded
+        synapse_store: If False, will not upload the file, but instead create an ExternalFileHandle that references
+                       the file on the local machine.
+                       If True, will upload the file based on StorageLocation determined by the entity_parent_id
+        md5:           The MD5 checksum for the file, if known. Otherwise if the file is a local file, it will be
+                       calculated automatically.
+        file_size:     The size the file, if known. Otherwise if the file is a local file, it will be calculated
+                       automatically.
+        mimetype:      The MIME type the file, if known. Otherwise if the file is a local file, it will be
+                       calculated automatically.
+
+    Returns:
+        A dictionary of a new FileHandle as a dict that represents the uploaded file
+    """
+    if path is None:
+        raise ValueError("path can not be None")
+
+    # if doing a external file handle with no actual upload
+    if not synapse_store:
+        return await create_external_file_handle(
+            syn, path, mimetype=mimetype, md5=md5, file_size=file_size
+        )
+
+    # expand the path because past this point an upload is required and some upload functions require an absolute path
+    expanded_upload_path = os.path.expandvars(os.path.expanduser(path))
+
+    if md5 is None and os.path.isfile(expanded_upload_path):
+        md5 = utils.md5_for_file(expanded_upload_path).hexdigest()
+
+    entity_parent_id = id_of(parent_entity)
+
+    # determine the upload function based on the UploadDestination
+    location = await get_upload_destination(
+        entity_id=entity_parent_id, synapse_client=syn
+    )
+    upload_destination_type = location["concreteType"]
+    trace.get_current_span().set_attributes(
+        {
+            "synapse.parent_id": entity_parent_id,
+            "synapse.upload_destination_type": upload_destination_type,
+        }
+    )
+
+    if (
+        sts_transfer.is_boto_sts_transfer_enabled(syn)
+        and await sts_transfer.is_storage_location_sts_enabled_async(
+            syn, entity_parent_id, location
+        )
+        and upload_destination_type == concrete_types.EXTERNAL_S3_UPLOAD_DESTINATION
+    ):
+        log_upload_message(
+            syn,
+            "\n"
+            + "#" * 50
+            + "\n Uploading file to external S3 storage using boto3 \n"
+            + "#" * 50
+            + "\n",
+        )
+
+        return await upload_synapse_sts_boto_s3(
+            syn=syn,
+            parent_id=entity_parent_id,
+            upload_destination=location,
+            local_path=expanded_upload_path,
+            mimetype=mimetype,
+            md5=md5,
+        )
+
+    elif upload_destination_type in (
+        concrete_types.SYNAPSE_S3_UPLOAD_DESTINATION,
+        concrete_types.EXTERNAL_S3_UPLOAD_DESTINATION,
+        concrete_types.EXTERNAL_GCP_UPLOAD_DESTINATION,
+    ):
+        if upload_destination_type == concrete_types.SYNAPSE_S3_UPLOAD_DESTINATION:
+            storage_str = "Uploading to Synapse storage"
+        elif upload_destination_type == concrete_types.EXTERNAL_S3_UPLOAD_DESTINATION:
+            storage_str = "Uploading to your external S3 storage"
+        else:
+            storage_str = "Uploading to your external Google Bucket storage"
+
+        return await upload_synapse_s3(
+            syn=syn,
+            file_path=expanded_upload_path,
+            storage_location_id=location["storageLocationId"],
+            mimetype=mimetype,
+            md5=md5,
+            storage_str=storage_str,
+        )
+    # external file handle (sftp)
+    elif upload_destination_type == concrete_types.EXTERNAL_UPLOAD_DESTINATION:
+        if location["uploadType"] == "SFTP":
+            log_upload_message(
+                syn,
+                "\n%s\n%s\nUploading to: %s\n%s\n"
+                % (
+                    "#" * 50,
+                    location.get("banner", ""),
+                    urllib_parse.urlparse(location["url"]).netloc,
+                    "#" * 50,
+                ),
+            )
+            return await upload_external_file_handle_sftp(
+                syn=syn,
+                file_path=expanded_upload_path,
+                sftp_url=location["url"],
+                mimetype=mimetype,
+                md5=md5,
+            )
+        else:
+            raise NotImplementedError("Can only handle SFTP upload locations.")
+    # client authenticated S3
+    elif (
+        upload_destination_type
+        == concrete_types.EXTERNAL_OBJECT_STORE_UPLOAD_DESTINATION
+    ):
+        log_upload_message(
+            syn,
+            "\n%s\n%s\nUploading to endpoint: [%s] bucket: [%s]\n%s\n"
+            % (
+                "#" * 50,
+                location.get("banner", ""),
+                location.get("endpointUrl"),
+                location.get("bucket"),
+                "#" * 50,
+            ),
+        )
+        return await upload_client_auth_s3(
+            syn=syn,
+            file_path=expanded_upload_path,
+            bucket=location["bucket"],
+            endpoint_url=location["endpointUrl"],
+            key_prefix=location["keyPrefixUUID"],
+            storage_location_id=location["storageLocationId"],
+            mimetype=mimetype,
+            md5=md5,
+        )
+    else:  # unknown storage location
+        return await upload_synapse_s3(
+            syn=syn,
+            file_path=expanded_upload_path,
+            storage_location_id=None,
+            mimetype=mimetype,
+            md5=md5,
+            storage_str="Uploading to Synapse storage",
+        )
+
+
+async def create_external_file_handle(
+    syn: "Synapse",
+    path: str,
+    mimetype: str = None,
+    md5: str = None,
+    file_size: int = None,
+) -> Dict[str, Union[str, int]]:
+    is_local_file = False  # defaults to false
+    url = as_url(os.path.expandvars(os.path.expanduser(path)))
+    if is_url(url):
+        parsed_url = urllib_parse.urlparse(url)
+        parsed_path = file_url_to_path(url)
+        if parsed_url.scheme == "file" and os.path.isfile(parsed_path):
+            actual_md5 = md5_for_file(parsed_path).hexdigest()
+            if md5 is not None and md5 != actual_md5:
+                raise SynapseMd5MismatchError(
+                    "The specified md5 [%s] does not match the calculated md5 [%s] for local file [%s]",
+                    md5,
+                    actual_md5,
+                    parsed_path,
+                )
+            md5 = actual_md5
+            file_size = os.stat(parsed_path).st_size
+            is_local_file = True
+    else:
+        raise ValueError("externalUrl [%s] is not a valid url", url)
+
+    # just creates the file handle because there is nothing to upload
+    file_handle = await post_external_filehandle(
+        external_url=url, mimetype=mimetype, md5=md5, file_size=file_size
+    )
+    if is_local_file:
+        syn.cache.add(file_handle["id"], file_url_to_path(url))
+    trace.get_current_span().set_attributes(
+        {"synapse.file_handle_id": file_handle["id"]}
+    )
+    return file_handle
+
+
+async def upload_external_file_handle_sftp(
+    syn: "Synapse", file_path: str, sftp_url: str, mimetype: str = None, md5: str = None
+) -> Dict[str, Union[str, int]]:
+    username, password = syn._getUserCredentials(url=sftp_url)
+    uploaded_url = SFTPWrapper.upload_file(
+        file_path, urllib_parse.unquote(sftp_url), username, password
+    )
+
+    file_handle = await post_external_filehandle(
+        external_url=uploaded_url,
+        mimetype=mimetype,
+        md5=md5 or md5_for_file(file_path).hexdigest(),
+        file_size=os.stat(file_path).st_size,
+    )
+    syn.cache.add(file_handle["id"], file_path)
+    return file_handle
+
+
+async def upload_synapse_s3(
+    syn: "Synapse",
+    file_path: str,
+    storage_location_id=None,
+    mimetype: str = None,
+    force_restart: bool = False,
+    md5: str = None,
+    storage_str: str = None,
+):
+    file_handle_id = await multipart_upload_file_async(
+        syn=syn,
+        file_path=file_path,
+        content_type=mimetype,
+        storage_location_id=storage_location_id,
+        md5=md5,
+        force_restart=force_restart,
+        storage_str=storage_str,
+    )
+    syn.cache.add(file_handle_id=file_handle_id, path=file_path, md5=md5)
+
+    return await get_file_handle(file_handle_id=file_handle_id, synapse_client=syn)
+
+
+async def upload_synapse_sts_boto_s3(
+    syn: "Synapse",
+    parent_id: str,
+    upload_destination,
+    local_path: str,
+    mimetype: str = None,
+    md5: str = None,
+) -> Dict[str, Union[str, int, bool]]:
+    """
+    When uploading to Synapse storage normally the back end will generate a random prefix
+    for our uploaded object. Since in this case the client is responsible for the remote
+    key, the client will instead generate a random prefix. this both ensures we don't have a collision
+    with an existing S3 object and also mitigates potential performance issues, although
+    key locality performance issues are likely resolved as of:
+    <https://aws.amazon.com/about-aws/whats-new/2018/07/amazon-s3-announces-increased-request-rate-performance/>
+
+    Arguments:
+        syn: The synapse client
+        parent_id: The synapse ID of the parent.
+        upload_destination: The upload destination
+        local_path: The local path to the file to upload.
+        mimetype: The mimetype is known. Defaults to None.
+        md5: MD5 checksum for the file, if known.
+
+    Returns:
+        _description_
+    """
+    key_prefix = str(uuid.uuid4())
+
+    bucket_name = upload_destination["bucket"]
+    storage_location_id = upload_destination["storageLocationId"]
+    remote_file_key = "/".join(
+        [upload_destination["baseKey"], key_prefix, os.path.basename(local_path)]
+    )
+
+    def upload_fn(credentials):
+        return S3ClientWrapper.upload_file(
+            bucket=bucket_name,
+            endpoint_url=None,
+            remote_file_key=remote_file_key,
+            upload_file_path=local_path,
+            credentials=credentials,
+            transfer_config_kwargs={"max_concurrency": syn.max_threads},
+        )
+
+    loop = asyncio.get_event_loop()
+
+    await loop.run_in_executor(
+        None,
+        lambda: sts_transfer.with_boto_sts_credentials(
+            upload_fn, syn, parent_id, "read_write"
+        ),
+    )
+
+    return await post_external_s3_file_handle(
+        bucket_name=bucket_name,
+        s3_file_key=remote_file_key,
+        file_path=local_path,
+        storage_location_id=storage_location_id,
+        mimetype=mimetype,
+        md5=md5,
+        synapse_client=syn,
+    )
+
+
+async def upload_client_auth_s3(
+    syn: "Synapse",
+    file_path: str,
+    bucket: str,
+    endpoint_url: str,
+    key_prefix: str,
+    storage_location_id: int,
+    mimetype: str = None,
+    md5: str = None,
+) -> Dict[str, Union[str, int]]:
+    """Use the S3 client to upload a file to an S3 bucket."""
+    profile = syn._get_client_authenticated_s3_profile(endpoint_url, bucket)
+    file_key = key_prefix + "/" + os.path.basename(file_path)
+    loop = asyncio.get_event_loop()
+
+    await loop.run_in_executor(
+        None,
+        lambda: S3ClientWrapper.upload_file(
+            bucket, endpoint_url, file_key, file_path, profile_name=profile
+        ),
+    )
+
+    file_handle = await post_external_object_store_filehandle(
+        s3_file_key=file_key,
+        file_path=file_path,
+        storage_location_id=storage_location_id,
+        mimetype=mimetype,
+        md5=md5,
+        synapse_client=syn,
+    )
+    syn.cache.add(file_handle["id"], file_path)
+
+    return file_handle

--- a/synapseclient/core/upload/upload_functions_async.py
+++ b/synapseclient/core/upload/upload_functions_async.py
@@ -86,8 +86,8 @@ async def upload_file_handle(
     expanded_upload_path = os.path.expandvars(os.path.expanduser(path))
 
     if md5 is None and os.path.isfile(expanded_upload_path):
-        md5 = await utils.md5_for_file_multithreading(
-            filename=expanded_upload_path, thread_pool_executor=syn._executor
+        md5 = await utils.md5_for_file_multiprocessing(
+            filename=expanded_upload_path, process_pool_executor=syn._process_executor
         )
 
     entity_parent_id = id_of(parent_entity)
@@ -221,8 +221,8 @@ async def create_external_file_handle(
         parsed_url = urllib_parse.urlparse(url)
         parsed_path = file_url_to_path(url)
         if parsed_url.scheme == "file" and os.path.isfile(parsed_path):
-            actual_md5 = await utils.md5_for_file_multithreading(
-                filename=parsed_path, thread_pool_executor=syn._executor
+            actual_md5 = await utils.md5_for_file_multiprocessing(
+                filename=parsed_path, process_pool_executor=syn._process_executor
             )
             if md5 is not None and md5 != actual_md5:
                 raise SynapseMd5MismatchError(
@@ -261,8 +261,8 @@ async def upload_external_file_handle_sftp(
         external_url=uploaded_url,
         mimetype=mimetype,
         md5=md5
-        or await utils.md5_for_file_multithreading(
-            filename=file_path, thread_pool_executor=syn._executor
+        or await utils.md5_for_file_multiprocessing(
+            filename=file_path, process_pool_executor=syn._process_executor
         ),
         file_size=os.stat(file_path).st_size,
     )

--- a/synapseclient/core/upload/upload_utils.py
+++ b/synapseclient/core/upload/upload_utils.py
@@ -1,0 +1,51 @@
+"""Common utility functions used during upload."""
+
+import math
+import re
+
+
+def get_file_chunk(file_path, part_number, chunk_size) -> bytes:
+    """Read the nth chunk from the file."""
+    with open(file_path, "rb") as f:
+        f.seek((part_number - 1) * chunk_size)
+        return f.read(chunk_size)
+
+
+def get_data_chunk(data: bytes, part_number: int, chunk_size: int) -> bytes:
+    """Return the nth chunk of a buffer."""
+    return data[((part_number - 1) * chunk_size) : part_number * chunk_size]
+
+
+def get_part_size(
+    part_size: int, file_size: int, minimum_part_size: int, max_number_of_parts: int
+) -> int:
+    """Calculate the part size for a multipart upload."""
+    # can't exceed the maximum allowed num parts
+    part_size = max(
+        part_size, minimum_part_size, int(math.ceil(file_size / max_number_of_parts))
+    )
+    return part_size
+
+
+def copy_part_request_body_provider_fn(_) -> None:
+    """For an upload copy there are no bytes"""
+    return None
+
+
+def copy_md5_fn(_, response) -> str:
+    """
+    For a multipart copy we use the md5 returned by the UploadPartCopy command
+    when we add the part to the Synapse upload
+
+    we extract the md5 from the <ETag> element in the response.
+    use lookahead and lookbehind to find the opening and closing ETag elements but
+    do not include those in the match, thus the entire matched string (group 0) will be
+    what was between those elements.
+    """
+
+    md5_hex = re.search(
+        "(?<=<ETag>).*?(?=<\\/ETag>)", (response.content.decode("utf-8"))
+    ).group(0)
+
+    # remove quotes found in the ETag to get at the normalized ETag
+    return md5_hex.replace("&quot;", "").replace('"', "")

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -129,7 +129,6 @@ async def md5_for_file_multithreading(
     )
 
 
-@tracer.start_as_current_span("Utils::md5_for_file")
 async def md5_for_file_multiprocessing(
     filename: str,
     process_pool_executor: ProcessPoolExecutor,
@@ -150,10 +149,11 @@ async def md5_for_file_multiprocessing(
     Returns:
         The MD5 Checksum
     """
-    loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(
-        process_pool_executor, md5_for_file_hex, filename, block_size
-    )
+    with tracer.start_as_current_span("Utils::md5_for_file_multiprocessing"):
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            process_pool_executor, md5_for_file_hex, filename, block_size
+        )
 
 
 @tracer.start_as_current_span("Utils::md5_fn")

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -24,7 +24,7 @@ import urllib.parse as urllib_parse
 import uuid
 import warnings
 import zipfile
-from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor
 from dataclasses import asdict, is_dataclass
 from typing import TYPE_CHECKING, Callable, TypeVar
 
@@ -101,34 +101,6 @@ def md5_for_file_hex(
     return md5_for_file(filename, block_size, callback).hexdigest()
 
 
-@tracer.start_as_current_span("Utils::md5_for_file")
-async def md5_for_file_multithreading(
-    filename: str,
-    thread_pool_executor: ThreadPoolExecutor,
-    block_size: int = 2 * MB,
-    callback: typing.Callable = None,
-):
-    """
-    Calculates the MD5 of the given file.
-    See source <http://stackoverflow.com/questions/1131220/get-md5-hash-of-a-files-without-open-it-in-python>.
-
-    Arguments:
-        filename: The file to read in
-        thread_pool_executor: The thread pool executor to use for the calculation.
-        block_size: How much of the file to read in at once (bytes).
-                    Defaults to 2 MB.
-        callback: The callback function that help us show loading spinner on terminal.
-                    Defaults to None.
-
-    Returns:
-        The MD5 Checksum
-    """
-    loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(
-        thread_pool_executor, md5_for_file, filename, block_size, callback
-    )
-
-
 async def md5_for_file_multiprocessing(
     filename: str,
     process_pool_executor: ProcessPoolExecutor,
@@ -143,8 +115,6 @@ async def md5_for_file_multiprocessing(
         process_pool_executor: The process pool executor to use for the calculation.
         block_size: How much of the file to read in at once (bytes).
                     Defaults to 2 MB.
-        callback: The callback function that help us show loading spinner on terminal.
-                    Defaults to None.
 
     Returns:
         The MD5 Checksum

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -48,6 +48,7 @@ tracer = trace.get_tracer("synapseclient")
 SLASH_PREFIX_REGEX = re.compile(r"\/[A-Za-z]:")
 
 
+@tracer.start_as_current_span("Utils::md5_for_file")
 def md5_for_file(
     filename: str, block_size: int = 2 * MB, callback: typing.Callable = None
 ):
@@ -78,6 +79,7 @@ def md5_for_file(
     return md5
 
 
+@tracer.start_as_current_span("Utils::md5_fn")
 def md5_fn(part, _) -> str:
     """Calculate the MD5 of a file-like object.
 

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -1000,7 +1000,14 @@ class File(FileSynchronousProtocol, AccessControllable):
                 and os.path.isfile(self.path)
                 and md5_stored_in_synapse
                 and md5_stored_in_synapse
-                == (local_file_md5_hex := utils.md5_for_file(self.path).hexdigest())
+                == (
+                    local_file_md5_hex := (
+                        await utils.md5_for_file_multithreading(
+                            filename=self.path,
+                            thread_pool_executor=syn._executor,
+                        )
+                    )
+                )
             ):
                 needs_upload = False
         if self.data_file_handle_id is not None:

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -1002,9 +1002,9 @@ class File(FileSynchronousProtocol, AccessControllable):
                 and md5_stored_in_synapse
                 == (
                     local_file_md5_hex := (
-                        await utils.md5_for_file_multithreading(
+                        await utils.md5_for_file_multiprocessing(
                             filename=self.path,
-                            thread_pool_executor=syn._executor,
+                            process_pool_executor=syn._process_executor,
                         )
                     )
                 )

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -1,5 +1,6 @@
 """Script to work with Synapse files."""
 
+# pylint: disable=protected-access
 import asyncio
 import dataclasses
 import os
@@ -1004,7 +1005,7 @@ class File(FileSynchronousProtocol, AccessControllable):
                     local_file_md5_hex := (
                         await utils.md5_for_file_multiprocessing(
                             filename=self.path,
-                            process_pool_executor=syn._process_executor,
+                            process_pool_executor=syn._get_process_pool_executor(),
                         )
                     )
                 )

--- a/synapseclient/models/services/__init__.py
+++ b/synapseclient/models/services/__init__.py
@@ -2,6 +2,7 @@ from synapseclient.models.services.storable_entity_components import (
     store_entity_components,
     FailureStrategy,
 )
+from synapseclient.models.services.storable_entity import store_entity
 from synapseclient.models.services.search import get_id
 
-__all__ = ["store_entity_components", "FailureStrategy", "get_id"]
+__all__ = ["store_entity_components", "store_entity", "FailureStrategy", "get_id"]

--- a/synapseclient/models/services/search.py
+++ b/synapseclient/models/services/search.py
@@ -20,13 +20,13 @@ from synapseclient.core.exceptions import (
 )
 
 if TYPE_CHECKING:
-    from synapseclient.models import Folder, Project
+    from synapseclient.models import Folder, Project, File
 
 tracer = trace.get_tracer("synapseclient")
 
 
 async def get_id(
-    entity: Union["Project", "Folder"],
+    entity: Union["Project", "Folder", "File"],
     failure_strategy: Optional[FailureStrategy] = FailureStrategy.RAISE_EXCEPTION,
     synapse_client: Optional[Synapse] = None,
 ) -> Union[str, None]:

--- a/synapseclient/models/services/storable_entity.py
+++ b/synapseclient/models/services/storable_entity.py
@@ -1,0 +1,104 @@
+"""Script used to store an entity to Synapse."""
+
+from typing import TYPE_CHECKING, Dict, Optional, Union
+
+from opentelemetry import trace
+
+from synapseclient import Synapse
+from synapseclient.api import post_entity, put_entity
+from synapseclient.core.utils import get_properties
+
+if TYPE_CHECKING:
+    from synapseclient.models import File, Folder, Project
+
+tracer = trace.get_tracer("synapseclient")
+
+
+async def store_entity(
+    resource: Union["File", "Folder", "Project"],
+    entity: Dict[str, Union[str, bool, int, float]],
+    synapse_client: Optional[Synapse] = None,
+) -> bool:
+    """
+    Function to store an entity to synapse.
+
+    TODO: This function is not complete and is a work in progress.
+
+
+    Arguments:
+        resource: The root dataclass instance we are storing data for.
+        entity: The entity to store.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        If a read from Synapse is required to retireve the current state of the entity.
+    """
+    query_params = {}
+    increment_version = False
+    # Create or update Entity in Synapse
+    if resource.id:
+        trace.get_current_span().set_attributes({"synapse.id": resource.id})
+        if hasattr(resource, "version_number"):
+            if (
+                resource.version_label
+                and resource.version_label
+                != resource._last_persistent_instance.version_label
+            ):
+                # a versionLabel implicitly implies incrementing
+                increment_version = True
+            elif resource.force_version and resource.version_number:
+                increment_version = True
+                entity["versionLabel"] = str(resource.version_number + 1)
+
+            if increment_version:
+                query_params["newVersion"] = "true"
+
+        updated_entity = await put_entity(
+            entity_id=resource.id,
+            request=get_properties(entity),
+            new_version=increment_version,
+            synapse_client=synapse_client,
+        )
+    else:
+        # TODO
+        # If Link, get the target name, version number and concrete type and store in link properties
+        # if properties["concreteType"] == "org.sagebionetworks.repo.model.Link":
+        #     target_properties = self._getEntity(
+        #         properties["linksTo"]["targetId"],
+        #         version=properties["linksTo"].get("targetVersionNumber"),
+        #     )
+        #     if target_properties["parentId"] == properties["parentId"]:
+        #         raise ValueError(
+        #             "Cannot create a Link to an entity under the same parent."
+        #         )
+        #     properties["linksToClassName"] = target_properties["concreteType"]
+        #     if (
+        #         target_properties.get("versionNumber") is not None
+        #         and properties["linksTo"].get("targetVersionNumber") is not None
+        #     ):
+        #         properties["linksTo"]["targetVersionNumber"] = target_properties[
+        #             "versionNumber"
+        #         ]
+        #     properties["name"] = target_properties["name"]
+
+        updated_entity = await post_entity(
+            request=get_properties(entity),
+            synapse_client=synapse_client,
+        )
+
+    # TODO: Deal with access restrictions
+    # if isRestricted:
+    #     self._createAccessRequirementIfNone(properties)
+
+    # Return the updated Entity object
+    # entity = Entity.create(properties, annotations, local_state)
+    # return_data = self.get(entity, downloadFile=False)
+
+    trace.get_current_span().set_attributes(
+        {
+            "synapse.id": updated_entity.get("id", ""),
+            "synapse.concrete_type": updated_entity.get("concreteType", ""),
+        }
+    )
+    return updated_entity

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,28 +1,28 @@
+"""Set up for integration tests."""
+
 import asyncio
 import logging
+import os
 import platform
-import uuid
-import os, time
-import sys
 import shutil
+import sys
 import tempfile
+import time
+import uuid
 
 import pytest
-
-from synapseclient.models import (
-    Project as Project_Model,
-    Team,
-)
-from synapseclient import Entity, Synapse, Project
-from synapseclient.core import utils
-from synapseclient.core.logging_setup import SILENT_LOGGER_NAME
-
 from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import OS_DESCRIPTION, OS_TYPE, SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
-from opentelemetry.sdk.resources import SERVICE_NAME, OS_TYPE, OS_DESCRIPTION, Resource
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.trace.sampling import ALWAYS_OFF
+
+from synapseclient import Entity, Project, Synapse
+from synapseclient.core import utils
+from synapseclient.core.logging_setup import SILENT_LOGGER_NAME
+from synapseclient.models import Project as Project_Model
+from synapseclient.models import Team
 
 tracer = trace.get_tracer("synapseclient")
 
@@ -31,7 +31,7 @@ pytest session level fixtures shared by all integration tests.
 """
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(autouse=True)
 def event_loop(request):
     """
     Redefine the event loop to support session/module-scoped fixtures;

--- a/tests/integration/synapseclient/models/async/test_file_async.py
+++ b/tests/integration/synapseclient/models/async/test_file_async.py
@@ -511,12 +511,12 @@ class TestFileStore:
             await new_file.store_async()
 
         assert (
-            str(e.value)
-            == f"409 Client Error: \nAn entity with the name: {file.name} already exists with a parentId: {project_model.id}"
+            f"409 Client Error: An entity with the name: {file.name} already exists with a parentId: {project_model.id}"
+            in str(e.value)
         )
 
     @pytest.mark.asyncio
-    async def test_store_force_version(
+    async def test_store_force_version_no_change(
         self, project_model: Project, file: File
     ) -> None:
         # GIVEN a file
@@ -537,8 +537,39 @@ class TestFileStore:
         # THEN the version should not be updated
         assert file.version_number == 1
 
-        # WHEN I store the file again with force_version=True
+        # WHEN I store the file again with force_version=True and no change was made
         file.force_version = True
+        await file.store_async()
+
+        # THEN the version should not be updated
+        assert file.version_number == 1
+
+    @pytest.mark.asyncio
+    async def test_store_force_version_with_change(
+        self, project_model: Project, file: File
+    ) -> None:
+        # GIVEN a file
+        file.name = str(uuid.uuid4())
+
+        # WHEN I store the file
+        await file.store_async(parent=project_model)
+        self.schedule_for_cleanup(file.id)
+
+        # THEN I expect the file to be stored
+        assert file.id is not None
+        assert file.version_number == 1
+
+        # WHEN I store the file again with force_version=False
+        file.force_version = False
+        file.description = "aaaaaaaaaaaaaaaa"
+        await file.store_async()
+
+        # THEN the version should not be updated
+        assert file.version_number == 1
+
+        # WHEN I store the file again with force_version=True and I update a field
+        file.force_version = True
+        file.description = "new description"
         await file.store_async()
 
         # THEN the version should be updated
@@ -559,7 +590,7 @@ class TestFileStore:
         file.is_restricted = True
 
         with patch(
-            "synapseclient.client.Synapse._createAccessRequirementIfNone"
+            "synapseclient.models.services.storable_entity.create_access_requirements_if_none"
         ) as intercepted:
             # WHEN I store the file
             await file.store_async(parent=project_model)
@@ -810,7 +841,7 @@ class TestDelete:
         # THEN I expect the file to be deleted
         with pytest.raises(SynapseHTTPError) as e:
             await file.get_async()
-        assert str(e.value) == f"404 Client Error: \nEntity {file.id} is in trash can."
+        assert f"404 Client Error: \nEntity {file.id} is in trash can." in str(e.value)
 
     @pytest.mark.asyncio
     async def test_delete_specific_version(self, file: File) -> None:
@@ -830,8 +861,8 @@ class TestDelete:
         with pytest.raises(SynapseHTTPError) as e:
             await File(id=file.id, version_number=1).get_async()
         assert (
-            str(e.value)
-            == f"404 Client Error: \nCannot find a node with id {file.id} and version 1"
+            f"404 Client Error: \nCannot find a node with id {file.id} and version 1"
+            in str(e.value)
         )
 
         # AND the second version to still exist
@@ -882,12 +913,15 @@ class TestGet:
     async def test_get_by_id(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
+        assert file.path is not None
+        path_for_file = file.path
 
         # WHEN I get the file by id
         file_copy = await File(id=file.id).get_async()
 
         # THEN I expect the file to be returned
         assert file_copy.id == file.id
+        assert file_copy.path == path_for_file
 
     @pytest.mark.asyncio
     async def test_get_previous_version(self, file: File) -> None:

--- a/tests/integration/synapseclient/models/async/test_folder_async.py
+++ b/tests/integration/synapseclient/models/async/test_folder_async.py
@@ -368,9 +368,8 @@ class TestFolderDelete:
         with pytest.raises(SynapseHTTPError) as e:
             await stored_folder.get()
 
-        assert (
-            str(e.value)
-            == f"404 Client Error: \nEntity {stored_folder.id} is in trash can."
+        assert f"404 Client Error: \nEntity {stored_folder.id} is in trash can." in str(
+            e.value
         )
 
 

--- a/tests/integration/synapseclient/models/async/test_project_async.py
+++ b/tests/integration/synapseclient/models/async/test_project_async.py
@@ -369,8 +369,8 @@ class TestProjectDelete:
             await stored_project.get_async()
 
         assert (
-            str(e.value)
-            == f"404 Client Error: \nEntity {stored_project.id} is in trash can."
+            f"404 Client Error: \nEntity {stored_project.id} is in trash can."
+            in str(e.value)
         )
 
 

--- a/tests/integration/synapseclient/models/synchronous/test_folder.py
+++ b/tests/integration/synapseclient/models/synchronous/test_folder.py
@@ -353,9 +353,8 @@ class TestFolderDelete:
         with pytest.raises(SynapseHTTPError) as e:
             stored_folder.get()
 
-        assert (
-            str(e.value)
-            == f"404 Client Error: \nEntity {stored_folder.id} is in trash can."
+        assert f"404 Client Error: \nEntity {stored_folder.id} is in trash can." in str(
+            e.value
         )
 
 

--- a/tests/integration/synapseclient/models/synchronous/test_project.py
+++ b/tests/integration/synapseclient/models/synchronous/test_project.py
@@ -358,8 +358,8 @@ class TestProjectDelete:
             stored_project.get()
 
         assert (
-            str(e.value)
-            == f"404 Client Error: \nEntity {stored_project.id} is in trash can."
+            f"404 Client Error: \nEntity {stored_project.id} is in trash can."
+            in str(e.value)
         )
 
 


### PR DESCRIPTION
Problem:

1. The current upload process was slow as pieces that could be executed concurrently were executed sequentially.
2. Items like MD5 calculation are CPU bound which blocks the Python GIL from doing anything else.

Solution:

1. Part uploads are pushed to other threads
2. MD5 checksum calculations are pushed to other processes (To prevent blocking the main AsyncIO Thread)
3. All HTTP calls are using AsyncIO async/await syntax to prevent any blocking while we are waiting for network I/O

Testing:
Some initial testing figures:

10 files, 100MB/file, 1GB total:
Before: 33s
After: 16s

1 file, 10GB:
Before: 221s - Average ~73.5 MB/s
After: 164s - Average ~124 MB/s