### PR TITLE
[SYNPY-1474] Correct order of credentials in comment

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -716,10 +716,10 @@ class Synapse(object):
         If no login arguments are provided or only username is provided, login() will attempt to log in using
          information from these sources (in order of preference):
 
-        1. User defined arguments during a CLI session
-        2. User's Personal Access Token (aka: Synapse Auth Token)
+        1. .synapseConfig file (in user home folder unless configured otherwise)
+        2. User defined arguments during a CLI session
+        3. User's Personal Access Token (aka: Synapse Auth Token)
             from the environment variable: SYNAPSE_AUTH_TOKEN
-        3. .synapseConfig file (in user home folder unless configured otherwise)
         4. Retrieves user's authentication token from AWS SSM Parameter store (if configured)
 
         Arguments:

--- a/synapseclient/core/credentials/credential_provider.py
+++ b/synapseclient/core/credentials/credential_provider.py
@@ -209,9 +209,9 @@ class SynapseCredentialsProviderChain(object):
 
     By default this class uses the following providers in this order:
 
-    1. [UserArgsCredentialsProvider][synapseclient.core.credentials.credential_provider.UserArgsCredentialsProvider]
-    2. [EnvironmentVariableCredentialsProvider][synapseclient.core.credentials.credential_provider.EnvironmentVariableCredentialsProvider]
-    3. [ConfigFileCredentialsProvider][synapseclient.core.credentials.credential_provider.ConfigFileCredentialsProvider]
+    1. [ConfigFileCredentialsProvider][synapseclient.core.credentials.credential_provider.ConfigFileCredentialsProvider]
+    2. [UserArgsCredentialsProvider][synapseclient.core.credentials.credential_provider.UserArgsCredentialsProvider]
+    3. [EnvironmentVariableCredentialsProvider][synapseclient.core.credentials.credential_provider.EnvironmentVariableCredentialsProvider]
     4. [AWSParameterStoreCredentialsProvider][synapseclient.core.credentials.credential_provider.AWSParameterStoreCredentialsProvider]
 
     Attributes:


### PR DESCRIPTION
**Problem:**
The order of credentials being tried was incorrect in the comment

**Solution:**
Correct the comment to match the code from: https://github.com/Sage-Bionetworks/synapsePythonClient/blob/develop/synapseclient/core/credentials/credential_provider.py#L258