### PR TITLE
[SYNPY-1456] Revert to old ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
           path: |
             ${{ steps.get-dependencies.outputs.site_packages_loc }}
             ${{ steps.get-dependencies.outputs.site_bin_dir }}
-          key: ${{ runner.os }}-${{ matrix.python }}-build-${{ env.cache-name }}-${{ hashFiles('setup.py') }}-v16
+          key: ${{ runner.os }}-${{ matrix.python }}-build-${{ env.cache-name }}-${{ hashFiles('setup.py') }}-v17
 
       - name: Install py-dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12, windows-2022]
+        os: [ubuntu-20.04, macos-12, windows-2022]
 
         # if changing the below change the run-integration-tests versions and the check-deploy versions
         python: [3.8, '3.9', '3.10', '3.11']
@@ -200,7 +200,7 @@ jobs:
           if-no-files-found: ignore
       - name: Upload coverage report
         uses: actions/upload-artifact@v2
-        if: ${{ contains(fromJSON('["3.9"]'), matrix.python) && contains(fromJSON('["ubuntu-22.04"]'), matrix.os)}}
+        if: ${{ contains(fromJSON('["3.9"]'), matrix.python) && contains(fromJSON('["ubuntu-20.04"]'), matrix.os)}}
         with:
           name: coverage-report
           path: coverage.xml


### PR DESCRIPTION
Problem:
****
1. Running integration tests in ubuntu-22.04 takes between 3-4 hours to complete.

**Solution:**

1. Revert ubuntu versions for the GH runner

**Testing:**

1. Verified after this change that a pipeline run only took ~30 minutes to complete