### PR TITLE
[SYNPY-1456] Flaky integration tests due to connection issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,7 +202,7 @@ jobs:
           if-no-files-found: ignore
       - name: Upload coverage report
         uses: actions/upload-artifact@v2
-        if: ${{ contains(fromJSON('["3.9"]'), matrix.python) && contains(fromJSON('["ubuntu-20.04"]'), matrix.os)}}
+        if: ${{ contains(fromJSON('["3.9"]'), matrix.python) && contains(fromJSON('["ubuntu-22.04"]'), matrix.os)}}
         with:
           name: coverage-report
           path: coverage.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
           path: |
             ${{ steps.get-dependencies.outputs.site_packages_loc }}
             ${{ steps.get-dependencies.outputs.site_bin_dir }}
-          key: ${{ runner.os }}-${{ matrix.python }}-build-${{ env.cache-name }}-${{ hashFiles('setup.py') }}-v15
+          key: ${{ runner.os }}-${{ matrix.python }}-build-${{ env.cache-name }}-${{ hashFiles('setup.py') }}-v16
 
       - name: Install py-dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,7 +189,7 @@ jobs:
           fi
 
           # use loadscope to avoid issues running tests concurrently that share scoped fixtures
-          pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration -n auto --ignore=tests/integration/synapseclient/test_command_line_client.py --dist loadscope
+          pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration -n auto --ignore=tests/integration/synapseclient/test_command_line_client.py --ignore=tests/integration/synapseclient/test_tables.py --dist loadscope
 
           # Execute the CLI tests in a non-dist way because they were causing some test instability when being run concurrently
           # pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration/synapseclient/test_command_line_client.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,6 @@ on:
     tags-ignore:
       - '**'
 
-  pull_request:
-
   release:
     types:
       - 'published'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2019]
+        os: [ubuntu-22.04, macos-12, windows-2022]
 
         # if changing the below change the run-integration-tests versions and the check-deploy versions
         python: [3.8, '3.9', '3.10', '3.11']
@@ -74,7 +74,7 @@ jobs:
           path: |
             ${{ steps.get-dependencies.outputs.site_packages_loc }}
             ${{ steps.get-dependencies.outputs.site_bin_dir }}
-          key: ${{ runner.os }}-${{ matrix.python }}-build-${{ env.cache-name }}-${{ hashFiles('setup.py') }}-v14
+          key: ${{ runner.os }}-${{ matrix.python }}-build-${{ env.cache-name }}-${{ hashFiles('setup.py') }}-v15
 
       - name: Install py-dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
@@ -114,7 +114,7 @@ jobs:
           fi
       - name: OpenTelemtry pre-check
         id: otel-check
-        if: ${{ steps.secret-check.outputs.secrets_available == 'true' && steps.secret-check.outputs.synapse_pat_available == 'true' && !(startsWith(matrix.os, 'windows')) }}
+        if: ${{ steps.secret-check.outputs.secrets_available == 'true' && steps.secret-check.outputs.synapse_pat_available == 'true' }}
         shell: bash
         run: |
           # Leave disabled during normal integration test runs - Enable when we want to
@@ -128,13 +128,13 @@ jobs:
             # sudo ./aws/install
             # curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
             # sudo dpkg -i session-manager-plugin.deb
-      - name: Create AWS Config
-        if: ${{ steps.otel-check.outputs.run_opentelemetry == 'true' }}
-        shell: bash
-        run: |
-          touch test.awsConfig
-          printf "[default]\nregion = us-east-1\ncredential_process = \"tests/integration/synapse_creds.sh\" \"https://sc.sageit.org\" \"${{ secrets.synapse_personal_access_token }}\"\n" >> test.awsConfig
-          chmod +x tests/integration/synapse_creds.sh
+      # - name: Create AWS Config
+      #   if: ${{ steps.otel-check.outputs.run_opentelemetry == 'true' }}
+      #   shell: bash
+      #   run: |
+      #     touch test.awsConfig
+      #     printf "[default]\nregion = us-east-1\ncredential_process = \"tests/integration/synapse_creds.sh\" \"https://sc.sageit.org\" \"${{ secrets.synapse_personal_access_token }}\"\n" >> test.awsConfig
+      #     chmod +x tests/integration/synapse_creds.sh
       # If you are exporting data using `otlp` you can start a port forwading session
       # - name: SSM Port Forward Start
       #   if: ${{ steps.otel-check.outputs.run_opentelemetry == 'true' }}
@@ -189,10 +189,10 @@ jobs:
           fi
 
           # use loadscope to avoid issues running tests concurrently that share scoped fixtures
-          pytest -sv --cov-append --cov=. --cov-report xml tests/integration -n auto --ignore=tests/integration/synapseclient/test_command_line_client.py --dist loadscope
+          pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration -n auto --ignore=tests/integration/synapseclient/test_command_line_client.py --dist loadscope
 
           # Execute the CLI tests in a non-dist way because they were causing some test instability when being run concurrently
-          pytest -sv --cov-append --cov=. --cov-report xml tests/integration/synapseclient/test_command_line_client.py
+          # pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration/synapseclient/test_command_line_client.py
       - name: Upload otel spans
         uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,7 +189,7 @@ jobs:
           fi
 
           # use loadscope to avoid issues running tests concurrently that share scoped fixtures
-          pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration -n auto --ignore=tests/integration/synapseclient/test_command_line_client.py --ignore=tests/integration/synapseclient/test_tables.py --dist loadscope
+          pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration -n auto --ignore=tests/integration/synapseclient/test_command_line_client.py --dist loadscope
 
           # Execute the CLI tests in a non-dist way because they were causing some test instability when being run concurrently
           # pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration/synapseclient/test_command_line_client.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,30 +5,38 @@ Welcome, and thanks for your interest in contributing to the Synapse Python clie
 By contributing, you are agreeing that we may redistribute your work under this [license](LICENSE.md).
 
 # Table of contents
-- [How to contribute](#how-to-contribute)
-   * [Reporting bugs or feature requests](#reporting-bugs-or-feature-requests)
-- [Getting started](#getting-started)
-    + [Internal Sage collaborators: Clone this repository](#internal-sage-collaborators-clone-this-repository)
-    + [External collaborators: Fork and clone this repository](#external-collaborators-fork-and-clone-this-repository)
-    + [Installing the Python Client in a virtual environment with pipenv](#installing-the-python-client-in-a-virtual-environment-with-pipenv)
-    + [Set up pre-commit](#set-up-pre-commit)
-    + [Authentication](#authentication)
-- [The development life cycle](#the-development-life-cycle)
-   * [Development](#development)
-   * [Testing](#testing)
-      + [Integration testing against the dev synapse server](#integration-testing-against-the-dev-synapse-server)
-      + [Running OpenTelemetry in Integration Tests](#running-opentelemetry-in-integration-tests)
-   * [Asynchronous methods](#asynchronous-methods)
-      + [Creating a new async method](#creating-a-new-async-method)
-      + [Creating a new async method to be called by someone using the client](#creating-a-new-async-method-to-be-called-by-someone-using-the-client)
-      + [Creating a new async method to be called internally by the client](#creating-a-new-async-method-to-be-called-internally-by-the-client)
-      + [Modifying an existing async method](#modifying-an-existing-async-method)
-   * [Code style](#code-style)
-   * [OpenTelemetry](#opentelemetry)
-      + [Attributes within traces](#attributes-within-traces)
-      + [Adding new spans](#adding-new-spans)
-   * [Python doc pages](#python-doc-pages)
-   * [Repository Admins](#repository-admins)
+- [Contributing](#contributing)
+- [Table of contents](#table-of-contents)
+  - [I don't want to read this whole thing I just have a question!](#i-dont-want-to-read-this-whole-thing-i-just-have-a-question)
+  - [How to contribute](#how-to-contribute)
+    - [Reporting bugs or feature requests](#reporting-bugs-or-feature-requests)
+  - [Getting started](#getting-started)
+      - [Internal Sage collaborators: Clone this repository](#internal-sage-collaborators-clone-this-repository)
+      - [External collaborators: Fork and clone this repository](#external-collaborators-fork-and-clone-this-repository)
+      - [Installing the Python Client in a virtual environment with pipenv](#installing-the-python-client-in-a-virtual-environment-with-pipenv)
+      - [Set up pre-commit](#set-up-pre-commit)
+      - [Authentication](#authentication)
+  - [The development life cycle](#the-development-life-cycle)
+    - [Development](#development)
+    - [Testing](#testing)
+      - [Integration testing against the `dev` synapse server](#integration-testing-against-the-dev-synapse-server)
+      - [Running OpenTelemetry in Integration Tests](#running-opentelemetry-in-integration-tests)
+      - [Integration testing for external collaborators](#integration-testing-for-external-collaborators)
+    - [Asynchronous methods](#asynchronous-methods)
+      - [Creating a new async method](#creating-a-new-async-method)
+        - [Creating a new async method to be called by someone using the client](#creating-a-new-async-method-to-be-called-by-someone-using-the-client)
+        - [Creating a new async method to be called internally by the client](#creating-a-new-async-method-to-be-called-internally-by-the-client)
+        - [Modifying an existing async method](#modifying-an-existing-async-method)
+    - [Code style](#code-style)
+      - [Some additional expectations:](#some-additional-expectations)
+    - [OpenTelemetry](#opentelemetry)
+      - [Attributes within traces](#attributes-within-traces)
+      - [Adding new spans](#adding-new-spans)
+    - [Python doc pages](#python-doc-pages)
+      - [Running the documents page on your local machine](#running-the-documents-page-on-your-local-machine)
+      - [Guidelines for new documents](#guidelines-for-new-documents)
+      - [Lessons learned for integration testing](#lessons-learned-for-integration-testing)
+    - [Repository Admins](#repository-admins)
 
 ## I don't want to read this whole thing I just have a question!
 
@@ -355,6 +363,19 @@ Some links for further reading:
 
 - https://mkdocstrings.github.io/
 - https://mkdocstrings.github.io/python/
+
+#### Lessons learned for integration testing
+The re-use of connection pools during integration tests needs to be considered. During
+April 2024 it was found that during a single run of all integration tests almost 400
+connections were created and subsequently closed during the test run. As such the
+following set of guidelines should be followed:
+
+- All tests should use the `async` keyword. This allows any tests to share the
+underlying HTTPX async client for requests.
+- Any non `session` scoped fixtures should not execute an HTTP request. If the fixture
+does need to execute a request it should not be scoped to `function`. This is because
+each scope level runs it's own event loop; Connection pools cannot be shared between
+each of the event loops.
 
 ### Repository Admins
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -567,18 +567,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:b59355bf4a1408563969526f314611dbeacc151cf90ecb22af295dcc4fe18def",
-                "sha256:e39516e4ca21612932599819662759c04485d53ca457996a913163da11f052a4"
+                "sha256:decf52f8d5d8a1b10c9ff2a0e96ee207ed79e33d2e53fdf0880a5cbef70785e0",
+                "sha256:e836b71d79671270fccac0a4d4c8ec239a6b82ea47c399b64675aa597d0ee63b"
             ],
-            "version": "==1.34.93"
+            "version": "==1.34.95"
         },
         "botocore": {
             "hashes": [
-                "sha256:6fbd5a53a2adc9b3d4ebd90ae0ede83a91a41d96231f8a5984051f75495f246d",
-                "sha256:79d39b0b87e962991c6dd55e78ce15155099f6fb741be88b1b8a456a702cc150"
+                "sha256:6bd76a2eadb42b91fa3528392e981ad5b4dfdee3968fa5b904278acf6cbf15ff",
+                "sha256:ead5823e0dd6751ece5498cb979fd9abf190e691c8833bcac6876fd6ca261fa7"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.93"
+            "version": "==1.34.95"
         },
         "certifi": {
             "hashes": [
@@ -906,11 +906,11 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:404e5e9253aa60ad457cae1be07c0f0ca90a63931200a47d9b6a6af84fd7b45f",
-                "sha256:d13f466618bfde72bd2c18255e269f72542c6e70e7bac83a0232d6b1cc5c8cf4"
+                "sha256:43339835842f110ca7ae60f1e1c160714c5a6afd15a2873419ab185334975c0f",
+                "sha256:6ea72da3be9b8c82afd3edcf99f2fffbb5076335a5ae4d03248bb5b6c3eae78a"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.13.4"
+            "version": "==3.14.0"
         },
         "flake8": {
             "hashes": [
@@ -1148,10 +1148,10 @@
         },
         "mkdocs-material": {
             "hashes": [
-                "sha256:7473e06e17e23af608a30ef583fdde8f36389dd3ef56b1d503eed54c89c9618c",
-                "sha256:ea96e150b6c95f5e4ffe47d78bb712c7bacdd91d2a0bec47f46b6fa0705a86ec"
+                "sha256:986eef0250d22f70fb06ce0f4eac64cc92bd797a589ec3892ce31fad976fe3da",
+                "sha256:ad0094a7597bcb5d0cc3e8e543a10927c2581f7f647b9bb4861600f583180f9b"
             ],
-            "version": "==9.5.19"
+            "version": "==9.5.20"
         },
         "mkdocs-material-extensions": {
             "hashes": [
@@ -1489,10 +1489,10 @@
         },
         "pytest-asyncio": {
             "hashes": [
-                "sha256:40a7eae6dded22c7b604986855ea48400ab15b069ae38116e8c01238e9eeb64d",
-                "sha256:8666c1c8ac02631d7c51ba282e0c69a8a452b211ffedf2599099845da5c5c37b"
+                "sha256:68516fdd1018ac57b846c9846b954f0393b26f094764a28c955eabb0536a4e8a",
+                "sha256:ffe523a89c1c222598c76856e76852b787504ddb72dd5d9b6617ffa8aa2cde5f"
             ],
-            "version": "==0.21.1"
+            "version": "==0.23.6"
         },
         "pytest-cov": {
             "hashes": [
@@ -1622,102 +1622,88 @@
         },
         "regex": {
             "hashes": [
-                "sha256:00169caa125f35d1bca6045d65a662af0202704489fada95346cfa092ec23f39",
-                "sha256:03576e3a423d19dda13e55598f0fd507b5d660d42c51b02df4e0d97824fdcae3",
-                "sha256:03e68f44340528111067cecf12721c3df4811c67268b897fbe695c95f860ac42",
-                "sha256:0534b034fba6101611968fae8e856c1698da97ce2efb5c2b895fc8b9e23a5834",
-                "sha256:08dea89f859c3df48a440dbdcd7b7155bc675f2fa2ec8c521d02dc69e877db70",
-                "sha256:0a38d151e2cdd66d16dab550c22f9521ba79761423b87c01dae0a6e9add79c0d",
-                "sha256:0c8290b44d8b0af4e77048646c10c6e3aa583c1ca67f3b5ffb6e06cf0c6f0f89",
-                "sha256:10188fe732dec829c7acca7422cdd1bf57d853c7199d5a9e96bb4d40db239c73",
-                "sha256:1210365faba7c2150451eb78ec5687871c796b0f1fa701bfd2a4a25420482d26",
-                "sha256:12f6a3f2f58bb7344751919a1876ee1b976fe08b9ffccb4bbea66f26af6017b9",
-                "sha256:159dc4e59a159cb8e4e8f8961eb1fa5d58f93cb1acd1701d8aff38d45e1a84a6",
-                "sha256:20b7a68444f536365af42a75ccecb7ab41a896a04acf58432db9e206f4e525d6",
-                "sha256:23cff1b267038501b179ccbbd74a821ac4a7192a1852d1d558e562b507d46013",
-                "sha256:2c72608e70f053643437bd2be0608f7f1c46d4022e4104d76826f0839199347a",
-                "sha256:3399dd8a7495bbb2bacd59b84840eef9057826c664472e86c91d675d007137f5",
-                "sha256:34422d5a69a60b7e9a07a690094e824b66f5ddc662a5fc600d65b7c174a05f04",
-                "sha256:370c68dc5570b394cbaadff50e64d705f64debed30573e5c313c360689b6aadc",
-                "sha256:3a1018e97aeb24e4f939afcd88211ace472ba566efc5bdf53fd8fd7f41fa7170",
-                "sha256:3d5ac5234fb5053850d79dd8eb1015cb0d7d9ed951fa37aa9e6249a19aa4f336",
-                "sha256:4313ab9bf6a81206c8ac28fdfcddc0435299dc88cad12cc6305fd0e78b81f9e4",
-                "sha256:445ca8d3c5a01309633a0c9db57150312a181146315693273e35d936472df912",
-                "sha256:479595a4fbe9ed8f8f72c59717e8cf222da2e4c07b6ae5b65411e6302af9708e",
-                "sha256:4918fd5f8b43aa7ec031e0fef1ee02deb80b6afd49c85f0790be1dc4ce34cb50",
-                "sha256:4aba818dcc7263852aabb172ec27b71d2abca02a593b95fa79351b2774eb1d2b",
-                "sha256:4e819a806420bc010489f4e741b3036071aba209f2e0989d4750b08b12a9343f",
-                "sha256:4facc913e10bdba42ec0aee76d029aedda628161a7ce4116b16680a0413f658a",
-                "sha256:549c3584993772e25f02d0656ac48abdda73169fe347263948cf2b1cead622f3",
-                "sha256:5c02fcd2bf45162280613d2e4a1ca3ac558ff921ae4e308ecb307650d3a6ee51",
-                "sha256:5f580c651a72b75c39e311343fe6875d6f58cf51c471a97f15a938d9fe4e0d37",
-                "sha256:62120ed0de69b3649cc68e2965376048793f466c5a6c4370fb27c16c1beac22d",
-                "sha256:6295004b2dd37b0835ea5c14a33e00e8cfa3c4add4d587b77287825f3418d310",
-                "sha256:65436dce9fdc0aeeb0a0effe0839cb3d6a05f45aa45a4d9f9c60989beca78b9c",
-                "sha256:684008ec44ad275832a5a152f6e764bbe1914bea10968017b6feaecdad5736e0",
-                "sha256:684e52023aec43bdf0250e843e1fdd6febbe831bd9d52da72333fa201aaa2335",
-                "sha256:6cc38067209354e16c5609b66285af17a2863a47585bcf75285cab33d4c3b8df",
-                "sha256:6f2f017c5be19984fbbf55f8af6caba25e62c71293213f044da3ada7091a4455",
-                "sha256:743deffdf3b3481da32e8a96887e2aa945ec6685af1cfe2bcc292638c9ba2f48",
-                "sha256:7571f19f4a3fd00af9341c7801d1ad1967fc9c3f5e62402683047e7166b9f2b4",
-                "sha256:7731728b6568fc286d86745f27f07266de49603a6fdc4d19c87e8c247be452af",
-                "sha256:785c071c982dce54d44ea0b79cd6dfafddeccdd98cfa5f7b86ef69b381b457d9",
-                "sha256:78fddb22b9ef810b63ef341c9fcf6455232d97cfe03938cbc29e2672c436670e",
-                "sha256:7bb966fdd9217e53abf824f437a5a2d643a38d4fd5fd0ca711b9da683d452969",
-                "sha256:7cbc5d9e8a1781e7be17da67b92580d6ce4dcef5819c1b1b89f49d9678cc278c",
-                "sha256:803b8905b52de78b173d3c1e83df0efb929621e7b7c5766c0843704d5332682f",
-                "sha256:80b696e8972b81edf0af2a259e1b2a4a661f818fae22e5fa4fa1a995fb4a40fd",
-                "sha256:81500ed5af2090b4a9157a59dbc89873a25c33db1bb9a8cf123837dcc9765047",
-                "sha256:89ec7f2c08937421bbbb8b48c54096fa4f88347946d4747021ad85f1b3021b3c",
-                "sha256:8ba6745440b9a27336443b0c285d705ce73adb9ec90e2f2004c64d95ab5a7598",
-                "sha256:8c91e1763696c0eb66340c4df98623c2d4e77d0746b8f8f2bee2c6883fd1fe18",
-                "sha256:8d015604ee6204e76569d2f44e5a210728fa917115bef0d102f4107e622b08d5",
-                "sha256:8d1f86f3f4e2388aa3310b50694ac44daefbd1681def26b4519bd050a398dc5a",
-                "sha256:8f83b6fd3dc3ba94d2b22717f9c8b8512354fd95221ac661784df2769ea9bba9",
-                "sha256:8fc6976a3395fe4d1fbeb984adaa8ec652a1e12f36b56ec8c236e5117b585427",
-                "sha256:904c883cf10a975b02ab3478bce652f0f5346a2c28d0a8521d97bb23c323cc8b",
-                "sha256:911742856ce98d879acbea33fcc03c1d8dc1106234c5e7d068932c945db209c0",
-                "sha256:91797b98f5e34b6a49f54be33f72e2fb658018ae532be2f79f7c63b4ae225145",
-                "sha256:95399831a206211d6bc40224af1c635cb8790ddd5c7493e0bd03b85711076a53",
-                "sha256:956b58d692f235cfbf5b4f3abd6d99bf102f161ccfe20d2fd0904f51c72c4c66",
-                "sha256:98c1165f3809ce7774f05cb74e5408cd3aa93ee8573ae959a97a53db3ca3180d",
-                "sha256:9ab40412f8cd6f615bfedea40c8bf0407d41bf83b96f6fc9ff34976d6b7037fd",
-                "sha256:9df1bfef97db938469ef0a7354b2d591a2d438bc497b2c489471bec0e6baf7c4",
-                "sha256:a01fe2305e6232ef3e8f40bfc0f0f3a04def9aab514910fa4203bafbc0bb4682",
-                "sha256:a70b51f55fd954d1f194271695821dd62054d949efd6368d8be64edd37f55c86",
-                "sha256:a7ccdd1c4a3472a7533b0a7aa9ee34c9a2bef859ba86deec07aff2ad7e0c3b94",
-                "sha256:b340cccad138ecb363324aa26893963dcabb02bb25e440ebdf42e30963f1a4e0",
-                "sha256:b74586dd0b039c62416034f811d7ee62810174bb70dffcca6439f5236249eb09",
-                "sha256:b9d320b3bf82a39f248769fc7f188e00f93526cc0fe739cfa197868633d44701",
-                "sha256:ba2336d6548dee3117520545cfe44dc28a250aa091f8281d28804aa8d707d93d",
-                "sha256:ba8122e3bb94ecda29a8de4cf889f600171424ea586847aa92c334772d200331",
-                "sha256:bd727ad276bb91928879f3aa6396c9a1d34e5e180dce40578421a691eeb77f47",
-                "sha256:c21fc21a4c7480479d12fd8e679b699f744f76bb05f53a1d14182b31f55aac76",
-                "sha256:c2d0e7cbb6341e830adcbfa2479fdeebbfbb328f11edd6b5675674e7a1e37730",
-                "sha256:c2ef6f7990b6e8758fe48ad08f7e2f66c8f11dc66e24093304b87cae9037bb4a",
-                "sha256:c4ed75ea6892a56896d78f11006161eea52c45a14994794bcfa1654430984b22",
-                "sha256:cccc79a9be9b64c881f18305a7c715ba199e471a3973faeb7ba84172abb3f317",
-                "sha256:d0800631e565c47520aaa04ae38b96abc5196fe8b4aa9bd864445bd2b5848a7a",
-                "sha256:d2da13568eff02b30fd54fccd1e042a70fe920d816616fda4bf54ec705668d81",
-                "sha256:d61ae114d2a2311f61d90c2ef1358518e8f05eafda76eaf9c772a077e0b465ec",
-                "sha256:d83c2bc678453646f1a18f8db1e927a2d3f4935031b9ad8a76e56760461105dd",
-                "sha256:dd5acc0a7d38fdc7a3a6fd3ad14c880819008ecb3379626e56b163165162cc46",
-                "sha256:df79012ebf6f4efb8d307b1328226aef24ca446b3ff8d0e30202d7ebcb977a8c",
-                "sha256:e0a2df336d1135a0b3a67f3bbf78a75f69562c1199ed9935372b82215cddd6e2",
-                "sha256:e2f142b45c6fed48166faeb4303b4b58c9fcd827da63f4cf0a123c3480ae11fb",
-                "sha256:e697e1c0238133589e00c244a8b676bc2cfc3ab4961318d902040d099fec7483",
-                "sha256:e757d475953269fbf4b441207bb7dbdd1c43180711b6208e129b637792ac0b93",
-                "sha256:e87ab229332ceb127a165612d839ab87795972102cb9830e5f12b8c9a5c1b508",
-                "sha256:ea355eb43b11764cf799dda62c658c4d2fdb16af41f59bb1ccfec517b60bcb07",
-                "sha256:ec7e0043b91115f427998febaa2beb82c82df708168b35ece3accb610b91fac1",
-                "sha256:eeaa0b5328b785abc344acc6241cffde50dc394a0644a968add75fcefe15b9d4",
-                "sha256:f2d80a6749724b37853ece57988b39c4e79d2b5fe2869a86e8aeae3bbeef9eb0",
-                "sha256:fa454d26f2e87ad661c4f0c5a5fe4cf6aab1e307d1b94f16ffdfcb089ba685c0",
-                "sha256:fb83cc090eac63c006871fd24db5e30a1f282faa46328572661c0a24a2323a08",
-                "sha256:fd80d1280d473500d8086d104962a82d77bfbf2b118053824b7be28cd5a79ea5"
+                "sha256:05d9b6578a22db7dedb4df81451f360395828b04f4513980b6bd7a1412c679cc",
+                "sha256:08a1749f04fee2811c7617fdd46d2e46d09106fa8f475c884b65c01326eb15c5",
+                "sha256:0940038bec2fe9e26b203d636c44d31dd8766abc1fe66262da6484bd82461ccf",
+                "sha256:0a2a512d623f1f2d01d881513af9fc6a7c46e5cfffb7dc50c38ce959f9246c94",
+                "sha256:0a54a047b607fd2d2d52a05e6ad294602f1e0dec2291152b745870afc47c1397",
+                "sha256:0dd3f69098511e71880fb00f5815db9ed0ef62c05775395968299cb400aeab82",
+                "sha256:1031a5e7b048ee371ab3653aad3030ecfad6ee9ecdc85f0242c57751a05b0ac4",
+                "sha256:108e2dcf0b53a7c4ab8986842a8edcb8ab2e59919a74ff51c296772e8e74d0ae",
+                "sha256:144a1fc54765f5c5c36d6d4b073299832aa1ec6a746a6452c3ee7b46b3d3b11d",
+                "sha256:19d6c11bf35a6ad077eb23852827f91c804eeb71ecb85db4ee1386825b9dc4db",
+                "sha256:1f687a28640f763f23f8a9801fe9e1b37338bb1ca5d564ddd41619458f1f22d1",
+                "sha256:224803b74aab56aa7be313f92a8d9911dcade37e5f167db62a738d0c85fdac4b",
+                "sha256:23a412b7b1a7063f81a742463f38821097b6a37ce1e5b89dd8e871d14dbfd86b",
+                "sha256:25f87ae6b96374db20f180eab083aafe419b194e96e4f282c40191e71980c666",
+                "sha256:2630ca4e152c221072fd4a56d4622b5ada876f668ecd24d5ab62544ae6793ed6",
+                "sha256:28e1f28d07220c0f3da0e8fcd5a115bbb53f8b55cecf9bec0c946eb9a059a94c",
+                "sha256:2b51739ddfd013c6f657b55a508de8b9ea78b56d22b236052c3a85a675102dc6",
+                "sha256:2cc1b87bba1dd1a898e664a31012725e48af826bf3971e786c53e32e02adae6c",
+                "sha256:2fef0b38c34ae675fcbb1b5db760d40c3fc3612cfa186e9e50df5782cac02bcd",
+                "sha256:36f392dc7763fe7924575475736bddf9ab9f7a66b920932d0ea50c2ded2f5636",
+                "sha256:374f690e1dd0dbdcddea4a5c9bdd97632cf656c69113f7cd6a361f2a67221cb6",
+                "sha256:3986217ec830c2109875be740531feb8ddafe0dfa49767cdcd072ed7e8927962",
+                "sha256:39fb166d2196413bead229cd64a2ffd6ec78ebab83fff7d2701103cf9f4dfd26",
+                "sha256:4290035b169578ffbbfa50d904d26bec16a94526071ebec3dadbebf67a26b25e",
+                "sha256:43548ad74ea50456e1c68d3c67fff3de64c6edb85bcd511d1136f9b5376fc9d1",
+                "sha256:44a22ae1cfd82e4ffa2066eb3390777dc79468f866f0625261a93e44cdf6482b",
+                "sha256:457c2cd5a646dd4ed536c92b535d73548fb8e216ebee602aa9f48e068fc393f3",
+                "sha256:459226445c7d7454981c4c0ce0ad1a72e1e751c3e417f305722bbcee6697e06a",
+                "sha256:47af45b6153522733aa6e92543938e97a70ce0900649ba626cf5aad290b737b6",
+                "sha256:499334ad139557de97cbc4347ee921c0e2b5e9c0f009859e74f3f77918339257",
+                "sha256:57ba112e5530530fd175ed550373eb263db4ca98b5f00694d73b18b9a02e7185",
+                "sha256:5ce479ecc068bc2a74cb98dd8dba99e070d1b2f4a8371a7dfe631f85db70fe6e",
+                "sha256:5dbc1bcc7413eebe5f18196e22804a3be1bfdfc7e2afd415e12c068624d48247",
+                "sha256:6277d426e2f31bdbacb377d17a7475e32b2d7d1f02faaecc48d8e370c6a3ff31",
+                "sha256:66372c2a01782c5fe8e04bff4a2a0121a9897e19223d9eab30c54c50b2ebeb7f",
+                "sha256:670fa596984b08a4a769491cbdf22350431970d0112e03d7e4eeaecaafcd0fec",
+                "sha256:6f435946b7bf7a1b438b4e6b149b947c837cb23c704e780c19ba3e6855dbbdd3",
+                "sha256:7413167c507a768eafb5424413c5b2f515c606be5bb4ef8c5dee43925aa5718b",
+                "sha256:7c3d389e8d76a49923683123730c33e9553063d9041658f23897f0b396b2386f",
+                "sha256:7d77b6f63f806578c604dca209280e4c54f0fa9a8128bb8d2cc5fb6f99da4150",
+                "sha256:7e76b9cfbf5ced1aca15a0e5b6f229344d9b3123439ffce552b11faab0114a02",
+                "sha256:7f3502f03b4da52bbe8ba962621daa846f38489cae5c4a7b5d738f15f6443d17",
+                "sha256:7fe9739a686dc44733d52d6e4f7b9c77b285e49edf8570754b322bca6b85b4cc",
+                "sha256:83ab366777ea45d58f72593adf35d36ca911ea8bd838483c1823b883a121b0e4",
+                "sha256:84077821c85f222362b72fdc44f7a3a13587a013a45cf14534df1cbbdc9a6796",
+                "sha256:8bb381f777351bd534462f63e1c6afb10a7caa9fa2a421ae22c26e796fe31b1f",
+                "sha256:92da587eee39a52c91aebea8b850e4e4f095fe5928d415cb7ed656b3460ae79a",
+                "sha256:9301cc6db4d83d2c0719f7fcda37229691745168bf6ae849bea2e85fc769175d",
+                "sha256:965fd0cf4694d76f6564896b422724ec7b959ef927a7cb187fc6b3f4e4f59833",
+                "sha256:99d6a550425cc51c656331af0e2b1651e90eaaa23fb4acde577cf15068e2e20f",
+                "sha256:99ef6289b62042500d581170d06e17f5353b111a15aa6b25b05b91c6886df8fc",
+                "sha256:a1409c4eccb6981c7baabc8888d3550df518add6e06fe74fa1d9312c1838652d",
+                "sha256:a74fcf77d979364f9b69fcf8200849ca29a374973dc193a7317698aa37d8b01c",
+                "sha256:aaa179975a64790c1f2701ac562b5eeb733946eeb036b5bcca05c8d928a62f10",
+                "sha256:ac69b394764bb857429b031d29d9604842bc4cbfd964d764b1af1868eeebc4f0",
+                "sha256:b45d4503de8f4f3dc02f1d28a9b039e5504a02cc18906cfe744c11def942e9eb",
+                "sha256:b7d893c8cf0e2429b823ef1a1d360a25950ed11f0e2a9df2b5198821832e1947",
+                "sha256:b8eb28995771c087a73338f695a08c9abfdf723d185e57b97f6175c5051ff1ae",
+                "sha256:b91d529b47798c016d4b4c1d06cc826ac40d196da54f0de3c519f5a297c5076a",
+                "sha256:bc365ce25f6c7c5ed70e4bc674f9137f52b7dd6a125037f9132a7be52b8a252f",
+                "sha256:bf29304a8011feb58913c382902fde3395957a47645bf848eea695839aa101b7",
+                "sha256:c06bf3f38f0707592898428636cbb75d0a846651b053a1cf748763e3063a6925",
+                "sha256:c77d10ec3c1cf328b2f501ca32583625987ea0f23a0c2a49b37a39ee5c4c4630",
+                "sha256:cd196d056b40af073d95a2879678585f0b74ad35190fac04ca67954c582c6b61",
+                "sha256:d7a353ebfa7154c871a35caca7bfd8f9e18666829a1dc187115b80e35a29393e",
+                "sha256:d84308f097d7a513359757c69707ad339da799e53b7393819ec2ea36bc4beb58",
+                "sha256:dd7ef715ccb8040954d44cfeff17e6b8e9f79c8019daae2fd30a8806ef5435c0",
+                "sha256:e672cf9caaf669053121f1766d659a8813bd547edef6e009205378faf45c67b8",
+                "sha256:ecc6148228c9ae25ce403eade13a0961de1cb016bdb35c6eafd8e7b87ad028b1",
+                "sha256:f1c5742c31ba7d72f2dedf7968998730664b45e38827637e0f04a2ac7de2f5f1",
+                "sha256:f1d6e4b7b2ae3a6a9df53efbf199e4bfcff0959dbdb5fd9ced34d4407348e39a",
+                "sha256:f2fc053228a6bd3a17a9b0a3f15c3ab3cf95727b00557e92e1cfe094b88cc662",
+                "sha256:f57515750d07e14743db55d59759893fdb21d2668f39e549a7d6cad5d70f9fea",
+                "sha256:f85151ec5a232335f1be022b09fbbe459042ea1951d8a48fef251223fc67eee1",
+                "sha256:fb0315a2b26fde4005a7c401707c5352df274460f2f85b209cf6024271373013",
+                "sha256:fc0916c4295c64d6890a46e02d4482bb5ccf33bf1a824c0eaa9e83b148291f90",
+                "sha256:fd24fd140b69f0b0bcc9165c397e9b2e89ecbeda83303abf2a072609f60239e2",
+                "sha256:fdae0120cddc839eb8e3c15faa8ad541cc6d906d3eb24d82fb041cfe2807bc1e",
+                "sha256:fe00f4fe11c8a521b173e6324d862ee7ee3412bf7107570c9b564fe1119b56fb"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2024.4.16"
+            "markers": "python_version >= '3.8'",
+            "version": "==2024.4.28"
         },
         "requests": {
             "hashes": [
@@ -1813,11 +1799,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:0846377ea76e818daaa3e00a4365c018bc3ac9760cbb3544de542885aad61fb3",
-                "sha256:ec25a9671a5102c8d2657f62792a27b48f016664c6873f6beed3800008577210"
+                "sha256:604bfdceaeece392802e6ae48e69cec49168b9c5f4a44e483963f9242eb0e78b",
+                "sha256:7aa9982a728ae5892558bff6a2839c00b9ed145523ece2274fad6f414690ae75"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==20.26.0"
+            "version": "==20.26.1"
         },
         "watchdog": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -210,11 +210,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca",
-                "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
+                "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc",
+                "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.6"
+            "version": "==3.7"
         },
         "importlib-metadata": {
             "hashes": [
@@ -357,11 +357,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
-                "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
+                "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0",
+                "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==4.10.0"
+            "version": "==4.11.0"
         },
         "urllib3": {
             "hashes": [
@@ -489,14 +489,6 @@
             "markers": "python_version >= '3.6'",
             "version": "==1.0.1"
         },
-        "attrs": {
-            "hashes": [
-                "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30",
-                "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==23.2.0"
-        },
         "babel": {
             "hashes": [
                 "sha256:6919867db036398ba21eb5c7a0f6b28ab8cbc3ae7a73a44ebe34ae74a4e7d363",
@@ -575,18 +567,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:a33585ef0d811ee0dffd92a96108344997a3059262c57349be0761d7885f6ae7",
-                "sha256:cbfabd99c113bbb1708c2892e864b6dd739593b97a76fbb2e090a7d965b63b82"
+                "sha256:33cf93f6de5176f1188c923f4de1ae149ed723b89ed12e434f2b2f628491769e",
+                "sha256:9733ce811bd82feab506ad9309e375a79cabe8c6149061971c17754ce8997551"
             ],
-            "version": "==1.34.72"
+            "version": "==1.34.83"
         },
         "botocore": {
             "hashes": [
-                "sha256:342edb6f91d5839e790411822fc39f9c712c87cdaa7f3b1999f50b1ca16c4a14",
-                "sha256:a6b92735a73c19a7e540d77320420da3af3f32c91fa661c738c0b8c9f912d782"
+                "sha256:0a3fbbe018416aeefa8978454fb0b8129adbaf556647b72269bf02e4bf1f4161",
+                "sha256:0f302aa76283d4df62b4fbb6d3d20115c1a8957fc02171257fc93904d69d5636"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.72"
+            "version": "==1.34.83"
         },
         "certifi": {
             "hashes": [
@@ -906,19 +898,19 @@
         },
         "execnet": {
             "hashes": [
-                "sha256:88256416ae766bc9e8895c76a87928c0012183da3cc4fc18016e6f050e025f41",
-                "sha256:cc59bc4423742fd71ad227122eb0dd44db51efb3dc4095b45ac9a08c770096af"
+                "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc",
+                "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.0.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.1.1"
         },
         "filelock": {
             "hashes": [
-                "sha256:5ffa845303983e7a0b7ae17636509bc97997d58afeafa72fb141a17b152284cb",
-                "sha256:a79895a25bbefdf55d1a2a0a80968f7dbb28edcd6d4234a0afb3f37ecde4b546"
+                "sha256:404e5e9253aa60ad457cae1be07c0f0ca90a63931200a47d9b6a6af84fd7b45f",
+                "sha256:d13f466618bfde72bd2c18255e269f72542c6e70e7bac83a0232d6b1cc5c8cf4"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.13.3"
+            "version": "==3.13.4"
         },
         "flake8": {
             "hashes": [
@@ -990,11 +982,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca",
-                "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
+                "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc",
+                "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.6"
+            "version": "==3.7"
         },
         "importlib-metadata": {
             "hashes": [
@@ -1037,11 +1029,11 @@
         },
         "markdown": {
             "hashes": [
-                "sha256:d43323865d89fc0cb9b20c75fc8ad313af307cc087e84b657d9eec768eddeadd",
-                "sha256:e1ac7b3dc550ee80e602e71c1d168002f062e49f1b11e26a36264dafd4df2ef8"
+                "sha256:48f276f4d8cfb8ce6527c8f79e2ee29708508bf4d40aa410fbc3b4ee832c850f",
+                "sha256:ed4f41f6daecbeeb96e576ce414c41d2d876daa9a16cb35fa8ed8c2ddfad0224"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.5.2"
+            "version": "==3.6"
         },
         "markdown-include": {
             "hashes": [
@@ -1148,10 +1140,10 @@
         },
         "mkdocs-material": {
             "hashes": [
-                "sha256:39f03cca45e82bf54eb7456b5a18bd252eabfdd67f237a229471484a0a4d4635",
-                "sha256:e5c96dec3d19491de49ca643fc1dbb92b278e43cdb816c775bc47db77d9b62fb"
+                "sha256:06ae1275a72db1989cf6209de9e9ecdfbcfdbc24c58353877b2bb927dbe413e4",
+                "sha256:14a2a60119a785e70e765dd033e6211367aca9fc70230e577c1cf6a326949571"
             ],
-            "version": "==9.5.15"
+            "version": "==9.5.17"
         },
         "mkdocs-material-extensions": {
             "hashes": [
@@ -1170,17 +1162,17 @@
         },
         "mkdocstrings": {
             "hashes": [
-                "sha256:b4206f9a2ca8a648e222d5a0ca1d36ba7dee53c88732818de183b536f9042b5d",
-                "sha256:cc83f9a1c8724fc1be3c2fa071dd73d91ce902ef6a79710249ec8d0ee1064401"
+                "sha256:5c9cf2a32958cd161d5428699b79c8b0988856b0d4a8c5baf8395fc1bf4087c3",
+                "sha256:f327b234eb8d2551a306735436e157d0a22d45f79963c60a8b585d5f7a94c1d2"
             ],
-            "version": "==0.24.1"
+            "version": "==0.24.3"
         },
         "mkdocstrings-python": {
             "hashes": [
-                "sha256:6e1a442367cf75d30cf69774cbb1ad02aebec58bfff26087439df4955efecfde",
-                "sha256:fad27d7314b4ec9c0359a187b477fb94c65ef561fdae941dca1b717c59aae96f"
+                "sha256:8546a103c9b22e1778c72c887696acc39a6635fedde3c912ce00f967518a8847",
+                "sha256:96d82f6424e08db6245e4a15ca95619f4ecd0ddd254c0aa590d4181814e16ee5"
             ],
-            "version": "==1.9.0"
+            "version": "==1.9.2"
         },
         "mypy-extensions": {
             "hashes": [
@@ -1428,10 +1420,11 @@
         },
         "pycparser": {
             "hashes": [
-                "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
-                "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"
+                "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6",
+                "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"
             ],
-            "version": "==2.21"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.22"
         },
         "pyflakes": {
             "hashes": [
@@ -1481,17 +1474,17 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
-                "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
+                "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280",
+                "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"
             ],
-            "version": "==6.2.5"
+            "version": "==7.4.4"
         },
         "pytest-asyncio": {
             "hashes": [
-                "sha256:83cbf01169ce3e8eb71c6c278ccb0574d1a7a3bb8eaaf5e50e0ad342afb33b36",
-                "sha256:f129998b209d04fcc65c96fc85c11e5316738358909a8399e93be553d7656442"
+                "sha256:68516fdd1018ac57b846c9846b954f0393b26f094764a28c955eabb0536a4e8a",
+                "sha256:ffe523a89c1c222598c76856e76852b787504ddb72dd5d9b6617ffa8aa2cde5f"
             ],
-            "version": "==0.20.3"
+            "version": "==0.23.6"
         },
         "pytest-cov": {
             "hashes": [
@@ -1736,11 +1729,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:0ff4183f8f42cd8fa3acea16c45205521a4ef28f73c6391d8a25e92893134f2e",
-                "sha256:c21c49fb1042386df081cb5d86759792ab89efca84cf114889191cd09aacc80c"
+                "sha256:48c518e350470d98cfa2944a31edbfc897c9a7d8fa4847da66d89f0f5fb64b57",
+                "sha256:e1fd0ca7ba442e4be8a415dcca867b8018777dd5f95f4492bb4dc7d77dbc8bd8"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==69.2.0"
+            "version": "==69.3.0"
         },
         "six": {
             "hashes": [
@@ -1770,14 +1763,6 @@
             ],
             "version": "==0.12.1"
         },
-        "toml": {
-            "hashes": [
-                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
-            ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
-            "version": "==0.10.2"
-        },
         "tomli": {
             "hashes": [
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
@@ -1796,11 +1781,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
-                "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
+                "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0",
+                "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==4.10.0"
+            "version": "==4.11.0"
         },
         "tzdata": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -170,11 +170,11 @@
         },
         "exceptiongroup": {
             "hashes": [
-                "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14",
-                "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"
+                "sha256:5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad",
+                "sha256:a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==1.2.0"
+            "version": "==1.2.1"
         },
         "googleapis-common-protos": {
             "hashes": [
@@ -540,45 +540,45 @@
         },
         "black": {
             "hashes": [
-                "sha256:2818cf72dfd5d289e48f37ccfa08b460bf469e67fb7c4abb07edc2e9f16fb63f",
-                "sha256:41622020d7120e01d377f74249e677039d20e6344ff5851de8a10f11f513bf93",
-                "sha256:4acf672def7eb1725f41f38bf6bf425c8237248bb0804faa3965c036f7672d11",
-                "sha256:4be5bb28e090456adfc1255e03967fb67ca846a03be7aadf6249096100ee32d0",
-                "sha256:4f1373a7808a8f135b774039f61d59e4be7eb56b2513d3d2f02a8b9365b8a8a9",
-                "sha256:56f52cfbd3dabe2798d76dbdd299faa046a901041faf2cf33288bc4e6dae57b5",
-                "sha256:65b76c275e4c1c5ce6e9870911384bff5ca31ab63d19c76811cb1fb162678213",
-                "sha256:65c02e4ea2ae09d16314d30912a58ada9a5c4fdfedf9512d23326128ac08ac3d",
-                "sha256:6905238a754ceb7788a73f02b45637d820b2f5478b20fec82ea865e4f5d4d9f7",
-                "sha256:79dcf34b33e38ed1b17434693763301d7ccbd1c5860674a8f871bd15139e7837",
-                "sha256:7bb041dca0d784697af4646d3b62ba4a6b028276ae878e53f6b4f74ddd6db99f",
-                "sha256:7d5e026f8da0322b5662fa7a8e752b3fa2dac1c1cbc213c3d7ff9bdd0ab12395",
-                "sha256:9f50ea1132e2189d8dff0115ab75b65590a3e97de1e143795adb4ce317934995",
-                "sha256:a0c9c4a0771afc6919578cec71ce82a3e31e054904e7197deacbc9382671c41f",
-                "sha256:aadf7a02d947936ee418777e0247ea114f78aff0d0959461057cae8a04f20597",
-                "sha256:b5991d523eee14756f3c8d5df5231550ae8993e2286b8014e2fdea7156ed0959",
-                "sha256:bf21b7b230718a5f08bd32d5e4f1db7fc8788345c8aea1d155fc17852b3410f5",
-                "sha256:c45f8dff244b3c431b36e3224b6be4a127c6aca780853574c00faf99258041eb",
-                "sha256:c7ed6668cbbfcd231fa0dc1b137d3e40c04c7f786e626b405c62bcd5db5857e4",
-                "sha256:d7de8d330763c66663661a1ffd432274a2f92f07feeddd89ffd085b5744f85e7",
-                "sha256:e19cb1c6365fd6dc38a6eae2dcb691d7d83935c10215aef8e6c38edee3f77abd",
-                "sha256:e2af80566f43c85f5797365077fb64a393861a3730bd110971ab7a0c94e873e7"
+                "sha256:257d724c2c9b1660f353b36c802ccece186a30accc7742c176d29c146df6e474",
+                "sha256:37aae07b029fa0174d39daf02748b379399b909652a806e5708199bd93899da1",
+                "sha256:415e686e87dbbe6f4cd5ef0fbf764af7b89f9057b97c908742b6008cc554b9c0",
+                "sha256:48a85f2cb5e6799a9ef05347b476cce6c182d6c71ee36925a6c194d074336ef8",
+                "sha256:7768a0dbf16a39aa5e9a3ded568bb545c8c2727396d063bbaf847df05b08cd96",
+                "sha256:7e122b1c4fb252fd85df3ca93578732b4749d9be076593076ef4d07a0233c3e1",
+                "sha256:88c57dc656038f1ab9f92b3eb5335ee9b021412feaa46330d5eba4e51fe49b04",
+                "sha256:8e537d281831ad0e71007dcdcbe50a71470b978c453fa41ce77186bbe0ed6021",
+                "sha256:98e123f1d5cfd42f886624d84464f7756f60ff6eab89ae845210631714f6db94",
+                "sha256:accf49e151c8ed2c0cdc528691838afd217c50412534e876a19270fea1e28e2d",
+                "sha256:b1530ae42e9d6d5b670a34db49a94115a64596bc77710b1d05e9801e62ca0a7c",
+                "sha256:b9176b9832e84308818a99a561e90aa479e73c523b3f77afd07913380ae2eab7",
+                "sha256:bdde6f877a18f24844e381d45e9947a49e97933573ac9d4345399be37621e26c",
+                "sha256:be8bef99eb46d5021bf053114442914baeb3649a89dc5f3a555c88737e5e98fc",
+                "sha256:bf10f7310db693bb62692609b397e8d67257c55f949abde4c67f9cc574492cc7",
+                "sha256:c872b53057f000085da66a19c55d68f6f8ddcac2642392ad3a355878406fbd4d",
+                "sha256:d36ed1124bb81b32f8614555b34cc4259c3fbc7eec17870e8ff8ded335b58d8c",
+                "sha256:da33a1a5e49c4122ccdfd56cd021ff1ebc4a1ec4e2d01594fef9b6f267a9e741",
+                "sha256:dd1b5a14e417189db4c7b64a6540f31730713d173f0b63e55fabd52d61d8fdce",
+                "sha256:e151054aa00bad1f4e1f04919542885f89f5f7d086b8a59e5000e6c616896ffb",
+                "sha256:eaea3008c281f1038edb473c1aa8ed8143a5535ff18f978a318f10302b254063",
+                "sha256:ef703f83fc32e131e9bcc0a5094cfe85599e7109f896fe8bc96cc402f3eb4b6e"
             ],
-            "version": "==24.3.0"
+            "version": "==24.4.2"
         },
         "boto3": {
             "hashes": [
-                "sha256:33cf93f6de5176f1188c923f4de1ae149ed723b89ed12e434f2b2f628491769e",
-                "sha256:9733ce811bd82feab506ad9309e375a79cabe8c6149061971c17754ce8997551"
+                "sha256:b59355bf4a1408563969526f314611dbeacc151cf90ecb22af295dcc4fe18def",
+                "sha256:e39516e4ca21612932599819662759c04485d53ca457996a913163da11f052a4"
             ],
-            "version": "==1.34.83"
+            "version": "==1.34.93"
         },
         "botocore": {
             "hashes": [
-                "sha256:0a3fbbe018416aeefa8978454fb0b8129adbaf556647b72269bf02e4bf1f4161",
-                "sha256:0f302aa76283d4df62b4fbb6d3d20115c1a8957fc02171257fc93904d69d5636"
+                "sha256:6fbd5a53a2adc9b3d4ebd90ae0ede83a91a41d96231f8a5984051f75495f246d",
+                "sha256:79d39b0b87e962991c6dd55e78ce15155099f6fb741be88b1b8a456a702cc150"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.83"
+            "version": "==1.34.93"
         },
         "certifi": {
             "hashes": [
@@ -779,61 +779,61 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:00838a35b882694afda09f85e469c96367daa3f3f2b097d846a7216993d37f4c",
-                "sha256:0513b9508b93da4e1716744ef6ebc507aff016ba115ffe8ecff744d1322a7b63",
-                "sha256:09c3255458533cb76ef55da8cc49ffab9e33f083739c8bd4f58e79fecfe288f7",
-                "sha256:09ef9199ed6653989ebbcaacc9b62b514bb63ea2f90256e71fea3ed74bd8ff6f",
-                "sha256:09fa497a8ab37784fbb20ab699c246053ac294d13fc7eb40ec007a5043ec91f8",
-                "sha256:0f9f50e7ef2a71e2fae92774c99170eb8304e3fdf9c8c3c7ae9bab3e7229c5cf",
-                "sha256:137eb07173141545e07403cca94ab625cc1cc6bc4c1e97b6e3846270e7e1fea0",
-                "sha256:1f384c3cc76aeedce208643697fb3e8437604b512255de6d18dae3f27655a384",
-                "sha256:201bef2eea65e0e9c56343115ba3814e896afe6d36ffd37bab783261db430f76",
-                "sha256:38dd60d7bf242c4ed5b38e094baf6401faa114fc09e9e6632374388a404f98e7",
-                "sha256:3b799445b9f7ee8bf299cfaed6f5b226c0037b74886a4e11515e569b36fe310d",
-                "sha256:3ea79bb50e805cd6ac058dfa3b5c8f6c040cb87fe83de10845857f5535d1db70",
-                "sha256:40209e141059b9370a2657c9b15607815359ab3ef9918f0196b6fccce8d3230f",
-                "sha256:41c9c5f3de16b903b610d09650e5e27adbfa7f500302718c9ffd1c12cf9d6818",
-                "sha256:54eb8d1bf7cacfbf2a3186019bcf01d11c666bd495ed18717162f7eb1e9dd00b",
-                "sha256:598825b51b81c808cb6f078dcb972f96af96b078faa47af7dfcdf282835baa8d",
-                "sha256:5fc1de20b2d4a061b3df27ab9b7c7111e9a710f10dc2b84d33a4ab25065994ec",
-                "sha256:623512f8ba53c422fcfb2ce68362c97945095b864cda94a92edbaf5994201083",
-                "sha256:690db6517f09336559dc0b5f55342df62370a48f5469fabf502db2c6d1cffcd2",
-                "sha256:69eb372f7e2ece89f14751fbcbe470295d73ed41ecd37ca36ed2eb47512a6ab9",
-                "sha256:73bfb9c09951125d06ee473bed216e2c3742f530fc5acc1383883125de76d9cd",
-                "sha256:742a76a12aa45b44d236815d282b03cfb1de3b4323f3e4ec933acfae08e54ade",
-                "sha256:7c95949560050d04d46b919301826525597f07b33beba6187d04fa64d47ac82e",
-                "sha256:8130a2aa2acb8788e0b56938786c33c7c98562697bf9f4c7d6e8e5e3a0501e4a",
-                "sha256:8a2b2b78c78293782fd3767d53e6474582f62443d0504b1554370bde86cc8227",
-                "sha256:8ce1415194b4a6bd0cdcc3a1dfbf58b63f910dcb7330fe15bdff542c56949f87",
-                "sha256:9ca28a302acb19b6af89e90f33ee3e1906961f94b54ea37de6737b7ca9d8827c",
-                "sha256:a4cdc86d54b5da0df6d3d3a2f0b710949286094c3a6700c21e9015932b81447e",
-                "sha256:aa5b1c1bfc28384f1f53b69a023d789f72b2e0ab1b3787aae16992a7ca21056c",
-                "sha256:aadacf9a2f407a4688d700e4ebab33a7e2e408f2ca04dbf4aef17585389eff3e",
-                "sha256:ae71e7ddb7a413dd60052e90528f2f65270aad4b509563af6d03d53e979feafd",
-                "sha256:b14706df8b2de49869ae03a5ccbc211f4041750cd4a66f698df89d44f4bd30ec",
-                "sha256:b1a93009cb80730c9bca5d6d4665494b725b6e8e157c1cb7f2db5b4b122ea562",
-                "sha256:b2991665420a803495e0b90a79233c1433d6ed77ef282e8e152a324bbbc5e0c8",
-                "sha256:b2c5edc4ac10a7ef6605a966c58929ec6c1bd0917fb8c15cb3363f65aa40e677",
-                "sha256:b4d33f418f46362995f1e9d4f3a35a1b6322cb959c31d88ae56b0298e1c22357",
-                "sha256:b91cbc4b195444e7e258ba27ac33769c41b94967919f10037e6355e998af255c",
-                "sha256:c74880fc64d4958159fbd537a091d2a585448a8f8508bf248d72112723974cbd",
-                "sha256:c901df83d097649e257e803be22592aedfd5182f07b3cc87d640bbb9afd50f49",
-                "sha256:cac99918c7bba15302a2d81f0312c08054a3359eaa1929c7e4b26ebe41e9b286",
-                "sha256:cc4f1358cb0c78edef3ed237ef2c86056206bb8d9140e73b6b89fbcfcbdd40e1",
-                "sha256:ccd341521be3d1b3daeb41960ae94a5e87abe2f46f17224ba5d6f2b8398016cf",
-                "sha256:ce4b94265ca988c3f8e479e741693d143026632672e3ff924f25fab50518dd51",
-                "sha256:cf271892d13e43bc2b51e6908ec9a6a5094a4df1d8af0bfc360088ee6c684409",
-                "sha256:d5ae728ff3b5401cc320d792866987e7e7e880e6ebd24433b70a33b643bb0384",
-                "sha256:d71eec7d83298f1af3326ce0ff1d0ea83c7cb98f72b577097f9083b20bdaf05e",
-                "sha256:d898fe162d26929b5960e4e138651f7427048e72c853607f2b200909794ed978",
-                "sha256:d89d7b2974cae412400e88f35d86af72208e1ede1a541954af5d944a8ba46c57",
-                "sha256:dfa8fe35a0bb90382837b238fff375de15f0dcdb9ae68ff85f7a63649c98527e",
-                "sha256:e0be5efd5127542ef31f165de269f77560d6cdef525fffa446de6f7e9186cfb2",
-                "sha256:fdfafb32984684eb03c2d83e1e51f64f0906b11e64482df3c5db936ce3839d48",
-                "sha256:ff7687ca3d7028d8a5f0ebae95a6e4827c5616b31a4ee1192bdfde697db110d4"
+                "sha256:075299460948cd12722a970c7eae43d25d37989da682997687b34ae6b87c0ef0",
+                "sha256:07dfdd492d645eea1bd70fb1d6febdcf47db178b0d99161d8e4eed18e7f62fe7",
+                "sha256:0cbdf2cae14a06827bec50bd58e49249452d211d9caddd8bd80e35b53cb04631",
+                "sha256:2055c4fb9a6ff624253d432aa471a37202cd8f458c033d6d989be4499aed037b",
+                "sha256:262fffc1f6c1a26125d5d573e1ec379285a3723363f3bd9c83923c9593a2ac25",
+                "sha256:280132aada3bc2f0fac939a5771db4fbb84f245cb35b94fae4994d4c1f80dae7",
+                "sha256:2b57780b51084d5223eee7b59f0d4911c31c16ee5aa12737c7a02455829ff067",
+                "sha256:2bd7065249703cbeb6d4ce679c734bef0ee69baa7bff9724361ada04a15b7e3b",
+                "sha256:3235d7c781232e525b0761730e052388a01548bd7f67d0067a253887c6e8df46",
+                "sha256:33c020d3322662e74bc507fb11488773a96894aa82a622c35a5a28673c0c26f5",
+                "sha256:357754dcdfd811462a725e7501a9b4556388e8ecf66e79df6f4b988fa3d0b39a",
+                "sha256:39793731182c4be939b4be0cdecde074b833f6171313cf53481f869937129ed3",
+                "sha256:3c2b77f295edb9fcdb6a250f83e6481c679335ca7e6e4a955e4290350f2d22a4",
+                "sha256:41327143c5b1d715f5f98a397608f90ab9ebba606ae4e6f3389c2145410c52b1",
+                "sha256:427e1e627b0963ac02d7c8730ca6d935df10280d230508c0ba059505e9233475",
+                "sha256:432949a32c3e3f820af808db1833d6d1631664d53dd3ce487aa25d574e18ad1c",
+                "sha256:4ba01d9ba112b55bfa4b24808ec431197bb34f09f66f7cb4fd0258ff9d3711b1",
+                "sha256:4d0e206259b73af35c4ec1319fd04003776e11e859936658cb6ceffdeba0f5be",
+                "sha256:51431d0abbed3a868e967f8257c5faf283d41ec882f58413cf295a389bb22e58",
+                "sha256:565b2e82d0968c977e0b0f7cbf25fd06d78d4856289abc79694c8edcce6eb2de",
+                "sha256:6782cd6216fab5a83216cc39f13ebe30adfac2fa72688c5a4d8d180cd52e8f6a",
+                "sha256:6afd2e84e7da40fe23ca588379f815fb6dbbb1b757c883935ed11647205111cb",
+                "sha256:710c62b6e35a9a766b99b15cdc56d5aeda0914edae8bb467e9c355f75d14ee95",
+                "sha256:84921b10aeb2dd453247fd10de22907984eaf80901b578a5cf0bb1e279a587cb",
+                "sha256:85a5dbe1ba1bf38d6c63b6d2c42132d45cbee6d9f0c51b52c59aa4afba057517",
+                "sha256:9c6384cc90e37cfb60435bbbe0488444e54b98700f727f16f64d8bfda0b84656",
+                "sha256:9dd88fce54abbdbf4c42fb1fea0e498973d07816f24c0e27a1ecaf91883ce69e",
+                "sha256:a81eb64feded34f40c8986869a2f764f0fe2db58c0530d3a4afbcde50f314880",
+                "sha256:a898c11dca8f8c97b467138004a30133974aacd572818c383596f8d5b2eb04a9",
+                "sha256:a9960dd1891b2ddf13a7fe45339cd59ecee3abb6b8326d8b932d0c5da208104f",
+                "sha256:a9a7ef30a1b02547c1b23fa9a5564f03c9982fc71eb2ecb7f98c96d7a0db5cf2",
+                "sha256:ad97ec0da94b378e593ef532b980c15e377df9b9608c7c6da3506953182398af",
+                "sha256:adf032b6c105881f9d77fa17d9eebe0ad1f9bfb2ad25777811f97c5362aa07f2",
+                "sha256:bbfe6389c5522b99768a93d89aca52ef92310a96b99782973b9d11e80511f932",
+                "sha256:bd4bacd62aa2f1a1627352fe68885d6ee694bdaebb16038b6e680f2924a9b2cc",
+                "sha256:bf0b4b8d9caa8d64df838e0f8dcf68fb570c5733b726d1494b87f3da85db3a2d",
+                "sha256:c379cdd3efc0658e652a14112d51a7668f6bfca7445c5a10dee7eabecabba19d",
+                "sha256:c58536f6892559e030e6924896a44098bc1290663ea12532c78cef71d0df8493",
+                "sha256:cbe6581fcff7c8e262eb574244f81f5faaea539e712a058e6707a9d272fe5b64",
+                "sha256:ced268e82af993d7801a9db2dbc1d2322e786c5dc76295d8e89473d46c6b84d4",
+                "sha256:cf3539007202ebfe03923128fedfdd245db5860a36810136ad95a564a2fdffff",
+                "sha256:cf62d17310f34084c59c01e027259076479128d11e4661bb6c9acb38c5e19bb8",
+                "sha256:d0194d654e360b3e6cc9b774e83235bae6b9b2cac3be09040880bb0e8a88f4a1",
+                "sha256:d3d117890b6eee85887b1eed41eefe2e598ad6e40523d9f94c4c4b213258e4a4",
+                "sha256:db2de4e546f0ec4b2787d625e0b16b78e99c3e21bc1722b4977c0dddf11ca84e",
+                "sha256:e768d870801f68c74c2b669fc909839660180c366501d4cc4b87efd6b0eee375",
+                "sha256:e7c211f25777746d468d76f11719e64acb40eed410d81c26cefac641975beb88",
+                "sha256:eed462b4541c540d63ab57b3fc69e7d8c84d5957668854ee4e408b50e92ce26a",
+                "sha256:f0bfe42523893c188e9616d853c47685e1c575fe25f737adf473d0405dcfa7eb",
+                "sha256:f609ebcb0242d84b7adeee2b06c11a2ddaec5464d21888b2c8255f5fd6a98ae4",
+                "sha256:fea9d3ca80bcf17edb2c08a4704259dadac196fe5e9274067e7a20511fad1743",
+                "sha256:fed7a72d54bd52f4aeb6c6e951f363903bd7d70bc1cad64dd1f087980d309ab9"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==7.4.4"
+            "version": "==7.5.0"
         },
         "cryptography": {
             "hashes": [
@@ -890,11 +890,11 @@
         },
         "exceptiongroup": {
             "hashes": [
-                "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14",
-                "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"
+                "sha256:5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad",
+                "sha256:a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==1.2.0"
+            "version": "==1.2.1"
         },
         "execnet": {
             "hashes": [
@@ -942,11 +942,11 @@
         },
         "griffe": {
             "hashes": [
-                "sha256:57046131384043ed078692b85d86b76568a686266cc036b9b56b704466f803ce",
-                "sha256:7e805e35617601355edcac0d3511cedc1ed0cb1f7645e2d336ae4b05bbae7b3b"
+                "sha256:34aee1571042f9bf00529bc715de4516fb6f482b164e90d030300601009e0223",
+                "sha256:8a4471c469ba980b87c843f1168850ce39d0c1d0c7be140dca2480f76c8e5446"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.42.1"
+            "version": "==0.44.0"
         },
         "h11": {
             "hashes": [
@@ -974,11 +974,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:10a7ca245cfcd756a554a7288159f72ff105ad233c7c4b9c6f0f4d108f5f6791",
-                "sha256:c4de0081837b211594f8e877a6b4fad7ca32bbfc1a9307fdd61c28bfe923f13e"
+                "sha256:37d93f380f4de590500d9dba7db359d0d3da95ffe7f9de1753faa159e71e7dfa",
+                "sha256:e5e00f54165f9047fbebeb4a560f9acfb8af4c88232be60a488e9b68d122745d"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.5.35"
+            "version": "==2.5.36"
         },
         "idna": {
             "hashes": [
@@ -1125,10 +1125,10 @@
         },
         "mkdocs": {
             "hashes": [
-                "sha256:3b3a78e736b31158d64dbb2f8ba29bd46a379d0c6e324c2246c3bc3d2189cfc1",
-                "sha256:eb7c99214dcb945313ba30426c2451b735992c73c2e10838f76d09e39ff4d0e2"
+                "sha256:1eb5cb7676b7d89323e62b56235010216319217d4af5ddc543a91beb8d125ea7",
+                "sha256:a73f735824ef83a4f3bcb7a231dcab23f5a838f88b7efc54a0eef5fbdbc3c512"
             ],
-            "version": "==1.5.3"
+            "version": "==1.6.0"
         },
         "mkdocs-autorefs": {
             "hashes": [
@@ -1138,12 +1138,20 @@
             "markers": "python_version >= '3.8'",
             "version": "==1.0.1"
         },
+        "mkdocs-get-deps": {
+            "hashes": [
+                "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c",
+                "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.2.0"
+        },
         "mkdocs-material": {
             "hashes": [
-                "sha256:06ae1275a72db1989cf6209de9e9ecdfbcfdbc24c58353877b2bb927dbe413e4",
-                "sha256:14a2a60119a785e70e765dd033e6211367aca9fc70230e577c1cf6a326949571"
+                "sha256:7473e06e17e23af608a30ef583fdde8f36389dd3ef56b1d503eed54c89c9618c",
+                "sha256:ea96e150b6c95f5e4ffe47d78bb712c7bacdd91d2a0bec47f46b6fa0705a86ec"
             ],
-            "version": "==9.5.17"
+            "version": "==9.5.19"
         },
         "mkdocs-material-extensions": {
             "hashes": [
@@ -1162,17 +1170,17 @@
         },
         "mkdocstrings": {
             "hashes": [
-                "sha256:5c9cf2a32958cd161d5428699b79c8b0988856b0d4a8c5baf8395fc1bf4087c3",
-                "sha256:f327b234eb8d2551a306735436e157d0a22d45f79963c60a8b585d5f7a94c1d2"
+                "sha256:066986b3fb5b9ef2d37c4417255a808f7e63b40ff8f67f6cab8054d903fbc91d",
+                "sha256:df1b63f26675fcde8c1b77e7ea996cd2f93220b148e06455428f676f5dc838f1"
             ],
-            "version": "==0.24.3"
+            "version": "==0.25.0"
         },
         "mkdocstrings-python": {
             "hashes": [
-                "sha256:8546a103c9b22e1778c72c887696acc39a6635fedde3c912ce00f967518a8847",
-                "sha256:96d82f6424e08db6245e4a15ca95619f4ecd0ddd254c0aa590d4181814e16ee5"
+                "sha256:71678fac657d4d2bb301eed4e4d2d91499c095fd1f8a90fa76422a87a5693828",
+                "sha256:ba833fbd9d178a4b9d5cb2553a4df06e51dc1f51e41559a4d2398c16a6f69ecc"
             ],
-            "version": "==1.9.2"
+            "version": "==1.10.0"
         },
         "mypy-extensions": {
             "hashes": [
@@ -1342,19 +1350,19 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068",
-                "sha256:ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768"
+                "sha256:031cd18d4ec63ec53e82dceaac0417d218a6863f7745dfcc9efe7793b7039bdf",
+                "sha256:17d5a1161b3fd67b390023cb2d3b026bbd40abde6fdb052dfbd3a29c3ba22ee1"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.2.0"
+            "version": "==4.2.1"
         },
         "pluggy": {
             "hashes": [
-                "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981",
-                "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be"
+                "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
+                "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.4.0"
+            "version": "==1.5.0"
         },
         "pre-commit": {
             "hashes": [
@@ -1444,11 +1452,11 @@
         },
         "pymdown-extensions": {
             "hashes": [
-                "sha256:c70e146bdd83c744ffc766b4671999796aba18842b268510a329f7f64700d584",
-                "sha256:f5cc7000d7ff0d1ce9395d216017fa4df3dde800afb1fb72d1c7d3fd35e710f4"
+                "sha256:3ab1db5c9e21728dabf75192d71471f8e50f216627e9a1fa9535ecb0231b9940",
+                "sha256:f938326115884f48c6059c67377c46cf631c733ef3629b6eed1349989d1b30cb"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==10.7.1"
+            "version": "==10.8.1"
         },
         "pynacl": {
             "hashes": [
@@ -1481,10 +1489,10 @@
         },
         "pytest-asyncio": {
             "hashes": [
-                "sha256:68516fdd1018ac57b846c9846b954f0393b26f094764a28c955eabb0536a4e8a",
-                "sha256:ffe523a89c1c222598c76856e76852b787504ddb72dd5d9b6617ffa8aa2cde5f"
+                "sha256:40a7eae6dded22c7b604986855ea48400ab15b069ae38116e8c01238e9eeb64d",
+                "sha256:8666c1c8ac02631d7c51ba282e0c69a8a452b211ffedf2599099845da5c5c37b"
             ],
-            "version": "==0.23.6"
+            "version": "==0.21.1"
         },
         "pytest-cov": {
             "hashes": [
@@ -1614,102 +1622,102 @@
         },
         "regex": {
             "hashes": [
-                "sha256:0694219a1d54336fd0445ea382d49d36882415c0134ee1e8332afd1529f0baa5",
-                "sha256:086dd15e9435b393ae06f96ab69ab2d333f5d65cbe65ca5a3ef0ec9564dfe770",
-                "sha256:094ba386bb5c01e54e14434d4caabf6583334090865b23ef58e0424a6286d3dc",
-                "sha256:09da66917262d9481c719599116c7dc0c321ffcec4b1f510c4f8a066f8768105",
-                "sha256:0ecf44ddf9171cd7566ef1768047f6e66975788258b1c6c6ca78098b95cf9a3d",
-                "sha256:0fda75704357805eb953a3ee15a2b240694a9a514548cd49b3c5124b4e2ad01b",
-                "sha256:11a963f8e25ab5c61348d090bf1b07f1953929c13bd2309a0662e9ff680763c9",
-                "sha256:150c39f5b964e4d7dba46a7962a088fbc91f06e606f023ce57bb347a3b2d4630",
-                "sha256:1b9d811f72210fa9306aeb88385b8f8bcef0dfbf3873410413c00aa94c56c2b6",
-                "sha256:1e0eabac536b4cc7f57a5f3d095bfa557860ab912f25965e08fe1545e2ed8b4c",
-                "sha256:22a86d9fff2009302c440b9d799ef2fe322416d2d58fc124b926aa89365ec482",
-                "sha256:22f3470f7524b6da61e2020672df2f3063676aff444db1daa283c2ea4ed259d6",
-                "sha256:263ef5cc10979837f243950637fffb06e8daed7f1ac1e39d5910fd29929e489a",
-                "sha256:283fc8eed679758de38fe493b7d7d84a198b558942b03f017b1f94dda8efae80",
-                "sha256:29171aa128da69afdf4bde412d5bedc335f2ca8fcfe4489038577d05f16181e5",
-                "sha256:298dc6354d414bc921581be85695d18912bea163a8b23cac9a2562bbcd5088b1",
-                "sha256:2aae8101919e8aa05ecfe6322b278f41ce2994c4a430303c4cd163fef746e04f",
-                "sha256:2f4e475a80ecbd15896a976aa0b386c5525d0ed34d5c600b6d3ebac0a67c7ddf",
-                "sha256:34e4af5b27232f68042aa40a91c3b9bb4da0eeb31b7632e0091afc4310afe6cb",
-                "sha256:37f8e93a81fc5e5bd8db7e10e62dc64261bcd88f8d7e6640aaebe9bc180d9ce2",
-                "sha256:3a17d3ede18f9cedcbe23d2daa8a2cd6f59fe2bf082c567e43083bba3fb00347",
-                "sha256:3b1de218d5375cd6ac4b5493e0b9f3df2be331e86520f23382f216c137913d20",
-                "sha256:43f7cd5754d02a56ae4ebb91b33461dc67be8e3e0153f593c509e21d219c5060",
-                "sha256:4558410b7a5607a645e9804a3e9dd509af12fb72b9825b13791a37cd417d73a5",
-                "sha256:4719bb05094d7d8563a450cf8738d2e1061420f79cfcc1fa7f0a44744c4d8f73",
-                "sha256:4bfc2b16e3ba8850e0e262467275dd4d62f0d045e0e9eda2bc65078c0110a11f",
-                "sha256:518440c991f514331f4850a63560321f833979d145d7d81186dbe2f19e27ae3d",
-                "sha256:51f4b32f793812714fd5307222a7f77e739b9bc566dc94a18126aba3b92b98a3",
-                "sha256:531ac6cf22b53e0696f8e1d56ce2396311254eb806111ddd3922c9d937151dae",
-                "sha256:5cd05d0f57846d8ba4b71d9c00f6f37d6b97d5e5ef8b3c3840426a475c8f70f4",
-                "sha256:5dd58946bce44b53b06d94aa95560d0b243eb2fe64227cba50017a8d8b3cd3e2",
-                "sha256:60080bb3d8617d96f0fb7e19796384cc2467447ef1c491694850ebd3670bc457",
-                "sha256:636ba0a77de609d6510235b7f0e77ec494d2657108f777e8765efc060094c98c",
-                "sha256:67d3ccfc590e5e7197750fcb3a2915b416a53e2de847a728cfa60141054123d4",
-                "sha256:68191f80a9bad283432385961d9efe09d783bcd36ed35a60fb1ff3f1ec2efe87",
-                "sha256:7502534e55c7c36c0978c91ba6f61703faf7ce733715ca48f499d3dbbd7657e0",
-                "sha256:7aa47c2e9ea33a4a2a05f40fcd3ea36d73853a2aae7b4feab6fc85f8bf2c9704",
-                "sha256:7d2af3f6b8419661a0c421584cfe8aaec1c0e435ce7e47ee2a97e344b98f794f",
-                "sha256:7e316026cc1095f2a3e8cc012822c99f413b702eaa2ca5408a513609488cb62f",
-                "sha256:88ad44e220e22b63b0f8f81f007e8abbb92874d8ced66f32571ef8beb0643b2b",
-                "sha256:88d1f7bef20c721359d8675f7d9f8e414ec5003d8f642fdfd8087777ff7f94b5",
-                "sha256:89723d2112697feaa320c9d351e5f5e7b841e83f8b143dba8e2d2b5f04e10923",
-                "sha256:8a0ccf52bb37d1a700375a6b395bff5dd15c50acb745f7db30415bae3c2b0715",
-                "sha256:8c2c19dae8a3eb0ea45a8448356ed561be843b13cbc34b840922ddf565498c1c",
-                "sha256:905466ad1702ed4acfd67a902af50b8db1feeb9781436372261808df7a2a7bca",
-                "sha256:9852b76ab558e45b20bf1893b59af64a28bd3820b0c2efc80e0a70a4a3ea51c1",
-                "sha256:98a2636994f943b871786c9e82bfe7883ecdaba2ef5df54e1450fa9869d1f756",
-                "sha256:9aa1a67bbf0f957bbe096375887b2505f5d8ae16bf04488e8b0f334c36e31360",
-                "sha256:9eda5f7a50141291beda3edd00abc2d4a5b16c29c92daf8d5bd76934150f3edc",
-                "sha256:a6d1047952c0b8104a1d371f88f4ab62e6275567d4458c1e26e9627ad489b445",
-                "sha256:a9b6d73353f777630626f403b0652055ebfe8ff142a44ec2cf18ae470395766e",
-                "sha256:a9cc99d6946d750eb75827cb53c4371b8b0fe89c733a94b1573c9dd16ea6c9e4",
-                "sha256:ad83e7545b4ab69216cef4cc47e344d19622e28aabec61574b20257c65466d6a",
-                "sha256:b014333bd0217ad3d54c143de9d4b9a3ca1c5a29a6d0d554952ea071cff0f1f8",
-                "sha256:b43523d7bc2abd757119dbfb38af91b5735eea45537ec6ec3a5ec3f9562a1c53",
-                "sha256:b521dcecebc5b978b447f0f69b5b7f3840eac454862270406a39837ffae4e697",
-                "sha256:b77e27b79448e34c2c51c09836033056a0547aa360c45eeeb67803da7b0eedaf",
-                "sha256:b7a635871143661feccce3979e1727c4e094f2bdfd3ec4b90dfd4f16f571a87a",
-                "sha256:b7fca9205b59c1a3d5031f7e64ed627a1074730a51c2a80e97653e3e9fa0d415",
-                "sha256:ba1b30765a55acf15dce3f364e4928b80858fa8f979ad41f862358939bdd1f2f",
-                "sha256:ba99d8077424501b9616b43a2d208095746fb1284fc5ba490139651f971d39d9",
-                "sha256:c25a8ad70e716f96e13a637802813f65d8a6760ef48672aa3502f4c24ea8b400",
-                "sha256:c3c4a78615b7762740531c27cf46e2f388d8d727d0c0c739e72048beb26c8a9d",
-                "sha256:c40281f7d70baf6e0db0c2f7472b31609f5bc2748fe7275ea65a0b4601d9b392",
-                "sha256:c7ad32824b7f02bb3c9f80306d405a1d9b7bb89362d68b3c5a9be53836caebdb",
-                "sha256:cb3fe77aec8f1995611f966d0c656fdce398317f850d0e6e7aebdfe61f40e1cd",
-                "sha256:cc038b2d8b1470364b1888a98fd22d616fba2b6309c5b5f181ad4483e0017861",
-                "sha256:cc37b9aeebab425f11f27e5e9e6cf580be7206c6582a64467a14dda211abc232",
-                "sha256:cc6bb9aa69aacf0f6032c307da718f61a40cf970849e471254e0e91c56ffca95",
-                "sha256:d126361607b33c4eb7b36debc173bf25d7805847346dd4d99b5499e1fef52bc7",
-                "sha256:d15b274f9e15b1a0b7a45d2ac86d1f634d983ca40d6b886721626c47a400bf39",
-                "sha256:d166eafc19f4718df38887b2bbe1467a4f74a9830e8605089ea7a30dd4da8887",
-                "sha256:d498eea3f581fbe1b34b59c697512a8baef88212f92e4c7830fcc1499f5b45a5",
-                "sha256:d6f7e255e5fa94642a0724e35406e6cb7001c09d476ab5fce002f652b36d0c39",
-                "sha256:d78bd484930c1da2b9679290a41cdb25cc127d783768a0369d6b449e72f88beb",
-                "sha256:d865984b3f71f6d0af64d0d88f5733521698f6c16f445bb09ce746c92c97c586",
-                "sha256:d902a43085a308cef32c0d3aea962524b725403fd9373dea18110904003bac97",
-                "sha256:d94a1db462d5690ebf6ae86d11c5e420042b9898af5dcf278bd97d6bda065423",
-                "sha256:da695d75ac97cb1cd725adac136d25ca687da4536154cdc2815f576e4da11c69",
-                "sha256:db2a0b1857f18b11e3b0e54ddfefc96af46b0896fb678c85f63fb8c37518b3e7",
-                "sha256:df26481f0c7a3f8739fecb3e81bc9da3fcfae34d6c094563b9d4670b047312e1",
-                "sha256:e14b73607d6231f3cc4622809c196b540a6a44e903bcfad940779c80dffa7be7",
-                "sha256:e2610e9406d3b0073636a3a2e80db05a02f0c3169b5632022b4e81c0364bcda5",
-                "sha256:e692296c4cc2873967771345a876bcfc1c547e8dd695c6b89342488b0ea55cd8",
-                "sha256:e693e233ac92ba83a87024e1d32b5f9ab15ca55ddd916d878146f4e3406b5c91",
-                "sha256:e81469f7d01efed9b53740aedd26085f20d49da65f9c1f41e822a33992cb1590",
-                "sha256:e8c7e08bb566de4faaf11984af13f6bcf6a08f327b13631d41d62592681d24fe",
-                "sha256:ed19b3a05ae0c97dd8f75a5d8f21f7723a8c33bbc555da6bbe1f96c470139d3c",
-                "sha256:efb2d82f33b2212898f1659fb1c2e9ac30493ac41e4d53123da374c3b5541e64",
-                "sha256:f44dd4d68697559d007462b0a3a1d9acd61d97072b71f6d1968daef26bc744bd",
-                "sha256:f72cbae7f6b01591f90814250e636065850c5926751af02bb48da94dfced7baa",
-                "sha256:f7bc09bc9c29ebead055bcba136a67378f03d66bf359e87d0f7c759d6d4ffa31",
-                "sha256:ff100b203092af77d1a5a7abe085b3506b7eaaf9abf65b73b7d6905b6cb76988"
+                "sha256:00169caa125f35d1bca6045d65a662af0202704489fada95346cfa092ec23f39",
+                "sha256:03576e3a423d19dda13e55598f0fd507b5d660d42c51b02df4e0d97824fdcae3",
+                "sha256:03e68f44340528111067cecf12721c3df4811c67268b897fbe695c95f860ac42",
+                "sha256:0534b034fba6101611968fae8e856c1698da97ce2efb5c2b895fc8b9e23a5834",
+                "sha256:08dea89f859c3df48a440dbdcd7b7155bc675f2fa2ec8c521d02dc69e877db70",
+                "sha256:0a38d151e2cdd66d16dab550c22f9521ba79761423b87c01dae0a6e9add79c0d",
+                "sha256:0c8290b44d8b0af4e77048646c10c6e3aa583c1ca67f3b5ffb6e06cf0c6f0f89",
+                "sha256:10188fe732dec829c7acca7422cdd1bf57d853c7199d5a9e96bb4d40db239c73",
+                "sha256:1210365faba7c2150451eb78ec5687871c796b0f1fa701bfd2a4a25420482d26",
+                "sha256:12f6a3f2f58bb7344751919a1876ee1b976fe08b9ffccb4bbea66f26af6017b9",
+                "sha256:159dc4e59a159cb8e4e8f8961eb1fa5d58f93cb1acd1701d8aff38d45e1a84a6",
+                "sha256:20b7a68444f536365af42a75ccecb7ab41a896a04acf58432db9e206f4e525d6",
+                "sha256:23cff1b267038501b179ccbbd74a821ac4a7192a1852d1d558e562b507d46013",
+                "sha256:2c72608e70f053643437bd2be0608f7f1c46d4022e4104d76826f0839199347a",
+                "sha256:3399dd8a7495bbb2bacd59b84840eef9057826c664472e86c91d675d007137f5",
+                "sha256:34422d5a69a60b7e9a07a690094e824b66f5ddc662a5fc600d65b7c174a05f04",
+                "sha256:370c68dc5570b394cbaadff50e64d705f64debed30573e5c313c360689b6aadc",
+                "sha256:3a1018e97aeb24e4f939afcd88211ace472ba566efc5bdf53fd8fd7f41fa7170",
+                "sha256:3d5ac5234fb5053850d79dd8eb1015cb0d7d9ed951fa37aa9e6249a19aa4f336",
+                "sha256:4313ab9bf6a81206c8ac28fdfcddc0435299dc88cad12cc6305fd0e78b81f9e4",
+                "sha256:445ca8d3c5a01309633a0c9db57150312a181146315693273e35d936472df912",
+                "sha256:479595a4fbe9ed8f8f72c59717e8cf222da2e4c07b6ae5b65411e6302af9708e",
+                "sha256:4918fd5f8b43aa7ec031e0fef1ee02deb80b6afd49c85f0790be1dc4ce34cb50",
+                "sha256:4aba818dcc7263852aabb172ec27b71d2abca02a593b95fa79351b2774eb1d2b",
+                "sha256:4e819a806420bc010489f4e741b3036071aba209f2e0989d4750b08b12a9343f",
+                "sha256:4facc913e10bdba42ec0aee76d029aedda628161a7ce4116b16680a0413f658a",
+                "sha256:549c3584993772e25f02d0656ac48abdda73169fe347263948cf2b1cead622f3",
+                "sha256:5c02fcd2bf45162280613d2e4a1ca3ac558ff921ae4e308ecb307650d3a6ee51",
+                "sha256:5f580c651a72b75c39e311343fe6875d6f58cf51c471a97f15a938d9fe4e0d37",
+                "sha256:62120ed0de69b3649cc68e2965376048793f466c5a6c4370fb27c16c1beac22d",
+                "sha256:6295004b2dd37b0835ea5c14a33e00e8cfa3c4add4d587b77287825f3418d310",
+                "sha256:65436dce9fdc0aeeb0a0effe0839cb3d6a05f45aa45a4d9f9c60989beca78b9c",
+                "sha256:684008ec44ad275832a5a152f6e764bbe1914bea10968017b6feaecdad5736e0",
+                "sha256:684e52023aec43bdf0250e843e1fdd6febbe831bd9d52da72333fa201aaa2335",
+                "sha256:6cc38067209354e16c5609b66285af17a2863a47585bcf75285cab33d4c3b8df",
+                "sha256:6f2f017c5be19984fbbf55f8af6caba25e62c71293213f044da3ada7091a4455",
+                "sha256:743deffdf3b3481da32e8a96887e2aa945ec6685af1cfe2bcc292638c9ba2f48",
+                "sha256:7571f19f4a3fd00af9341c7801d1ad1967fc9c3f5e62402683047e7166b9f2b4",
+                "sha256:7731728b6568fc286d86745f27f07266de49603a6fdc4d19c87e8c247be452af",
+                "sha256:785c071c982dce54d44ea0b79cd6dfafddeccdd98cfa5f7b86ef69b381b457d9",
+                "sha256:78fddb22b9ef810b63ef341c9fcf6455232d97cfe03938cbc29e2672c436670e",
+                "sha256:7bb966fdd9217e53abf824f437a5a2d643a38d4fd5fd0ca711b9da683d452969",
+                "sha256:7cbc5d9e8a1781e7be17da67b92580d6ce4dcef5819c1b1b89f49d9678cc278c",
+                "sha256:803b8905b52de78b173d3c1e83df0efb929621e7b7c5766c0843704d5332682f",
+                "sha256:80b696e8972b81edf0af2a259e1b2a4a661f818fae22e5fa4fa1a995fb4a40fd",
+                "sha256:81500ed5af2090b4a9157a59dbc89873a25c33db1bb9a8cf123837dcc9765047",
+                "sha256:89ec7f2c08937421bbbb8b48c54096fa4f88347946d4747021ad85f1b3021b3c",
+                "sha256:8ba6745440b9a27336443b0c285d705ce73adb9ec90e2f2004c64d95ab5a7598",
+                "sha256:8c91e1763696c0eb66340c4df98623c2d4e77d0746b8f8f2bee2c6883fd1fe18",
+                "sha256:8d015604ee6204e76569d2f44e5a210728fa917115bef0d102f4107e622b08d5",
+                "sha256:8d1f86f3f4e2388aa3310b50694ac44daefbd1681def26b4519bd050a398dc5a",
+                "sha256:8f83b6fd3dc3ba94d2b22717f9c8b8512354fd95221ac661784df2769ea9bba9",
+                "sha256:8fc6976a3395fe4d1fbeb984adaa8ec652a1e12f36b56ec8c236e5117b585427",
+                "sha256:904c883cf10a975b02ab3478bce652f0f5346a2c28d0a8521d97bb23c323cc8b",
+                "sha256:911742856ce98d879acbea33fcc03c1d8dc1106234c5e7d068932c945db209c0",
+                "sha256:91797b98f5e34b6a49f54be33f72e2fb658018ae532be2f79f7c63b4ae225145",
+                "sha256:95399831a206211d6bc40224af1c635cb8790ddd5c7493e0bd03b85711076a53",
+                "sha256:956b58d692f235cfbf5b4f3abd6d99bf102f161ccfe20d2fd0904f51c72c4c66",
+                "sha256:98c1165f3809ce7774f05cb74e5408cd3aa93ee8573ae959a97a53db3ca3180d",
+                "sha256:9ab40412f8cd6f615bfedea40c8bf0407d41bf83b96f6fc9ff34976d6b7037fd",
+                "sha256:9df1bfef97db938469ef0a7354b2d591a2d438bc497b2c489471bec0e6baf7c4",
+                "sha256:a01fe2305e6232ef3e8f40bfc0f0f3a04def9aab514910fa4203bafbc0bb4682",
+                "sha256:a70b51f55fd954d1f194271695821dd62054d949efd6368d8be64edd37f55c86",
+                "sha256:a7ccdd1c4a3472a7533b0a7aa9ee34c9a2bef859ba86deec07aff2ad7e0c3b94",
+                "sha256:b340cccad138ecb363324aa26893963dcabb02bb25e440ebdf42e30963f1a4e0",
+                "sha256:b74586dd0b039c62416034f811d7ee62810174bb70dffcca6439f5236249eb09",
+                "sha256:b9d320b3bf82a39f248769fc7f188e00f93526cc0fe739cfa197868633d44701",
+                "sha256:ba2336d6548dee3117520545cfe44dc28a250aa091f8281d28804aa8d707d93d",
+                "sha256:ba8122e3bb94ecda29a8de4cf889f600171424ea586847aa92c334772d200331",
+                "sha256:bd727ad276bb91928879f3aa6396c9a1d34e5e180dce40578421a691eeb77f47",
+                "sha256:c21fc21a4c7480479d12fd8e679b699f744f76bb05f53a1d14182b31f55aac76",
+                "sha256:c2d0e7cbb6341e830adcbfa2479fdeebbfbb328f11edd6b5675674e7a1e37730",
+                "sha256:c2ef6f7990b6e8758fe48ad08f7e2f66c8f11dc66e24093304b87cae9037bb4a",
+                "sha256:c4ed75ea6892a56896d78f11006161eea52c45a14994794bcfa1654430984b22",
+                "sha256:cccc79a9be9b64c881f18305a7c715ba199e471a3973faeb7ba84172abb3f317",
+                "sha256:d0800631e565c47520aaa04ae38b96abc5196fe8b4aa9bd864445bd2b5848a7a",
+                "sha256:d2da13568eff02b30fd54fccd1e042a70fe920d816616fda4bf54ec705668d81",
+                "sha256:d61ae114d2a2311f61d90c2ef1358518e8f05eafda76eaf9c772a077e0b465ec",
+                "sha256:d83c2bc678453646f1a18f8db1e927a2d3f4935031b9ad8a76e56760461105dd",
+                "sha256:dd5acc0a7d38fdc7a3a6fd3ad14c880819008ecb3379626e56b163165162cc46",
+                "sha256:df79012ebf6f4efb8d307b1328226aef24ca446b3ff8d0e30202d7ebcb977a8c",
+                "sha256:e0a2df336d1135a0b3a67f3bbf78a75f69562c1199ed9935372b82215cddd6e2",
+                "sha256:e2f142b45c6fed48166faeb4303b4b58c9fcd827da63f4cf0a123c3480ae11fb",
+                "sha256:e697e1c0238133589e00c244a8b676bc2cfc3ab4961318d902040d099fec7483",
+                "sha256:e757d475953269fbf4b441207bb7dbdd1c43180711b6208e129b637792ac0b93",
+                "sha256:e87ab229332ceb127a165612d839ab87795972102cb9830e5f12b8c9a5c1b508",
+                "sha256:ea355eb43b11764cf799dda62c658c4d2fdb16af41f59bb1ccfec517b60bcb07",
+                "sha256:ec7e0043b91115f427998febaa2beb82c82df708168b35ece3accb610b91fac1",
+                "sha256:eeaa0b5328b785abc344acc6241cffde50dc394a0644a968add75fcefe15b9d4",
+                "sha256:f2d80a6749724b37853ece57988b39c4e79d2b5fe2869a86e8aeae3bbeef9eb0",
+                "sha256:fa454d26f2e87ad661c4f0c5a5fe4cf6aab1e307d1b94f16ffdfcb089ba685c0",
+                "sha256:fb83cc090eac63c006871fd24db5e30a1f282faa46328572661c0a24a2323a08",
+                "sha256:fd80d1280d473500d8086d104962a82d77bfbf2b118053824b7be28cd5a79ea5"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2023.12.25"
+            "version": "==2024.4.16"
         },
         "requests": {
             "hashes": [
@@ -1729,11 +1737,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:48c518e350470d98cfa2944a31edbfc897c9a7d8fa4847da66d89f0f5fb64b57",
-                "sha256:e1fd0ca7ba442e4be8a415dcca867b8018777dd5f95f4492bb4dc7d77dbc8bd8"
+                "sha256:6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987",
+                "sha256:c636ac361bc47580504644275c9ad802c50415c7522212252c033bd15f301f32"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==69.3.0"
+            "version": "==69.5.1"
         },
         "six": {
             "hashes": [
@@ -1805,11 +1813,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:961c026ac520bac5f69acb8ea063e8a4f071bcc9457b9c1f28f6b085c511583a",
-                "sha256:e08e13ecdca7a0bd53798f356d5831434afa5b07b93f0abdf0797b7a06ffe197"
+                "sha256:0846377ea76e818daaa3e00a4365c018bc3ac9760cbb3544de542885aad61fb3",
+                "sha256:ec25a9671a5102c8d2657f62792a27b48f016664c6873f6beed3800008577210"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==20.25.1"
+            "version": "==20.26.0"
         },
         "watchdog": {
             "hashes": [

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+python_files = test_*.py unit_test_*.py
+asyncio_mode = auto

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,10 +60,10 @@ install_requires =
     async-lru~=2.0.4
     psutil~=5.9.8
 tests_require =
-    pytest>=6.0.0,<7.0
+    pytest>=7.0.0,<8.0
     pytest-mock>=3.0,<4.0
     pytest-socket~=0.6.0
-    pytest-asyncio~=0.19
+    pytest-asyncio>=0.23,<1.0
     flake8>=3.7.0,<4.0
     pytest-xdist[psutil]>=2.2,<3.0.0
     pytest-rerunfailures~=12.0
@@ -72,10 +72,10 @@ tests_require =
 
 [options.extras_require]
 dev =
-    pytest>=6.0.0,<7.0
+    pytest>=7.0.0,<8.0
     pytest-mock>=3.0,<4.0
     pytest-socket~=0.6.0
-    pytest-asyncio~=0.19
+    pytest-asyncio>=0.23,<1.0
     flake8>=3.7.0,<4.0
     pytest-xdist[psutil]>=2.2,<3.0.0
     pytest-rerunfailures~=12.0
@@ -85,10 +85,10 @@ dev =
     pre-commit
 
 tests =
-    pytest>=6.0.0,<7.0
+    pytest>=7.0.0,<8.0
     pytest-mock>=3.0,<4.0
     pytest-socket~=0.6.0
-    pytest-asyncio~=0.19
+    pytest-asyncio>=0.23,<1.0
     flake8>=3.7.0,<4.0
     pytest-xdist[psutil]>=2.2,<3.0.0
     pytest-rerunfailures~=12.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,9 @@ tests_require =
     pytest>=7.0.0,<8.0
     pytest-mock>=3.0,<4.0
     pytest-socket~=0.6.0
-    pytest-asyncio>=0.23,<1.0
+    # 0.22,0.23 are blacklisted because they have Async event loop bugs.
+    # See: https://github.com/pytest-dev/pytest-asyncio/issues/658
+    pytest-asyncio!=0.22.*,!=0.23.*,>=0.21
     flake8>=3.7.0,<4.0
     pytest-xdist[psutil]>=2.2,<3.0.0
     pytest-rerunfailures~=12.0
@@ -75,7 +77,7 @@ dev =
     pytest>=7.0.0,<8.0
     pytest-mock>=3.0,<4.0
     pytest-socket~=0.6.0
-    pytest-asyncio>=0.23,<1.0
+    pytest-asyncio!=0.22.*,!=0.23.*,>=0.21
     flake8>=3.7.0,<4.0
     pytest-xdist[psutil]>=2.2,<3.0.0
     pytest-rerunfailures~=12.0
@@ -88,7 +90,7 @@ tests =
     pytest>=7.0.0,<8.0
     pytest-mock>=3.0,<4.0
     pytest-socket~=0.6.0
-    pytest-asyncio>=0.23,<1.0
+    pytest-asyncio!=0.22.*,!=0.23.*,>=0.21
     flake8>=3.7.0,<4.0
     pytest-xdist[psutil]>=2.2,<3.0.0
     pytest-rerunfailures~=12.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,9 +63,7 @@ tests_require =
     pytest>=7.0.0,<8.0
     pytest-mock>=3.0,<4.0
     pytest-socket~=0.6.0
-    # 0.22,0.23 are blacklisted because they have Async event loop bugs.
-    # See: https://github.com/pytest-dev/pytest-asyncio/issues/658
-    pytest-asyncio!=0.22.*,!=0.23.*,>=0.21
+    pytest-asyncio>=0.23.6,<1.0
     flake8>=3.7.0,<4.0
     pytest-xdist[psutil]>=2.2,<3.0.0
     pytest-rerunfailures~=12.0
@@ -77,7 +75,7 @@ dev =
     pytest>=7.0.0,<8.0
     pytest-mock>=3.0,<4.0
     pytest-socket~=0.6.0
-    pytest-asyncio!=0.22.*,!=0.23.*,>=0.21
+    pytest-asyncio>=0.23.6,<1.0
     flake8>=3.7.0,<4.0
     pytest-xdist[psutil]>=2.2,<3.0.0
     pytest-rerunfailures~=12.0
@@ -90,7 +88,7 @@ tests =
     pytest>=7.0.0,<8.0
     pytest-mock>=3.0,<4.0
     pytest-socket~=0.6.0
-    pytest-asyncio!=0.22.*,!=0.23.*,>=0.21
+    pytest-asyncio>=0.23.6,<1.0
     flake8>=3.7.0,<4.0
     pytest-xdist[psutil]>=2.2,<3.0.0
     pytest-rerunfailures~=12.0

--- a/synapseclient/core/cache.py
+++ b/synapseclient/core/cache.py
@@ -87,7 +87,7 @@ class Cache:
             value = os.path.expandvars(os.path.expanduser(value))
             # create the cache_root_dir if it does not already exist
             if not os.path.exists(value):
-                os.makedirs(value)
+                os.makedirs(value, exist_ok=True)
         self.__dict__[key] = value
 
     def __init__(self, cache_root_dir=CACHE_ROOT_DIR, fanout=1000):

--- a/synapseclient/core/logging_setup.py
+++ b/synapseclient/core/logging_setup.py
@@ -96,6 +96,16 @@ logging_config.dictConfig(
                 "propagate": True,
             },
             SILENT_LOGGER_NAME: {"handlers": [], "level": "INFO", "propagate": False},
+            "httpx": {
+                "handlers": ["debug_stderr"],
+                "level": "DEBUG",
+                "propagate": True,
+            },
+            "httpcore": {
+                "handlers": ["debug_stderr"],
+                "level": "DEBUG",
+                "propagate": True,
+            },
         },
     }
 )

--- a/synapseclient/core/logging_setup.py
+++ b/synapseclient/core/logging_setup.py
@@ -96,16 +96,16 @@ logging_config.dictConfig(
                 "propagate": True,
             },
             SILENT_LOGGER_NAME: {"handlers": [], "level": "INFO", "propagate": False},
-            "httpx": {
-                "handlers": ["debug_stderr"],
-                "level": "DEBUG",
-                "propagate": True,
-            },
-            "httpcore": {
-                "handlers": ["debug_stderr"],
-                "level": "DEBUG",
-                "propagate": True,
-            },
+            # "httpx": {
+            #     "handlers": ["debug_stderr"],
+            #     "level": "DEBUG",
+            #     "propagate": True,
+            # },
+            # "httpcore": {
+            #     "handlers": ["debug_stderr"],
+            #     "level": "DEBUG",
+            #     "propagate": True,
+            # },
         },
     }
 )

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -13,7 +13,6 @@ import sys
 import time
 from logging import Logger
 from typing import Any, Coroutine, List, Tuple, Type, Union
-import uuid
 
 import httpx
 
@@ -594,11 +593,7 @@ def _log_for_retry(
             url_message_part,
             response_message,
         )
-        current_span = trace.get_current_span()
-        if current_span.is_recording():
-            current_span.set_attribute(
-                f"HTTP_RETRY_STATUS_CODES_{uuid.uuid4()}", str(response.status_code)
-            )
+
     elif caught_exception is not None:
         logger.debug("retrying exception: %s", str(caught_exception))
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -60,14 +60,14 @@ def syn() -> Synapse:
     """
     print("Python version:", sys.version)
 
-    syn = Synapse(debug=True, skip_checks=True)
+    syn = Synapse(debug=False, skip_checks=True)
     print("Testing against endpoints:")
     print("  " + syn.repoEndpoint)
     print("  " + syn.authEndpoint)
     print("  " + syn.fileHandleEndpoint)
     print("  " + syn.portalEndpoint + "\n")
 
-    # syn.logger = logging.getLogger(SILENT_LOGGER_NAME)
+    syn.logger = logging.getLogger(SILENT_LOGGER_NAME)
     syn.login()
     return syn
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,5 @@
 """Set up for integration tests."""
 
-import asyncio
 import logging
 import os
 import platform
@@ -21,12 +20,15 @@ from opentelemetry.sdk.trace.export import (
     SimpleSpanProcessor,
 )
 from opentelemetry.sdk.trace.sampling import ALWAYS_OFF
+import pytest_asyncio
 
 from synapseclient import Entity, Project, Synapse
 from synapseclient.core import utils
+from synapseclient.core.async_utils import wrap_async_to_sync
 from synapseclient.core.logging_setup import SILENT_LOGGER_NAME
 from synapseclient.models import Project as Project_Model
 from synapseclient.models import Team
+from pytest_asyncio import is_async_test
 
 tracer = trace.get_tracer("synapseclient")
 
@@ -35,19 +37,19 @@ pytest session level fixtures shared by all integration tests.
 """
 
 
-@pytest.fixture(autouse=True)
-def event_loop(request):
-    """
-    Redefine the event loop to support session/module-scoped fixtures;
-    see https://github.com/pytest-dev/pytest-asyncio/issues/371
-    """
-    policy = asyncio.get_event_loop_policy()
-    loop = policy.new_event_loop()
+def pytest_collection_modifyitems(items) -> None:
+    """Taken from docs at:
+    https://pytest-asyncio.readthedocs.io/en/latest/how-to-guides/run_session_tests_in_same_loop.html
 
-    try:
-        yield loop
-    finally:
-        loop.close()
+    I want to run all tests, even if they are not explictly async, within the same event
+    loop. This will allow our async_to_sync wrapper logic use the same event loop
+    for all tests. This implictly allows us to re-use the HTTP connection pooling for
+    all tests.
+    """
+    pytest_asyncio_tests = (item for item in items if is_async_test(item))
+    session_scope_marker = pytest.mark.asyncio(scope="session")
+    for async_test in pytest_asyncio_tests:
+        async_test.add_marker(session_scope_marker, append=False)
 
 
 @pytest.fixture(scope="session")
@@ -58,30 +60,29 @@ def syn() -> Synapse:
     """
     print("Python version:", sys.version)
 
-    syn = Synapse(debug=False, skip_checks=True)
+    syn = Synapse(debug=True, skip_checks=True)
     print("Testing against endpoints:")
     print("  " + syn.repoEndpoint)
     print("  " + syn.authEndpoint)
     print("  " + syn.fileHandleEndpoint)
     print("  " + syn.portalEndpoint + "\n")
 
-    syn.logger = logging.getLogger(SILENT_LOGGER_NAME)
+    # syn.logger = logging.getLogger(SILENT_LOGGER_NAME)
     syn.login()
     return syn
 
 
-@pytest.fixture(scope="session")
-@pytest.mark.asyncio
-def project_model(request, syn: Synapse) -> Project_Model:
+@pytest_asyncio.fixture(scope="session")
+async def project_model(request, syn: Synapse) -> Project_Model:
     """
     Create a project to be shared by all tests in the session. If xdist is being used
     a project is created for each worker node.
     """
 
     # Make one project for all the tests to use
-    proj = asyncio.run(
-        Project_Model(name="integration_test_project" + str(uuid.uuid4())).store_async()
-    )
+    proj = await Project_Model(
+        name="integration_test_project" + str(uuid.uuid4())
+    ).store_async()
 
     # set the working directory to a temp directory
     _old_working_directory = os.getcwd()
@@ -89,7 +90,7 @@ def project_model(request, syn: Synapse) -> Project_Model:
     os.chdir(working_directory)
 
     def project_teardown() -> None:
-        _cleanup(syn, [working_directory, proj.id])
+        wrap_async_to_sync(_cleanup(syn, [working_directory, proj.id]), syn)
         os.chdir(_old_working_directory)
 
     request.addfinalizer(project_teardown)
@@ -97,8 +98,8 @@ def project_model(request, syn: Synapse) -> Project_Model:
     return proj
 
 
-@pytest.fixture(scope="session")
-def project(request, syn: Synapse) -> Project:
+@pytest_asyncio.fixture(scope="session")
+async def project(request, syn: Synapse) -> Project:
     """
     Create a project to be shared by all tests in the session. If xdist is being used
     a project is created for each worker node.
@@ -113,7 +114,7 @@ def project(request, syn: Synapse) -> Project:
     os.chdir(working_directory)
 
     def project_teardown():
-        _cleanup(syn, [working_directory, proj])
+        wrap_async_to_sync(_cleanup(syn, [working_directory, proj]), syn)
         os.chdir(_old_working_directory)
 
     request.addfinalizer(project_teardown)
@@ -137,11 +138,11 @@ def clear_cache() -> None:
     get_upload_destination.cache_clear()
 
 
-@pytest.fixture(scope="module")
-def schedule_for_cleanup(request, syn: Synapse):
+@pytest_asyncio.fixture(scope="session")
+async def schedule_for_cleanup(request, syn: Synapse):
     """Returns a closure that takes an item that should be scheduled for cleanup.
-    The cleanup will occur after the module tests finish to limit the residue left behind
-    if a test session should be prematurely aborted for any reason."""
+    The cleanup will occur after the session finish to allow the deletes to take
+    advantage of any connection pooling."""
 
     items = []
 
@@ -149,14 +150,14 @@ def schedule_for_cleanup(request, syn: Synapse):
         items.append(item)
 
     def cleanup_scheduled_items():
-        _cleanup(syn, items)
+        wrap_async_to_sync(_cleanup(syn, items), syn)
 
     request.addfinalizer(cleanup_scheduled_items)
 
     return _append_cleanup
 
 
-def _cleanup(syn: Synapse, items):
+async def _cleanup(syn: Synapse, items):
     """cleanup junk created during testing"""
     for item in reversed(items):
         if (

--- a/tests/integration/synapseclient/core/test_REST_request_helpers.py
+++ b/tests/integration/synapseclient/core/test_REST_request_helpers.py
@@ -6,7 +6,7 @@ requests to the Synapse backend
 from synapseclient import Column
 
 
-def test_createColumns(syn):
+async def test_createColumns(syn):
     columns_to_create = [
         Column(name="FirstTestColumn", columnType="INTEGER"),
         Column(name="SecondTestColumn", columnType="DOUBLE"),

--- a/tests/integration/synapseclient/core/test_caching.py
+++ b/tests/integration/synapseclient/core/test_caching.py
@@ -41,7 +41,6 @@ async def sleep_and_end_test(syn: Synapse) -> None:
     syn.test_keepRunning = False
 
 
-@pytest.mark.asyncio
 async def test_threaded_access(
     syn: Synapse, project: Project, schedule_for_cleanup: Callable[..., None]
 ) -> None:

--- a/tests/integration/synapseclient/core/test_download.py
+++ b/tests/integration/synapseclient/core/test_download.py
@@ -11,7 +11,7 @@ import synapseclient.core.utils as utils
 from opentelemetry import trace
 
 
-def test_download_check_md5(syn, project, schedule_for_cleanup):
+async def test_download_check_md5(syn, project, schedule_for_cleanup):
     tempfile_path = utils.make_bogus_data_file()
     schedule_for_cleanup(tempfile_path)
     entity_bad_md5 = syn.store(
@@ -29,7 +29,7 @@ def test_download_check_md5(syn, project, schedule_for_cleanup):
 
 
 @pytest.mark.flaky(reruns=3)
-def test_resume_partial_download(syn, project, schedule_for_cleanup):
+async def test_resume_partial_download(syn, project, schedule_for_cleanup):
     original_file = utils.make_bogus_data_file(40000)
 
     entity = File(original_file, parent=project["id"])
@@ -70,7 +70,7 @@ def test_resume_partial_download(syn, project, schedule_for_cleanup):
     assert filecmp.cmp(original_file, path), "File comparison failed"
 
 
-def test_http_download__range_request_error(syn, project):
+async def test_http_download__range_request_error(syn, project):
     # SYNPY-525
 
     file_path = utils.make_bogus_data_file()

--- a/tests/integration/synapseclient/core/test_external_storage.py
+++ b/tests/integration/synapseclient/core/test_external_storage.py
@@ -91,7 +91,7 @@ class ExernalStorageTest(unittest.TestCase):
 
         return s3_client, folder, storage_location_setting["storageLocationId"]
 
-    def test_set_external_storage_location(self):
+    async def test_set_external_storage_location(self):
         """Test configuring an external storage location,
         saving a file there, and confirm that it is created and
         accessible as expected."""
@@ -120,7 +120,7 @@ class ExernalStorageTest(unittest.TestCase):
         bucket_name, _ = get_aws_env()
         s3_client.get_object(Bucket=bucket_name, Key=file_handle["key"])
 
-    def test_sts_external_storage_location(self):
+    async def test_sts_external_storage_location(self):
         """Test creating and using an external STS storage location.
         A custom storage location is created with sts enabled,
         a file is uploaded directly via boto using STS credentials,
@@ -188,7 +188,7 @@ class ExernalStorageTest(unittest.TestCase):
         with open(retrieved_file_entity.path, "r") as f:
             assert file_contents == f.read()
 
-    def test_boto_upload__acl(self):
+    async def test_boto_upload__acl(self):
         """Verify when we store a Synapse object using boto we apply a bucket-owner-full-control ACL to the object"""
         bucket_name, _ = get_aws_env()
         _, folder, storage_location_id = self._configure_storage_location(

--- a/tests/integration/synapseclient/core/upload/test_multipart_upload.py
+++ b/tests/integration/synapseclient/core/upload/test_multipart_upload.py
@@ -24,7 +24,7 @@ from synapseclient.core.upload.multipart_upload import (
 
 
 @pytest.mark.flaky(reruns=3, only_rerun=["SynapseHTTPError"])
-def test_round_trip(syn: Synapse, project: Project, schedule_for_cleanup):
+async def test_round_trip(syn: Synapse, project: Project, schedule_for_cleanup):
     fhid = None
     filepath = utils.make_bogus_binary_file(MIN_PART_SIZE + 777771)
     try:
@@ -51,7 +51,7 @@ def test_round_trip(syn: Synapse, project: Project, schedule_for_cleanup):
             print(traceback.format_exc())
 
 
-def test_single_thread_upload(syn: Synapse):
+async def test_single_thread_upload(syn: Synapse):
     synapseclient.core.config.single_threaded = True
     try:
         filepath = utils.make_bogus_binary_file(MIN_PART_SIZE * 2 + 1)
@@ -60,7 +60,9 @@ def test_single_thread_upload(syn: Synapse):
         synapseclient.core.config.single_threaded = False
 
 
-def test_randomly_failing_parts(syn: Synapse, project: Project, schedule_for_cleanup):
+async def test_randomly_failing_parts(
+    syn: Synapse, project: Project, schedule_for_cleanup
+):
     """Verify that we can recover gracefully with some randomly inserted errors
     while uploading parts."""
 
@@ -117,7 +119,7 @@ def test_randomly_failing_parts(syn: Synapse, project: Project, schedule_for_cle
                 print(traceback.format_exc())
 
 
-def test_multipart_upload_big_string(
+async def test_multipart_upload_big_string(
     syn: Synapse, project: Project, schedule_for_cleanup
 ):
     cities = [
@@ -264,13 +266,13 @@ def _multipart_copy_test(
 
 
 @pytest.mark.flaky(reruns=3, only_rerun=["SynapseHTTPError"])
-def test_multipart_copy(syn: Synapse, project: Project, schedule_for_cleanup):
+async def test_multipart_copy(syn: Synapse, project: Project, schedule_for_cleanup):
     """Test multi part copy using the minimum part size."""
     _multipart_copy_test(syn, project, schedule_for_cleanup, MIN_PART_SIZE)
 
 
 @skip("Skip in normal testing because the large size makes it slow")
-def test_multipart_copy__big_parts(
+async def test_multipart_copy__big_parts(
     syn: Synapse, project: Project, schedule_for_cleanup
 ):
     _multipart_copy_test(syn, project, schedule_for_cleanup, 100 * utils.MB)

--- a/tests/integration/synapseclient/core/upload/test_multipart_upload_async.py
+++ b/tests/integration/synapseclient/core/upload/test_multipart_upload_async.py
@@ -26,7 +26,6 @@ from synapseclient.core.upload.multipart_upload_async import (
 from synapseclient.models import File, Project
 
 
-@pytest.mark.asyncio
 async def test_round_trip(
     syn: Synapse, project_model: Project, schedule_for_cleanup: Callable[..., None]
 ) -> None:
@@ -71,7 +70,6 @@ async def test_round_trip(
             syn.logger.exception("Failed to cleanup")
 
 
-@pytest.mark.asyncio
 async def test_single_thread_upload(syn: Synapse) -> None:
     synapseclient.core.config.single_threaded = True
     try:
@@ -81,7 +79,6 @@ async def test_single_thread_upload(syn: Synapse) -> None:
         synapseclient.core.config.single_threaded = False
 
 
-@pytest.mark.asyncio
 async def test_randomly_failing_parts(
     syn: Synapse, project_model: Project, schedule_for_cleanup: Callable[..., None]
 ) -> None:
@@ -156,7 +153,6 @@ async def test_randomly_failing_parts(
                 syn.logger.exception("Failed to cleanup")
 
 
-@pytest.mark.asyncio
 async def test_multipart_upload_big_string(
     syn: Synapse, project_model: Project, schedule_for_cleanup: Callable[..., None]
 ) -> None:
@@ -304,7 +300,6 @@ async def _multipart_copy_test(
     assert file_content == dest_file_content
 
 
-@pytest.mark.asyncio
 async def test_multipart_copy(
     syn: Synapse, project: Project, schedule_for_cleanup: Callable[..., None]
 ) -> None:
@@ -312,7 +307,6 @@ async def test_multipart_copy(
     await _multipart_copy_test(syn, project, schedule_for_cleanup, MIN_PART_SIZE)
 
 
-@pytest.mark.asyncio
 @skip("Skip in normal testing because the large size makes it slow")
 async def test_multipart_copy__big_parts(
     syn: Synapse, project: Project, schedule_for_cleanup: Callable[..., None]

--- a/tests/integration/synapseclient/core/upload/test_sftp_upload.py
+++ b/tests/integration/synapseclient/core/upload/test_sftp_upload.py
@@ -75,7 +75,7 @@ def project_setting_id(request, syn, project):
 
 
 @unittest.skipIf(*check_test_preconditions())
-def test_synStore_sftpIntegration(syn, project, schedule_for_cleanup):
+async def test_synStore_sftpIntegration(syn, project, schedule_for_cleanup):
     """Creates a File Entity on an sftp server and add the external url."""
     filepath = utils.make_bogus_binary_file(1 * utils.MB - 777771)
     try:
@@ -100,7 +100,7 @@ def test_synStore_sftpIntegration(syn, project, schedule_for_cleanup):
 
 
 @unittest.skipIf(*check_test_preconditions())
-def test_synGet_sftpIntegration(syn, project):
+async def test_synGet_sftpIntegration(syn, project):
     # Create file by uploading directly to sftp and creating entity from URL
     server_prefix = get_sftp_server_prefix()
     username, password = syn._getUserCredentials(server_prefix)
@@ -122,7 +122,7 @@ def test_synGet_sftpIntegration(syn, project):
 
 
 @unittest.skipIf(*check_test_preconditions())
-def test_utils_sftp_upload_and_download(syn):
+async def test_utils_sftp_upload_and_download(syn):
     """Tries to upload a file to an sftp file"""
     server_prefix = get_sftp_server_prefix()
     username, password = syn._getUserCredentials(server_prefix)

--- a/tests/integration/synapseclient/integration_test.py
+++ b/tests/integration/synapseclient/integration_test.py
@@ -72,7 +72,7 @@ async def test_login(syn):
         syn.login(silent=True)
 
 
-def testCustomConfigFile(schedule_for_cleanup):
+async def testCustomConfigFile(schedule_for_cleanup):
     if os.path.isfile(client.CONFIG_FILE):
         configPath = "./CONFIGFILE"
         shutil.copyfile(client.CONFIG_FILE, configPath)

--- a/tests/integration/synapseclient/integration_test.py
+++ b/tests/integration/synapseclient/integration_test.py
@@ -35,7 +35,7 @@ FILE_DESCRIPTION = "A test file entity"
 NEW_DESCRIPTION = "new description"
 
 
-def test_login(syn):
+async def test_login(syn):
     try:
         config = configparser.RawConfigParser()
         config.read(client.CONFIG_FILE)
@@ -87,7 +87,7 @@ def testCustomConfigFile(schedule_for_cleanup):
 
 
 @pytest.mark.flaky(reruns=3, only_rerun=["SynapseHTTPError"])
-def test_entity_version(syn, project, schedule_for_cleanup):
+async def test_entity_version(syn, project, schedule_for_cleanup):
     # Make an Entity and make sure the version is one
     entity = File(parent=project["id"])
     entity["path"] = utils.make_bogus_data_file()
@@ -141,7 +141,7 @@ def test_entity_version(syn, project, schedule_for_cleanup):
     assert returnEntity.versionNumber == 1
 
 
-def test_md5_query(syn, project, schedule_for_cleanup):
+async def test_md5_query(syn, project, schedule_for_cleanup):
     # Add the same Entity several times
     path = utils.make_bogus_data_file()
     schedule_for_cleanup(path)
@@ -162,7 +162,7 @@ def test_md5_query(syn, project, schedule_for_cleanup):
     assert len(results) == num
 
 
-def test_uploadFile_given_dictionary(syn, project, schedule_for_cleanup):
+async def test_uploadFile_given_dictionary(syn, project, schedule_for_cleanup):
     # Make a Folder Entity the old fashioned way
     folder = {
         "concreteType": Folder._synapse_entity_type,
@@ -193,7 +193,7 @@ def test_uploadFile_given_dictionary(syn, project, schedule_for_cleanup):
     syn.get(entity["id"])
 
 
-def test_upload_file_with_force_version_false(
+async def test_upload_file_with_force_version_false(
     syn: Synapse, project: Project, schedule_for_cleanup
 ) -> None:
     # GIVEN A bogus file to upload to synapse
@@ -224,7 +224,7 @@ def test_upload_file_with_force_version_false(
     assert not mocked_file_handle_upload.called
 
 
-def test_upload_file_changed_with_force_version_false(
+async def test_upload_file_changed_with_force_version_false(
     syn: Synapse, project: Project, schedule_for_cleanup
 ) -> None:
     # GIVEN A bogus file to upload to synapse
@@ -260,7 +260,7 @@ def test_upload_file_changed_with_force_version_false(
 
 
 @pytest.mark.flaky(reruns=3, only_rerun=["SynapseHTTPError"])
-def test_uploadFileEntity(syn, project, schedule_for_cleanup):
+async def test_uploadFileEntity(syn, project, schedule_for_cleanup):
     # Create a FileEntity
     # Dictionaries default to FileEntity as a type
     fname = utils.make_bogus_data_file()
@@ -297,7 +297,7 @@ def test_uploadFileEntity(syn, project, schedule_for_cleanup):
     assert filecmp.cmp(fname, entity["path"])
 
 
-def test_download_multithreaded(syn, project, schedule_for_cleanup):
+async def test_download_multithreaded(syn, project, schedule_for_cleanup):
     # Create a FileEntity
     # Dictionaries default to FileEntity as a type
     fname = utils.make_bogus_data_file()
@@ -318,7 +318,7 @@ def test_download_multithreaded(syn, project, schedule_for_cleanup):
     syn.multi_threaded = False
 
 
-def test_downloadFile(schedule_for_cleanup):
+async def test_downloadFile(schedule_for_cleanup):
     # See if the a "wget" works
     filename = utils.download_file(
         "http://dev-versions.synapse.sagebase.org/sage_bionetworks_logo_274x128.png"
@@ -327,7 +327,7 @@ def test_downloadFile(schedule_for_cleanup):
     assert os.path.exists(filename)
 
 
-def test_version_check():
+async def test_version_check():
     # Check current version against dev-synapsePythonClient version file
     version_check(
         version_url="http://dev-versions.synapse.sagebase.org/synapsePythonClient"
@@ -360,7 +360,7 @@ def test_version_check():
     )
 
 
-def test_provenance(syn, project, schedule_for_cleanup):
+async def test_provenance(syn, project, schedule_for_cleanup):
     # Create a File Entity
     fname = utils.make_bogus_data_file()
     schedule_for_cleanup(fname)
@@ -408,7 +408,7 @@ def test_provenance(syn, project, schedule_for_cleanup):
     pytest.raises(SynapseHTTPError, syn.getProvenance, data_entity["id"])
 
 
-def test_annotations(syn, project, schedule_for_cleanup):
+async def test_annotations(syn, project, schedule_for_cleanup):
     # Get the annotations of an Entity
     entity = syn.store(Folder(parent=project["id"]))
     anno = syn.get_annotations(entity)
@@ -456,7 +456,7 @@ def test_annotations(syn, project, schedule_for_cleanup):
     assert annotation["maybe"] == [True, False]
 
 
-def test_annotations_on_file_during_create_no_annotations(
+async def test_annotations_on_file_during_create_no_annotations(
     syn: Synapse, project: Project, schedule_for_cleanup
 ):
     # GIVEN a bogus file
@@ -483,7 +483,7 @@ def test_annotations_on_file_during_create_no_annotations(
     assert not mock_set_annotations.called
 
 
-def test_annotations_on_file_during_create_with_annotations(
+async def test_annotations_on_file_during_create_with_annotations(
     syn: Synapse, project: Project, schedule_for_cleanup
 ):
     # GIVEN a bogus file
@@ -511,7 +511,7 @@ def test_annotations_on_file_during_create_with_annotations(
     assert len(annotations) == 2
 
 
-def test_get_user_profile(syn):
+async def test_get_user_profile(syn):
     p1 = syn.getUserProfile()
 
     # get by name
@@ -523,14 +523,14 @@ def test_get_user_profile(syn):
     assert p2.userName == p1.userName
 
 
-def test_findEntityIdByNameAndParent(syn, schedule_for_cleanup):
+async def test_findEntityIdByNameAndParent(syn, schedule_for_cleanup):
     project_name = str(uuid.uuid1())
     project_id = syn.store(Project(name=project_name))["id"]
     assert project_id == syn.findEntityId(project_name)
     schedule_for_cleanup(project_id)
 
 
-def test_getChildren(syn, schedule_for_cleanup):
+async def test_getChildren(syn, schedule_for_cleanup):
     # setup a hierarchy for folders
     # PROJECT
     # |     \
@@ -597,7 +597,7 @@ class TestPermissionsOnProject:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    def test_get_acl_default(self) -> None:
+    async def test_get_acl_default(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_default_permissions: Entity = self.syn.store(
             Project(name=str(uuid.uuid4()) + "test_get_acl_default_permissions")
@@ -623,7 +623,7 @@ class TestPermissionsOnProject:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_read_only_permissions_on_entity(self) -> None:
+    async def test_get_acl_read_only_permissions_on_entity(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_read_only_permissions: Entity = self.syn.store(
             Project(name=str(uuid.uuid4()) + "test_get_acl_read_permissions_on_project")
@@ -647,7 +647,7 @@ class TestPermissionsOnProject:
         expected_permissions = ["READ"]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_through_team_assigned_to_user(self) -> None:
+    async def test_get_acl_through_team_assigned_to_user(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_permissions_through_single_team: Entity = self.syn.store(
             Project(
@@ -710,7 +710,7 @@ class TestPermissionsOnProject:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_through_multiple_teams_assigned_to_user(self) -> None:
+    async def test_get_acl_through_multiple_teams_assigned_to_user(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_permissions_through_multiple_teams: Entity = self.syn.store(
             Project(
@@ -791,7 +791,7 @@ class TestPermissionsOnProject:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_for_project_with_public_and_registered_user(self) -> None:
+    async def test_get_acl_for_project_with_public_and_registered_user(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_permissions_for_public_and_authenticated_users: Entity = (
             self.syn.store(
@@ -875,7 +875,7 @@ class TestPermissionsOnEntityForCaller:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    def test_get_permissions_default(self) -> None:
+    async def test_get_permissions_default(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_default_permissions: Entity = self.syn.store(
             Project(name=str(uuid.uuid4()) + "test_get_permissions_default_permissions")
@@ -898,7 +898,7 @@ class TestPermissionsOnEntityForCaller:
         ]
         assert set(expected_permissions) == set(permissions.access_types)
 
-    def test_get_permissions_read_only_permissions_on_entity(self) -> None:
+    async def test_get_permissions_read_only_permissions_on_entity(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_read_only_permissions: Entity = self.syn.store(
             Project(
@@ -925,7 +925,7 @@ class TestPermissionsOnEntityForCaller:
 
         assert set(expected_permissions) == set(permissions.access_types)
 
-    def test_get_permissions_through_team_assigned_to_user(self) -> None:
+    async def test_get_permissions_through_team_assigned_to_user(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_permissions_through_single_team: Entity = self.syn.store(
             Project(
@@ -987,7 +987,9 @@ class TestPermissionsOnEntityForCaller:
         ]
         assert set(expected_permissions) == set(permissions.access_types)
 
-    def test_get_permissions_through_multiple_teams_assigned_to_user(self) -> None:
+    async def test_get_permissions_through_multiple_teams_assigned_to_user(
+        self,
+    ) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_permissions_through_multiple_teams: Entity = self.syn.store(
             Project(
@@ -1067,7 +1069,7 @@ class TestPermissionsOnEntityForCaller:
         ]
         assert set(expected_permissions) == set(permissions.access_types)
 
-    def test_get_permissions_for_project_with_registered_user(self) -> None:
+    async def test_get_permissions_for_project_with_registered_user(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_permissions_for_authenticated_users: Entity = self.syn.store(
             Project(
@@ -1121,7 +1123,7 @@ class TestPermissionsOnEntityForCaller:
         assert set(expected_permissions) == set(permissions.access_types)
 
 
-def test_create_delete_team(syn: Synapse) -> None:
+async def test_create_delete_team(syn: Synapse) -> None:
     # GIVEN information about a team I want to create
     name = "python_client_integration_test_team_" + str(uuid.uuid4())
     description = "test description"
@@ -1153,7 +1155,6 @@ class TestAsyncRestInterfaces:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    @pytest.mark.asyncio
     async def test_rest_get_async(self, project: Project) -> None:
         # GIVEN a project stored in synapse
 
@@ -1165,7 +1166,6 @@ class TestAsyncRestInterfaces:
         assert new_project_instance["name"] == project["name"]
         assert new_project_instance["etag"] == project["etag"]
 
-    @pytest.mark.asyncio
     async def test_rest_post_async(self, project: Project) -> None:
         # GIVEN A bogus file to upload to synapse
         path = utils.make_bogus_uuid_file()
@@ -1195,7 +1195,6 @@ class TestAsyncRestInterfaces:
         assert entity_bundle["entity"]["name"] == entity.name
         assert entity_bundle["entity"]["etag"] == entity.etag
 
-    @pytest.mark.asyncio
     async def test_rest_put_async(self, project: Project) -> None:
         # GIVEN A bogus file to upload to synapse
         path = utils.make_bogus_uuid_file()
@@ -1244,7 +1243,6 @@ class TestAsyncRestInterfaces:
         )
         assert entity_bundle_copy["entity"]["description"] == NEW_DESCRIPTION
 
-    @pytest.mark.asyncio
     async def test_rest_delete_async(self, project: Project) -> None:
         # GIVEN A bogus file to upload to synapse
         path = utils.make_bogus_uuid_file()

--- a/tests/integration/synapseclient/integration_test_Entity.py
+++ b/tests/integration/synapseclient/integration_test_Entity.py
@@ -25,7 +25,7 @@ from synapseclient.core.exceptions import SynapseError, SynapseHTTPError
 import synapseclient.core.utils as utils
 
 
-def test_Entity(syn: Synapse, project: Project, schedule_for_cleanup):
+async def test_Entity(syn: Synapse, project: Project, schedule_for_cleanup):
     # Update the project
     project_name = str(uuid.uuid4())
     project = Project(name=project_name)
@@ -168,7 +168,7 @@ def test_Entity(syn: Synapse, project: Project, schedule_for_cleanup):
     assert os.path.basename(a_file_cached.path) == os.path.basename(a_file.path)
 
 
-def test_special_characters(syn: Synapse, project: Project):
+async def test_special_characters(syn: Synapse, project: Project):
     folder = syn.store(
         Folder(
             "Special Characters Here",
@@ -190,7 +190,7 @@ def test_special_characters(syn: Synapse, project: Project):
     assert folder.russian_annotation[0] == "Обезьяна прикладом"
 
 
-def test_get_local_file(syn: Synapse, project: Project, schedule_for_cleanup):
+async def test_get_local_file(syn: Synapse, project: Project, schedule_for_cleanup):
     new_path = utils.make_bogus_data_file()
     schedule_for_cleanup(new_path)
     folder = Folder(
@@ -220,7 +220,7 @@ def test_get_local_file(syn: Synapse, project: Project, schedule_for_cleanup):
     pytest.raises(SynapseError, syn.get, new_path, limitSearch="syn1")
 
 
-def test_store_with_flags(syn: Synapse, project: Project, schedule_for_cleanup):
+async def test_store_with_flags(syn: Synapse, project: Project, schedule_for_cleanup):
     # -- CreateOrUpdate flag for Projects --
     # If we store a project with the same name, it should become an update
     projUpdate = Project(project.name)
@@ -304,7 +304,7 @@ def test_store_with_flags(syn: Synapse, project: Project, schedule_for_cleanup):
     assert ephemeralBogus.shoe_size == [11.5]
 
 
-def test_get_with_downloadLocation_and_ifcollision(
+async def test_get_with_downloadLocation_and_ifcollision(
     syn: Synapse, project: Project, schedule_for_cleanup
 ):
     # Store a File and delete it locally
@@ -359,7 +359,7 @@ def test_get_with_downloadLocation_and_ifcollision(
     os.remove(renamedBogus.path)
 
 
-def test_get_with_cache_hit_and_miss_with_ifcollision(
+async def test_get_with_cache_hit_and_miss_with_ifcollision(
     syn: Synapse, project: Project, schedule_for_cleanup, mocker: MockerFixture
 ):
     download_file_function = mocker.spy(obj=syn, name="_downloadFileHandle")
@@ -420,7 +420,7 @@ def test_get_with_cache_hit_and_miss_with_ifcollision(
     os.remove(filepath)
 
 
-def test_store_activity(syn: Synapse, project: Project, schedule_for_cleanup):
+async def test_store_activity(syn: Synapse, project: Project, schedule_for_cleanup):
     # Create a File and an Activity
     path = utils.make_bogus_binary_file()
     schedule_for_cleanup(path)
@@ -472,7 +472,9 @@ def test_store_activity(syn: Synapse, project: Project, schedule_for_cleanup):
     assert honking["id"] == honking2["id"]
 
 
-def test_store_isRestricted_flag(syn: Synapse, project: Project, schedule_for_cleanup):
+async def test_store_isRestricted_flag(
+    syn: Synapse, project: Project, schedule_for_cleanup
+):
     # Store a file with access requirements
     path = utils.make_bogus_binary_file()
     schedule_for_cleanup(path)
@@ -486,7 +488,7 @@ def test_store_isRestricted_flag(syn: Synapse, project: Project, schedule_for_cl
         assert intercepted.called
 
 
-def test_ExternalFileHandle(syn: Synapse, project: Project):
+async def test_ExternalFileHandle(syn: Synapse, project: Project):
     # Tests shouldn't have external dependencies, but this is a pretty picture of Singapore
     singapore_url = "http://upload.wikimedia.org/wikipedia/commons/thumb/3/3e/1_singapore_city_skyline_dusk_panorama_2011.jpg/1280px-1_singapore_city_skyline_dusk_panorama_2011.jpg"  # noqa
     singapore = File(singapore_url, parent=project, synapseStore=False)
@@ -522,7 +524,7 @@ def test_ExternalFileHandle(syn: Synapse, project: Project):
     assert s2.externalURL == singapore_2_url
 
 
-def test_synapseStore_flag(syn: Synapse, project: Project, schedule_for_cleanup):
+async def test_synapseStore_flag(syn: Synapse, project: Project, schedule_for_cleanup):
     # Store a path to a local file
     path = utils.make_bogus_data_file()
     schedule_for_cleanup(path)
@@ -590,7 +592,9 @@ def test_synapseStore_flag(syn: Synapse, project: Project, schedule_for_cleanup)
     )
 
 
-def test_create_or_update_project(syn: Synapse, project: Project, schedule_for_cleanup):
+async def test_create_or_update_project(
+    syn: Synapse, project: Project, schedule_for_cleanup
+):
     name = str(uuid.uuid4())
 
     project = Project(name, a=1, b=2)
@@ -614,7 +618,9 @@ def test_create_or_update_project(syn: Synapse, project: Project, schedule_for_c
     pytest.raises(Exception, syn.store, project, createOrUpdate=False)
 
 
-def test_download_file_false(syn: Synapse, project: Project, schedule_for_cleanup):
+async def test_download_file_false(
+    syn: Synapse, project: Project, schedule_for_cleanup
+):
     RENAME_SUFFIX = "blah" + str(uuid.uuid4())
 
     # Upload a file
@@ -640,7 +646,7 @@ def test_download_file_false(syn: Synapse, project: Project, schedule_for_cleanu
     assert reupload.name == file.name
 
 
-def test_download_file_URL_false(syn: Synapse, project: Project):
+async def test_download_file_URL_false(syn: Synapse, project: Project):
     # Upload an external file handle
     fileThatExists = "http://dev-versions.synapse.sagebase.org/synapsePythonClient"
     reupload = File(fileThatExists, synapseStore=False, parent=project)
@@ -671,7 +677,7 @@ def test_download_file_URL_false(syn: Synapse, project: Project):
 
 
 # SYNPY-366
-def test_download_local_file_URL_path(
+async def test_download_local_file_URL_path(
     syn: Synapse, project: Project, schedule_for_cleanup
 ):
     path = utils.make_bogus_data_file()
@@ -685,7 +691,7 @@ def test_download_local_file_URL_path(
 
 
 # SYNPY-424
-def test_store_file_handle_update_metadata(
+async def test_store_file_handle_update_metadata(
     syn: Synapse, project: Project, schedule_for_cleanup
 ):
     original_file_path = utils.make_bogus_data_file()
@@ -714,7 +720,7 @@ def test_store_file_handle_update_metadata(
     assert [os.path.basename(replacement_file_path)] == new_entity.files
 
 
-def test_store_DockerRepository(syn: Synapse, project: Project):
+async def test_store_DockerRepository(syn: Synapse, project: Project):
     repo_name = "some/repository/path"
     docker_repo = syn.store(DockerRepository(repo_name, parent=project))
     assert isinstance(docker_repo, DockerRepository)
@@ -723,7 +729,7 @@ def test_store_DockerRepository(syn: Synapse, project: Project):
 
 
 @pytest.mark.flaky(reruns=3, only_rerun=["SynapseHTTPError"])
-def test_store__changing_externalURL_by_changing_path(
+async def test_store__changing_externalURL_by_changing_path(
     syn: Synapse, project: Project, schedule_for_cleanup
 ):
     url = "https://www.synapse.org/Portal/clear.cache.gif"
@@ -752,7 +758,7 @@ def test_store__changing_externalURL_by_changing_path(
 
 
 @pytest.mark.flaky(reruns=3, only_rerun=["SynapseHTTPError"])
-def test_store__changing_from_Synapse_to_externalURL_by_changing_path(
+async def test_store__changing_from_Synapse_to_externalURL_by_changing_path(
     syn: Synapse, project: Project, schedule_for_cleanup
 ):
     # create a temp file

--- a/tests/integration/synapseclient/models/async/test_activity_async.py
+++ b/tests/integration/synapseclient/models/async/test_activity_async.py
@@ -21,7 +21,6 @@ class TestActivity:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    @pytest.mark.asyncio
     async def test_store_with_parent_and_id(self, project: Synapse_Project) -> None:
         # GIVEN a file in a project
         path = utils.make_bogus_uuid_file()
@@ -99,7 +98,6 @@ class TestActivity:
         # Clean up
         await result.delete_async(parent=file)
 
-    @pytest.mark.asyncio
     async def test_store_with_no_references(self, project: Synapse_Project) -> None:
         # GIVEN a file in a project that has an activity with no references
         activity = Activity(
@@ -134,7 +132,6 @@ class TestActivity:
         # Clean up
         await file.activity.delete_async(parent=file)
 
-    @pytest.mark.asyncio
     async def test_from_parent(self, project: Synapse_Project) -> None:
         # GIVEN a file in a project that has an activity
         activity = Activity(
@@ -185,7 +182,6 @@ class TestActivity:
         # Clean up
         await result.delete_async(parent=file)
 
-    @pytest.mark.asyncio
     async def test_delete(self, project: Synapse_Project) -> None:
         # GIVEN a file in a project that has an activity
         activity = Activity(

--- a/tests/integration/synapseclient/models/async/test_file_async.py
+++ b/tests/integration/synapseclient/models/async/test_file_async.py
@@ -997,27 +997,28 @@ class TestChangeMetadata:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    async def file(
+    def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> None:
         filename = utils.make_bogus_uuid_file()
         schedule_for_cleanup(filename)
-        file = await File(
+        file = File(
             path=filename,
             description=DESCRIPTION,
             content_type=CONTENT_TYPE,
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store_async()
-
-        schedule_for_cleanup(file.id)
+        )
         return file
 
-    async def test_change_name(self, file: File) -> None:
+    async def test_change_name(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.name is not None
         assert file.content_type == CONTENT_TYPE
@@ -1036,8 +1037,12 @@ class TestChangeMetadata:
         assert file_copy.name == new_filename
         assert file_copy.content_type == CONTENT_TYPE
 
-    async def test_change_content_type_and_download(self, file: File) -> None:
+    async def test_change_content_type_and_download(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.name is not None
         assert file.content_type == CONTENT_TYPE
@@ -1058,8 +1063,12 @@ class TestChangeMetadata:
         assert file_copy.name == current_filename
         assert file_copy.content_type == CONTENT_TYPE_JSON
 
-    async def test_change_content_type_and_download_and_name(self, file: File) -> None:
+    async def test_change_content_type_and_download_and_name(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.name is not None
         assert file.content_type == CONTENT_TYPE
@@ -1089,27 +1098,28 @@ class TestFrom:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    async def file(
+    def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> File:
         filename = utils.make_bogus_uuid_file()
         schedule_for_cleanup(filename)
-        file = await File(
+        file = File(
             path=filename,
             description=DESCRIPTION,
             content_type=CONTENT_TYPE,
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store_async()
-
-        schedule_for_cleanup(file.id)
+        )
         return file
 
-    async def test_from_id(self, file: File) -> None:
+    async def test_from_id(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
 
         # WHEN I get the file by id
@@ -1118,8 +1128,12 @@ class TestFrom:
         # THEN I expect the file to be returned
         assert file_copy.id == file.id
 
-    async def test_from_path(self, file: File) -> None:
+    async def test_from_path(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
 
@@ -1138,27 +1152,28 @@ class TestDelete:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    async def file(
+    def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> File:
         filename = utils.make_bogus_uuid_file()
         schedule_for_cleanup(filename)
-        file = await File(
+        file = File(
             path=filename,
             description=DESCRIPTION,
             content_type=CONTENT_TYPE,
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store_async()
-
-        schedule_for_cleanup(file.id)
+        )
         return file
 
-    async def test_delete(self, file: File) -> None:
+    async def test_delete(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
 
         # WHEN I delete the file
@@ -1169,8 +1184,12 @@ class TestDelete:
             await file.get_async()
         assert f"404 Client Error: \nEntity {file.id} is in trash can." in str(e.value)
 
-    async def test_delete_specific_version(self, file: File) -> None:
+    async def test_delete_specific_version(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.version_number == 1
 
@@ -1203,9 +1222,8 @@ class TestGet:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    async def file(
+    def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> File:
         filename = utils.make_bogus_uuid_file()
@@ -1217,13 +1235,16 @@ class TestGet:
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store()
+        )
 
-        schedule_for_cleanup(file.id)
         return file
 
-    async def test_get_by_path(self, file: File) -> None:
+    async def test_get_by_path(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
 
@@ -1233,8 +1254,12 @@ class TestGet:
         # THEN I expect the file to be returned
         assert file_copy.id == file.id
 
-    async def test_get_by_id(self, file: File) -> None:
+    async def test_get_by_id(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
         path_for_file = file.path
@@ -1246,8 +1271,12 @@ class TestGet:
         assert file_copy.id == file.id
         assert file_copy.path == path_for_file
 
-    async def test_get_previous_version(self, file: File) -> None:
+    async def test_get_previous_version(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.version_number == 1
 
@@ -1261,8 +1290,12 @@ class TestGet:
         assert file_copy.id == file.id
         assert file_copy.version_number == 1
 
-    async def test_get_keep_both_for_matching_filenames(self, file: File) -> None:
+    async def test_get_keep_both_for_matching_filenames(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
         assert file.name is not None
@@ -1300,8 +1333,12 @@ class TestGet:
         # AND the second file to have a different path
         assert os.path.basename(file_2.path) == f"{base_name}(1){extension}"
 
-    async def test_get_overwrite_local_for_matching_filenames(self, file: File) -> None:
+    async def test_get_overwrite_local_for_matching_filenames(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
         assert file.name is not None
@@ -1338,8 +1375,12 @@ class TestGet:
         assert file_1_md5 != file_2_md5
         assert utils.md5_for_file(file_2.path).hexdigest() == file_2_md5
 
-    async def test_get_keep_local_for_matching_filenames(self, file: File) -> None:
+    async def test_get_keep_local_for_matching_filenames(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
         assert file.name is not None
@@ -1377,8 +1418,12 @@ class TestGet:
         assert file_1_md5 != file_2_md5
         assert utils.md5_for_file(file.path).hexdigest() == file_1_md5
 
-    async def test_get_by_path_limit_search(self, file: File) -> None:
+    async def test_get_by_path_limit_search(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
 
@@ -1413,27 +1458,29 @@ class TestCopy:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    async def file(
+    def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> File:
         filename = utils.make_bogus_uuid_file()
         schedule_for_cleanup(filename)
-        file = await File(
+        file = File(
             path=filename,
             description=DESCRIPTION,
             content_type=CONTENT_TYPE,
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store_async()
+        )
 
-        schedule_for_cleanup(file.id)
         return file
 
-    async def test_copy_same_path(self, file: File) -> None:
+    async def test_copy_same_path(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
 
@@ -1450,8 +1497,12 @@ class TestCopy:
         # THEN I expect the paths to be the same file
         assert file_1.path == file_2.path
 
-    async def test_copy_annotations_and_activity(self, file: File) -> None:
+    async def test_copy_annotations_and_activity(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
 
@@ -1493,8 +1544,12 @@ class TestCopy:
         assert file_1.annotations == file_2.annotations
         assert file_1.activity == file_2.activity
 
-    async def test_copy_activity_only(self, file: File) -> None:
+    async def test_copy_activity_only(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
 
@@ -1537,8 +1592,12 @@ class TestCopy:
         assert not file_2.annotations and isinstance(file_2.annotations, dict)
         assert file_1.activity == file_2.activity
 
-    async def test_copy_with_no_activity_or_annotations(self, file: File) -> None:
+    async def test_copy_with_no_activity_or_annotations(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
 
@@ -1588,8 +1647,12 @@ class TestCopy:
         assert not file_2.annotations and isinstance(file_2.annotations, dict)
         assert file_2.activity is None
 
-    async def test_copy_previous_version(self, file: File) -> None:
+    async def test_copy_previous_version(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        await file.store_async()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
         assert file.version_number == 1

--- a/tests/integration/synapseclient/models/async/test_file_async.py
+++ b/tests/integration/synapseclient/models/async/test_file_async.py
@@ -49,7 +49,6 @@ class TestFileStore:
             version_label=str(uuid.uuid4()),
         )
 
-    @pytest.mark.asyncio
     async def test_store_in_project(self, project_model: Project, file: File) -> None:
         # GIVEN a file
         file.name = str(uuid.uuid4())
@@ -89,7 +88,6 @@ class TestFileStore:
         assert file.file_handle.key is not None
         assert file.file_handle.external_url is None
 
-    @pytest.mark.asyncio
     async def test_store_in_folder(self, project_model: Project, file: File) -> None:
         # GIVEN a file
         file.name = str(uuid.uuid4())
@@ -135,7 +133,6 @@ class TestFileStore:
         assert file.file_handle.key is not None
         assert file.file_handle.external_url is None
 
-    @pytest.mark.asyncio
     async def test_store_multiple_files(self, project_model: Project) -> None:
         # GIVEN a file
         filename = utils.make_bogus_uuid_file()
@@ -199,7 +196,6 @@ class TestFileStore:
             assert file.file_handle.key is not None
             assert file.file_handle.external_url is None
 
-    @pytest.mark.asyncio
     async def test_store_change_filename(
         self, project_model: Project, file: File
     ) -> None:
@@ -225,7 +221,6 @@ class TestFileStore:
         assert file.etag is not None
         assert before_etag != file.etag
 
-    @pytest.mark.asyncio
     async def test_store_move_file(self, project_model: Project, file: File) -> None:
         # GIVEN a file
         file.name = str(uuid.uuid4())
@@ -252,7 +247,6 @@ class TestFileStore:
         # AND the file does not have an updated ID
         assert before_file_id == file.id
 
-    @pytest.mark.asyncio
     async def test_store_same_data_file_handle_id(self, project_model: Project) -> None:
         # GIVEN a file
         filename = utils.make_bogus_uuid_file()
@@ -293,7 +287,6 @@ class TestFileStore:
             await file_2.get_async()
         ).file_handle.id
 
-    @pytest.mark.asyncio
     async def test_store_updated_file(self, project_model: Project) -> None:
         # GIVEN a file
         filename = utils.make_bogus_uuid_file()
@@ -324,7 +317,6 @@ class TestFileStore:
         assert file.file_handle.id is not None
         assert before_file_handle_id != file.file_handle.id
 
-    @pytest.mark.asyncio
     async def test_store_and_get_activity(
         self, project_model: Project, file: File
     ) -> None:
@@ -374,7 +366,6 @@ class TestFileStore:
         # THEN I expect that the activity is not returned
         assert file_copy_2.activity is None
 
-    @pytest.mark.asyncio
     async def test_store_annotations(self, project_model: Project, file: File) -> None:
         # GIVEN an annotation
         annotations_for_my_file = {
@@ -413,7 +404,6 @@ class TestFileStore:
         assert file.annotations["my_key_double"] == [1.2, 3.4, 5.6]
         assert file.annotations["my_key_long"] == [1, 2, 3]
 
-    @pytest.mark.asyncio
     async def test_setting_annotations_directly(
         self, project_model: Project, file: File
     ) -> None:
@@ -449,7 +439,6 @@ class TestFileStore:
         assert file.annotations["my_key_double"] == [1.2, 3.4, 5.6]
         assert file.annotations["my_key_long"] == [1, 2, 3]
 
-    @pytest.mark.asyncio
     async def test_removing_annotations_to_none(
         self, project_model: Project, file: File
     ) -> None:
@@ -489,7 +478,6 @@ class TestFileStore:
         file_copy = await File(id=file.id, download_file=False).get_async()
         assert not file_copy.annotations and isinstance(file_copy.annotations, dict)
 
-    @pytest.mark.asyncio
     async def test_removing_annotations_to_empty_dict(
         self, project_model: Project, file: File
     ) -> None:
@@ -529,7 +517,6 @@ class TestFileStore:
         file_copy = await File(id=file.id, download_file=False).get_async()
         assert not file_copy.annotations and isinstance(file_copy.annotations, dict)
 
-    @pytest.mark.asyncio
     async def test_store_without_upload(
         self, project_model: Project, file: File
     ) -> None:
@@ -575,7 +562,6 @@ class TestFileStore:
         assert file.file_handle.bucket_name is None
         assert file.file_handle.key is None
 
-    @pytest.mark.asyncio
     async def test_store_without_upload_non_matching_md5(
         self, project_model: Project, file: File
     ) -> None:
@@ -597,7 +583,6 @@ class TestFileStore:
             f"[{utils.md5_for_file_hex(file.path)}] for local file" in str(e.value)
         )
 
-    @pytest.mark.asyncio
     async def test_store_without_upload_non_matching_size(
         self, project_model: Project, file: File
     ) -> None:
@@ -646,7 +631,6 @@ class TestFileStore:
         assert file.file_handle.bucket_name is None
         assert file.file_handle.key is None
 
-    @pytest.mark.asyncio
     async def test_store_as_external_url(
         self, project_model: Project, file: File
     ) -> None:
@@ -697,7 +681,6 @@ class TestFileStore:
         assert file.file_handle.key is None
         assert file.file_handle.external_url == BOGUS_URL
 
-    @pytest.mark.asyncio
     async def test_store_as_external_url_with_content_size(
         self, project_model: Project, file: File
     ) -> None:
@@ -751,7 +734,6 @@ class TestFileStore:
         assert file.file_handle.key is None
         assert file.file_handle.external_url == BOGUS_URL
 
-    @pytest.mark.asyncio
     async def test_store_as_external_url_with_content_size_and_md5(
         self, project_model: Project, file: File
     ) -> None:
@@ -809,7 +791,6 @@ class TestFileStore:
         assert file.file_handle.external_url == BOGUS_URL
         assert file.file_handle.content_md5 == BOGUS_MD5
 
-    @pytest.mark.asyncio
     async def test_store_conflict_with_existing_object(
         self, project_model: Project, file: File
     ) -> None:
@@ -870,7 +851,6 @@ class TestFileStore:
             in str(e.value)
         )
 
-    @pytest.mark.asyncio
     async def test_store_force_version_no_change(
         self, project_model: Project, file: File
     ) -> None:
@@ -899,7 +879,6 @@ class TestFileStore:
         # THEN the version should not be updated
         assert file.version_number == 1
 
-    @pytest.mark.asyncio
     async def test_store_force_version_with_change(
         self, project_model: Project, file: File
     ) -> None:
@@ -930,7 +909,6 @@ class TestFileStore:
         # THEN the version should be updated
         assert file.version_number == 2
 
-    @pytest.mark.asyncio
     async def test_store_is_restricted(
         self, project_model: Project, file: File
     ) -> None:
@@ -954,7 +932,6 @@ class TestFileStore:
             # THEN I expect the file to be restricted
             assert intercepted.called
 
-    @pytest.mark.asyncio
     async def test_store_and_get_with_activity(
         self, project_model: Project, file: File
     ) -> None:
@@ -1020,25 +997,25 @@ class TestChangeMetadata:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
+    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    def file(
+    async def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> None:
         filename = utils.make_bogus_uuid_file()
         schedule_for_cleanup(filename)
-        file = File(
+        file = await File(
             path=filename,
             description=DESCRIPTION,
             content_type=CONTENT_TYPE,
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store()
+        ).store_async()
 
         schedule_for_cleanup(file.id)
         return file
 
-    @pytest.mark.asyncio
     async def test_change_name(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
@@ -1059,7 +1036,6 @@ class TestChangeMetadata:
         assert file_copy.name == new_filename
         assert file_copy.content_type == CONTENT_TYPE
 
-    @pytest.mark.asyncio
     async def test_change_content_type_and_download(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
@@ -1082,7 +1058,6 @@ class TestChangeMetadata:
         assert file_copy.name == current_filename
         assert file_copy.content_type == CONTENT_TYPE_JSON
 
-    @pytest.mark.asyncio
     async def test_change_content_type_and_download_and_name(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
@@ -1114,25 +1089,25 @@ class TestFrom:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
+    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    def file(
+    async def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> File:
         filename = utils.make_bogus_uuid_file()
         schedule_for_cleanup(filename)
-        file = File(
+        file = await File(
             path=filename,
             description=DESCRIPTION,
             content_type=CONTENT_TYPE,
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store()
+        ).store_async()
 
         schedule_for_cleanup(file.id)
         return file
 
-    @pytest.mark.asyncio
     async def test_from_id(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
@@ -1143,7 +1118,6 @@ class TestFrom:
         # THEN I expect the file to be returned
         assert file_copy.id == file.id
 
-    @pytest.mark.asyncio
     async def test_from_path(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
@@ -1164,25 +1138,25 @@ class TestDelete:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
+    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    def file(
+    async def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> File:
         filename = utils.make_bogus_uuid_file()
         schedule_for_cleanup(filename)
-        file = File(
+        file = await File(
             path=filename,
             description=DESCRIPTION,
             content_type=CONTENT_TYPE,
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store()
+        ).store_async()
 
         schedule_for_cleanup(file.id)
         return file
 
-    @pytest.mark.asyncio
     async def test_delete(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
@@ -1195,7 +1169,6 @@ class TestDelete:
             await file.get_async()
         assert f"404 Client Error: \nEntity {file.id} is in trash can." in str(e.value)
 
-    @pytest.mark.asyncio
     async def test_delete_specific_version(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
@@ -1230,8 +1203,9 @@ class TestGet:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
+    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    def file(
+    async def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> File:
         filename = utils.make_bogus_uuid_file()
@@ -1248,7 +1222,6 @@ class TestGet:
         schedule_for_cleanup(file.id)
         return file
 
-    @pytest.mark.asyncio
     async def test_get_by_path(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
@@ -1260,7 +1233,6 @@ class TestGet:
         # THEN I expect the file to be returned
         assert file_copy.id == file.id
 
-    @pytest.mark.asyncio
     async def test_get_by_id(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
@@ -1274,7 +1246,6 @@ class TestGet:
         assert file_copy.id == file.id
         assert file_copy.path == path_for_file
 
-    @pytest.mark.asyncio
     async def test_get_previous_version(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
@@ -1290,7 +1261,6 @@ class TestGet:
         assert file_copy.id == file.id
         assert file_copy.version_number == 1
 
-    @pytest.mark.asyncio
     async def test_get_keep_both_for_matching_filenames(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
@@ -1330,7 +1300,6 @@ class TestGet:
         # AND the second file to have a different path
         assert os.path.basename(file_2.path) == f"{base_name}(1){extension}"
 
-    @pytest.mark.asyncio
     async def test_get_overwrite_local_for_matching_filenames(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
@@ -1369,7 +1338,6 @@ class TestGet:
         assert file_1_md5 != file_2_md5
         assert utils.md5_for_file(file_2.path).hexdigest() == file_2_md5
 
-    @pytest.mark.asyncio
     async def test_get_keep_local_for_matching_filenames(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
@@ -1409,7 +1377,6 @@ class TestGet:
         assert file_1_md5 != file_2_md5
         assert utils.md5_for_file(file.path).hexdigest() == file_1_md5
 
-    @pytest.mark.asyncio
     async def test_get_by_path_limit_search(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
@@ -1446,25 +1413,25 @@ class TestCopy:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
+    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    def file(
+    async def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> File:
         filename = utils.make_bogus_uuid_file()
         schedule_for_cleanup(filename)
-        file = File(
+        file = await File(
             path=filename,
             description=DESCRIPTION,
             content_type=CONTENT_TYPE,
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store()
+        ).store_async()
 
         schedule_for_cleanup(file.id)
         return file
 
-    @pytest.mark.asyncio
     async def test_copy_same_path(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
@@ -1483,7 +1450,6 @@ class TestCopy:
         # THEN I expect the paths to be the same file
         assert file_1.path == file_2.path
 
-    @pytest.mark.asyncio
     async def test_copy_annotations_and_activity(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
@@ -1527,7 +1493,6 @@ class TestCopy:
         assert file_1.annotations == file_2.annotations
         assert file_1.activity == file_2.activity
 
-    @pytest.mark.asyncio
     async def test_copy_activity_only(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
@@ -1572,7 +1537,6 @@ class TestCopy:
         assert not file_2.annotations and isinstance(file_2.annotations, dict)
         assert file_1.activity == file_2.activity
 
-    @pytest.mark.asyncio
     async def test_copy_with_no_activity_or_annotations(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
@@ -1624,7 +1588,6 @@ class TestCopy:
         assert not file_2.annotations and isinstance(file_2.annotations, dict)
         assert file_2.activity is None
 
-    @pytest.mark.asyncio
     async def test_copy_previous_version(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None

--- a/tests/integration/synapseclient/models/async/test_folder_async.py
+++ b/tests/integration/synapseclient/models/async/test_folder_async.py
@@ -47,7 +47,6 @@ class TestFolderStore:
         folder = Folder(name=str(uuid.uuid4()), description=DESCRIPTION_FOLDER)
         return folder
 
-    @pytest.mark.asyncio
     async def test_store_folder(self, project_model: Project, folder: Folder) -> None:
         # GIVEN a Folder object and a Project object
 
@@ -71,7 +70,6 @@ class TestFolderStore:
             stored_folder.annotations, dict
         )
 
-    @pytest.mark.asyncio
     async def test_store_folder_with_file(
         self, project_model: Project, file: File, folder: Folder
     ) -> None:
@@ -105,7 +103,6 @@ class TestFolderStore:
         assert file.parent_id == stored_folder.id
         assert file.path is not None
 
-    @pytest.mark.asyncio
     async def test_store_folder_with_multiple_files(
         self, project_model: Project, folder: Folder
     ) -> None:
@@ -142,7 +139,6 @@ class TestFolderStore:
             assert file.parent_id == stored_folder.id
             assert file.path is not None
 
-    @pytest.mark.asyncio
     async def test_store_folder_with_multiple_files_and_folders(
         self, project_model: Project, folder: Folder
     ) -> None:
@@ -208,7 +204,6 @@ class TestFolderStore:
                 assert sub_file.parent_id == sub_folder.id
                 assert sub_file.path is not None
 
-    @pytest.mark.asyncio
     async def test_store_folder_with_annotations(
         self, project_model: Project, folder: Folder
     ) -> None:
@@ -261,7 +256,6 @@ class TestFolderGet:
         folder = Folder(name=str(uuid.uuid4()), description=DESCRIPTION_FOLDER)
         return folder
 
-    @pytest.mark.asyncio
     async def test_get_folder_by_id(
         self, project_model: Project, folder: Folder
     ) -> None:
@@ -288,7 +282,6 @@ class TestFolderGet:
         assert folder_copy.folders == []
         assert not folder_copy.annotations and isinstance(folder_copy.annotations, dict)
 
-    @pytest.mark.asyncio
     async def test_get_folder_by_name_and_parent_id_attribute(
         self, project_model: Project, folder: Folder
     ) -> None:
@@ -317,7 +310,6 @@ class TestFolderGet:
         assert folder_copy.folders == []
         assert not folder_copy.annotations and isinstance(folder_copy.annotations, dict)
 
-    @pytest.mark.asyncio
     async def test_get_folder_by_name_and_parent(
         self, project_model: Project, folder: Folder
     ) -> None:
@@ -360,7 +352,6 @@ class TestFolderDelete:
         folder = Folder(name=str(uuid.uuid4()), description=DESCRIPTION_FOLDER)
         return folder
 
-    @pytest.mark.asyncio
     async def test_delete_folder(self, project_model: Project, folder: Folder) -> None:
         # GIVEN a Folder object and a Project object
 
@@ -402,7 +393,6 @@ class TestFolderCopy:
         folder = Folder(name=str(uuid.uuid4()), description=DESCRIPTION_FOLDER)
         return folder
 
-    @pytest.mark.asyncio
     async def test_copy_folder_with_multiple_files_and_folders(
         self, project_model: Project, folder: Folder
     ) -> None:
@@ -477,7 +467,6 @@ class TestFolderCopy:
                 assert sub_file.name is not None
                 assert sub_file.parent_id == sub_folder.id
 
-    @pytest.mark.asyncio
     async def test_copy_folder_exclude_files(
         self, project_model: Project, folder: Folder
     ) -> None:
@@ -572,7 +561,6 @@ class TestFolderSyncFromSynapse:
         folder = Folder(name=str(uuid.uuid4()), description=DESCRIPTION_FOLDER)
         return folder
 
-    @pytest.mark.asyncio
     async def test_sync_from_synapse(
         self, project_model: Project, file: File, folder: Folder
     ) -> None:

--- a/tests/integration/synapseclient/models/async/test_permissions_async.py
+++ b/tests/integration/synapseclient/models/async/test_permissions_async.py
@@ -42,7 +42,6 @@ class TestAclOnProject:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    @pytest.mark.asyncio
     async def test_get_acl_default(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_default_permissions = await Project(
@@ -71,7 +70,6 @@ class TestAclOnProject:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    @pytest.mark.asyncio
     async def test_get_acl_read_only_permissions_on_entity(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_read_only_permissions = await Project(
@@ -109,7 +107,6 @@ class TestAclOnProject:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    @pytest.mark.asyncio
     async def test_get_acl_through_team_assigned_to_user(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_permissions_through_single_team = await Project(
@@ -167,7 +164,6 @@ class TestAclOnProject:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    @pytest.mark.asyncio
     async def test_get_acl_through_multiple_teams_assigned_to_user(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_permissions_through_multiple_teams = await Project(
@@ -241,7 +237,6 @@ class TestAclOnProject:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    @pytest.mark.asyncio
     async def test_get_acl_for_project_with_public_and_registered_user(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_permissions_for_public_and_authenticated_users = await Project(
@@ -314,7 +309,6 @@ class TestAclOnFolder:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    @pytest.mark.asyncio
     async def test_get_acl_default(self, project_model: Project) -> None:
         # GIVEN a folder created with default permissions of administrator
         folder_with_default_permissions = await Folder(
@@ -343,7 +337,6 @@ class TestAclOnFolder:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    @pytest.mark.asyncio
     async def test_get_acl_minimal_permissions_on_entity(
         self, project_model: Project
     ) -> None:
@@ -383,7 +376,6 @@ class TestAclOnFolder:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    @pytest.mark.asyncio
     async def test_get_acl_minimal_permissions_on_sub_folder(
         self, project_model: Project
     ) -> None:
@@ -444,7 +436,6 @@ class TestAclOnFolder:
         ]
         assert set(expected_permissions) == set(permissions_on_parent)
 
-    @pytest.mark.asyncio
     async def test_get_acl_through_team_assigned_to_user(
         self, project_model: Project
     ) -> None:
@@ -504,7 +495,6 @@ class TestAclOnFolder:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    @pytest.mark.asyncio
     async def test_get_acl_through_multiple_teams_assigned_to_user(
         self, project_model: Project
     ) -> None:
@@ -580,7 +570,6 @@ class TestAclOnFolder:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    @pytest.mark.asyncio
     async def test_get_acl_for_project_with_public_and_registered_user(
         self, project_model: Project
     ) -> None:
@@ -661,7 +650,6 @@ class TestAclOnFile:
         schedule_for_cleanup(filename)
         return File(path=filename)
 
-    @pytest.mark.asyncio
     async def test_get_acl_default(self, project_model: Project, file: File) -> None:
         # GIVEN a file created with default permissions of administrator
         file.name = str(uuid.uuid4()) + "test_get_acl_default_permissions"
@@ -689,7 +677,6 @@ class TestAclOnFile:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    @pytest.mark.asyncio
     async def test_get_acl_minimal_permissions_on_entity(
         self, project_model: Project, file: File
     ) -> None:
@@ -728,7 +715,6 @@ class TestAclOnFile:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    @pytest.mark.asyncio
     async def test_get_acl_through_team_assigned_to_user(
         self, project_model: Project, file: File
     ) -> None:
@@ -790,7 +776,6 @@ class TestAclOnFile:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    @pytest.mark.asyncio
     async def test_get_acl_through_multiple_teams_assigned_to_user(
         self, project_model: Project, file: File
     ) -> None:
@@ -867,7 +852,6 @@ class TestAclOnFile:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    @pytest.mark.asyncio
     async def test_get_acl_for_project_with_public_and_registered_user(
         self, project_model: Project, file: File
     ) -> None:
@@ -944,7 +928,6 @@ class TestAclOnTable:
         self.schedule_for_cleanup = schedule_for_cleanup
 
     @pytest.fixture(scope="function")
-    @pytest.mark.asyncio
     def table(self, project_model: Project) -> Table:
         # Creating columns for my table ======================================================
         columns = [
@@ -960,7 +943,6 @@ class TestAclOnTable:
 
         return table
 
-    @pytest.mark.asyncio
     async def test_get_acl_default(self, table: Table) -> None:
         # GIVEN a table created with default permissions of administrator
         table.name = str(uuid.uuid4()) + "test_get_acl_default_permissions"
@@ -988,7 +970,6 @@ class TestAclOnTable:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    @pytest.mark.asyncio
     async def test_get_acl_minimal_permissions_on_entity(self, table: Table) -> None:
         # GIVEN a table created with default permissions of administrator
         table.name = str(uuid.uuid4()) + "test_get_acl_read_permissions_on_project"
@@ -1025,7 +1006,6 @@ class TestAclOnTable:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    @pytest.mark.asyncio
     async def test_get_acl_through_team_assigned_to_user(self, table: Table) -> None:
         # GIVEN a table created with default permissions of administrator
         table.name = (
@@ -1083,7 +1063,6 @@ class TestAclOnTable:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    @pytest.mark.asyncio
     async def test_get_acl_through_multiple_teams_assigned_to_user(
         self, table: Table
     ) -> None:
@@ -1158,7 +1137,6 @@ class TestAclOnTable:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    @pytest.mark.asyncio
     async def test_get_acl_for_project_with_public_and_registered_user(
         self, table: Table
     ) -> None:
@@ -1237,7 +1215,6 @@ class TestPermissionsOnEntityForCaller:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    @pytest.mark.asyncio
     async def test_get_permissions_default(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_default_permissions = await Project(
@@ -1261,7 +1238,6 @@ class TestPermissionsOnEntityForCaller:
         ]
         assert set(expected_permissions) == set(permissions.access_types)
 
-    @pytest.mark.asyncio
     async def test_get_permissions_read_only_permissions_on_entity(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_read_only_permissions = await Project(
@@ -1286,7 +1262,6 @@ class TestPermissionsOnEntityForCaller:
 
         assert set(expected_permissions) == set(permissions.access_types)
 
-    @pytest.mark.asyncio
     async def test_get_permissions_through_team_assigned_to_user(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_permissions_through_single_team = await Project(
@@ -1344,7 +1319,6 @@ class TestPermissionsOnEntityForCaller:
         ]
         assert set(expected_permissions) == set(permissions.access_types)
 
-    @pytest.mark.asyncio
     async def test_get_permissions_through_multiple_teams_assigned_to_user(
         self,
     ) -> None:
@@ -1417,7 +1391,6 @@ class TestPermissionsOnEntityForCaller:
         ]
         assert set(expected_permissions) == set(permissions.access_types)
 
-    @pytest.mark.asyncio
     async def test_get_permissions_for_project_with_registered_user(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_permissions_for_authenticated_users = await Project(

--- a/tests/integration/synapseclient/models/async/test_project_async.py
+++ b/tests/integration/synapseclient/models/async/test_project_async.py
@@ -43,7 +43,6 @@ class TestProjectStore:
         project = Project(name=str(uuid.uuid4()), description=DERSCRIPTION_PROJECT)
         return project
 
-    @pytest.mark.asyncio
     async def test_store_project(self, project: Project) -> None:
         # GIVEN a Project object
 
@@ -67,7 +66,6 @@ class TestProjectStore:
             stored_project.annotations, dict
         )
 
-    @pytest.mark.asyncio
     async def test_store_project_with_file(self, file: File, project: Project) -> None:
         # GIVEN a File on the project
         project.files.append(file)
@@ -99,7 +97,6 @@ class TestProjectStore:
         assert file.parent_id == stored_project.id
         assert file.path is not None
 
-    @pytest.mark.asyncio
     async def test_store_project_with_folder_in_file_on_project_that_already_exists(
         self, file: File, project: Project
     ) -> None:
@@ -146,7 +143,6 @@ class TestProjectStore:
         assert file.parent_id == folder.id
         assert file.path is not None
 
-    @pytest.mark.asyncio
     async def test_store_project_with_multiple_files(self, project: Project) -> None:
         # GIVEN multiple files in a project
         files = []
@@ -182,7 +178,6 @@ class TestProjectStore:
             assert file.parent_id == stored_project.id
             assert file.path is not None
 
-    @pytest.mark.asyncio
     async def test_store_project_with_multiple_files_and_folders(
         self, project: Project
     ) -> None:
@@ -248,7 +243,6 @@ class TestProjectStore:
                 assert sub_file.parent_id == sub_folder.id
                 assert sub_file.path is not None
 
-    @pytest.mark.asyncio
     async def test_store_project_with_annotations(self, project: Project) -> None:
         # GIVEN a Project object and a Project object
         # AND annotations on the Project
@@ -299,7 +293,6 @@ class TestProjectGet:
         project = Project(name=str(uuid.uuid4()), description=DERSCRIPTION_PROJECT)
         return project
 
-    @pytest.mark.asyncio
     async def test_get_project_by_id(self, project: Project) -> None:
         # GIVEN a Project object
 
@@ -326,7 +319,6 @@ class TestProjectGet:
             project_copy.annotations, dict
         )
 
-    @pytest.mark.asyncio
     async def test_get_project_by_name_attribute(self, project: Project) -> None:
         # GIVEN a Project object
 
@@ -367,7 +359,6 @@ class TestProjectDelete:
         project = Project(name=str(uuid.uuid4()), description=DERSCRIPTION_PROJECT)
         return project
 
-    @pytest.mark.asyncio
     async def test_delete_project(self, project: Project) -> None:
         # GIVEN a Project object
 
@@ -410,7 +401,6 @@ class TestProjectCopy:
         project = Project(name=str(uuid.uuid4()), description=DERSCRIPTION_PROJECT)
         return project
 
-    @pytest.mark.asyncio
     async def test_copy_project_with_multiple_files_and_projects(
         self, project: Project
     ) -> None:
@@ -486,7 +476,6 @@ class TestProjectCopy:
                 assert sub_file.name is not None
                 assert sub_file.parent_id == sub_folder.id
 
-    @pytest.mark.asyncio
     async def test_copy_project_exclude_files(self, project: Project) -> None:
         # GIVEN a project to copy to
         destination_project = await Project(
@@ -579,7 +568,6 @@ class TestProjectSyncFromSynapse:
         project = Project(name=str(uuid.uuid4()), description=DERSCRIPTION_PROJECT)
         return project
 
-    @pytest.mark.asyncio
     async def test_sync_from_synapse(self, file: File, project: Project) -> None:
         root_directory_path = os.path.dirname(file.path)
 

--- a/tests/integration/synapseclient/models/async/test_team_async.py
+++ b/tests/integration/synapseclient/models/async/test_team_async.py
@@ -28,7 +28,6 @@ class TestTeam:
         self.TEST_USER = "DPETestUser2"
         self.TEST_MESSAGE = "test message"
 
-    @pytest.mark.asyncio
     async def test_create(self) -> None:
         # GIVEN a team object self.team
         # WHEN I create the team on Synapse
@@ -48,7 +47,6 @@ class TestTeam:
         # Clean up
         await test_team.delete_async()
 
-    @pytest.mark.asyncio
     async def test_delete(self) -> None:
         # GIVEN a team object self.team
         # WHEN I create the team on Synapse
@@ -62,7 +60,6 @@ class TestTeam:
         ):
             await Team.from_id_async(id=test_team.id)
 
-    @pytest.mark.asyncio
     async def test_get_with_id(self) -> None:
         # GIVEN a team created in Synapse
         synapse_team = await self.team.create_async()
@@ -83,7 +80,6 @@ class TestTeam:
         # Clean up
         await synapse_team.delete_async()
 
-    @pytest.mark.asyncio
     async def test_get_with_name(self) -> None:
         # GIVEN a team created in Synapse
         synapse_team = await self.team.create_async()
@@ -106,7 +102,6 @@ class TestTeam:
         # Clean up
         await synapse_team.delete_async()
 
-    @pytest.mark.asyncio
     async def test_from_id(self) -> None:
         # GIVEN a team object self.team
         # WHEN I create the team on Synapse
@@ -125,7 +120,6 @@ class TestTeam:
         # Clean up
         await test_team.delete_async()
 
-    @pytest.mark.asyncio
     async def test_from_name(self) -> None:
         # GIVEN a team object self.team
         # WHEN I create the team on Synapse
@@ -148,7 +142,6 @@ class TestTeam:
         # Clean up
         await test_team.delete_async()
 
-    @pytest.mark.asyncio
     async def test_members(self) -> None:
         # GIVEN a team object self.team
         # WHEN I create the team on Synapse
@@ -162,7 +155,6 @@ class TestTeam:
         # Clean up
         await test_team.delete_async()
 
-    @pytest.mark.asyncio
     async def test_invite(self) -> None:
         # GIVEN a team object self.team
         # WHEN I create the team on Synapse
@@ -183,7 +175,6 @@ class TestTeam:
         # Clean up
         await test_team.delete_async()
 
-    @pytest.mark.asyncio
     async def test_open_invitations(self) -> None:
         # GIVEN a team object self.team
         # WHEN I create the team on Synapse

--- a/tests/integration/synapseclient/models/async/test_user_async.py
+++ b/tests/integration/synapseclient/models/async/test_user_async.py
@@ -17,7 +17,6 @@ class TestUser:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    @pytest.mark.asyncio
     async def test_from_id(self) -> None:
         # GIVEN our test profile
         integration_test_profile = await UserProfile().get_async()
@@ -28,7 +27,6 @@ class TestUser:
         # THEN we expect the profile to be the same as the one we got from the fixture
         assert profile == integration_test_profile
 
-    @pytest.mark.asyncio
     async def test_from_username(self) -> None:
         # GIVEN our test profile
         integration_test_profile = await UserProfile().get_async()
@@ -41,7 +39,6 @@ class TestUser:
         # THEN we expect the profile to be the same as the one we got from the fixture
         assert profile == integration_test_profile
 
-    @pytest.mark.asyncio
     async def test_is_certified_id(self) -> None:
         # GIVEN out test profile
         integration_test_profile = await UserProfile().get_async()
@@ -55,7 +52,6 @@ class TestUser:
         # THEN we expect the profile to not be certified
         assert is_certified is False
 
-    @pytest.mark.asyncio
     async def test_is_certified_username(self) -> None:
         # GIVEN out test profile
         integration_test_profile = await UserProfile().get_async()

--- a/tests/integration/synapseclient/models/synchronous/test_activity.py
+++ b/tests/integration/synapseclient/models/synchronous/test_activity.py
@@ -21,7 +21,7 @@ class TestActivity:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    def test_store_with_parent_and_id(self, project: Synapse_Project) -> None:
+    async def test_store_with_parent_and_id(self, project: Synapse_Project) -> None:
         # GIVEN a file in a project
         path = utils.make_bogus_uuid_file()
         file = File(
@@ -98,7 +98,7 @@ class TestActivity:
         # Clean up
         result.delete(parent=file)
 
-    def test_store_with_no_references(self, project: Synapse_Project) -> None:
+    async def test_store_with_no_references(self, project: Synapse_Project) -> None:
         # GIVEN a file in a project that has an activity with no references
         activity = Activity(
             name="some_name",
@@ -132,7 +132,7 @@ class TestActivity:
         # Clean up
         file.activity.delete(parent=file)
 
-    def test_from_parent(self, project: Synapse_Project) -> None:
+    async def test_from_parent(self, project: Synapse_Project) -> None:
         # GIVEN a file in a project that has an activity
         activity = Activity(
             name="some_name",
@@ -182,7 +182,7 @@ class TestActivity:
         # Clean up
         result.delete(parent=file)
 
-    def test_delete(self, project: Synapse_Project) -> None:
+    async def test_delete(self, project: Synapse_Project) -> None:
         # GIVEN a file in a project that has an activity
         activity = Activity(
             name="some_name",

--- a/tests/integration/synapseclient/models/synchronous/test_file.py
+++ b/tests/integration/synapseclient/models/synchronous/test_file.py
@@ -1,7 +1,6 @@
 """Integration tests for the synapseclient.models.File class."""
 
 import os
-import time
 from unittest.mock import patch
 import uuid
 
@@ -987,27 +986,28 @@ class TestChangeMetadata:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    async def file(
+    def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> None:
         filename = utils.make_bogus_uuid_file()
         schedule_for_cleanup(filename)
-        file = await File(
+        file = File(
             path=filename,
             description=DESCRIPTION,
             content_type=CONTENT_TYPE,
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store_async()
-
-        schedule_for_cleanup(file.id)
+        )
         return file
 
-    async def test_change_name(self, file: File) -> None:
+    async def test_change_name(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.name is not None
         assert file.content_type == CONTENT_TYPE
@@ -1026,8 +1026,12 @@ class TestChangeMetadata:
         assert file_copy.name == new_filename
         assert file_copy.content_type == CONTENT_TYPE
 
-    async def test_change_content_type_and_download(self, file: File) -> None:
+    async def test_change_content_type_and_download(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.name is not None
         assert file.content_type == CONTENT_TYPE
@@ -1046,8 +1050,12 @@ class TestChangeMetadata:
         assert file_copy.name == current_filename
         assert file_copy.content_type == CONTENT_TYPE_JSON
 
-    async def test_change_content_type_and_download_and_name(self, file: File) -> None:
+    async def test_change_content_type_and_download_and_name(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.name is not None
         assert file.content_type == CONTENT_TYPE
@@ -1077,27 +1085,28 @@ class TestFrom:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    async def file(
+    def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> File:
         filename = utils.make_bogus_uuid_file()
         schedule_for_cleanup(filename)
-        file = await File(
+        file = File(
             path=filename,
             description=DESCRIPTION,
             content_type=CONTENT_TYPE,
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store_async()
-
-        schedule_for_cleanup(file.id)
+        )
         return file
 
-    async def test_from_id(self, file: File) -> None:
+    async def test_from_id(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
 
         # WHEN I get the file by id
@@ -1106,8 +1115,12 @@ class TestFrom:
         # THEN I expect the file to be returned
         assert file_copy.id == file.id
 
-    async def test_from_path(self, file: File) -> None:
+    async def test_from_path(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
 
@@ -1126,27 +1139,28 @@ class TestDelete:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    async def file(
+    def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> File:
         filename = utils.make_bogus_uuid_file()
         schedule_for_cleanup(filename)
-        file = await File(
+        file = File(
             path=filename,
             description=DESCRIPTION,
             content_type=CONTENT_TYPE,
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store_async()
-
-        schedule_for_cleanup(file.id)
+        )
         return file
 
-    async def test_delete(self, file: File) -> None:
+    async def test_delete(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
 
         # WHEN I delete the file
@@ -1157,8 +1171,12 @@ class TestDelete:
             file.get()
         assert f"404 Client Error: \nEntity {file.id} is in trash can." in str(e.value)
 
-    async def test_delete_specific_version(self, file: File) -> None:
+    async def test_delete_specific_version(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.version_number == 1
 
@@ -1191,27 +1209,29 @@ class TestGet:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    async def file(
+    def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> File:
         filename = utils.make_bogus_uuid_file()
         schedule_for_cleanup(filename)
-        file = await File(
+        file = File(
             path=filename,
             description=DESCRIPTION,
             content_type=CONTENT_TYPE,
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store_async()
+        )
 
-        schedule_for_cleanup(file.id)
         return file
 
-    async def test_get_by_path(self, file: File) -> None:
+    async def test_get_by_path(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
 
@@ -1221,8 +1241,12 @@ class TestGet:
         # THEN I expect the file to be returned
         assert file_copy.id == file.id
 
-    async def test_get_by_id(self, file: File) -> None:
+    async def test_get_by_id(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
         path_for_file = file.path
@@ -1234,8 +1258,12 @@ class TestGet:
         assert file_copy.id == file.id
         assert file_copy.path == path_for_file
 
-    async def test_get_previous_version(self, file: File) -> None:
+    async def test_get_previous_version(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.version_number == 1
 
@@ -1249,8 +1277,12 @@ class TestGet:
         assert file_copy.id == file.id
         assert file_copy.version_number == 1
 
-    async def test_get_keep_both_for_matching_filenames(self, file: File) -> None:
+    async def test_get_keep_both_for_matching_filenames(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
         assert file.name is not None
@@ -1286,8 +1318,12 @@ class TestGet:
         # AND the second file to have a different path
         assert os.path.basename(file_2.path) == f"{base_name}(1){extension}"
 
-    async def test_get_overwrite_local_for_matching_filenames(self, file: File) -> None:
+    async def test_get_overwrite_local_for_matching_filenames(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
         assert file.name is not None
@@ -1324,8 +1360,12 @@ class TestGet:
         assert file_1_md5 != file_2_md5
         assert utils.md5_for_file(file_2.path).hexdigest() == file_2_md5
 
-    async def test_get_keep_local_for_matching_filenames(self, file: File) -> None:
+    async def test_get_keep_local_for_matching_filenames(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
         assert file.name is not None
@@ -1363,8 +1403,12 @@ class TestGet:
         assert file_1_md5 != file_2_md5
         assert utils.md5_for_file(file.path).hexdigest() == file_1_md5
 
-    async def test_get_by_path_limit_search(self, file: File) -> None:
+    async def test_get_by_path_limit_search(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
 
@@ -1399,27 +1443,29 @@ class TestCopy:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    async def file(
+    def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> File:
         filename = utils.make_bogus_uuid_file()
         schedule_for_cleanup(filename)
-        file = await File(
+        file = File(
             path=filename,
             description=DESCRIPTION,
             content_type=CONTENT_TYPE,
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store_async()
+        )
 
-        schedule_for_cleanup(file.id)
         return file
 
-    async def test_copy_same_path(self, file: File) -> None:
+    async def test_copy_same_path(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
 
@@ -1436,8 +1482,12 @@ class TestCopy:
         # THEN I expect the paths to be the same file
         assert file_1.path == file_2.path
 
-    async def test_copy_annotations_and_activity(self, file: File) -> None:
+    async def test_copy_annotations_and_activity(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
 
@@ -1479,8 +1529,12 @@ class TestCopy:
         assert file_1.annotations == file_2.annotations
         assert file_1.activity == file_2.activity
 
-    async def test_copy_activity_only(self, file: File) -> None:
+    async def test_copy_activity_only(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
 
@@ -1523,8 +1577,12 @@ class TestCopy:
         assert not file_2.annotations and isinstance(file_2.annotations, dict)
         assert file_1.activity == file_2.activity
 
-    async def test_copy_with_no_activity_or_annotations(self, file: File) -> None:
+    async def test_copy_with_no_activity_or_annotations(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
 
@@ -1570,8 +1628,12 @@ class TestCopy:
         assert not file_2.annotations and isinstance(file_2.annotations, dict)
         assert file_2.activity is None
 
-    async def test_copy_previous_version(self, file: File) -> None:
+    async def test_copy_previous_version(
+        self, file: File, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
         # GIVEN a file stored in synapse
+        file.store()
+        schedule_for_cleanup(file.id)
         assert file.id is not None
         assert file.path is not None
         assert file.version_number == 1

--- a/tests/integration/synapseclient/models/synchronous/test_file.py
+++ b/tests/integration/synapseclient/models/synchronous/test_file.py
@@ -49,7 +49,7 @@ class TestFileStore:
             version_label=str(uuid.uuid4()),
         )
 
-    def test_store_in_project(self, project_model: Project, file: File) -> None:
+    async def test_store_in_project(self, project_model: Project, file: File) -> None:
         # GIVEN a file
         file.name = str(uuid.uuid4())
 
@@ -88,7 +88,7 @@ class TestFileStore:
         assert file.file_handle.key is not None
         assert file.file_handle.external_url is None
 
-    def test_store_in_folder(self, project_model: Project, file: File) -> None:
+    async def test_store_in_folder(self, project_model: Project, file: File) -> None:
         # GIVEN a file
         file.name = str(uuid.uuid4())
 
@@ -131,7 +131,7 @@ class TestFileStore:
         assert file.file_handle.key is not None
         assert file.file_handle.external_url is None
 
-    def test_store_multiple_files(self, project_model: Project) -> None:
+    async def test_store_multiple_files(self, project_model: Project) -> None:
         # GIVEN a file
         filename = utils.make_bogus_uuid_file()
         self.schedule_for_cleanup(filename)
@@ -192,7 +192,9 @@ class TestFileStore:
             assert file.file_handle.key is not None
             assert file.file_handle.external_url is None
 
-    def test_store_change_filename(self, project_model: Project, file: File) -> None:
+    async def test_store_change_filename(
+        self, project_model: Project, file: File
+    ) -> None:
         # GIVEN a file
         file.name = str(uuid.uuid4())
         file.parent_id = project_model.id
@@ -215,7 +217,7 @@ class TestFileStore:
         assert file.etag is not None
         assert before_etag != file.etag
 
-    def test_store_move_file(self, project_model: Project, file: File) -> None:
+    async def test_store_move_file(self, project_model: Project, file: File) -> None:
         # GIVEN a file
         file.name = str(uuid.uuid4())
         file.parent_id = project_model.id
@@ -239,7 +241,7 @@ class TestFileStore:
         # AND the file does not have an updated ID
         assert before_file_id == file.id
 
-    def test_store_same_data_file_handle_id(self, project_model: Project) -> None:
+    async def test_store_same_data_file_handle_id(self, project_model: Project) -> None:
         # GIVEN a file
         filename = utils.make_bogus_uuid_file()
         self.schedule_for_cleanup(filename)
@@ -277,7 +279,7 @@ class TestFileStore:
         # created. To handle for this I am just confirming the IDs match
         assert (file_1.get()).file_handle.id == (file_2.get()).file_handle.id
 
-    def test_store_updated_file(self, project_model: Project) -> None:
+    async def test_store_updated_file(self, project_model: Project) -> None:
         # GIVEN a file
         filename = utils.make_bogus_uuid_file()
         self.schedule_for_cleanup(filename)
@@ -307,7 +309,9 @@ class TestFileStore:
         assert file.file_handle.id is not None
         assert before_file_handle_id != file.file_handle.id
 
-    def test_store_and_get_activity(self, project_model: Project, file: File) -> None:
+    async def test_store_and_get_activity(
+        self, project_model: Project, file: File
+    ) -> None:
         # GIVEN an activity
         activity = Activity(
             name="some_name",
@@ -352,7 +356,7 @@ class TestFileStore:
         # THEN I expect that the activity is not returned
         assert file_copy_2.activity is None
 
-    def test_store_annotations(self, project_model: Project, file: File) -> None:
+    async def test_store_annotations(self, project_model: Project, file: File) -> None:
         # GIVEN an annotation
         annotations_for_my_file = {
             "my_single_key_string": "a",
@@ -390,7 +394,7 @@ class TestFileStore:
         assert file.annotations["my_key_double"] == [1.2, 3.4, 5.6]
         assert file.annotations["my_key_long"] == [1, 2, 3]
 
-    def test_setting_annotations_directly(
+    async def test_setting_annotations_directly(
         self, project_model: Project, file: File
     ) -> None:
         # GIVEN a file with the annotation
@@ -425,7 +429,7 @@ class TestFileStore:
         assert file.annotations["my_key_double"] == [1.2, 3.4, 5.6]
         assert file.annotations["my_key_long"] == [1, 2, 3]
 
-    def test_removing_annotations_to_none(
+    async def test_removing_annotations_to_none(
         self, project_model: Project, file: File
     ) -> None:
         # GIVEN an annotation
@@ -464,7 +468,7 @@ class TestFileStore:
         file_copy = File(id=file.id, download_file=False).get()
         assert not file_copy.annotations and isinstance(file_copy.annotations, dict)
 
-    def test_removing_annotations_to_empty_dict(
+    async def test_removing_annotations_to_empty_dict(
         self, project_model: Project, file: File
     ) -> None:
         # GIVEN an annotation
@@ -503,7 +507,9 @@ class TestFileStore:
         file_copy = File(id=file.id, download_file=False).get()
         assert not file_copy.annotations and isinstance(file_copy.annotations, dict)
 
-    def test_store_without_upload(self, project_model: Project, file: File) -> None:
+    async def test_store_without_upload(
+        self, project_model: Project, file: File
+    ) -> None:
         # GIVEN a file
         file.name = str(uuid.uuid4())
 
@@ -546,7 +552,7 @@ class TestFileStore:
         assert file.file_handle.bucket_name is None
         assert file.file_handle.key is None
 
-    def test_store_without_upload_non_matching_md5(
+    async def test_store_without_upload_non_matching_md5(
         self, project_model: Project, file: File
     ) -> None:
         # GIVEN a file
@@ -567,7 +573,7 @@ class TestFileStore:
             f"[{utils.md5_for_file_hex(file.path)}] for local file" in str(e.value)
         )
 
-    def test_store_without_upload_non_matching_size(
+    async def test_store_without_upload_non_matching_size(
         self, project_model: Project, file: File
     ) -> None:
         # GIVEN a file
@@ -615,7 +621,9 @@ class TestFileStore:
         assert file.file_handle.bucket_name is None
         assert file.file_handle.key is None
 
-    def test_store_as_external_url(self, project_model: Project, file: File) -> None:
+    async def test_store_as_external_url(
+        self, project_model: Project, file: File
+    ) -> None:
         # GIVEN a file
         file.name = str(uuid.uuid4())
 
@@ -663,7 +671,7 @@ class TestFileStore:
         assert file.file_handle.key is None
         assert file.file_handle.external_url == BOGUS_URL
 
-    def test_store_as_external_url_with_content_size(
+    async def test_store_as_external_url_with_content_size(
         self, project_model: Project, file: File
     ) -> None:
         # GIVEN a file
@@ -716,7 +724,7 @@ class TestFileStore:
         assert file.file_handle.key is None
         assert file.file_handle.external_url == BOGUS_URL
 
-    def test_store_as_external_url_with_content_size_and_md5(
+    async def test_store_as_external_url_with_content_size_and_md5(
         self, project_model: Project, file: File
     ) -> None:
         # GIVEN a file
@@ -773,7 +781,7 @@ class TestFileStore:
         assert file.file_handle.external_url == BOGUS_URL
         assert file.file_handle.content_md5 == BOGUS_MD5
 
-    def test_store_conflict_with_existing_object(
+    async def test_store_conflict_with_existing_object(
         self, project_model: Project, file: File
     ) -> None:
         # GIVEN a file
@@ -833,7 +841,7 @@ class TestFileStore:
             in str(e.value)
         )
 
-    def test_store_force_version_no_change(
+    async def test_store_force_version_no_change(
         self, project_model: Project, file: File
     ) -> None:
         # GIVEN a file
@@ -861,7 +869,7 @@ class TestFileStore:
         # THEN the version should not be updated
         assert file.version_number == 1
 
-    def test_store_force_version_with_change(
+    async def test_store_force_version_with_change(
         self, project_model: Project, file: File
     ) -> None:
         # GIVEN a file
@@ -891,7 +899,9 @@ class TestFileStore:
         # THEN the version should be updated
         assert file.version_number == 2
 
-    def test_store_is_restricted(self, project_model: Project, file: File) -> None:
+    async def test_store_is_restricted(
+        self, project_model: Project, file: File
+    ) -> None:
         """Tests that setting is_restricted is calling the correct Synapse method. We are
         not testing the actual behavior of the method, only that it is called with the
         correct arguments. We do not want to actually restrict the file in Synapse as it
@@ -912,7 +922,7 @@ class TestFileStore:
             # THEN I expect the file to be restricted
             assert intercepted.called
 
-    def test_store_and_get_with_activity(
+    async def test_store_and_get_with_activity(
         self, project_model: Project, file: File
     ) -> None:
         # GIVEN a file
@@ -977,25 +987,26 @@ class TestChangeMetadata:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
+    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    def file(
+    async def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> None:
         filename = utils.make_bogus_uuid_file()
         schedule_for_cleanup(filename)
-        file = File(
+        file = await File(
             path=filename,
             description=DESCRIPTION,
             content_type=CONTENT_TYPE,
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store()
+        ).store_async()
 
         schedule_for_cleanup(file.id)
         return file
 
-    def test_change_name(self, file: File) -> None:
+    async def test_change_name(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
         assert file.name is not None
@@ -1015,7 +1026,7 @@ class TestChangeMetadata:
         assert file_copy.name == new_filename
         assert file_copy.content_type == CONTENT_TYPE
 
-    def test_change_content_type_and_download(self, file: File) -> None:
+    async def test_change_content_type_and_download(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
         assert file.name is not None
@@ -1035,7 +1046,7 @@ class TestChangeMetadata:
         assert file_copy.name == current_filename
         assert file_copy.content_type == CONTENT_TYPE_JSON
 
-    def test_change_content_type_and_download_and_name(self, file: File) -> None:
+    async def test_change_content_type_and_download_and_name(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
         assert file.name is not None
@@ -1066,25 +1077,26 @@ class TestFrom:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
+    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    def file(
+    async def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> File:
         filename = utils.make_bogus_uuid_file()
         schedule_for_cleanup(filename)
-        file = File(
+        file = await File(
             path=filename,
             description=DESCRIPTION,
             content_type=CONTENT_TYPE,
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store()
+        ).store_async()
 
         schedule_for_cleanup(file.id)
         return file
 
-    def test_from_id(self, file: File) -> None:
+    async def test_from_id(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
 
@@ -1094,7 +1106,7 @@ class TestFrom:
         # THEN I expect the file to be returned
         assert file_copy.id == file.id
 
-    def test_from_path(self, file: File) -> None:
+    async def test_from_path(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
         assert file.path is not None
@@ -1114,25 +1126,26 @@ class TestDelete:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
+    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    def file(
+    async def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> File:
         filename = utils.make_bogus_uuid_file()
         schedule_for_cleanup(filename)
-        file = File(
+        file = await File(
             path=filename,
             description=DESCRIPTION,
             content_type=CONTENT_TYPE,
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store()
+        ).store_async()
 
         schedule_for_cleanup(file.id)
         return file
 
-    def test_delete(self, file: File) -> None:
+    async def test_delete(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
 
@@ -1144,7 +1157,7 @@ class TestDelete:
             file.get()
         assert f"404 Client Error: \nEntity {file.id} is in trash can." in str(e.value)
 
-    def test_delete_specific_version(self, file: File) -> None:
+    async def test_delete_specific_version(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
         assert file.version_number == 1
@@ -1178,25 +1191,26 @@ class TestGet:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
+    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    def file(
+    async def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> File:
         filename = utils.make_bogus_uuid_file()
         schedule_for_cleanup(filename)
-        file = File(
+        file = await File(
             path=filename,
             description=DESCRIPTION,
             content_type=CONTENT_TYPE,
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store()
+        ).store_async()
 
         schedule_for_cleanup(file.id)
         return file
 
-    def test_get_by_path(self, file: File) -> None:
+    async def test_get_by_path(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
         assert file.path is not None
@@ -1207,7 +1221,7 @@ class TestGet:
         # THEN I expect the file to be returned
         assert file_copy.id == file.id
 
-    def test_get_by_id(self, file: File) -> None:
+    async def test_get_by_id(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
         assert file.path is not None
@@ -1220,7 +1234,7 @@ class TestGet:
         assert file_copy.id == file.id
         assert file_copy.path == path_for_file
 
-    def test_get_previous_version(self, file: File) -> None:
+    async def test_get_previous_version(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
         assert file.version_number == 1
@@ -1235,7 +1249,7 @@ class TestGet:
         assert file_copy.id == file.id
         assert file_copy.version_number == 1
 
-    def test_get_keep_both_for_matching_filenames(self, file: File) -> None:
+    async def test_get_keep_both_for_matching_filenames(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
         assert file.path is not None
@@ -1272,7 +1286,7 @@ class TestGet:
         # AND the second file to have a different path
         assert os.path.basename(file_2.path) == f"{base_name}(1){extension}"
 
-    def test_get_overwrite_local_for_matching_filenames(self, file: File) -> None:
+    async def test_get_overwrite_local_for_matching_filenames(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
         assert file.path is not None
@@ -1310,7 +1324,7 @@ class TestGet:
         assert file_1_md5 != file_2_md5
         assert utils.md5_for_file(file_2.path).hexdigest() == file_2_md5
 
-    def test_get_keep_local_for_matching_filenames(self, file: File) -> None:
+    async def test_get_keep_local_for_matching_filenames(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
         assert file.path is not None
@@ -1349,7 +1363,7 @@ class TestGet:
         assert file_1_md5 != file_2_md5
         assert utils.md5_for_file(file.path).hexdigest() == file_1_md5
 
-    def test_get_by_path_limit_search(self, file: File) -> None:
+    async def test_get_by_path_limit_search(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
         assert file.path is not None
@@ -1385,25 +1399,26 @@ class TestCopy:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
+    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True, scope="function")
-    def file(
+    async def file(
         self, schedule_for_cleanup: Callable[..., None], project_model: Project
     ) -> File:
         filename = utils.make_bogus_uuid_file()
         schedule_for_cleanup(filename)
-        file = File(
+        file = await File(
             path=filename,
             description=DESCRIPTION,
             content_type=CONTENT_TYPE,
             version_comment=VERSION_COMMENT,
             version_label=str(uuid.uuid4()),
             parent_id=project_model.id,
-        ).store()
+        ).store_async()
 
         schedule_for_cleanup(file.id)
         return file
 
-    def test_copy_same_path(self, file: File) -> None:
+    async def test_copy_same_path(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
         assert file.path is not None
@@ -1421,7 +1436,7 @@ class TestCopy:
         # THEN I expect the paths to be the same file
         assert file_1.path == file_2.path
 
-    def test_copy_annotations_and_activity(self, file: File) -> None:
+    async def test_copy_annotations_and_activity(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
         assert file.path is not None
@@ -1464,7 +1479,7 @@ class TestCopy:
         assert file_1.annotations == file_2.annotations
         assert file_1.activity == file_2.activity
 
-    def test_copy_activity_only(self, file: File) -> None:
+    async def test_copy_activity_only(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
         assert file.path is not None
@@ -1508,7 +1523,7 @@ class TestCopy:
         assert not file_2.annotations and isinstance(file_2.annotations, dict)
         assert file_1.activity == file_2.activity
 
-    def test_copy_with_no_activity_or_annotations(self, file: File) -> None:
+    async def test_copy_with_no_activity_or_annotations(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
         assert file.path is not None
@@ -1555,7 +1570,7 @@ class TestCopy:
         assert not file_2.annotations and isinstance(file_2.annotations, dict)
         assert file_2.activity is None
 
-    def test_copy_previous_version(self, file: File) -> None:
+    async def test_copy_previous_version(self, file: File) -> None:
         # GIVEN a file stored in synapse
         assert file.id is not None
         assert file.path is not None

--- a/tests/integration/synapseclient/models/synchronous/test_folder.py
+++ b/tests/integration/synapseclient/models/synchronous/test_folder.py
@@ -47,7 +47,7 @@ class TestFolderStore:
         folder = Folder(name=str(uuid.uuid4()), description=DESCRIPTION_FOLDER)
         return folder
 
-    def test_store_folder(self, project_model: Project, folder: Folder) -> None:
+    async def test_store_folder(self, project_model: Project, folder: Folder) -> None:
         # GIVEN a Folder object and a Project object
 
         # WHEN I store the Folder on Synapse
@@ -70,7 +70,7 @@ class TestFolderStore:
             stored_folder.annotations, dict
         )
 
-    def test_store_folder_with_file(
+    async def test_store_folder_with_file(
         self, project_model: Project, file: File, folder: Folder
     ) -> None:
         # GIVEN a File on the folder
@@ -103,7 +103,7 @@ class TestFolderStore:
         assert file.parent_id == stored_folder.id
         assert file.path is not None
 
-    def test_store_folder_with_multiple_files(
+    async def test_store_folder_with_multiple_files(
         self, project_model: Project, folder: Folder
     ) -> None:
         # GIVEN multiple files in a folder
@@ -140,7 +140,7 @@ class TestFolderStore:
             assert file.parent_id == stored_folder.id
             assert file.path is not None
 
-    def test_store_folder_with_multiple_files_and_folders(
+    async def test_store_folder_with_multiple_files_and_folders(
         self, project_model: Project, folder: Folder
     ) -> None:
         # GIVEN multiple files in a folder
@@ -205,7 +205,7 @@ class TestFolderStore:
                 assert sub_file.parent_id == sub_folder.id
                 assert sub_file.path is not None
 
-    def test_store_folder_with_annotations(
+    async def test_store_folder_with_annotations(
         self, project_model: Project, folder: Folder
     ) -> None:
         # GIVEN a Folder object and a Project object
@@ -255,7 +255,9 @@ class TestFolderGet:
         folder = Folder(name=str(uuid.uuid4()), description=DESCRIPTION_FOLDER)
         return folder
 
-    def test_get_folder_by_id(self, project_model: Project, folder: Folder) -> None:
+    async def test_get_folder_by_id(
+        self, project_model: Project, folder: Folder
+    ) -> None:
         # GIVEN a Folder object and a Project object
 
         # AND the folder is stored in synapse
@@ -279,7 +281,7 @@ class TestFolderGet:
         assert folder_copy.folders == []
         assert not folder_copy.annotations and isinstance(folder_copy.annotations, dict)
 
-    def test_get_folder_by_name_and_parent_id_attribute(
+    async def test_get_folder_by_name_and_parent_id_attribute(
         self, project_model: Project, folder: Folder
     ) -> None:
         # GIVEN a Folder object and a Project object
@@ -307,7 +309,7 @@ class TestFolderGet:
         assert folder_copy.folders == []
         assert not folder_copy.annotations and isinstance(folder_copy.annotations, dict)
 
-    def test_get_folder_by_name_and_parent(
+    async def test_get_folder_by_name_and_parent(
         self, project_model: Project, folder: Folder
     ) -> None:
         # GIVEN a Folder object and a Project object
@@ -347,7 +349,7 @@ class TestFolderDelete:
         folder = Folder(name=str(uuid.uuid4()), description=DESCRIPTION_FOLDER)
         return folder
 
-    def test_delete_folder(self, project_model: Project, folder: Folder) -> None:
+    async def test_delete_folder(self, project_model: Project, folder: Folder) -> None:
         # GIVEN a Folder object and a Project object
 
         # AND the folder is stored in synapse
@@ -388,7 +390,7 @@ class TestFolderCopy:
         folder = Folder(name=str(uuid.uuid4()), description=DESCRIPTION_FOLDER)
         return folder
 
-    def test_copy_folder_with_multiple_files_and_folders(
+    async def test_copy_folder_with_multiple_files_and_folders(
         self, project_model: Project, folder: Folder
     ) -> None:
         # GIVEN a folder to copy to
@@ -460,7 +462,7 @@ class TestFolderCopy:
                 assert sub_file.name is not None
                 assert sub_file.parent_id == sub_folder.id
 
-    def test_copy_folder_exclude_files(
+    async def test_copy_folder_exclude_files(
         self, project_model: Project, folder: Folder
     ) -> None:
         # GIVEN a folder to copy to
@@ -552,7 +554,7 @@ class TestFolderSyncFromSynapse:
         folder = Folder(name=str(uuid.uuid4()), description=DESCRIPTION_FOLDER)
         return folder
 
-    def test_sync_from_synapse(
+    async def test_sync_from_synapse(
         self, project_model: Project, file: File, folder: Folder
     ) -> None:
         root_directory_path = os.path.dirname(file.path)

--- a/tests/integration/synapseclient/models/synchronous/test_permissions.py
+++ b/tests/integration/synapseclient/models/synchronous/test_permissions.py
@@ -42,7 +42,7 @@ class TestAclOnProject:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    def test_get_acl_default(self) -> None:
+    async def test_get_acl_default(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_default_permissions = Project(
             name=str(uuid.uuid4()) + "test_get_acl_default_permissions"
@@ -68,7 +68,7 @@ class TestAclOnProject:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_read_only_permissions_on_entity(self) -> None:
+    async def test_get_acl_read_only_permissions_on_entity(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_read_only_permissions = Project(
             name=str(uuid.uuid4()) + "test_get_acl_read_permissions_on_project"
@@ -103,7 +103,7 @@ class TestAclOnProject:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_through_team_assigned_to_user(self) -> None:
+    async def test_get_acl_through_team_assigned_to_user(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_permissions_through_single_team = Project(
             name=str(uuid.uuid4())
@@ -160,7 +160,7 @@ class TestAclOnProject:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_through_multiple_teams_assigned_to_user(self) -> None:
+    async def test_get_acl_through_multiple_teams_assigned_to_user(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_permissions_through_multiple_teams = Project(
             name=str(uuid.uuid4())
@@ -231,7 +231,7 @@ class TestAclOnProject:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_for_project_with_public_and_registered_user(self) -> None:
+    async def test_get_acl_for_project_with_public_and_registered_user(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_permissions_for_public_and_authenticated_users = Project(
             name=str(uuid.uuid4()) + "test_get_acl_for_project_with_registered_user"
@@ -305,7 +305,7 @@ class TestAclOnFolder:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    def test_get_acl_default(self, project_model: Project) -> None:
+    async def test_get_acl_default(self, project_model: Project) -> None:
         # GIVEN a folder created with default permissions of administrator
         folder_with_default_permissions = Folder(
             name=str(uuid.uuid4()) + "test_get_acl_default_permissions",
@@ -331,7 +331,7 @@ class TestAclOnFolder:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_minimal_permissions_on_entity(
+    async def test_get_acl_minimal_permissions_on_entity(
         self, project_model: Project
     ) -> None:
         # GIVEN a folder created with default permissions of administrator
@@ -368,7 +368,7 @@ class TestAclOnFolder:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_minimal_permissions_on_sub_folder(
+    async def test_get_acl_minimal_permissions_on_sub_folder(
         self, project_model: Project
     ) -> None:
         # GIVEN a parent folder with default permissions
@@ -426,7 +426,7 @@ class TestAclOnFolder:
         ]
         assert set(expected_permissions) == set(permissions_on_parent)
 
-    def test_get_acl_through_team_assigned_to_user(
+    async def test_get_acl_through_team_assigned_to_user(
         self, project_model: Project
     ) -> None:
         # GIVEN a folder created with default permissions of administrator
@@ -485,7 +485,7 @@ class TestAclOnFolder:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_through_multiple_teams_assigned_to_user(
+    async def test_get_acl_through_multiple_teams_assigned_to_user(
         self, project_model: Project
     ) -> None:
         # GIVEN a folder created with default permissions of administrator
@@ -558,7 +558,7 @@ class TestAclOnFolder:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_for_project_with_public_and_registered_user(
+    async def test_get_acl_for_project_with_public_and_registered_user(
         self, project_model: Project
     ) -> None:
         # GIVEN a folder created with default permissions of administrator
@@ -640,7 +640,7 @@ class TestAclOnFile:
         schedule_for_cleanup(filename)
         return File(path=filename)
 
-    def test_get_acl_default(self, project_model: Project, file: File) -> None:
+    async def test_get_acl_default(self, project_model: Project, file: File) -> None:
         # GIVEN a file created with default permissions of administrator
         file.name = str(uuid.uuid4()) + "test_get_acl_default_permissions"
         file_with_default_permissions = file.store(parent=project_model)
@@ -665,7 +665,7 @@ class TestAclOnFile:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_minimal_permissions_on_entity(
+    async def test_get_acl_minimal_permissions_on_entity(
         self, project_model: Project, file: File
     ) -> None:
         # GIVEN a file created with default permissions of administrator
@@ -701,7 +701,7 @@ class TestAclOnFile:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_through_team_assigned_to_user(
+    async def test_get_acl_through_team_assigned_to_user(
         self, project_model: Project, file: File
     ) -> None:
         # GIVEN a file created with default permissions of administrator
@@ -760,7 +760,7 @@ class TestAclOnFile:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_through_multiple_teams_assigned_to_user(
+    async def test_get_acl_through_multiple_teams_assigned_to_user(
         self, project_model: Project, file: File
     ) -> None:
         # GIVEN a file created with default permissions of administrator
@@ -834,7 +834,7 @@ class TestAclOnFile:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_for_project_with_public_and_registered_user(
+    async def test_get_acl_for_project_with_public_and_registered_user(
         self, project_model: Project, file: File
     ) -> None:
         # GIVEN a file created with default permissions of administrator
@@ -923,7 +923,7 @@ class TestAclOnTable:
 
         return table
 
-    def test_get_acl_default(self, table: Table) -> None:
+    async def test_get_acl_default(self, table: Table) -> None:
         # GIVEN a table created with default permissions of administrator
         table.name = str(uuid.uuid4()) + "test_get_acl_default_permissions"
         table_with_default_permissions = table.store_schema()
@@ -948,7 +948,7 @@ class TestAclOnTable:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_minimal_permissions_on_entity(self, table: Table) -> None:
+    async def test_get_acl_minimal_permissions_on_entity(self, table: Table) -> None:
         # GIVEN a table created with default permissions of administrator
         table.name = str(uuid.uuid4()) + "test_get_acl_read_permissions_on_project"
         project_with_minimal_permissions = table.store_schema()
@@ -982,7 +982,7 @@ class TestAclOnTable:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_through_team_assigned_to_user(self, table: Table) -> None:
+    async def test_get_acl_through_team_assigned_to_user(self, table: Table) -> None:
         # GIVEN a table created with default permissions of administrator
         table.name = (
             str(uuid.uuid4()) + "test_get_acl_through_team_assigned_to_user_and_project"
@@ -1039,7 +1039,7 @@ class TestAclOnTable:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_through_multiple_teams_assigned_to_user(
+    async def test_get_acl_through_multiple_teams_assigned_to_user(
         self, table: Table
     ) -> None:
         # GIVEN a table created with default permissions of administrator
@@ -1113,7 +1113,7 @@ class TestAclOnTable:
         ]
         assert set(expected_permissions) == set(permissions)
 
-    def test_get_acl_for_project_with_public_and_registered_user(
+    async def test_get_acl_for_project_with_public_and_registered_user(
         self, table: Table
     ) -> None:
         # GIVEN a table created with default permissions of administrator
@@ -1189,7 +1189,7 @@ class TestPermissionsOnEntityForCaller:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    def test_get_permissions_default(self) -> None:
+    async def test_get_permissions_default(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_default_permissions = Project(
             name=str(uuid.uuid4()) + "test_get_permissions_default_permissions"
@@ -1212,7 +1212,7 @@ class TestPermissionsOnEntityForCaller:
         ]
         assert set(expected_permissions) == set(permissions.access_types)
 
-    def test_get_permissions_read_only_permissions_on_entity(self) -> None:
+    async def test_get_permissions_read_only_permissions_on_entity(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_read_only_permissions = Project(
             name=str(uuid.uuid4()) + "test_get_permissions_read_permissions_on_project"
@@ -1236,7 +1236,7 @@ class TestPermissionsOnEntityForCaller:
 
         assert set(expected_permissions) == set(permissions.access_types)
 
-    def test_get_permissions_through_team_assigned_to_user(self) -> None:
+    async def test_get_permissions_through_team_assigned_to_user(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_permissions_through_single_team = Project(
             name=str(uuid.uuid4())
@@ -1291,7 +1291,7 @@ class TestPermissionsOnEntityForCaller:
         ]
         assert set(expected_permissions) == set(permissions.access_types)
 
-    def test_get_permissions_through_multiple_teams_assigned_to_user(
+    async def test_get_permissions_through_multiple_teams_assigned_to_user(
         self,
     ) -> None:
         # GIVEN a project created with default permissions of administrator
@@ -1361,7 +1361,7 @@ class TestPermissionsOnEntityForCaller:
         ]
         assert set(expected_permissions) == set(permissions.access_types)
 
-    def test_get_permissions_for_project_with_registered_user(self) -> None:
+    async def test_get_permissions_for_project_with_registered_user(self) -> None:
         # GIVEN a project created with default permissions of administrator
         project_with_permissions_for_authenticated_users = Project(
             name=str(uuid.uuid4())

--- a/tests/integration/synapseclient/models/synchronous/test_project.py
+++ b/tests/integration/synapseclient/models/synchronous/test_project.py
@@ -43,7 +43,7 @@ class TestProjectStore:
         project = Project(name=str(uuid.uuid4()), description=DERSCRIPTION_PROJECT)
         return project
 
-    def test_store_project(self, project: Project) -> None:
+    async def test_store_project(self, project: Project) -> None:
         # GIVEN a Project object
 
         # WHEN I store the Project on Synapse
@@ -66,7 +66,7 @@ class TestProjectStore:
             stored_project.annotations, dict
         )
 
-    def test_store_project_with_file(self, file: File, project: Project) -> None:
+    async def test_store_project_with_file(self, file: File, project: Project) -> None:
         # GIVEN a File on the project
         project.files.append(file)
 
@@ -97,7 +97,7 @@ class TestProjectStore:
         assert file.parent_id == stored_project.id
         assert file.path is not None
 
-    def test_store_project_with_folder_in_file_on_project_that_already_exists(
+    async def test_store_project_with_folder_in_file_on_project_that_already_exists(
         self, file: File, project: Project
     ) -> None:
         # GIVEN that the project is already stored in Synapse
@@ -143,7 +143,7 @@ class TestProjectStore:
         assert file.parent_id == folder.id
         assert file.path is not None
 
-    def test_store_project_with_multiple_files(self, project: Project) -> None:
+    async def test_store_project_with_multiple_files(self, project: Project) -> None:
         # GIVEN multiple files in a project
         files = []
         for _ in range(3):
@@ -178,7 +178,7 @@ class TestProjectStore:
             assert file.parent_id == stored_project.id
             assert file.path is not None
 
-    def test_store_project_with_multiple_files_and_folders(
+    async def test_store_project_with_multiple_files_and_folders(
         self, project: Project
     ) -> None:
         # GIVEN multiple files in a project
@@ -243,7 +243,7 @@ class TestProjectStore:
                 assert sub_file.parent_id == sub_folder.id
                 assert sub_file.path is not None
 
-    def test_store_project_with_annotations(self, project: Project) -> None:
+    async def test_store_project_with_annotations(self, project: Project) -> None:
         # GIVEN a Project object and a Project object
         # AND annotations on the Project
         annotations = {
@@ -291,7 +291,7 @@ class TestProjectGet:
         project = Project(name=str(uuid.uuid4()), description=DERSCRIPTION_PROJECT)
         return project
 
-    def test_get_project_by_id(self, project: Project) -> None:
+    async def test_get_project_by_id(self, project: Project) -> None:
         # GIVEN a Project object
 
         # AND the project is stored in synapse
@@ -317,7 +317,7 @@ class TestProjectGet:
             stored_project.annotations, dict
         )
 
-    def test_get_project_by_name_attribute(self, project: Project) -> None:
+    async def test_get_project_by_name_attribute(self, project: Project) -> None:
         # GIVEN a Project object
 
         # AND the project is stored in synapse
@@ -357,7 +357,7 @@ class TestProjectDelete:
         project = Project(name=str(uuid.uuid4()), description=DERSCRIPTION_PROJECT)
         return project
 
-    def test_delete_project(self, project: Project) -> None:
+    async def test_delete_project(self, project: Project) -> None:
         # GIVEN a Project object
 
         # AND the project is stored in synapse
@@ -399,7 +399,7 @@ class TestProjectCopy:
         project = Project(name=str(uuid.uuid4()), description=DERSCRIPTION_PROJECT)
         return project
 
-    def test_copy_project_with_multiple_files_and_projects(
+    async def test_copy_project_with_multiple_files_and_projects(
         self, project: Project
     ) -> None:
         # GIVEN a project to copy to
@@ -472,7 +472,7 @@ class TestProjectCopy:
                 assert sub_file.name is not None
                 assert sub_file.parent_id == sub_folder.id
 
-    def test_copy_project_exclude_files(self, project: Project) -> None:
+    async def test_copy_project_exclude_files(self, project: Project) -> None:
         # GIVEN a project to copy to
         destination_project = Project(
             name=str(uuid.uuid4()), description="Destination for project copy"
@@ -562,7 +562,7 @@ class TestProjectSyncFromSynapse:
         project = Project(name=str(uuid.uuid4()), description=DERSCRIPTION_PROJECT)
         return project
 
-    def test_sync_from_synapse(self, file: File, project: Project) -> None:
+    async def test_sync_from_synapse(self, file: File, project: Project) -> None:
         root_directory_path = os.path.dirname(file.path)
 
         # GIVEN multiple files in the source project

--- a/tests/integration/synapseclient/models/synchronous/test_team.py
+++ b/tests/integration/synapseclient/models/synchronous/test_team.py
@@ -28,7 +28,7 @@ class TestTeam:
         self.TEST_USER = "DPETestUser2"
         self.TEST_MESSAGE = "test message"
 
-    def test_create(self) -> None:
+    async def test_create(self) -> None:
         # GIVEN a team object self.team
         # WHEN I create the team on Synapse
         test_team = self.team.create()
@@ -47,7 +47,7 @@ class TestTeam:
         # Clean up
         test_team.delete()
 
-    def test_delete(self) -> None:
+    async def test_delete(self) -> None:
         # GIVEN a team object self.team
         # WHEN I create the team on Synapse
         test_team = self.team.create()
@@ -60,7 +60,7 @@ class TestTeam:
         ):
             Team.from_id(id=test_team.id)
 
-    def test_get_with_id(self) -> None:
+    async def test_get_with_id(self) -> None:
         # GIVEN a team created in Synapse
         synapse_team = self.team.create()
         # AND a locally created Team object with the same id and name
@@ -80,7 +80,7 @@ class TestTeam:
         # Clean up
         synapse_team.delete()
 
-    def test_get_with_name(self) -> None:
+    async def test_get_with_name(self) -> None:
         # GIVEN a team created in Synapse
         synapse_team = self.team.create()
         # This sleep is necessary because the API is eventually consistent
@@ -102,7 +102,7 @@ class TestTeam:
         # Clean up
         synapse_team.delete()
 
-    def test_from_id(self) -> None:
+    async def test_from_id(self) -> None:
         # GIVEN a team object self.team
         # WHEN I create the team on Synapse
         test_team = self.team.create()
@@ -120,7 +120,7 @@ class TestTeam:
         # Clean up
         test_team.delete()
 
-    def test_from_name(self) -> None:
+    async def test_from_name(self) -> None:
         # GIVEN a team object self.team
         # WHEN I create the team on Synapse
         test_team = self.team.create()
@@ -142,7 +142,7 @@ class TestTeam:
         # Clean up
         test_team.delete()
 
-    def test_members(self) -> None:
+    async def test_members(self) -> None:
         # GIVEN a team object self.team
         # WHEN I create the team on Synapse
         test_team = self.team.create()
@@ -155,7 +155,7 @@ class TestTeam:
         # Clean up
         test_team.delete()
 
-    def test_invite(self) -> None:
+    async def test_invite(self) -> None:
         # GIVEN a team object self.team
         # WHEN I create the team on Synapse
         test_team = self.team.create()
@@ -175,7 +175,7 @@ class TestTeam:
         # Clean up
         test_team.delete()
 
-    def test_open_invitations(self) -> None:
+    async def test_open_invitations(self) -> None:
         # GIVEN a team object self.team
         # WHEN I create the team on Synapse
         test_team = self.team.create()

--- a/tests/integration/synapseclient/models/synchronous/test_user.py
+++ b/tests/integration/synapseclient/models/synchronous/test_user.py
@@ -17,7 +17,7 @@ class TestUser:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    def test_from_id(self) -> None:
+    async def test_from_id(self) -> None:
         # GIVEN our test profile
         integration_test_profile = UserProfile().get()
 
@@ -27,7 +27,7 @@ class TestUser:
         # THEN we expect the profile to be the same as the one we got from the fixture
         assert profile == integration_test_profile
 
-    def test_from_username(self) -> None:
+    async def test_from_username(self) -> None:
         # GIVEN our test profile
         integration_test_profile = UserProfile().get()
 
@@ -37,7 +37,7 @@ class TestUser:
         # THEN we expect the profile to be the same as the one we got from the fixture
         assert profile == integration_test_profile
 
-    def test_is_certified_id(self) -> None:
+    async def test_is_certified_id(self) -> None:
         # GIVEN out test profile
         integration_test_profile = UserProfile().get()
 
@@ -50,7 +50,7 @@ class TestUser:
         # THEN we expect the profile to not be certified
         assert is_certified is False
 
-    def test_is_certified_username(self) -> None:
+    async def test_is_certified_username(self) -> None:
         # GIVEN out test profile
         integration_test_profile = UserProfile().get()
 

--- a/tests/integration/synapseclient/test_command_line_client.py
+++ b/tests/integration/synapseclient/test_command_line_client.py
@@ -32,7 +32,7 @@ from io import StringIO
 
 
 @pytest.fixture(scope="function")
-def test_state(syn: Synapse, project: Project, schedule_for_cleanup):
+async def test_state(syn: Synapse, project: Project, schedule_for_cleanup):
     class State:
         def __init__(self):
             self.syn = syn
@@ -88,7 +88,7 @@ def parse(regex, output):
         raise Exception('ERROR parsing output: "' + str(output) + '"')
 
 
-def test_command_line_client(test_state):
+async def test_command_line_client(test_state):
     print("TESTING CMD LINE CLIENT")
     # Create a Project
     output = run(
@@ -265,7 +265,7 @@ def test_command_line_client(test_state):
     run(test_state, "synapse" "--skip-checks", "delete", project_id)
 
 
-def test_command_line_client_annotations(test_state):
+async def test_command_line_client_annotations(test_state):
     # Create a Project
     output = run(
         test_state,
@@ -409,7 +409,7 @@ def test_command_line_client_annotations(test_state):
     assert annotations["foo"] == [456]
 
 
-def test_command_line_store_and_submit(test_state):
+async def test_command_line_store_and_submit(test_state):
     # Create a Project
     output = run(
         test_state,
@@ -562,7 +562,7 @@ def test_command_line_store_and_submit(test_state):
     run(test_state, "synapse" "--skip-checks", "delete", project_id)
 
 
-def test_command_get_recursive_and_query(test_state):
+async def test_command_get_recursive_and_query(test_state):
     """Tests the 'synapse get -r' and 'synapse get -q' functions"""
 
     project_entity = test_state.project
@@ -652,7 +652,7 @@ def test_command_get_recursive_and_query(test_state):
     test_state.schedule_for_cleanup(new_paths[0])
 
 
-def test_command_copy(test_state):
+async def test_command_copy(test_state):
     """Tests the 'synapse cp' function"""
 
     # Create a Project
@@ -751,7 +751,7 @@ def test_command_copy(test_state):
     )
 
 
-def test_command_line_using_paths(test_state):
+async def test_command_line_using_paths(test_state):
     # Create a Project
     project_entity = test_state.syn.store(Project(name=str(uuid.uuid4())))
     test_state.schedule_for_cleanup(project_entity.id)
@@ -849,7 +849,7 @@ def test_command_line_using_paths(test_state):
     run(test_state, "synapse" "--skip-checks", "show", filename)
 
 
-def test_table_query(test_state):
+async def test_table_query(test_state):
     """Test command line ability to do table query."""
 
     cols = [
@@ -896,7 +896,7 @@ def test_table_query(test_state):
     )
 
 
-def test_login(test_state):
+async def test_login(test_state):
     alt_syn = Synapse()
     username = "username"
     auth_token = "my_auth_token"
@@ -919,7 +919,7 @@ def test_login(test_state):
         mock_get_user_profile.assert_called_once_with()
 
 
-def test_configPath(test_state):
+async def test_configPath(test_state):
     """Test using a user-specified configPath for Synapse configuration file."""
 
     tmp_config_file = tempfile.NamedTemporaryFile(suffix=".synapseConfig", delete=False)
@@ -967,7 +967,7 @@ def _create_temp_file_with_cleanup(schedule_for_cleanup, specific_file_text=None
     return filename
 
 
-def test_create__with_description(test_state):
+async def test_create__with_description(test_state):
     output = run(
         test_state,
         "synapse",
@@ -983,7 +983,7 @@ def test_create__with_description(test_state):
     _description_wiki_check(test_state.syn, output, test_state.description_text)
 
 
-def test_store__with_description(test_state):
+async def test_store__with_description(test_state):
     output = run(
         test_state,
         "synapse",
@@ -999,7 +999,7 @@ def test_store__with_description(test_state):
     _description_wiki_check(test_state.syn, output, test_state.description_text)
 
 
-def test_add__with_description(test_state):
+async def test_add__with_description(test_state):
     output = run(
         test_state,
         "synapse",
@@ -1015,7 +1015,7 @@ def test_add__with_description(test_state):
     _description_wiki_check(test_state.syn, output, test_state.description_text)
 
 
-def test_create__with_descriptionFile(test_state):
+async def test_create__with_descriptionFile(test_state):
     output = run(
         test_state,
         "synapse",
@@ -1031,7 +1031,7 @@ def test_create__with_descriptionFile(test_state):
     _description_wiki_check(test_state.syn, output, test_state.description_text)
 
 
-def test_store__with_descriptionFile(test_state):
+async def test_store__with_descriptionFile(test_state):
     output = run(
         test_state,
         "synapse",
@@ -1047,7 +1047,7 @@ def test_store__with_descriptionFile(test_state):
     _description_wiki_check(test_state.syn, output, test_state.description_text)
 
 
-def test_add__with_descriptionFile(test_state):
+async def test_add__with_descriptionFile(test_state):
     output = run(
         test_state,
         "synapse",
@@ -1063,7 +1063,7 @@ def test_add__with_descriptionFile(test_state):
     _description_wiki_check(test_state.syn, output, test_state.description_text)
 
 
-def test_create__update_description(test_state):
+async def test_create__update_description(test_state):
     name = str(uuid.uuid4())
     output = run(
         test_state,
@@ -1093,7 +1093,7 @@ def test_create__update_description(test_state):
     _description_wiki_check(test_state.syn, output, test_state.update_description_text)
 
 
-def test_store__update_description(test_state):
+async def test_store__update_description(test_state):
     name = str(uuid.uuid4())
     output = run(
         test_state,
@@ -1123,7 +1123,7 @@ def test_store__update_description(test_state):
     _description_wiki_check(test_state.syn, output, test_state.update_description_text)
 
 
-def test_add__update_description(test_state):
+async def test_add__update_description(test_state):
     name = str(uuid.uuid4())
     output = run(
         test_state,
@@ -1153,7 +1153,7 @@ def test_add__update_description(test_state):
     _description_wiki_check(test_state.syn, output, test_state.update_description_text)
 
 
-def test_create__same_project_name(test_state):
+async def test_create__same_project_name(test_state):
     """Test creating project that already exists returns the existing project."""
 
     name = str(uuid.uuid4())
@@ -1171,7 +1171,7 @@ def test_create__same_project_name(test_state):
 
 
 @patch.object(utils.sys.stdin, "isatty")
-def test_storeTable_csv(mock_sys, test_state):
+async def test_storeTable_csv(mock_sys, test_state):
     # when running on windows os with multiple CPU, the sys.stdin.isatty will return True
     # Thus we mock the utils.sys.stdin.
     mock_sys.return_value = False

--- a/tests/integration/synapseclient/test_evaluations.py
+++ b/tests/integration/synapseclient/test_evaluations.py
@@ -11,7 +11,7 @@ from synapseclient.core.exceptions import SynapseHTTPError
 
 
 @pytest.mark.flaky(reruns=3, only_rerun=["SynapseHTTPError"])
-def test_evaluations(syn: Synapse, project: Project):
+async def test_evaluations(syn: Synapse, project: Project):
     # Create an Evaluation
     name = "Test Evaluation %s" % str(uuid.uuid4())
     ev = Evaluation(
@@ -172,7 +172,7 @@ def test_evaluations(syn: Synapse, project: Project):
     pytest.raises(SynapseHTTPError, syn.getEvaluation, ev)
 
 
-def test_teams(syn: Synapse, schedule_for_cleanup):
+async def test_teams(syn: Synapse, schedule_for_cleanup):
     name = "My Uniquely Named Team " + str(uuid.uuid4())
     team = syn.store(Team(name=name, description="A fake team for testing..."))
     schedule_for_cleanup(team)

--- a/tests/integration/synapseclient/test_json_schema_services.py
+++ b/tests/integration/synapseclient/test_json_schema_services.py
@@ -15,7 +15,7 @@ async def test_available_services(syn):
 
 
 @pytest.fixture
-def js(syn):
+def js(syn: synapseclient.Synapse):
     return syn.service("json_schema")
 
 

--- a/tests/integration/synapseclient/test_json_schema_services.py
+++ b/tests/integration/synapseclient/test_json_schema_services.py
@@ -8,7 +8,7 @@ import synapseclient
 from synapseclient.core.exceptions import SynapseHTTPError
 
 
-def test_available_services(syn):
+async def test_available_services(syn):
     services = syn.get_available_services()  # Output: ['json_schema']
     available_services = ["json_schema"]
     assert set(services) == set(available_services)
@@ -20,7 +20,7 @@ def js(syn):
 
 
 @pytest.mark.flaky(reruns=3, only_rerun=["SynapseHTTPError"])
-def test_json_schema_organization(js):
+async def test_json_schema_organization(js):
     # Schema organizations must start with a string
     js_org = "a" + str(uuid.uuid4()).replace("-", "")
     # Create, manage, and delete a JSON Schema organization
@@ -89,7 +89,7 @@ class TestJsonSchemaSchemas:
     def teardown(self):
         self.my_org.delete()
 
-    def test_json_schema_schemas_org_create_schema(self):
+    async def test_json_schema_schemas_org_create_schema(self):
         # Create json schema
         new_version = self.my_org.create_json_schema(
             self.simple_schema, self.schema_name, f"0.{self.rint}.1"
@@ -107,7 +107,7 @@ class TestJsonSchemaSchemas:
         assert full_body["properties"] == self.simple_schema["properties"]
         new_version.delete()
 
-    def test_json_schema_schemas_js_create_schema(self, js):
+    async def test_json_schema_schemas_js_create_schema(self, js):
         # Create json schema
         # Version 2 of creating json schema
         my_schema = js.JsonSchema(self.my_org, self.schema_name)
@@ -118,7 +118,7 @@ class TestJsonSchemaSchemas:
         assert schema1 is schema2
         new_version.delete()
 
-    def test_json_schema_schemas_js_version_create_schema(self, js):
+    async def test_json_schema_schemas_js_version_create_schema(self, js):
         # Create json schema
         # Version 3 of creating json schema
         my_version = js.JsonSchemaVersion(
@@ -131,7 +131,7 @@ class TestJsonSchemaSchemas:
         assert schema1 is schema2
         new_version.delete()
 
-    def test_json_schema_validate(self, js, syn, schedule_for_cleanup):
+    async def test_json_schema_validate(self, js, syn, schedule_for_cleanup):
         project_name = str(uuid.uuid4()).replace("-", "")
         project = synapseclient.Project(name=project_name)
         project.firstName = "test"

--- a/tests/integration/synapseclient/test_tables.py
+++ b/tests/integration/synapseclient/test_tables.py
@@ -47,7 +47,7 @@ def _init_query_timeout(request, syn):
 
 
 @pytest.mark.flaky(reruns=3)
-def test_create_and_update_file_view(
+async def test_create_and_update_file_view(
     syn: Synapse, project: Project, schedule_for_cleanup
 ):
     # Create a folder
@@ -166,7 +166,7 @@ def test_create_and_update_file_view(
     assert new_view_dict[0]["fileFormat"] == "PNG"
 
 
-def test_entity_view_add_annotation_columns(syn, project, schedule_for_cleanup):
+async def test_entity_view_add_annotation_columns(syn, project, schedule_for_cleanup):
     folder1 = syn.store(
         Folder(
             name=str(uuid.uuid4()) + "test_entity_view_add_annotation_columns_proj1",
@@ -220,7 +220,7 @@ def test_entity_view_add_annotation_columns(syn, project, schedule_for_cleanup):
     syn.store(entity_view)
 
 
-def test_rowset_tables(syn, project):
+async def test_rowset_tables(syn, project):
     cols = [
         Column(name="name", columnType="STRING", maximumSize=1000),
         Column(name="foo", columnType="STRING", enumValues=["foo", "bar", "bat"]),
@@ -244,7 +244,7 @@ def test_rowset_tables(syn, project):
     assert len(row_reference_set1["rows"]) == 4
 
 
-def test_materialized_view(syn, project):
+async def test_materialized_view(syn, project):
     """Test creation of materialized view"""
     # Define schema
     cols = [
@@ -309,7 +309,7 @@ def test_materialized_view(syn, project):
     )
 
 
-def test_dataset(syn, project):
+async def test_dataset(syn, project):
     cols = [
         Column(name="id", columnType="ENTITYID"),
         Column(name="name", columnType="STRING"),
@@ -329,7 +329,7 @@ def test_dataset(syn, project):
 
 
 @pytest.mark.flaky(reruns=3)
-def test_tables_csv(syn, project):
+async def test_tables_csv(syn, project):
     # Define schema
     cols = [
         Column(name="Name", columnType="STRING"),
@@ -367,7 +367,7 @@ def test_tables_csv(syn, project):
 
 
 @pytest.mark.flaky(reruns=3)
-def test_tables_pandas(syn, project):
+async def test_tables_pandas(syn, project):
     # create a pandas DataFrame
     df = pd.DataFrame(
         {
@@ -508,7 +508,7 @@ def dontruntest_big_csvs(syn, project, schedule_for_cleanup):
     CsvFileTable.from_table_query(syn, "select * from %s" % schema1.id)
 
 
-def test_synapse_integer_columns_with_missing_values_from_dataframe(
+async def test_synapse_integer_columns_with_missing_values_from_dataframe(
     syn, project, schedule_for_cleanup
 ):
     # SYNPY-267
@@ -547,7 +547,7 @@ def test_synapse_integer_columns_with_missing_values_from_dataframe(
     assert_frame_equal(df, df2)
 
 
-def test_store_table_datetime(syn, project):
+async def test_store_table_datetime(syn, project):
     current_datetime = datetime.fromtimestamp(round(time.time(), 3)).replace(
         tzinfo=timezone.utc
     )
@@ -625,12 +625,12 @@ def partial_rowset_test_state(syn, project):
 
 
 class TestPartialRowSet:
-    def test_partial_row_view_csv_query_table(self, partial_rowset_test_state):
+    async def test_partial_row_view_csv_query_table(self, partial_rowset_test_state):
         """
         Test PartialRow updates to tables from cvs queries
         """
         test_state = partial_rowset_test_state
-        self._test_method(
+        await self._test_method(
             test_state.syn,
             test_state.table_schema,
             "csv",
@@ -638,12 +638,14 @@ class TestPartialRowSet:
             test_state.expected_table_cells,
         )
 
-    def test_partial_row_view_csv_query_entity_view(self, partial_rowset_test_state):
+    async def test_partial_row_view_csv_query_entity_view(
+        self, partial_rowset_test_state
+    ):
         """
         Test PartialRow updates to entity views from cvs queries
         """
         test_state = partial_rowset_test_state
-        self._test_method(
+        await self._test_method(
             test_state.syn,
             test_state.view_schema,
             "csv",
@@ -651,12 +653,12 @@ class TestPartialRowSet:
             test_state.expected_view_cells,
         )
 
-    def test_parital_row_rowset_query_table(self, partial_rowset_test_state):
+    async def test_parital_row_rowset_query_table(self, partial_rowset_test_state):
         """
         Test PartialRow updates to tables from rowset queries
         """
         test_state = partial_rowset_test_state
-        self._test_method(
+        await self._test_method(
             test_state.syn,
             test_state.table_schema,
             "rowset",
@@ -664,12 +666,14 @@ class TestPartialRowSet:
             test_state.expected_table_cells,
         )
 
-    def test_parital_row_rowset_query_entity_view(self, partial_rowset_test_state):
+    async def test_parital_row_rowset_query_entity_view(
+        self, partial_rowset_test_state
+    ):
         """
         Test PartialRow updates to entity views from rowset queries
         """
         test_state = partial_rowset_test_state
-        self._test_method(
+        await self._test_method(
             test_state.syn,
             test_state.view_schema,
             "rowset",
@@ -677,7 +681,9 @@ class TestPartialRowSet:
             test_state.expected_view_cells,
         )
 
-    def _test_method(self, syn, schema, resultsAs, partial_changes, expected_results):
+    async def _test_method(
+        self, syn, schema, resultsAs, partial_changes, expected_results
+    ):
         query_results = self._query_with_retry(
             syn,
             "SELECT * FROM %s" % utils.id_of(schema),

--- a/tests/integration/synapseclient/test_wikis.py
+++ b/tests/integration/synapseclient/test_wikis.py
@@ -10,7 +10,7 @@ import synapseclient.core.utils as utils
 
 
 @pytest.mark.flaky(reruns=3)
-def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup):
+async def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup):
     # Upload a file to be attached to a Wiki
     filename = utils.make_bogus_data_file()
     attachname = utils.make_bogus_data_file()
@@ -80,7 +80,7 @@ def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup):
     pytest.raises(SynapseHTTPError, syn.getWiki, project)
 
 
-def test_create_or_update_wiki(syn, project):
+async def test_create_or_update_wiki(syn, project):
     # create wiki once
     syn.store(
         Wiki(
@@ -103,7 +103,7 @@ def test_create_or_update_wiki(syn, project):
     assert new_title == syn.getWiki(wiki.ownerId)["title"]
 
 
-def test_wiki_version(syn, project):
+async def test_wiki_version(syn, project):
     # create a new project to avoid artifacts from previous tests
     project = syn.store(Project(name=str(uuid.uuid4())))
     wiki = syn.store(

--- a/tests/integration/synapseutils/test_synapseutils_copy.py
+++ b/tests/integration/synapseutils/test_synapseutils_copy.py
@@ -28,7 +28,7 @@ import synapseutils
 # Add Test for UPDATE
 # Add test for existing provenance but the orig doesn't have provenance
 @pytest.mark.flaky(reruns=10)
-def test_copy(syn: Synapse, schedule_for_cleanup):
+async def test_copy(syn: Synapse, schedule_for_cleanup):
     try:
         execute_test_copy(syn, schedule_for_cleanup)
     except FunctionTimedOut:
@@ -360,7 +360,7 @@ class TestCopyWiki:
 
         self.first_headers = self.syn.getWikiHeaders(self.project_entity)
 
-    def test_copy_Wiki(self):
+    async def test_copy_Wiki(self):
         second_headers = synapseutils.copyWiki(
             self.syn,
             self.project_entity.id,
@@ -406,7 +406,7 @@ class TestCopyWiki:
             # check that attachment file names are the same
             assert orig_file == new_file
 
-    def test_entitySubPageId_and_destinationSubPageId(self):
+    async def test_entitySubPageId_and_destinationSubPageId(self):
         # Test: entitySubPageId
         second_header = synapseutils.copyWiki(
             self.syn,
@@ -449,8 +449,9 @@ class TestCopyWiki:
 
 
 class TestCopyFileHandles:
+    @pytest.mark.asyncio(scope="session")
     @pytest.fixture(autouse=True)
-    def init(self, syn, schedule_for_cleanup):
+    async def init(self, syn, schedule_for_cleanup):
         self.syn = syn
 
         # create external file handles for https://www.synapse.org/images/logo.svg,
@@ -475,7 +476,7 @@ class TestCopyFileHandles:
         test_entity_1 = self.syn.store(test_entity_1)
         self.obj_id_1 = str(test_entity_1["id"][3:])
 
-    def test_copy_file_handles(self):
+    async def test_copy_file_handles(self):
         # define inputs
         file_handles = [self.file_handle_id_1]
         associate_object_types = ["FileEntity"]

--- a/tests/integration/synapseutils/test_synapseutils_migrate.py
+++ b/tests/integration/synapseutils/test_synapseutils_migrate.py
@@ -53,7 +53,7 @@ def _assert_storage_location(file_handles, storage_location_id):
         assert fh["storageLocationId"] == storage_location_id
 
 
-def test_migrate_project(
+async def test_migrate_project(
     request, syn: Synapse, schedule_for_cleanup, storage_location_id
 ):
     test_name = request.node.name

--- a/tests/integration/synapseutils/test_synapseutils_walk.py
+++ b/tests/integration/synapseutils/test_synapseutils_walk.py
@@ -10,7 +10,7 @@ import synapseutils
 
 
 @pytest.mark.flaky(reruns=3)
-def test_walk(syn, schedule_for_cleanup):
+async def test_walk(syn, schedule_for_cleanup):
     try:
         execute_test_walk(syn, schedule_for_cleanup)
     except FunctionTimedOut:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,18 +1,18 @@
-import logging
-import platform
-import urllib.request
-
-from unittest import mock
-from pytest_socket import disable_socket, SocketBlockedError
-import pytest
-import os, time
-
-from synapseclient import Synapse
-from synapseclient.core.logging_setup import SILENT_LOGGER_NAME
-
 """
 pytest unit test session level fixtures
 """
+
+import logging
+import os
+import platform
+import time
+import urllib.request
+
+import pytest
+from pytest_socket import SocketBlockedError, disable_socket
+
+from synapseclient import Synapse
+from synapseclient.core.logging_setup import SILENT_LOGGER_NAME
 
 
 def pytest_runtest_setup():

--- a/tests/unit/synapseclient/core/unit_test_retry.py
+++ b/tests/unit/synapseclient/core/unit_test_retry.py
@@ -129,7 +129,6 @@ def test_with_retry__no_status_code():
 class TestAsyncRetry:
     """Unit tests for the with_retry_time_based_async function."""
 
-    @pytest.mark.asyncio
     async def test_with_retry(self) -> None:
         retry_params = {"retry_max_wait_before_failure": 1}
         response = AsyncMock()
@@ -186,7 +185,6 @@ class TestAsyncRetry:
         assert "Bar" in str(ex_cm.value)
         assert mocked_function.call_count > 13
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "values",
         (
@@ -213,7 +211,6 @@ class TestAsyncRetry:
         )
         assert returned_response == response
 
-    @pytest.mark.asyncio
     async def test_with_retry__expected_status_code(self) -> None:
         """Verify using retry expected_status_codes"""
 
@@ -234,7 +231,6 @@ class TestAsyncRetry:
         )
         assert response == matching_response
 
-    @pytest.mark.asyncio
     async def test_with_retry__no_status_code(self) -> None:
         """Verify that with_retry can also be used on any function
         even whose return values don't have status_codes.

--- a/tests/unit/synapseclient/models/async/unit_test_activity_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_activity_async.py
@@ -143,7 +143,6 @@ class TestActivity:
         assert activity.executed[1].target_id == SYN_789
         assert activity.executed[1].target_version_number == 1
 
-    @pytest.mark.asyncio
     async def test_store_with_id(self) -> None:
         # GIVEN an activity with an id
         activity = Activity(
@@ -200,7 +199,6 @@ class TestActivity:
             assert result_of_store.executed[1].target_id == SYN_789
             assert result_of_store.executed[1].target_version_number == 1
 
-    @pytest.mark.asyncio
     async def test_store_with_parent(self) -> None:
         # GIVEN an activity with a parent
         activity = Activity(
@@ -255,7 +253,6 @@ class TestActivity:
             assert result_of_store.executed[1].target_id == SYN_789
             assert result_of_store.executed[1].target_version_number == 1
 
-    @pytest.mark.asyncio
     async def test_from_parent(self) -> None:
         # GIVEN a parent with an activity
         parent = File("syn999", version_number=1)
@@ -298,7 +295,6 @@ class TestActivity:
             assert result_of_get.executed[1].target_id == SYN_789
             assert result_of_get.executed[1].target_version_number == 1
 
-    @pytest.mark.asyncio
     async def test_delete(self) -> None:
         # GIVEN a parent with an activity
         parent = File(id="syn999")

--- a/tests/unit/synapseclient/models/async/unit_test_file_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_file_async.py
@@ -110,7 +110,6 @@ class TestFile:
             "externalURL": FILE_HANDLE_EXTERNAL_URL,
         }
 
-    @pytest.mark.asyncio
     async def test_fill_from_dict(self) -> None:
         # GIVEN an example Synapse File `get_example_synapse_file_output`
         # WHEN I call `fill_from_dict` with the example Synapse File
@@ -151,7 +150,6 @@ class TestFile:
         assert file_output.file_handle.is_preview
         assert file_output.file_handle.external_url == FILE_HANDLE_EXTERNAL_URL
 
-    @pytest.mark.asyncio
     async def test_store_with_id_and_path(self) -> None:
         # GIVEN an example file
         file = File(id=SYN_123, path=PATH, description=MODIFIED_DESCRIPTION)
@@ -233,7 +231,6 @@ class TestFile:
             assert result.file_handle.is_preview
             assert result.file_handle.external_url == FILE_HANDLE_EXTERNAL_URL
 
-    @pytest.mark.asyncio
     async def test_store_with_id_and_file_handle(self) -> None:
         # GIVEN an example file
         file = File(
@@ -310,7 +307,6 @@ class TestFile:
             assert result.file_handle.is_preview
             assert result.file_handle.external_url == FILE_HANDLE_EXTERNAL_URL
 
-    @pytest.mark.asyncio
     async def test_store_with_parent_and_path(self) -> None:
         # GIVEN An actual file
         bogus_file = utils.make_bogus_uuid_file()
@@ -396,7 +392,6 @@ class TestFile:
             assert result.file_handle.is_preview
             assert result.file_handle.external_url == FILE_HANDLE_EXTERNAL_URL
 
-    @pytest.mark.asyncio
     async def test_store_with_parent_id_and_path(self) -> None:
         # GIVEN An actual file
         bogus_file = utils.make_bogus_uuid_file()
@@ -483,7 +478,6 @@ class TestFile:
             assert result.file_handle.is_preview
             assert result.file_handle.external_url == FILE_HANDLE_EXTERNAL_URL
 
-    @pytest.mark.asyncio
     async def test_store_with_components(self) -> None:
         # GIVEN An actual file
         bogus_file = utils.make_bogus_uuid_file()
@@ -590,7 +584,6 @@ class TestFile:
             assert result.file_handle.is_preview
             assert result.file_handle.external_url == FILE_HANDLE_EXTERNAL_URL
 
-    @pytest.mark.asyncio
     async def test_store_id_with_no_path_or_file_handle(self) -> None:
         # GIVEN an example file
         file = File(id=SYN_123, description=MODIFIED_DESCRIPTION)
@@ -602,7 +595,6 @@ class TestFile:
         # THEN we should get an error
         assert str(e.value) == CANNOT_STORE_FILE_ERROR
 
-    @pytest.mark.asyncio
     async def test_store_path_with_no_id(self) -> None:
         # GIVEN an example file
         file = File(path=PATH, description=MODIFIED_DESCRIPTION)
@@ -614,7 +606,6 @@ class TestFile:
         # THEN we should get an error
         assert str(e.value) == CANNOT_STORE_FILE_ERROR
 
-    @pytest.mark.asyncio
     async def test_store_id_with_parent_id(self) -> None:
         # GIVEN an example file
         file = File(
@@ -628,7 +619,6 @@ class TestFile:
         # THEN we should get an error
         assert str(e.value) == CANNOT_STORE_FILE_ERROR
 
-    @pytest.mark.asyncio
     async def test_store_id_with_parent(self) -> None:
         # GIVEN an example file
         file = File(id=SYN_123, description=MODIFIED_DESCRIPTION)
@@ -640,7 +630,6 @@ class TestFile:
         # THEN we should get an error
         assert str(e.value) == CANNOT_STORE_FILE_ERROR
 
-    @pytest.mark.asyncio
     async def test_change_file_metadata(self) -> None:
         # GIVEN an example file
         file = File(id=SYN_123, description=MODIFIED_DESCRIPTION)
@@ -701,7 +690,6 @@ class TestFile:
             assert result.file_handle.is_preview
             assert result.file_handle.external_url == FILE_HANDLE_EXTERNAL_URL
 
-    @pytest.mark.asyncio
     async def test_change_file_metadata_missing_id(self) -> None:
         # GIVEN an example file
         file = File(description=MODIFIED_DESCRIPTION)
@@ -713,7 +701,6 @@ class TestFile:
         # THEN we should get an error
         assert str(e.value) == "The file must have an ID to change metadata."
 
-    @pytest.mark.asyncio
     async def test_get_with_id(self) -> None:
         # GIVEN an example file
         file = File(id=SYN_123, description=MODIFIED_DESCRIPTION)
@@ -783,7 +770,6 @@ class TestFile:
             assert result.file_handle.is_preview
             assert result.file_handle.external_url == FILE_HANDLE_EXTERNAL_URL
 
-    @pytest.mark.asyncio
     async def test_get_with_path(self) -> None:
         # GIVEN an example file
         file = File(path=PATH, description=MODIFIED_DESCRIPTION)
@@ -843,7 +829,6 @@ class TestFile:
             assert result.file_handle.is_preview
             assert result.file_handle.external_url == FILE_HANDLE_EXTERNAL_URL
 
-    @pytest.mark.asyncio
     async def test_from_path(self) -> None:
         # GIVEN an example path
         path = PATH
@@ -906,7 +891,6 @@ class TestFile:
             assert result.file_handle.is_preview
             assert result.file_handle.external_url == FILE_HANDLE_EXTERNAL_URL
 
-    @pytest.mark.asyncio
     async def test_from_id(self) -> None:
         # GIVEN an example id
         synapse_id = SYN_123
@@ -979,7 +963,6 @@ class TestFile:
             assert result.file_handle.is_preview
             assert result.file_handle.external_url == FILE_HANDLE_EXTERNAL_URL
 
-    @pytest.mark.asyncio
     async def test_get_missing_id_and_path(self) -> None:
         # GIVEN an example file
         file = File(description=MODIFIED_DESCRIPTION)
@@ -991,7 +974,6 @@ class TestFile:
         # THEN we should get an error
         assert str(e.value) == "The file must have an ID or path to get."
 
-    @pytest.mark.asyncio
     async def test_delete(self) -> None:
         # GIVEN an example file
         file = File(id=SYN_123, description=MODIFIED_DESCRIPTION)
@@ -1010,7 +992,6 @@ class TestFile:
                 version=None,
             )
 
-    @pytest.mark.asyncio
     async def test_delete_missing_id(self) -> None:
         # GIVEN an example file
         file = File(description=MODIFIED_DESCRIPTION)
@@ -1022,7 +1003,6 @@ class TestFile:
         # THEN we should get an error
         assert str(e.value) == "The file must have an ID to delete."
 
-    @pytest.mark.asyncio
     async def test_delete_version_missing_version(self) -> None:
         # GIVEN an example file
         file = File(id="syn123", description=MODIFIED_DESCRIPTION)

--- a/tests/unit/synapseclient/models/async/unit_test_folder_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_folder_async.py
@@ -57,7 +57,6 @@ class TestFolder:
         assert folder_output.created_by == CREATED_BY
         assert folder_output.modified_by == MODIFIED_BY
 
-    @pytest.mark.asyncio
     async def test_store_with_id(self) -> None:
         # GIVEN a Folder object
         folder = Folder(
@@ -107,7 +106,6 @@ class TestFolder:
             assert result.created_by == CREATED_BY
             assert result.modified_by == MODIFIED_BY
 
-    @pytest.mark.asyncio
     async def test_store_with_no_changes(self) -> None:
         # GIVEN a Folder object
         folder = Folder(
@@ -136,7 +134,6 @@ class TestFolder:
             # AND the folder should only contain the ID
             assert result.id == SYN_123
 
-    @pytest.mark.asyncio
     async def test_store_after_get(self) -> None:
         # GIVEN a Folder object
         folder = Folder(
@@ -180,7 +177,6 @@ class TestFolder:
             # AND the folder should only contain the ID
             assert result.id == SYN_123
 
-    @pytest.mark.asyncio
     async def test_store_after_get_with_changes(self) -> None:
         # GIVEN a Folder object
         folder = Folder(
@@ -242,7 +238,6 @@ class TestFolder:
             assert result.created_by == CREATED_BY
             assert result.modified_by == MODIFIED_BY
 
-    @pytest.mark.asyncio
     async def test_store_with_annotations(self) -> None:
         # GIVEN a Folder object
         folder = Folder(
@@ -309,7 +304,6 @@ class TestFolder:
             assert result.created_by == CREATED_BY
             assert result.modified_by == MODIFIED_BY
 
-    @pytest.mark.asyncio
     async def test_store_with_name_and_parent_id(self) -> None:
         # GIVEN a Folder object
         folder = Folder(
@@ -369,7 +363,6 @@ class TestFolder:
             assert result.created_by == CREATED_BY
             assert result.modified_by == MODIFIED_BY
 
-    @pytest.mark.asyncio
     async def test_store_with_name_and_parent(self) -> None:
         # GIVEN a Folder object
         folder = Folder(
@@ -428,7 +421,6 @@ class TestFolder:
             assert result.created_by == CREATED_BY
             assert result.modified_by == MODIFIED_BY
 
-    @pytest.mark.asyncio
     async def test_store_no_id_name_or_parent(self) -> None:
         # GIVEN a Folder object
         folder = Folder()
@@ -443,7 +435,6 @@ class TestFolder:
             "(name and (`parent_id` or parent with an id)) set."
         )
 
-    @pytest.mark.asyncio
     async def test_store_no_id_or_name(self) -> None:
         # GIVEN a Folder object
         folder = Folder(parent_id=PARENT_ID)
@@ -458,7 +449,6 @@ class TestFolder:
             "(name and (`parent_id` or parent with an id)) set."
         )
 
-    @pytest.mark.asyncio
     async def test_store_no_id_or_parent(self) -> None:
         # GIVEN a Folder object
         folder = Folder(name=FOLDER_NAME)
@@ -473,7 +463,6 @@ class TestFolder:
             "(name and (`parent_id` or parent with an id)) set."
         )
 
-    @pytest.mark.asyncio
     async def test_get_by_id(self) -> None:
         # GIVEN a Folder object
         folder = Folder(
@@ -504,7 +493,6 @@ class TestFolder:
             assert result.created_by == CREATED_BY
             assert result.modified_by == MODIFIED_BY
 
-    @pytest.mark.asyncio
     async def test_get_by_name_and_parent(self) -> None:
         # GIVEN a Folder object
         folder = Folder(
@@ -546,7 +534,6 @@ class TestFolder:
             assert result.created_by == CREATED_BY
             assert result.modified_by == MODIFIED_BY
 
-    @pytest.mark.asyncio
     async def test_get_by_name_and_parent_not_found(self) -> None:
         # GIVEN a Folder object
         folder = Folder(
@@ -572,7 +559,6 @@ class TestFolder:
                 parent=folder.parent_id,
             )
 
-    @pytest.mark.asyncio
     async def test_delete_with_id(self) -> None:
         # GIVEN a Folder object
         folder = Folder(
@@ -592,7 +578,6 @@ class TestFolder:
                 obj=folder.id,
             )
 
-    @pytest.mark.asyncio
     async def test_delete_missing_id(self) -> None:
         # GIVEN a Folder object
         folder = Folder()
@@ -604,7 +589,6 @@ class TestFolder:
         # THEN we should get an error
         assert str(e.value) == "The folder must have an id set."
 
-    @pytest.mark.asyncio
     async def test_copy(self) -> None:
         # GIVEN a Folder object
         folder = Folder(
@@ -655,7 +639,6 @@ class TestFolder:
             # AND the file should be stored
             assert result.id == SYN_456
 
-    @pytest.mark.asyncio
     async def test_copy_missing_id(self) -> None:
         # GIVEN a Folder object
         folder = Folder()
@@ -667,7 +650,6 @@ class TestFolder:
         # THEN we should get an error
         assert str(e.value) == "The folder must have an ID and parent_id to copy."
 
-    @pytest.mark.asyncio
     async def test_copy_missing_destination(self) -> None:
         # GIVEN a Folder object
         folder = Folder(id=SYN_123)
@@ -679,7 +661,6 @@ class TestFolder:
         # THEN we should get an error
         assert str(e.value) == "The folder must have an ID and parent_id to copy."
 
-    @pytest.mark.asyncio
     async def test_sync_from_synapse(self) -> None:
         # GIVEN a Folder object
         folder = Folder(

--- a/tests/unit/synapseclient/models/async/unit_test_project_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_project_async.py
@@ -56,7 +56,6 @@ class TestProject:
         assert project_output.created_by == CREATED_BY
         assert project_output.modified_by == MODIFIED_BY
 
-    @pytest.mark.asyncio
     async def test_store_with_id(self) -> None:
         # GIVEN a Project object
         project = Project(
@@ -105,7 +104,6 @@ class TestProject:
             assert result.created_by == CREATED_BY
             assert result.modified_by == MODIFIED_BY
 
-    @pytest.mark.asyncio
     async def test_store_with_no_changes(self) -> None:
         # GIVEN a Project object
         project = Project(
@@ -134,7 +132,6 @@ class TestProject:
             # AND the project should only contain the ID
             assert result.id == PROJECT_ID
 
-    @pytest.mark.asyncio
     async def test_store_after_get(self) -> None:
         # GIVEN a Project object
         project = Project(
@@ -178,7 +175,6 @@ class TestProject:
             # AND the project should only contain the ID
             assert result.id == PROJECT_ID
 
-    @pytest.mark.asyncio
     async def test_store_after_get_with_changes(self) -> None:
         # GIVEN a Project object
         project = Project(
@@ -239,7 +235,6 @@ class TestProject:
             assert result.created_by == CREATED_BY
             assert result.modified_by == MODIFIED_BY
 
-    @pytest.mark.asyncio
     async def test_store_with_annotations(self) -> None:
         # GIVEN a Project object
         project = Project(
@@ -305,7 +300,6 @@ class TestProject:
             assert result.created_by == CREATED_BY
             assert result.modified_by == MODIFIED_BY
 
-    @pytest.mark.asyncio
     async def test_store_with_name_and_parent_id(self) -> None:
         # GIVEN a Project object
         project = Project(
@@ -364,7 +358,6 @@ class TestProject:
             assert result.created_by == CREATED_BY
             assert result.modified_by == MODIFIED_BY
 
-    @pytest.mark.asyncio
     async def test_store_no_id_or_name(self) -> None:
         # GIVEN a Project object
         project = Project(parent_id=PARENT_ID)
@@ -376,7 +369,6 @@ class TestProject:
         # THEN we should get an error
         assert str(e.value) == "Project ID or Name is required"
 
-    @pytest.mark.asyncio
     async def test_get_by_id(self) -> None:
         # GIVEN a Project object
         project = Project(
@@ -407,7 +399,6 @@ class TestProject:
             assert result.created_by == CREATED_BY
             assert result.modified_by == MODIFIED_BY
 
-    @pytest.mark.asyncio
     async def test_get_by_name_and_parent(self) -> None:
         # GIVEN a Project object
         project = Project(
@@ -449,7 +440,6 @@ class TestProject:
             assert result.created_by == CREATED_BY
             assert result.modified_by == MODIFIED_BY
 
-    @pytest.mark.asyncio
     async def test_get_by_name_and_parent_not_found(self) -> None:
         # GIVEN a Project object
         project = Project(
@@ -475,7 +465,6 @@ class TestProject:
                 parent=project.parent_id,
             )
 
-    @pytest.mark.asyncio
     async def test_delete_with_id(self) -> None:
         # GIVEN a Project object
         project = Project(
@@ -495,7 +484,6 @@ class TestProject:
                 obj=project.id,
             )
 
-    @pytest.mark.asyncio
     async def test_delete_missing_id(self) -> None:
         # GIVEN a Project object
         project = Project()
@@ -507,7 +495,6 @@ class TestProject:
         # THEN we should get an error
         assert str(e.value) == "Entity ID or Name/Parent is required"
 
-    @pytest.mark.asyncio
     async def test_copy(self) -> None:
         # GIVEN a Project object
         project = Project(
@@ -559,7 +546,6 @@ class TestProject:
             # AND the file should be stored
             assert result.id == "syn456"
 
-    @pytest.mark.asyncio
     async def test_copy_missing_id(self) -> None:
         # GIVEN a Project object
         project = Project()
@@ -571,7 +557,6 @@ class TestProject:
         # THEN we should get an error
         assert str(e.value) == "The project must have an ID and destination_id to copy."
 
-    @pytest.mark.asyncio
     async def test_copy_missing_destination(self) -> None:
         # GIVEN a Project object
         project = Project(id=PROJECT_ID)
@@ -583,7 +568,6 @@ class TestProject:
         # THEN we should get an error
         assert str(e.value) == "The project must have an ID and destination_id to copy."
 
-    @pytest.mark.asyncio
     async def test_sync_from_synapse(self) -> None:
         # GIVEN a Project object
         project = Project(

--- a/tests/unit/synapseclient/models/async/unit_test_team_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_team_async.py
@@ -78,7 +78,6 @@ class TestTeam:
         assert team.created_by == self.USER
         assert team.modified_by == self.USER
 
-    @pytest.mark.asyncio
     async def test_create(self) -> None:
         with patch.object(
             self.syn,
@@ -107,7 +106,6 @@ class TestTeam:
             assert team.can_public_join is False
             assert team.can_request_membership is True
 
-    @pytest.mark.asyncio
     async def test_delete(self) -> None:
         with patch.object(
             self.syn,
@@ -121,7 +119,6 @@ class TestTeam:
             # THEN I expect the patched method to be called as expected
             patch_delete_team.assert_called_once_with(id=1)
 
-    @pytest.mark.asyncio
     async def test_get_with_id(self) -> None:
         with patch.object(
             self.syn,
@@ -141,7 +138,6 @@ class TestTeam:
             assert team.name == self.NAME
             assert team.description == self.DESCRIPTION
 
-    @pytest.mark.asyncio
     async def test_get_with_name(self) -> None:
         with patch.object(
             self.syn,
@@ -161,7 +157,6 @@ class TestTeam:
             assert team.name == self.NAME
             assert team.description == self.DESCRIPTION
 
-    @pytest.mark.asyncio
     async def test_get_with_no_id_or_name(self) -> None:
         # GIVEN a team object with no id or name
         team = Team()
@@ -170,7 +165,6 @@ class TestTeam:
             # THEN I expect an error to be raised
             await team.get_async()
 
-    @pytest.mark.asyncio
     async def test_from_id(self) -> None:
         with patch.object(
             Team,
@@ -186,7 +180,6 @@ class TestTeam:
             assert team.name == self.NAME
             assert team.description == self.DESCRIPTION
 
-    @pytest.mark.asyncio
     async def test_from_name(self) -> None:
         with patch.object(
             Team,
@@ -202,7 +195,6 @@ class TestTeam:
             assert team.name == self.NAME
             assert team.description == self.DESCRIPTION
 
-    @pytest.mark.asyncio
     async def test_members(self) -> None:
         with patch.object(
             self.syn,
@@ -220,7 +212,6 @@ class TestTeam:
             assert team_members[0].team_id == 1
             assert isinstance(team_members[0].member, UserGroupHeader)
 
-    @pytest.mark.asyncio
     async def test_invite(self) -> None:
         with patch.object(
             self.syn,
@@ -244,7 +235,6 @@ class TestTeam:
             # AND I expect the expected invite to be returned
             assert invite == self.invite_response
 
-    @pytest.mark.asyncio
     async def test_open_invitations(self) -> None:
         with patch.object(
             self.syn,

--- a/tests/unit/synapseclient/models/async/unit_test_user_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_user_async.py
@@ -123,7 +123,6 @@ class TestUser:
         ]
         assert user_profile.created_on == CREATED_ON
 
-    @pytest.mark.asyncio
     async def test_get_id(self) -> None:
         # GIVEN a user profile
         user_profile = UserProfile(id=123)
@@ -166,7 +165,6 @@ class TestUser:
             ]
             assert profile.created_on == CREATED_ON
 
-    @pytest.mark.asyncio
     async def test_get_username(self) -> None:
         # GIVEN a user profile
         user_profile = UserProfile(username=USER_NAME)
@@ -209,7 +207,6 @@ class TestUser:
             ]
             assert profile.created_on == CREATED_ON
 
-    @pytest.mark.asyncio
     async def test_get_neither(self) -> None:
         # GIVEN a blank user profile
         user_profile = UserProfile()
@@ -252,7 +249,6 @@ class TestUser:
             ]
             assert profile.created_on == CREATED_ON
 
-    @pytest.mark.asyncio
     async def test_get_from_id(self) -> None:
         # GIVEN no user profile
 
@@ -294,7 +290,6 @@ class TestUser:
             ]
             assert profile.created_on == CREATED_ON
 
-    @pytest.mark.asyncio
     async def test_get_from_username(self) -> None:
         # GIVEN no user profile
 
@@ -336,7 +331,6 @@ class TestUser:
             ]
             assert profile.created_on == CREATED_ON
 
-    @pytest.mark.asyncio
     async def test_is_certified_id(self) -> None:
         # GIVEN a user profile
         user_profile = UserProfile(id=123)
@@ -355,7 +349,6 @@ class TestUser:
             # AND we should get the profile back
             assert is_certified == True
 
-    @pytest.mark.asyncio
     async def test_is_certified_username(self) -> None:
         # GIVEN a user profile
         user_profile = UserProfile(username=USER_NAME)
@@ -374,7 +367,6 @@ class TestUser:
             # AND we should get the profile back
             assert is_certified == True
 
-    @pytest.mark.asyncio
     async def test_is_certified_neither(self) -> None:
         # GIVEN a user profile
         user_profile = UserProfile()


### PR DESCRIPTION
**Problem:**

1. The HTTP connection pool was not being reused in integration tests. As a result a typical single run would create and tear down almost 400 connections.
2. When a connection error occurred retry logic would retry the HTTP request which would in most cases fail the test since Synapse would conflict with the data it already has.
These errors kept showing up
```
ConnectionResetError: [WinError 10054] An existing connection was forcibly closed by the remote host
ConnectionResetError: [Errno 104] Connection reset by peer
```
3. Builds were taking place during both the PR creation and commits. This means after a PR is created any new commits caused 2 builds to be ran.

**Solution:**

1. Upgrading to pytest-v7, and a newer pytest-asyncio
2. Updating the context of all integration tests to run within a singular asyncio event loop which allows us to share an HTTP connection pool: https://pytest-asyncio.readthedocs.io/en/latest/how-to-guides/run_session_tests_in_same_loop.html
3. Wrapping the start of the integration tests with a rerun of 3 retries per test that fails to allow for some level of recoverability
4. Only running builds on commit. This prevents running the build pipeline twice.

**Testing:**

1. Relying on successful runs of the CI pipeline
Verified that fewer connections are attempted (~400 -> ~200):
![image](https://github.com/Sage-Bionetworks/synapsePythonClient/assets/17128019/6202e522-ed36-4f77-ada4-77ad36e460b6)
