### PR TITLE
[SYNPY-1356] Moving file semaphore under file store

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -402,6 +402,7 @@ class Synapse(object):
         self.max_threads = transfer_config["max_threads"]
         self._thread_executor = {}
         self._process_executor = {}
+        self._parallel_file_transfer_semaphore = {}
         self._md5_semaphore = {}
         self.use_boto_sts_transfers = transfer_config["use_boto_sts"]
 
@@ -561,6 +562,29 @@ class Synapse(object):
         self._md5_semaphore.update({asyncio_event_loop: asyncio.Semaphore(1)})
 
         return self._md5_semaphore[asyncio_event_loop]
+
+    def _get_parallel_file_transfer_semaphore(
+        self, asyncio_event_loop: asyncio.AbstractEventLoop
+    ) -> asyncio.Semaphore:
+        """
+        Retrieve the semaphore for the Synapse client. Or create a new one if it does
+        not exist. This semaphore is used to limit the number of files that can actively
+        enter the uploading/downloading process.
+
+        This is expected to be called from within an AsyncIO loop.
+        """
+        if (
+            hasattr(self, "_parallel_file_transfer_semaphore")
+            and asyncio_event_loop in self._parallel_file_transfer_semaphore
+            and self._parallel_file_transfer_semaphore[asyncio_event_loop] is not None
+        ):
+            return self._parallel_file_transfer_semaphore[asyncio_event_loop]
+
+        self._parallel_file_transfer_semaphore.update(
+            {asyncio_event_loop: asyncio.Semaphore(max(self.max_threads * 2, 1))}
+        )
+
+        return self._parallel_file_transfer_semaphore[asyncio_event_loop]
 
     # initialize logging
     def _init_logger(self):

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -572,6 +572,22 @@ class Synapse(object):
         enter the uploading/downloading process.
 
         This is expected to be called from within an AsyncIO loop.
+
+        By default the number of files that can enter the "uploading" state will be
+        limited to 2 * max_threads. This is to ensure that the files that are entering
+        into the "uploading" state will have priority to finish. Additionally, it means
+        that there should be a good spread of files getting up to the "uploading"
+        state, entering the "uploading" state, and finishing the "uploading" state.
+
+        If we break these states down into large components they would look like:
+        - Before "uploading" state: HTTP rest calls to retrieve what data Synapse has
+        - Entering "uploading" state: MD5 calculation and HTTP rest calls to determine
+          how/where to upload a file to.
+        - During "uploading" state: Uploading the file to a storage provider.
+        - After "uploading" state: HTTP rest calls to finalize the upload.
+
+        This has not yet been applied to parallel file downloads. That will take place
+        later on.
         """
         if (
             hasattr(self, "_parallel_file_transfer_semaphore")

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -726,7 +726,10 @@ class File(FileSynchronousProtocol, AccessControllable):
 
         if self.path:
             self.path = os.path.expanduser(self.path)
-            await self._upload_file(synapse_client=client)
+            async with client._get_parallel_file_transfer_semaphore(
+                asyncio_event_loop=asyncio.get_running_loop()
+            ):
+                await self._upload_file(synapse_client=client)
         elif self.data_file_handle_id:
             self.path = client.cache.get(file_handle_id=self.data_file_handle_id)
 

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -565,7 +565,7 @@ class _SyncUploader:
             int(max_concurrent_file_transfers or self._syn.max_threads), 1
         )
         # self._file_semaphore = threading.BoundedSemaphore(self._max_concurrent_file_transfers)
-        self._file_semaphore_async = None
+        # self._file_semaphore_async = None
 
     @staticmethod
     def _order_items(
@@ -600,9 +600,9 @@ class _SyncUploader:
         return results
 
     async def upload(self, items: typing.Iterable[_SyncUploadItem]) -> None:
-        self._file_semaphore_async = asyncio.BoundedSemaphore(
-            self._max_concurrent_file_transfers
-        )
+        # self._file_semaphore_async = asyncio.BoundedSemaphore(
+        #     self._max_concurrent_file_transfers
+        # )
         # Create dict of path -> File Entity
         path_to_file_entity = {item.entity.path: item for item in items}
 
@@ -671,58 +671,58 @@ class _SyncUploader:
         store_args,
         finished_items,
     ) -> File:
-        try:
-            await self._file_semaphore_async.acquire()
-            used_activity = []
-            executed_activity = []
-            for used_item in used + executed:
-                possible_file = finished_items.get(used_item, None)
-                if possible_file:
-                    used_item = possible_file.id
-                if is_url(used_item):
-                    if used_item in used:
-                        used_activity.append(UsedURL(url=used_item))
-                    else:
-                        executed_activity.append(UsedURL(url=used_item))
-
-                # -- Synapse Entity ID (assuming the string is an ID)
-                elif isinstance(used_item, str):
-                    if not is_synapse_id_str(used_item):
-                        raise ValueError(f"{used_item} is not a valid Synapse id")
-                    synid, version = get_synid_and_version(
-                        used_item
-                    )  # Handle synapseIds of from syn234.4
-                    target_version = None
-                    if version:
-                        target_version = int(version)
-                    if used_item in used:
-                        used_activity.append(
-                            UsedEntity(
-                                target_id=synid, target_version_number=target_version
-                            )
-                        )
-                    else:
-                        executed_activity.append(
-                            UsedEntity(
-                                target_id=synid, target_version_number=target_version
-                            )
-                        )
+        # try:
+        # await self._file_semaphore_async.acquire()
+        used_activity = []
+        executed_activity = []
+        for used_item in used + executed:
+            possible_file = finished_items.get(used_item, None)
+            if possible_file:
+                used_item = possible_file.id
+            if is_url(used_item):
+                if used_item in used:
+                    used_activity.append(UsedURL(url=used_item))
                 else:
-                    raise SynapseError(
-                        f"Unexpected parameters in used or executed Activity fields: {used_item}."
-                    )
-            if used_activity and executed_activity:
-                item.activity = Activity(
-                    name=store_args.get("activityName", None),
-                    description=store_args.get("activityDescription", None),
-                    used=used_activity,
-                    executed=executed_activity,
-                )
-            await item.store_async()
-            return item
+                    executed_activity.append(UsedURL(url=used_item))
 
-        finally:
-            self._file_semaphore_async.release()
+            # -- Synapse Entity ID (assuming the string is an ID)
+            elif isinstance(used_item, str):
+                if not is_synapse_id_str(used_item):
+                    raise ValueError(f"{used_item} is not a valid Synapse id")
+                synid, version = get_synid_and_version(
+                    used_item
+                )  # Handle synapseIds of from syn234.4
+                target_version = None
+                if version:
+                    target_version = int(version)
+                if used_item in used:
+                    used_activity.append(
+                        UsedEntity(
+                            target_id=synid, target_version_number=target_version
+                        )
+                    )
+                else:
+                    executed_activity.append(
+                        UsedEntity(
+                            target_id=synid, target_version_number=target_version
+                        )
+                    )
+            else:
+                raise SynapseError(
+                    f"Unexpected parameters in used or executed Activity fields: {used_item}."
+                )
+        if used_activity and executed_activity:
+            item.activity = Activity(
+                name=store_args.get("activityName", None),
+                description=store_args.get("activityDescription", None),
+                used=used_activity,
+                executed=executed_activity,
+            )
+        await item.store_async()
+        return item
+
+        # finally:
+        #     self._file_semaphore_async.release()
 
 
 def generateManifest(syn, allFiles, filename, provenance_cache=None) -> None:

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -550,7 +550,6 @@ class _SyncUploader:
     def __init__(
         self,
         syn: Synapse,
-        max_concurrent_file_transfers: int = None,
     ):
         """
         Arguments:
@@ -559,13 +558,6 @@ class _SyncUploader:
                       can be scheduled
         """
         self._syn = syn
-
-        # TODO: Extract this to a shared location that is further up the stack
-        self._max_concurrent_file_transfers = max(
-            int(max_concurrent_file_transfers or self._syn.max_threads), 1
-        )
-        # self._file_semaphore = threading.BoundedSemaphore(self._max_concurrent_file_transfers)
-        # self._file_semaphore_async = None
 
     @staticmethod
     def _order_items(
@@ -600,9 +592,6 @@ class _SyncUploader:
         return results
 
     async def upload(self, items: typing.Iterable[_SyncUploadItem]) -> None:
-        # self._file_semaphore_async = asyncio.BoundedSemaphore(
-        #     self._max_concurrent_file_transfers
-        # )
         # Create dict of path -> File Entity
         path_to_file_entity = {item.entity.path: item for item in items}
 
@@ -671,8 +660,6 @@ class _SyncUploader:
         store_args,
         finished_items,
     ) -> File:
-        # try:
-        # await self._file_semaphore_async.acquire()
         used_activity = []
         executed_activity = []
         for used_item in used + executed:
@@ -720,9 +707,6 @@ class _SyncUploader:
             )
         await item.store_async()
         return item
-
-        # finally:
-        #     self._file_semaphore_async.release()
 
 
 def generateManifest(syn, allFiles, filename, provenance_cache=None) -> None:


### PR DESCRIPTION
**Problem:**

1. The sync util function had a mechanism to limit the number of files that can enter the store process.

**Solution:**

1. Adding a semaphore to the client.
2. Moving code from the sync function into the File.store_async() function that wraps the upload method. Now only a limited amount of files can enter into the "uploading" state.

**Testing:**
I tested out storing a few different data sizes.
1000/1GiB: 125.61s
1/10GiB: 170.75s
100/10GiB: 156.92s

These numbers are in-line with the bench marked numbers collected on the table here: https://github.com/Sage-Bionetworks/synapsePythonClient/blob/620937a91398a2446b0483619ae88a15adede3f8/docs/explanations/benchmarking.md#some-insights