### PR TITLE
[SYNPY-1453] Guard around modified time item in cache

### DIFF
--- a/synapseclient/core/cache.py
+++ b/synapseclient/core/cache.py
@@ -153,6 +153,9 @@ class Cache:
         then it is a new entry and we can return the value. If it does not, then it
         is an old entry and we should return the `cache_map_entry` itself.
 
+        The caveat is that `cache_map_entry` needs to be a string to return the value
+        otherwise it will return None.
+
         Arguments:
             cache_map_entry: The entry from the cache map
 
@@ -161,8 +164,9 @@ class Cache:
         """
         if cache_map_entry is not None and "modified_time" in cache_map_entry:
             return cache_map_entry.get("modified_time", None)
-        else:
+        elif cache_map_entry is not None and isinstance(cache_map_entry, str):
             return cache_map_entry
+        return None
 
     def _get_cache_content_md5(
         self, cache_map_entry: typing.Union[str, dict, None]

--- a/tests/unit/synapseclient/core/unit_test_Cache.py
+++ b/tests/unit/synapseclient/core/unit_test_Cache.py
@@ -579,7 +579,103 @@ class TestModificationsToCacheContent:
         )
         assert unmodified is False
 
-    def test_cache_item_unmodified_modified_items_is_modified_timestamp(self):
+    def test_cache_no_modified_time_key(self):
+        # GIVEN a temp directory and a cache object
+        tmp_dir = tempfile.mkdtemp()
+        my_cache = cache.Cache(cache_root_dir=tmp_dir)
+
+        # AND a file created in my cache directory
+        file_path = utils.touch(
+            os.path.join(
+                my_cache.get_cache_dir(131202),
+                "file_1_test_cache_no_modified_time_key.ext",
+            )
+        )
+        file_modification_time = cache.epoch_time_to_iso(
+            math.floor(cache._get_modified_time(file_path))
+        )
+
+        # WHEN the modified_time key is not present
+        unmodified = my_cache._cache_item_unmodified(
+            cache_map_entry={
+                "not_modified_time": file_modification_time,
+                "content_md5": utils.md5_for_file(file_path).hexdigest(),
+            },
+            path=file_path,
+        )
+        # THEN we expect the file to be modified
+        assert unmodified is False
+
+    def test_cache_no_modified_time_and_no_content_md5_key(self):
+        # GIVEN a temp directory and a cache object
+        tmp_dir = tempfile.mkdtemp()
+        my_cache = cache.Cache(cache_root_dir=tmp_dir)
+
+        # AND a file created in my cache directory
+        file_path = utils.touch(
+            os.path.join(
+                my_cache.get_cache_dir(131203),
+                "file_1_test_cache_no_content_md5_key.ext",
+            )
+        )
+        file_modification_time = cache.epoch_time_to_iso(
+            math.floor(cache._get_modified_time(file_path))
+        )
+
+        # WHEN the modified_time and content_md5 key is not present
+        unmodified = my_cache._cache_item_unmodified(
+            cache_map_entry={
+                "not_modified_time": file_modification_time,
+                "not_content_md5": utils.md5_for_file(file_path).hexdigest(),
+            },
+            path=file_path,
+        )
+        # THEN we expect the file to be modified
+        assert unmodified is False
+
+    def test_cache_empty_cache_map(self):
+        # GIVEN a temp directory and a cache object
+        tmp_dir = tempfile.mkdtemp()
+        my_cache = cache.Cache(cache_root_dir=tmp_dir)
+
+        # AND a file created in my cache directory
+        file_path = utils.touch(
+            os.path.join(
+                my_cache.get_cache_dir(131203),
+                "file_1_test_cache_no_content_md5_key.ext",
+            )
+        )
+
+        # WHEN the cache map is an empty dict
+        unmodified = my_cache._cache_item_unmodified(
+            cache_map_entry={},
+            path=file_path,
+        )
+        # THEN we expect the file to be modified
+        assert unmodified is False
+
+    def test_cache_none_cache_map(self):
+        # GIVEN a temp directory and a cache object
+        tmp_dir = tempfile.mkdtemp()
+        my_cache = cache.Cache(cache_root_dir=tmp_dir)
+
+        # AND a file created in my cache directory
+        file_path = utils.touch(
+            os.path.join(
+                my_cache.get_cache_dir(131203),
+                "file_1_test_cache_no_content_md5_key.ext",
+            )
+        )
+
+        # WHEN the cache map is an empty dict
+        unmodified = my_cache._cache_item_unmodified(
+            cache_map_entry=None,
+            path=file_path,
+        )
+        # THEN we expect the file to be modified
+        assert unmodified is False
+
+    def test_cache_item_unmodified_modified_items_is_modified_timestamp_new_file(self):
         # GIVEN a temp directory and a cache object
         tmp_dir = tempfile.mkdtemp()
         my_cache = cache.Cache(cache_root_dir=tmp_dir)


### PR DESCRIPTION
**Problem:**

1. In the cache if a cache value was a dictionary but it did not contain the exact key of `modified_time` the code would return back the parent dict - causing further code to fail that was expecting a string to be returned.

**Solution:**

1. Adding a guard statement in `_get_cache_modified_time` that verified that the data returned is going to be a string or the value for `modified_time`

**Testing:**

Added unit tests around the logic that verify the behavior if the cache map:

1. Is a dict but does not contain `modified_time` key
2. Is a dict but contains neither of the expected keys
3. The entry is an empty dict
4. The entry is None