### PR TITLE
[SYNPY-1470] Remove SonarCloud's dependency on test job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,7 +206,6 @@ jobs:
           path: coverage.xml
 
   sonarcloud:
-    needs: [test]
     name: SonarCloud
     runs-on: ubuntu-20.04
     steps:
@@ -222,6 +221,7 @@ jobs:
         run: sed -i "s/<source>\/home\/runner\/work\/synapsePythonClient<\/source>/<source>\/github\/workspace<\/source>/g" coverage.xml
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
+        if: ${{ always() }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,7 +226,7 @@ jobs:
           name: coverage-report
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057
       - name: Override Coverage Source Path for Sonar
-        if: ${{ success() }}
+        if: steps.check_coverage_report.outputs.files_exists == 'true'
         run: sed -i "s/<source>\/home\/runner\/work\/synapsePythonClient<\/source>/<source>\/github\/workspace<\/source>/g" coverage.xml
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,7 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Download coverage report
         uses: actions/download-artifact@v2
-        if: steps.upload_converage_report.outputs.exists = "true"
+        if: steps.upload_converage_report.outputs.exists == "true"
         with:
           name: coverage-report
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,7 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Download coverage report
         uses: actions/download-artifact@v2
-        if: steps.upload_converage_report.outputs.exists = true
+        if: steps.upload_converage_report.outputs.exists = "true"
         with:
           name: coverage-report
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,7 +221,7 @@ jobs:
           files: "coverage.xml"
       - name: Download coverage report
         uses: actions/download-artifact@v2
-        if: steps.check_coverage_report.outputs.files_exists == "true"
+        if: steps.check_coverage_report.outputs.files_exists == 'true'
         with:
           name: coverage-report
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,9 +214,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Check coverage report existence
+        id: check_coverage_report
+        uses: andstor/file-existence-action@v3
+        with:
+          files: "coverage.xml"
       - name: Download coverage report
         uses: actions/download-artifact@v2
-        if: steps.upload_coverage_report.outputs.exists == "true"
+        if: steps.check_coverage_report.outputs.files_exists == "true"
         with:
           name: coverage-report
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,7 +199,7 @@ jobs:
           path: tests/integration/otel_spans_integration_testing_*.ndjson
           if-no-files-found: ignore
       - name: Upload coverage report
-        id: upload_converage_report
+        id: upload_coverage_report
         uses: actions/upload-artifact@v2
         if: ${{ contains(fromJSON('["3.9"]'), matrix.python) && contains(fromJSON('["ubuntu-20.04"]'), matrix.os)}}
         with:
@@ -216,7 +216,7 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Download coverage report
         uses: actions/download-artifact@v2
-        if: steps.upload_converage_report.outputs.exists == "true"
+        if: steps.upload_coverage_report.outputs.exists == "true"
         with:
           name: coverage-report
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,6 +199,7 @@ jobs:
           path: tests/integration/otel_spans_integration_testing_*.ndjson
           if-no-files-found: ignore
       - name: Upload coverage report
+        id: upload_converage_report
         uses: actions/upload-artifact@v2
         if: ${{ contains(fromJSON('["3.9"]'), matrix.python) && contains(fromJSON('["ubuntu-20.04"]'), matrix.os)}}
         with:
@@ -206,6 +207,7 @@ jobs:
           path: coverage.xml
 
   sonarcloud:
+    needs: [test]
     name: SonarCloud
     runs-on: ubuntu-20.04
     steps:
@@ -214,10 +216,12 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Download coverage report
         uses: actions/download-artifact@v2
+        if: steps.upload_converage_report.outputs.exists == 'true'
         with:
           name: coverage-report
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057
       - name: Override Coverage Source Path for Sonar
+        if: ${{ success() }}
         run: sed -i "s/<source>\/home\/runner\/work\/synapsePythonClient<\/source>/<source>\/github\/workspace<\/source>/g" coverage.xml
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master


### PR DESCRIPTION
Problem:
Currently, sonarcloud only executes when tests pass, but even if tests fail, it's valuable for sonarcloud to execute.

Solution:
Let SonarCloud scan always run no matter what status of the previous steps. Add a separate step to check if coverage report exist, if not, skip downloading coverage report. Run `Override Coverage Source Path for Sonar`, only if the coverage report download step has succeeded. 

Testing:
1. Skip downloading the coverage report when the coverage report does not exist
2. The SonarCloud scan runs even though `Override Coverage Source Path for Sonar` fails.
<img width="578" alt="Screenshot 2024-05-09 at 8 45 42 PM" src="https://github.com/Sage-Bionetworks/synapsePythonClient/assets/90745557/a15e2441-354b-449b-8143-907ce5ce88f5">
3. Skip Override Coverage Source Path for Sonar when the coverage report does not exist.
<img width="541" alt="Screenshot 2024-05-10 at 9 08 14 AM" src="https://github.com/Sage-Bionetworks/synapsePythonClient/assets/90745557/84d057cc-7ae5-401a-8fee-c14921947550">

