### PR TITLE
[SYNPY-1420] Clean up otel spans

### DIFF
--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -355,18 +355,17 @@ async def with_retry_time_based_async(
                 logger=logger, response=response, caught_exception=caught_exception
             )
 
-            with tracer.start_as_current_span("Synapse::retry_wait"):
-                backoff_wait = calculate_exponential_backoff(
-                    retries=retries,
-                    base_wait=retry_base_wait,
-                    wait_random_lower=retry_wait_random_lower,
-                    wait_random_upper=retry_wait_random_upper,
-                    back_off_factor=retry_back_off_factor,
-                    max_back_off=retry_max_back_off,
-                )
-                total_wait += backoff_wait
-                await asyncio.sleep(backoff_wait)
-                continue
+            backoff_wait = calculate_exponential_backoff(
+                retries=retries,
+                base_wait=retry_base_wait,
+                wait_random_lower=retry_wait_random_lower,
+                wait_random_upper=retry_wait_random_upper,
+                back_off_factor=retry_back_off_factor,
+                max_back_off=retry_max_back_off,
+            )
+            total_wait += backoff_wait
+            await asyncio.sleep(backoff_wait)
+            continue
 
         # Out of retries, re-raise the exception or return the response
         if caught_exception_info is not None and caught_exception_info[0] is not None:
@@ -478,18 +477,17 @@ def with_retry_time_based(
                 logger=logger, response=response, caught_exception=caught_exception
             )
 
-            with tracer.start_as_current_span("Synapse::retry_wait"):
-                backoff_wait = calculate_exponential_backoff(
-                    retries=retries,
-                    base_wait=retry_base_wait,
-                    wait_random_lower=retry_wait_random_lower,
-                    wait_random_upper=retry_wait_random_upper,
-                    back_off_factor=retry_back_off_factor,
-                    max_back_off=retry_max_back_off,
-                )
-                total_wait += backoff_wait
-                time.sleep(backoff_wait)
-                continue
+            backoff_wait = calculate_exponential_backoff(
+                retries=retries,
+                base_wait=retry_base_wait,
+                wait_random_lower=retry_wait_random_lower,
+                wait_random_upper=retry_wait_random_upper,
+                back_off_factor=retry_back_off_factor,
+                max_back_off=retry_max_back_off,
+            )
+            total_wait += backoff_wait
+            time.sleep(backoff_wait)
+            continue
 
         # Out of retries, re-raise the exception or return the response
         if caught_exception_info is not None and caught_exception_info[0] is not None:

--- a/synapseclient/core/upload/upload_functions_async.py
+++ b/synapseclient/core/upload/upload_functions_async.py
@@ -34,7 +34,6 @@ if TYPE_CHECKING:
 tracer = trace.get_tracer("synapseclient")
 
 
-@tracer.start_as_current_span("upload_functions::upload_file_handle")
 async def upload_file_handle(
     syn: "Synapse",
     parent_entity_id: str,

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -126,8 +126,8 @@ async def md5_for_file_multiprocessing(
     Returns:
         The MD5 Checksum
     """
-    with tracer.start_as_current_span("Utils::md5_for_file_multiprocessing"):
-        async with md5_semaphore:
+    async with md5_semaphore:
+        with tracer.start_as_current_span("Utils::md5_for_file_multiprocessing"):
             future = process_pool_executor.submit(
                 md5_for_file_hex, filename, block_size
             )

--- a/synapseclient/models/annotations.py
+++ b/synapseclient/models/annotations.py
@@ -8,7 +8,7 @@ from opentelemetry import context, trace
 from synapseclient import Synapse
 from synapseclient.annotations import ANNO_TYPE_TO_FUNC
 from synapseclient.api import set_annotations
-from synapseclient.core.async_utils import async_to_sync, otel_trace_method
+from synapseclient.core.async_utils import async_to_sync
 from synapseclient.core.utils import run_and_attach_otel_context
 from synapseclient.models.protocols.annotations_protocol import (
     AnnotationsSynchronousProtocol,
@@ -64,9 +64,6 @@ class Annotations(AnnotationsSynchronousProtocol):
     this field must match the current etag on the object. Not required if being used as
     a member variable on another class."""
 
-    @otel_trace_method(
-        method_to_trace_name=lambda self, **kwargs: f"Annotation_store: {self.id}"
-    )
     async def store_async(
         self,
         synapse_client: Optional[Synapse] = None,


### PR DESCRIPTION
**Problem:**

1. OTEL span were a bit all over the place with varying depth and information

**Solution:**

1. Focus OTEL spans on the I/O portions of the application to know when requests are start/stopping or long running MD5 calculations are taking place

**Testing:**

1. Verified by running the upload benchmark script and checking a Jaeger container deployed on my local:
![image](https://github.com/Sage-Bionetworks/synapsePythonClient/assets/17128019/56081c9c-c780-407b-9bd6-6a0b71821627)
