### PR TITLE
[SYNPY-1470]Remove SonarCloud's dependency on test job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,7 +206,6 @@ jobs:
           path: coverage.xml
 
   sonarcloud:
-    needs: [test]
     name: SonarCloud
     runs-on: ubuntu-20.04
     steps:
@@ -222,6 +221,7 @@ jobs:
         run: sed -i "s/<source>\/home\/runner\/work\/synapsePythonClient<\/source>/<source>\/github\/workspace<\/source>/g" coverage.xml
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
+        if: ${{ always() }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,7 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Download coverage report
         uses: actions/download-artifact@v2
-        if: steps.upload_converage_report.outputs.exists = "true"
+        if: steps.upload_converage_report.outputs.exists == "true"
         with:
           name: coverage-report
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,7 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Download coverage report
         uses: actions/download-artifact@v2
-        if: steps.upload_converage_report.outputs.exists = true
+        if: steps.upload_converage_report.outputs.exists = "true"
         with:
           name: coverage-report
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,9 +214,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Check coverage report existence
+        id: check_coverage_report
+        uses: andstor/file-existence-action@v3
+        with:
+          files: "coverage.xml"
       - name: Download coverage report
         uses: actions/download-artifact@v2
-        if: steps.upload_coverage_report.outputs.exists == "true"
+        if: steps.check_coverage_report.outputs.files_exists == "true"
         with:
           name: coverage-report
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,7 +199,7 @@ jobs:
           path: tests/integration/otel_spans_integration_testing_*.ndjson
           if-no-files-found: ignore
       - name: Upload coverage report
-        id: upload_converage_report
+        id: upload_coverage_report
         uses: actions/upload-artifact@v2
         if: ${{ contains(fromJSON('["3.9"]'), matrix.python) && contains(fromJSON('["ubuntu-20.04"]'), matrix.os)}}
         with:
@@ -216,7 +216,7 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Download coverage report
         uses: actions/download-artifact@v2
-        if: steps.upload_converage_report.outputs.exists == "true"
+        if: steps.upload_coverage_report.outputs.exists == "true"
         with:
           name: coverage-report
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,6 +199,7 @@ jobs:
           path: tests/integration/otel_spans_integration_testing_*.ndjson
           if-no-files-found: ignore
       - name: Upload coverage report
+        id: upload_converage_report
         uses: actions/upload-artifact@v2
         if: ${{ contains(fromJSON('["3.9"]'), matrix.python) && contains(fromJSON('["ubuntu-20.04"]'), matrix.os)}}
         with:
@@ -206,6 +207,7 @@ jobs:
           path: coverage.xml
 
   sonarcloud:
+    needs: [test]
     name: SonarCloud
     runs-on: ubuntu-20.04
     steps:
@@ -214,10 +216,12 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Download coverage report
         uses: actions/download-artifact@v2
+        if: steps.upload_converage_report.outputs.exists == 'true'
         with:
           name: coverage-report
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057
       - name: Override Coverage Source Path for Sonar
+        if: ${{ success() }}
         run: sed -i "s/<source>\/home\/runner\/work\/synapsePythonClient<\/source>/<source>\/github\/workspace<\/source>/g" coverage.xml
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master


### PR DESCRIPTION
Problem:

Currently, SonarCloud only executes when tests pass, but even if tests fail, its valuable for sonarcloud to execute.

Solution:

Remove `needs:[test]` so it doesn't require the test job complete successfully before kicking off SonarCloud job. Add `if: ${{ always() }}` in the  SonarCloud step so the it can be run at all time no matter the status of previous steps. 