### PR TITLE
[SYNPY-1341 & SYNPY-1479] Change syntax for conditional of ghcr release job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -378,72 +378,72 @@ jobs:
         with:
           name: ${{ needs.package.outputs.bdist-package-name }}
           path: dist
-      # - name: deploy-to-test-pypi
-      #   if: 'github.event.release.prerelease'
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     repository-url: https://test.pypi.org/legacy/
-      # - name: deploy-to-prod-pypi
-      #   if: '!github.event.release.prerelease'
-      #   uses: pypa/gh-action-pypi-publish@release/v1
+      - name: deploy-to-test-pypi
+        if: 'github.event.release.prerelease'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+      - name: deploy-to-prod-pypi
+        if: '!github.event.release.prerelease'
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   # on each of our matrix platforms, download the newly uploaded package from pypi and confirm its version
-  # check-deploy:
-  #   needs: deploy
+  check-deploy:
+    needs: deploy
 
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-20.04, macos-11, windows-2019]
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-11, windows-2019]
 
-  #       # python versions should be consistent with the strategy matrix and the runs-integration-tests versions
-  #       python: [3.8, '3.9', '3.10', '3.11']
+        # python versions should be consistent with the strategy matrix and the runs-integration-tests versions
+        python: [3.8, '3.9', '3.10', '3.11']
 
-  #   runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
 
-  #   steps:
-  #     - uses: actions/setup-python@v4
-  #       with:
-  #         python-version: ${{ matrix.python }}
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
 
-  #     - name: check-pypi
-  #       shell: bash
-  #       run: |
-  #         if [[ "${{ github.event.release.prerelease}}" == "false" ]]; then
-  #           PYPI_INDEX_URL="https://pypi.org/simple/"
-  #         else
-  #           PYPI_INDEX_URL="https://test.pypi.org/simple/"
-  #         fi
+      - name: check-pypi
+        shell: bash
+        run: |
+          if [[ "${{ github.event.release.prerelease}}" == "false" ]]; then
+            PYPI_INDEX_URL="https://pypi.org/simple/"
+          else
+            PYPI_INDEX_URL="https://test.pypi.org/simple/"
+          fi
 
-  #         RELEASE_TAG="${{ github.event.release.tag_name }}"
-  #         if [[ $RELEASE_TAG =~ ^v?([[:digit:]\.]+)(-rc)? ]]; then
-  #           VERSION="${BASH_REMATCH[1]}"
-  #           if [[ "${{ github.event.release.prerelease}}" == "true" ]]; then
-  #             VERSION="$VERSION.$GITHUB_RUN_NUMBER"
-  #           fi
-  #         else
-  #           echo "Unrecognized release tag"
-  #           exit 1
-  #         fi
+          RELEASE_TAG="${{ github.event.release.tag_name }}"
+          if [[ $RELEASE_TAG =~ ^v?([[:digit:]\.]+)(-rc)? ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+            if [[ "${{ github.event.release.prerelease}}" == "true" ]]; then
+              VERSION="$VERSION.$GITHUB_RUN_NUMBER"
+            fi
+          else
+            echo "Unrecognized release tag"
+            exit 1
+          fi
 
-  #         # it can take some time for the packages to become available in pypi after uploading
-  #         for i in 5 10 20 40; do
-  #           if pip3 install --index-url $PYPI_INDEX_URL --extra-index-url https://pypi.org/simple "synapseclient==$VERSION"; then
-  #             ACTUAL_VERSION=$(synapse --version)
+          # it can take some time for the packages to become available in pypi after uploading
+          for i in 5 10 20 40; do
+            if pip3 install --index-url $PYPI_INDEX_URL --extra-index-url https://pypi.org/simple "synapseclient==$VERSION"; then
+              ACTUAL_VERSION=$(synapse --version)
 
-  #             if [ -n "$(echo "$ACTUAL_VERSION" | grep -oF "$VERSION")" ]; then
-  #               echo "Successfully installed version $VERSION"
-  #               exit 0
-  #             else
-  #               echo "Expected version $VERSION, found $ACTUAL_VERSION instead"
-  #               exit 1
-  #             fi
-  #           fi
+              if [ -n "$(echo "$ACTUAL_VERSION" | grep -oF "$VERSION")" ]; then
+                echo "Successfully installed version $VERSION"
+                exit 0
+              else
+                echo "Expected version $VERSION, found $ACTUAL_VERSION instead"
+                exit 1
+              fi
+            fi
 
-  #           sleep $i
-  #         done
+            sleep $i
+          done
 
-  #         echo "Failed to install expected version $VERSION"
-  #         exit 1
+          echo "Failed to install expected version $VERSION"
+          exit 1
 
   # containerize the package and upload to the GHCR upon new release
   ghcr-build-and-push-on-release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -378,72 +378,72 @@ jobs:
         with:
           name: ${{ needs.package.outputs.bdist-package-name }}
           path: dist
-      - name: deploy-to-test-pypi
-        if: 'github.event.release.prerelease'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-      - name: deploy-to-prod-pypi
-        if: '!github.event.release.prerelease'
-        uses: pypa/gh-action-pypi-publish@release/v1
+      # - name: deploy-to-test-pypi
+      #   if: 'github.event.release.prerelease'
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     repository-url: https://test.pypi.org/legacy/
+      # - name: deploy-to-prod-pypi
+      #   if: '!github.event.release.prerelease'
+      #   uses: pypa/gh-action-pypi-publish@release/v1
 
   # on each of our matrix platforms, download the newly uploaded package from pypi and confirm its version
-  check-deploy:
-    needs: deploy
+  # check-deploy:
+  #   needs: deploy
 
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, macos-11, windows-2019]
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-20.04, macos-11, windows-2019]
 
-        # python versions should be consistent with the strategy matrix and the runs-integration-tests versions
-        python: [3.8, '3.9', '3.10', '3.11']
+  #       # python versions should be consistent with the strategy matrix and the runs-integration-tests versions
+  #       python: [3.8, '3.9', '3.10', '3.11']
 
-    runs-on: ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
 
-    steps:
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python }}
+  #   steps:
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: ${{ matrix.python }}
 
-      - name: check-pypi
-        shell: bash
-        run: |
-          if [[ "${{ github.event.release.prerelease}}" == "false" ]]; then
-            PYPI_INDEX_URL="https://pypi.org/simple/"
-          else
-            PYPI_INDEX_URL="https://test.pypi.org/simple/"
-          fi
+  #     - name: check-pypi
+  #       shell: bash
+  #       run: |
+  #         if [[ "${{ github.event.release.prerelease}}" == "false" ]]; then
+  #           PYPI_INDEX_URL="https://pypi.org/simple/"
+  #         else
+  #           PYPI_INDEX_URL="https://test.pypi.org/simple/"
+  #         fi
 
-          RELEASE_TAG="${{ github.event.release.tag_name }}"
-          if [[ $RELEASE_TAG =~ ^v?([[:digit:]\.]+)(-rc)? ]]; then
-            VERSION="${BASH_REMATCH[1]}"
-            if [[ "${{ github.event.release.prerelease}}" == "true" ]]; then
-              VERSION="$VERSION.$GITHUB_RUN_NUMBER"
-            fi
-          else
-            echo "Unrecognized release tag"
-            exit 1
-          fi
+  #         RELEASE_TAG="${{ github.event.release.tag_name }}"
+  #         if [[ $RELEASE_TAG =~ ^v?([[:digit:]\.]+)(-rc)? ]]; then
+  #           VERSION="${BASH_REMATCH[1]}"
+  #           if [[ "${{ github.event.release.prerelease}}" == "true" ]]; then
+  #             VERSION="$VERSION.$GITHUB_RUN_NUMBER"
+  #           fi
+  #         else
+  #           echo "Unrecognized release tag"
+  #           exit 1
+  #         fi
 
-          # it can take some time for the packages to become available in pypi after uploading
-          for i in 5 10 20 40; do
-            if pip3 install --index-url $PYPI_INDEX_URL --extra-index-url https://pypi.org/simple "synapseclient==$VERSION"; then
-              ACTUAL_VERSION=$(synapse --version)
+  #         # it can take some time for the packages to become available in pypi after uploading
+  #         for i in 5 10 20 40; do
+  #           if pip3 install --index-url $PYPI_INDEX_URL --extra-index-url https://pypi.org/simple "synapseclient==$VERSION"; then
+  #             ACTUAL_VERSION=$(synapse --version)
 
-              if [ -n "$(echo "$ACTUAL_VERSION" | grep -oF "$VERSION")" ]; then
-                echo "Successfully installed version $VERSION"
-                exit 0
-              else
-                echo "Expected version $VERSION, found $ACTUAL_VERSION instead"
-                exit 1
-              fi
-            fi
+  #             if [ -n "$(echo "$ACTUAL_VERSION" | grep -oF "$VERSION")" ]; then
+  #               echo "Successfully installed version $VERSION"
+  #               exit 0
+  #             else
+  #               echo "Expected version $VERSION, found $ACTUAL_VERSION instead"
+  #               exit 1
+  #             fi
+  #           fi
 
-            sleep $i
-          done
+  #           sleep $i
+  #         done
 
-          echo "Failed to install expected version $VERSION"
-          exit 1
+  #         echo "Failed to install expected version $VERSION"
+  #         exit 1
 
   # containerize the package and upload to the GHCR upon new release (whether pre-release or not)
   ghcr-build-and-push-on-release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -378,72 +378,72 @@ jobs:
         with:
           name: ${{ needs.package.outputs.bdist-package-name }}
           path: dist
-      # - name: deploy-to-test-pypi
-      #   if: 'github.event.release.prerelease'
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     repository-url: https://test.pypi.org/legacy/
-      # - name: deploy-to-prod-pypi
-      #   if: '!github.event.release.prerelease'
-      #   uses: pypa/gh-action-pypi-publish@release/v1
+      - name: deploy-to-test-pypi
+        if: 'github.event.release.prerelease'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+      - name: deploy-to-prod-pypi
+        if: '!github.event.release.prerelease'
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   # on each of our matrix platforms, download the newly uploaded package from pypi and confirm its version
-  # check-deploy:
-  #   needs: deploy
+  check-deploy:
+    needs: deploy
 
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-20.04, macos-11, windows-2019]
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-11, windows-2019]
 
-  #       # python versions should be consistent with the strategy matrix and the runs-integration-tests versions
-  #       python: [3.8, '3.9', '3.10', '3.11']
+        # python versions should be consistent with the strategy matrix and the runs-integration-tests versions
+        python: [3.8, '3.9', '3.10', '3.11']
 
-  #   runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
 
-  #   steps:
-  #     - uses: actions/setup-python@v4
-  #       with:
-  #         python-version: ${{ matrix.python }}
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
 
-  #     - name: check-pypi
-  #       shell: bash
-  #       run: |
-  #         if [[ "${{ github.event.release.prerelease}}" == "false" ]]; then
-  #           PYPI_INDEX_URL="https://pypi.org/simple/"
-  #         else
-  #           PYPI_INDEX_URL="https://test.pypi.org/simple/"
-  #         fi
+      - name: check-pypi
+        shell: bash
+        run: |
+          if [[ "${{ github.event.release.prerelease}}" == "false" ]]; then
+            PYPI_INDEX_URL="https://pypi.org/simple/"
+          else
+            PYPI_INDEX_URL="https://test.pypi.org/simple/"
+          fi
 
-  #         RELEASE_TAG="${{ github.event.release.tag_name }}"
-  #         if [[ $RELEASE_TAG =~ ^v?([[:digit:]\.]+)(-rc)? ]]; then
-  #           VERSION="${BASH_REMATCH[1]}"
-  #           if [[ "${{ github.event.release.prerelease}}" == "true" ]]; then
-  #             VERSION="$VERSION.$GITHUB_RUN_NUMBER"
-  #           fi
-  #         else
-  #           echo "Unrecognized release tag"
-  #           exit 1
-  #         fi
+          RELEASE_TAG="${{ github.event.release.tag_name }}"
+          if [[ $RELEASE_TAG =~ ^v?([[:digit:]\.]+)(-rc)? ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+            if [[ "${{ github.event.release.prerelease}}" == "true" ]]; then
+              VERSION="$VERSION.$GITHUB_RUN_NUMBER"
+            fi
+          else
+            echo "Unrecognized release tag"
+            exit 1
+          fi
 
-  #         # it can take some time for the packages to become available in pypi after uploading
-  #         for i in 5 10 20 40; do
-  #           if pip3 install --index-url $PYPI_INDEX_URL --extra-index-url https://pypi.org/simple "synapseclient==$VERSION"; then
-  #             ACTUAL_VERSION=$(synapse --version)
+          # it can take some time for the packages to become available in pypi after uploading
+          for i in 5 10 20 40; do
+            if pip3 install --index-url $PYPI_INDEX_URL --extra-index-url https://pypi.org/simple "synapseclient==$VERSION"; then
+              ACTUAL_VERSION=$(synapse --version)
 
-  #             if [ -n "$(echo "$ACTUAL_VERSION" | grep -oF "$VERSION")" ]; then
-  #               echo "Successfully installed version $VERSION"
-  #               exit 0
-  #             else
-  #               echo "Expected version $VERSION, found $ACTUAL_VERSION instead"
-  #               exit 1
-  #             fi
-  #           fi
+              if [ -n "$(echo "$ACTUAL_VERSION" | grep -oF "$VERSION")" ]; then
+                echo "Successfully installed version $VERSION"
+                exit 0
+              else
+                echo "Expected version $VERSION, found $ACTUAL_VERSION instead"
+                exit 1
+              fi
+            fi
 
-  #           sleep $i
-  #         done
+            sleep $i
+          done
 
-  #         echo "Failed to install expected version $VERSION"
-  #         exit 1
+          echo "Failed to install expected version $VERSION"
+          exit 1
 
   # containerize the package and upload to the GHCR upon new release (whether pre-release or not)
   ghcr-build-and-push-on-release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -447,8 +447,8 @@ jobs:
 
   # containerize the package and upload to the GHCR upon new release
   ghcr-build-and-push-on-release:
-    needs: package
-    if: github.event_name == 'release' && github.event.release.prerelease == 'false'
+    needs: check-deploy
+    if: '!github.event.release.prerelease'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -445,10 +445,9 @@ jobs:
           echo "Failed to install expected version $VERSION"
           exit 1
 
-  # containerize the package and upload to the GHCR upon new release
+  # containerize the package and upload to the GHCR upon new release (whether pre-release or not)
   ghcr-build-and-push-on-release:
     needs: deploy
-    if: '!github.event.release.prerelease'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -468,8 +467,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker image
+      - name: Build and push Docker image (official release)
         id: docker_build
+        if: '!github.event.release.prerelease'
         uses: docker/build-push-action@v3
         with:
           push: true
@@ -477,10 +477,26 @@ jobs:
           tags: ghcr.io/sage-bionetworks/synapsepythonclient:latest,ghcr.io/sage-bionetworks/synapsepythonclient:${{ env.RELEASE_VERSION }}
           file: ./Dockerfile
           platforms: linux/amd64
-          cache-from: type=registry,ref=ghcr.io/sage-bionetworks/synapsepythonclient:latest
-          cache-to: type=inline
-      - name: Output image digest
-        run: echo "The image digest is ${{ steps.docker_build.outputs.digest }}"
+          cache-from: type=registry,ref=ghcr.io/sage-bionetworks/synapsepythonclient:build-cache
+          cache-to: type=registry,mode=max,ref=ghcr.io/sage-bionetworks/synapsepythonclient:build-cache
+      - name: Build and push Docker image (pre-release)
+        id: docker_build_prerelease
+        if: 'github.event.release.prerelease'
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          provenance: false
+          tags: ghcr.io/sage-bionetworks/synapsepythonclient:${{ env.RELEASE_VERSION }}-prerelease
+          file: ./Dockerfile
+          platforms: linux/amd64
+          cache-from: type=registry,ref=ghcr.io/sage-bionetworks/synapsepythonclient:build-cache-prerelease
+          cache-to: type=registry,mode=max,ref=ghcr.io/sage-bionetworks/synapsepythonclient:build-cache-prerelease
+      - name: Output image digest (official release)
+        if: '!github.event.release.prerelease'
+        run: echo "The image digest for official release is ${{ steps.docker_build.outputs.digest }}"
+      - name: Output image digest (pre-release)
+        if: 'github.event.release.prerelease'
+        run: echo "The image digest for pre-release is ${{ steps.docker_build_prerelease.outputs.digest }}"
 
   # containerize the package and upload to the GHCR upon commit in develop
   ghcr-build-and-push-on-develop:
@@ -510,7 +526,7 @@ jobs:
           tags: ghcr.io/sage-bionetworks/synapsepythonclient:develop-${{ github.sha }}
           file: ./Dockerfile
           platforms: linux/amd64
-          cache-from: type=registry,ref=ghcr.io/sage-bionetworks/synapsepythonclient:latest
+          cache-from: type=registry,ref=ghcr.io/sage-bionetworks/synapsepythonclient:build-cache
           cache-to: type=inline
       - name: Output image digest
         run: echo "The image digest is ${{ steps.docker_build.outputs.digest }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -378,76 +378,76 @@ jobs:
         with:
           name: ${{ needs.package.outputs.bdist-package-name }}
           path: dist
-      - name: deploy-to-test-pypi
-        if: 'github.event.release.prerelease'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-      - name: deploy-to-prod-pypi
-        if: '!github.event.release.prerelease'
-        uses: pypa/gh-action-pypi-publish@release/v1
+      # - name: deploy-to-test-pypi
+      #   if: 'github.event.release.prerelease'
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     repository-url: https://test.pypi.org/legacy/
+      # - name: deploy-to-prod-pypi
+      #   if: '!github.event.release.prerelease'
+      #   uses: pypa/gh-action-pypi-publish@release/v1
 
   # on each of our matrix platforms, download the newly uploaded package from pypi and confirm its version
-  check-deploy:
-    needs: deploy
+  # check-deploy:
+  #   needs: deploy
 
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, macos-11, windows-2019]
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-20.04, macos-11, windows-2019]
 
-        # python versions should be consistent with the strategy matrix and the runs-integration-tests versions
-        python: [3.8, '3.9', '3.10', '3.11']
+  #       # python versions should be consistent with the strategy matrix and the runs-integration-tests versions
+  #       python: [3.8, '3.9', '3.10', '3.11']
 
-    runs-on: ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
 
-    steps:
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python }}
+  #   steps:
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: ${{ matrix.python }}
 
-      - name: check-pypi
-        shell: bash
-        run: |
-          if [[ "${{ github.event.release.prerelease}}" == "false" ]]; then
-            PYPI_INDEX_URL="https://pypi.org/simple/"
-          else
-            PYPI_INDEX_URL="https://test.pypi.org/simple/"
-          fi
+  #     - name: check-pypi
+  #       shell: bash
+  #       run: |
+  #         if [[ "${{ github.event.release.prerelease}}" == "false" ]]; then
+  #           PYPI_INDEX_URL="https://pypi.org/simple/"
+  #         else
+  #           PYPI_INDEX_URL="https://test.pypi.org/simple/"
+  #         fi
 
-          RELEASE_TAG="${{ github.event.release.tag_name }}"
-          if [[ $RELEASE_TAG =~ ^v?([[:digit:]\.]+)(-rc)? ]]; then
-            VERSION="${BASH_REMATCH[1]}"
-            if [[ "${{ github.event.release.prerelease}}" == "true" ]]; then
-              VERSION="$VERSION.$GITHUB_RUN_NUMBER"
-            fi
-          else
-            echo "Unrecognized release tag"
-            exit 1
-          fi
+  #         RELEASE_TAG="${{ github.event.release.tag_name }}"
+  #         if [[ $RELEASE_TAG =~ ^v?([[:digit:]\.]+)(-rc)? ]]; then
+  #           VERSION="${BASH_REMATCH[1]}"
+  #           if [[ "${{ github.event.release.prerelease}}" == "true" ]]; then
+  #             VERSION="$VERSION.$GITHUB_RUN_NUMBER"
+  #           fi
+  #         else
+  #           echo "Unrecognized release tag"
+  #           exit 1
+  #         fi
 
-          # it can take some time for the packages to become available in pypi after uploading
-          for i in 5 10 20 40; do
-            if pip3 install --index-url $PYPI_INDEX_URL --extra-index-url https://pypi.org/simple "synapseclient==$VERSION"; then
-              ACTUAL_VERSION=$(synapse --version)
+  #         # it can take some time for the packages to become available in pypi after uploading
+  #         for i in 5 10 20 40; do
+  #           if pip3 install --index-url $PYPI_INDEX_URL --extra-index-url https://pypi.org/simple "synapseclient==$VERSION"; then
+  #             ACTUAL_VERSION=$(synapse --version)
 
-              if [ -n "$(echo "$ACTUAL_VERSION" | grep -oF "$VERSION")" ]; then
-                echo "Successfully installed version $VERSION"
-                exit 0
-              else
-                echo "Expected version $VERSION, found $ACTUAL_VERSION instead"
-                exit 1
-              fi
-            fi
+  #             if [ -n "$(echo "$ACTUAL_VERSION" | grep -oF "$VERSION")" ]; then
+  #               echo "Successfully installed version $VERSION"
+  #               exit 0
+  #             else
+  #               echo "Expected version $VERSION, found $ACTUAL_VERSION instead"
+  #               exit 1
+  #             fi
+  #           fi
 
-            sleep $i
-          done
+  #           sleep $i
+  #         done
 
-          echo "Failed to install expected version $VERSION"
-          exit 1
+  #         echo "Failed to install expected version $VERSION"
+  #         exit 1
 
   # containerize the package and upload to the GHCR upon new release
   ghcr-build-and-push-on-release:
-    needs: check-deploy
+    needs: deploy
     if: '!github.event.release.prerelease'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
### problems

**_problem 1)_** The latest `v4.3.0` release did not trigger the CI job written to push the latest `synapsepythonclient` package to the GHCR.
_**problem 2)**_ It would be nice to have a pre-release image before an official release that validators can use to verify functionality is working as expected

### solution

- [x] Update the `if:` and `needs:` conditionals to prevent this job from being skipped when a new release comes out.
- [x] Add a new step to the "ghcr on release" job that releases a pre-release image

### testing & preview

_**RE: problem 1)**_
<img width="1001" alt="image" src="https://github.com/Sage-Bionetworks/synapsePythonClient/assets/32107699/7341207a-fea4-42ab-bc90-e45eaf80e4e4">

<img width="583" alt="image" src="https://github.com/Sage-Bionetworks/synapsePythonClient/assets/32107699/33b9ae51-476b-4530-8211-88cb7d8acf6a">

_**RE: problem 2)**_

pre-release: https://github.com/Sage-Bionetworks/synapsePythonClient/releases/tag/v0.0.0-rc

package: https://github.com/Sage-Bionetworks/synapsePythonClient/pkgs/container/synapsepythonclient/224686708?tag=v0.0.0-rc-prerelease

<img width="615" alt="image" src="https://github.com/Sage-Bionetworks/synapsePythonClient/assets/32107699/4b8aa65c-a07c-4823-b3a5-2ba444032dbb">
