### PR TITLE
[SYNPY-1466] update user agent for command line 

### DIFF
--- a/synapseclient/__init__.py
+++ b/synapseclient/__init__.py
@@ -88,6 +88,11 @@ USER_AGENT = {
     % (__version__, requests.utils.default_user_agent())
 }
 
+USER_AGENT_COMMAND_LINE = {
+    "User-Agent": "synapsecommandlineclient/%s %s"
+    % (__version__, requests.utils.default_user_agent())
+}
+
 # patch json
 from .core.models import custom_json  # noqa
 

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -1871,8 +1871,10 @@ def _authenticate_login(
 
 def main():
     args = build_parser().parse_args()
-    synapseclient.USER_AGENT["User-Agent"] = (
-        "synapsecommandlineclient " + synapseclient.USER_AGENT["User-Agent"]
+    synapseclient.USER_AGENT[
+        "User-Agent"
+    ] = "synapsecommandlineclient" + synapseclient.USER_AGENT["User-Agent"].replace(
+        "synapseclient", ""
     )
     if args.otel:
         trace.set_tracer_provider(

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -1871,11 +1871,7 @@ def _authenticate_login(
 
 def main():
     args = build_parser().parse_args()
-    synapseclient.USER_AGENT[
-        "User-Agent"
-    ] = "synapsecommandlineclient" + synapseclient.USER_AGENT["User-Agent"].replace(
-        "synapseclient", ""
-    )
+    synapseclient.USER_AGENT = synapseclient.USER_AGENT_COMMAND_LINE
     if args.otel:
         trace.set_tracer_provider(
             TracerProvider(


### PR DESCRIPTION
Problem:

In the datawarehouse, the client version isn’t being parsed for user_agent of the synapse command line client

Solution:

Update the user agent of the  synapse command line client by removing the `synapseclient` substring with empty string so the client version can be pulld by Synapse-ETL-Jobs

Testing:

Passed both unit test and integration test