### PR TITLE
[SYNPY-1464] Adding Annotations to sync and async docs

### DIFF
--- a/docs/reference/oop/models.md
+++ b/docs/reference/oop/models.md
@@ -156,6 +156,11 @@ at your own risk.
       - is_certified
 ::: synapseclient.models.UserPreference
 ---
+::: synapseclient.models.Annotations
+    options:
+      members:
+      - from_dict
+---
 ::: synapseclient.models.mixins.AccessControllable
 ---
 

--- a/docs/reference/oop/models_async.md
+++ b/docs/reference/oop/models_async.md
@@ -93,3 +93,8 @@ functionally equivalent.
       - from_id_async
       - from_username_async
       - is_certified_async
+---
+::: synapseclient.models.Annotations
+    options:
+      members:
+      - store_async


### PR DESCRIPTION
### problem

Annotations OOP documentation was missing from the docs

### solution

Added Annotations section to the docs

### testing & preview

<img width="1251" alt="image" src="https://github.com/Sage-Bionetworks/synapsePythonClient/assets/32107699/70cd03d2-ed1d-49d4-a5cc-59fc929a03f4">

<img width="1202" alt="image" src="https://github.com/Sage-Bionetworks/synapsePythonClient/assets/32107699/42380a93-bb2d-4136-8110-5617f242293d">
