### PR TITLE
[SYNPY-1476] Splitting logic for downloading content from client.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ CONFIGFILE
 
 htmlcov/
 .coverage
+.coverage.*
+cov.xml
 coverage.xml
 
 .ipynb_checkpoints

--- a/docs/guides/data_storage.md
+++ b/docs/guides/data_storage.md
@@ -269,7 +269,6 @@ Creating new version for file entity syn999
 Completed migration of syn123. 2 files migrated. 0 errors encountered
 Writing csv log to /tmp/migrate.csv
 ```
-.. _sts_storage_locations:
 
 ## STS Storage Locations
 

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,646 @@
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint
+# in a server-like mode.
+clear-cache-post-run=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, messages with a category besides ERROR or FATAL are
+# suppressed, and no reports are done by default. Error mode is compatible with
+# disabling specific errors.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold under which the program will exit with error.
+fail-under=10
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems,
+# it can't be used as an escape character.
+ignore-paths=
+
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
+ignore-patterns=^\.#
+
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well as
+# Unix pattern matching.
+ignored-modules=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
+prefer-stubs=no
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.8
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
+
+# Add paths to the list of the source roots. Supports globbing patterns. The
+# source root is an absolute path or a path relative to the current working
+# directory used to determine a package namespace for modules located under the
+# source root.
+source-roots=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type alias names. If left empty, type
+# alias names will be checked with the set naming style.
+#typealias-rgx=
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+#variable-rgx=
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      asyncSetUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make,os._exit
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow explicit reexports by alias from a package __init__.
+allow-reexport-from-package=no
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        use-implicit-booleaness-not-comparison-to-string,
+        use-implicit-booleaness-not-comparison-to-zero,
+        import-outside-toplevel,
+        protected-access
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[METHOD_ARGS]
+
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+notes-rgx=
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+# Let 'consider-using-join' be raised when the separator to join on would be
+# non-empty (resulting in expected fixes of the type: ``"- " + " -
+# ".join(items)``)
+suggest-join-with-non-empty-separator=yes
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+msg-template=
+
+# Set the output format. Available formats are: text, parseable, colorized,
+# json2 (improved json format), json (old json format) and msvs (visual
+# studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+#output-format=
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=yes
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. No available dictionaries : You need to install
+# both the python package and the system dependency for enchant to work.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -1,5 +1,5 @@
 # These are all of the models that are used by the Synapse client.
-from .annotations import set_annotations
+from .annotations import set_annotations, set_annotations_async
 from .configuration_services import (
     get_client_authenticated_s3_profile,
     get_config_authentication,
@@ -38,6 +38,7 @@ from .file_services import (
 __all__ = [
     # annotations
     "set_annotations",
+    "set_annotations_async",
     "get_entity_id_bundle2",
     "get_entity_id_version_bundle2",
     "post_entity_bundle2_create",

--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -63,7 +63,6 @@ __all__ = [
     "create_access_requirements_if_none",
     "delete_entity_generated_by",
     # configuration_services
-    "get_client_authenticated_s3_profile",
     "get_config_file",
     "get_config_section_dict",
     "get_config_authentication",

--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -1,5 +1,12 @@
 # These are all of the models that are used by the Synapse client.
 from .annotations import set_annotations
+from .configuration_services import (
+    get_client_authenticated_s3_profile,
+    get_config_authentication,
+    get_config_file,
+    get_config_section_dict,
+    get_transfer_config,
+)
 from .entity_bundle_services_v2 import (
     get_entity_id_bundle2,
     get_entity_id_version_bundle2,
@@ -7,24 +14,25 @@ from .entity_bundle_services_v2 import (
     put_entity_id_bundle2,
 )
 from .entity_services import (
+    create_access_requirements_if_none,
+    delete_entity_generated_by,
     get_entity,
     get_upload_destination,
     get_upload_destination_location,
     post_entity,
     put_entity,
-    create_access_requirements_if_none,
-    delete_entity_generated_by,
 )
 from .file_services import (
+    AddPartResponse,
     get_file_handle,
+    get_file_handle_for_download,
     post_external_filehandle,
     post_external_object_store_filehandle,
     post_external_s3_file_handle,
     post_file_multipart,
-    put_file_multipart_complete,
     post_file_multipart_presigned_urls,
     put_file_multipart_add,
-    AddPartResponse,
+    put_file_multipart_complete,
 )
 
 __all__ = [
@@ -45,6 +53,7 @@ __all__ = [
     "post_file_multipart_presigned_urls",
     "put_file_multipart_add",
     "AddPartResponse",
+    "get_file_handle_for_download",
     # entity_services
     "get_entity",
     "put_entity",
@@ -53,4 +62,11 @@ __all__ = [
     "get_upload_destination_location",
     "create_access_requirements_if_none",
     "delete_entity_generated_by",
+    # configuration_services
+    "get_client_authenticated_s3_profile",
+    "get_config_file",
+    "get_config_section_dict",
+    "get_config_authentication",
+    "get_client_authenticated_s3_profile",
+    "get_transfer_config",
 ]

--- a/synapseclient/api/annotations.py
+++ b/synapseclient/api/annotations.py
@@ -47,3 +47,36 @@ def set_annotations(
             }
         ),
     )
+
+
+async def set_annotations_async(
+    annotations: "Annotations",
+    synapse_client: Optional["Synapse"] = None,
+):
+    """Call to synapse and set the annotations for the given input.
+
+    Arguments:
+        annotations: The annotations to set. This is expected to have the id, etag,
+            and annotations filled in.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns: The annotations set in Synapse.
+    """
+    annotations_dict = asdict(annotations)
+
+    synapse_annotations = _convert_to_annotations_list(
+        annotations_dict["annotations"] or {}
+    )
+    from synapseclient import Synapse
+
+    return await Synapse.get_client(synapse_client=synapse_client).rest_put_async(
+        f"/entity/{annotations.id}/annotations2",
+        body=json.dumps(
+            {
+                "id": annotations.id,
+                "etag": annotations.etag,
+                "annotations": synapse_annotations,
+            }
+        ),
+    )

--- a/synapseclient/api/configuration_services.py
+++ b/synapseclient/api/configuration_services.py
@@ -116,7 +116,7 @@ def get_transfer_config(
         section_name="transfer", config_path=config_path
     ).items():
         if v:
-            if k == "max_threads" and v:
+            if k == "max_threads":
                 try:
                     transfer_config["max_threads"] = int(v)
                 except ValueError as cause:

--- a/synapseclient/api/configuration_services.py
+++ b/synapseclient/api/configuration_services.py
@@ -4,6 +4,8 @@ file, environment variables, or other means.
 
 import configparser
 import functools
+import urllib.parse
+
 from typing import Dict
 
 from synapseclient.core.constants import config_file_constants
@@ -70,7 +72,7 @@ def get_client_authenticated_s3_profile(
         The authenticated S3 profile
     """
 
-    config_section = endpoint + "/" + bucket
+    config_section = urllib.parse.urljoin(base=endpoint, url=bucket)
     return get_config_section_dict(
         section_name=config_section, config_path=config_path
     ).get("profile_name", "default")

--- a/synapseclient/api/configuration_services.py
+++ b/synapseclient/api/configuration_services.py
@@ -1,0 +1,136 @@
+"""This module is responsible for exposing access to any configuration either through
+file, environment variables, or other means.
+"""
+
+import configparser
+import functools
+from typing import Dict
+
+from synapseclient.core.constants import config_file_constants
+from synapseclient.core.pool_provider import DEFAULT_NUM_THREADS
+
+
+@functools.lru_cache()
+def get_config_file(config_path: str) -> configparser.RawConfigParser:
+    """
+    Retrieves the client configuration information.
+
+    Arguments:
+        config_path:  Path to configuration file on local file system
+
+    Returns:
+        A RawConfigParser populated with properties from the user's configuration file.
+    """
+
+    try:
+        config = configparser.RawConfigParser()
+        config.read(config_path)  # Does not fail if the file does not exist
+        return config
+    except configparser.Error as ex:
+        raise ValueError(f"Error parsing Synapse config file: {config_path}") from ex
+
+
+def get_config_section_dict(
+    section_name: str,
+    config_path: str,
+) -> Dict[str, str]:
+    """
+    Get a profile section in the configuration file with the section name.
+
+    Arguments:
+        section_name: The name of the profile section in the configuration file
+        config_path:  Path to configuration file on local file system
+
+    Returns:
+        A dictionary containing the configuration profile section content
+    """
+    config = get_config_file(config_path)
+    try:
+        return dict(config.items(section_name))
+    except configparser.NoSectionError:
+        # section not present
+        return {}
+
+
+def get_client_authenticated_s3_profile(
+    endpoint: str,
+    bucket: str,
+    config_path: str,
+) -> Dict[str, str]:
+    """
+    Get the authenticated S3 profile from the configuration file.
+
+    Arguments:
+        endpoint: The location of the target service
+        bucket:   AWS S3 bucket name
+        config_path:  Path to configuration file on local file system
+
+    Returns:
+        The authenticated S3 profile
+    """
+
+    config_section = endpoint + "/" + bucket
+    return get_config_section_dict(
+        section_name=config_section, config_path=config_path
+    ).get("profile_name", "default")
+
+
+def get_config_authentication(
+    config_path: str,
+) -> Dict[str, str]:
+    """
+    Get the authentication section of the configuration file.
+
+    Arguments:
+        config_path:  Path to configuration file on local file system
+
+    Returns:
+        The authentication section of the configuration file
+    """
+    return get_config_section_dict(
+        section_name=config_file_constants.AUTHENTICATION_SECTION_NAME,
+        config_path=config_path,
+    )
+
+
+def get_transfer_config(
+    config_path: str,
+) -> Dict[str, str]:
+    """section_name=
+    Get the transfer profile from the configuration file.
+
+    Arguments:
+        config_path:  Path to configuration file on local file system
+
+    Raises:
+        ValueError: Invalid max_threads value. Should be equal or less than 16.
+        ValueError: Invalid use_boto_sts value. Should be true or false.
+
+    Returns:
+        The transfer profile
+    """
+    # defaults
+    transfer_config = {"max_threads": DEFAULT_NUM_THREADS, "use_boto_sts": False}
+
+    for k, v in get_config_section_dict(
+        section_name="transfer", config_path=config_path
+    ).items():
+        if v:
+            if k == "max_threads" and v:
+                try:
+                    transfer_config["max_threads"] = int(v)
+                except ValueError as cause:
+                    raise ValueError(
+                        f"Invalid transfer.max_threads config setting {v}"
+                    ) from cause
+
+            elif k == "use_boto_sts":
+                lower_v = v.lower()
+                if lower_v not in ("true", "false"):
+                    raise ValueError(
+                        f"Invalid transfer.use_boto_sts config setting {v}"
+                    )
+
+                transfer_config["use_boto_sts"] = "true" == lower_v
+
+    return transfer_config

--- a/synapseclient/api/configuration_services.py
+++ b/synapseclient/api/configuration_services.py
@@ -42,7 +42,8 @@ def get_config_section_dict(
         config_path:  Path to configuration file on local file system
 
     Returns:
-        A dictionary containing the configuration profile section content
+        A dictionary containing the configuration profile section content. If the
+        section does not exist, an empty dictionary is returned.
     """
     config = get_config_file(config_path)
     try:
@@ -96,7 +97,7 @@ def get_config_authentication(
 def get_transfer_config(
     config_path: str,
 ) -> Dict[str, str]:
-    """section_name=
+    """
     Get the transfer profile from the configuration file.
 
     Arguments:

--- a/synapseclient/api/file_services.py
+++ b/synapseclient/api/file_services.py
@@ -378,13 +378,16 @@ async def get_file_handle_for_download(
     Arguments:
         file_handle_id:   ID of fileHandle to download
         synapse_id:       The ID of the object associated with the file e.g. syn234
-        entity_type:     Type of object associated with a file e.g. FileEntity, TableEntity <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/FileHandleAssociateType.html>
+        entity_type:     Type of object associated with a file e.g. FileEntity,
+            TableEntity
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/FileHandleAssociateType.html>
         synapse_client: If not passed in or None this will use the last client from
             the `.login()` method.
 
     Raises:
         SynapseFileNotFoundError: If the fileHandleId is not found in Synapse.
-        SynapseError:             If the user does not have the permission to access the fileHandleId.
+        SynapseError: If the user does not have the permission to access the
+            fileHandleId.
 
     Returns:
         A dictionary with keys: fileHandle, fileHandleId and preSignedURL
@@ -416,6 +419,7 @@ async def get_file_handle_for_download(
         )
     elif failure == "UNAUTHORIZED":
         raise SynapseError(
-            f"You are not authorized to access fileHandleId {file_handle_id} associated with the Synapse {entity_type}: {synapse_id}"
+            f"You are not authorized to access fileHandleId {file_handle_id} "
+            f"associated with the Synapse {entity_type}: {synapse_id}"
         )
     return result

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -4082,7 +4082,7 @@ class Synapse(object):
         bucket_name=None,
         base_key=None,
         sts_enabled=False,
-    ):
+    ) -> Tuple[Folder, Dict[str, str], Dict[str, str]]:
         """
         Create a storage location in the given parent, either in the given folder or by creating a new
         folder in that parent with the given name. This will both create a StorageLocationSetting,

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -670,7 +670,8 @@ class Synapse(object):
 
     @deprecated(
         version="4.4.0",
-        reason="To be removed in 5.0.0. Moved to synapseclient/api/configuration_services.py::get_config_file",
+        reason="To be removed in 5.0.0. "
+        "Moved to synapseclient/api/configuration_services.py::get_config_file",
     )
     @functools.lru_cache()
     def getConfigFile(self, configPath: str) -> configparser.RawConfigParser:
@@ -832,7 +833,8 @@ class Synapse(object):
 
     @deprecated(
         version="4.4.0",
-        reason="To be removed in 5.0.0. Moved to synapseclient/api/configuration_services.py::get_config_section_dict",
+        reason="To be removed in 5.0.0. "
+        "Moved to synapseclient/api/configuration_services.py::get_config_section_dict",
     )
     def _get_config_section_dict(self, section_name: str) -> Dict[str, str]:
         """
@@ -853,7 +855,8 @@ class Synapse(object):
 
     @deprecated(
         version="4.4.0",
-        reason="To be removed in 5.0.0. Moved to synapseclient/api/configuration_services.py::get_config_authentication",
+        reason="To be removed in 5.0.0. "
+        "Moved to synapseclient/api/configuration_services.py::get_config_authentication",
     )
     def _get_config_authentication(self) -> Dict[str, str]:
         """
@@ -869,7 +872,8 @@ class Synapse(object):
 
     @deprecated(
         version="4.4.0",
-        reason="To be removed in 5.0.0. Moved to synapseclient/api/configuration_services.py::get_client_authenticated_s3_profile",
+        reason="To be removed in 5.0.0. "
+        "Moved to synapseclient/api/configuration_services.py::get_client_authenticated_s3_profile",
     )
     def _get_client_authenticated_s3_profile(
         self, endpoint: str, bucket: str
@@ -891,7 +895,8 @@ class Synapse(object):
 
     @deprecated(
         version="4.4.0",
-        reason="To be removed in 5.0.0. Moved to synapseclient/api/configuration_services.py::get_transfer_config",
+        reason="To be removed in 5.0.0. "
+        "Moved to synapseclient/api/configuration_services.py::get_transfer_config",
     )
     def _get_transfer_config(self) -> Dict[str, str]:
         """
@@ -1621,7 +1626,8 @@ class Synapse(object):
 
     @deprecated(
         version="4.4.0",
-        reason="To be removed in 5.0.0. Moved to synapseclient/core/download/download_functions.py::ensure_download_location_is_directory",
+        reason="To be removed in 5.0.0. "
+        "Moved to synapseclient/core/download/download_functions.py::ensure_download_location_is_directory",
     )
     def _ensure_download_location_is_directory(self, downloadLocation: str) -> str:
         """
@@ -1645,7 +1651,8 @@ class Synapse(object):
 
     @deprecated(
         version="4.4.0",
-        reason="To be removed in 5.0.0. Moved to synapseclient/core/download/download_functions.py::download_file_entity",
+        reason="To be removed in 5.0.0. "
+        "Moved to synapseclient/core/download/download_functions.py::download_file_entity",
     )
     def _download_file_entity(
         self,
@@ -1741,7 +1748,8 @@ class Synapse(object):
 
     @deprecated(
         version="4.4.0",
-        reason="To be removed in 5.0.0. Moved to synapseclient/core/download/download_functions.py::resolve_download_path_collisions",
+        reason="To be removed in 5.0.0. "
+        "Moved to synapseclient/core/download/download_functions.py::resolve_download_path_collisions",
     )
     def _resolve_download_path_collisions(
         self,
@@ -3188,7 +3196,8 @@ class Synapse(object):
 
     @deprecated(
         version="4.4.0",
-        reason="To be removed in 5.0.0. Moved to synapseclient/api/file_services.py::get_file_handle_for_download",
+        reason="To be removed in 5.0.0. "
+        "Moved to synapseclient/api/file_services.py::get_file_handle_for_download",
     )
     def _getFileHandleDownload(
         self, fileHandleId: str, objectId: str, objectType: str = None
@@ -3238,7 +3247,8 @@ class Synapse(object):
     @staticmethod
     @deprecated(
         version="4.4.0",
-        reason="To be removed in 5.0.0. Moved to synapseclient/core/download/download_functions.py::is_retryable_download_error",
+        reason="To be removed in 5.0.0. "
+        "Moved to synapseclient/core/download/download_functions.py::is_retryable_download_error",
     )
     def _is_retryable_download_error(ex: Exception) -> bool:
         """
@@ -3259,7 +3269,8 @@ class Synapse(object):
 
     @deprecated(
         version="4.4.0",
-        reason="To be removed in 5.0.0. Moved to synapseclient/core/download/download_functions.py::download_by_file_handle",
+        reason="To be removed in 5.0.0. "
+        "Moved to synapseclient/core/download/download_functions.py::download_by_file_handle",
     )
     def _downloadFileHandle(
         self,
@@ -3386,7 +3397,8 @@ class Synapse(object):
 
     @deprecated(
         version="4.4.0",
-        reason="To be removed in 5.0.0. Moved to synapseclient/core/download/download_functions.py::download_from_url_multi_threaded",
+        reason="To be removed in 5.0.0. "
+        "Moved to synapseclient/core/download/download_functions.py::download_from_url_multi_threaded",
     )
     def _download_from_url_multi_threaded(
         self,
@@ -3451,7 +3463,8 @@ class Synapse(object):
 
     @deprecated(
         version="4.4.0",
-        reason="To be removed in 5.0.0. Moved to synapseclient/core/download/download_functions.py::is_synapse_uri",
+        reason="To be removed in 5.0.0. "
+        "Moved to synapseclient/core/download/download_functions.py::is_synapse_uri",
     )
     def _is_synapse_uri(self, uri: str) -> bool:
         """
@@ -3469,7 +3482,8 @@ class Synapse(object):
 
     @deprecated(
         version="4.4.0",
-        reason="To be removed in 5.0.0. Moved to synapseclient/core/download/download_functions.py::download_from_url",
+        reason="To be removed in 5.0.0. "
+        "Moved to synapseclient/core/download/download_functions.py::download_from_url",
     )
     def _download_from_URL(
         self,
@@ -3614,7 +3628,7 @@ class Synapse(object):
                     else:
                         mode = "wb"
                         previouslyTransferred = 0
-                        sig = hashlib.new("md5", usedforsecurity=False)
+                        sig = hashlib.new("md5", usedforsecurity=False)  # nosec
 
                     try:
                         with open(temp_destination, mode) as fd:

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -3,13 +3,10 @@ The `Synapse` object encapsulates a connection to the Synapse service and is use
 retrieving data, and recording provenance of data analysis.
 """
 import asyncio
-import asyncio_atexit
 import collections
 import collections.abc
 import configparser
 import csv
-import numbers
-import threading
 import errno
 import functools
 import getpass
@@ -17,11 +14,12 @@ import hashlib
 import json
 import logging
 import mimetypes
+import numbers
 import os
-import requests
 import shutil
 import sys
 import tempfile
+import threading
 import time
 import typing
 import urllib.parse as urllib_urlparse
@@ -29,109 +27,122 @@ import urllib.request as urllib_request
 import warnings
 import webbrowser
 import zipfile
-import httpx
-
-from deprecated import deprecated
-
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import asyncio_atexit
+import httpx
+import requests
+from deprecated import deprecated
 from loky import get_reusable_executor
+from opentelemetry import trace
+from opentelemetry.trace import SpanKind
 
 import synapseclient
-from .annotations import (
-    from_synapse_annotations,
-    to_synapse_annotations,
-    Annotations,
-    convert_old_annotation_json,
-    check_annotations_changed,
-)
-from .activity import Activity
 import synapseclient.core.multithread_download as multithread_download
-from .entity import (
-    Entity,
-    File,
-    Folder,
-    Versionable,
-    split_entity_namespaces,
-    is_versionable,
-    is_container,
-    is_synapse_entity,
+from synapseclient.api import (
+    get_client_authenticated_s3_profile,
+    get_config_file,
+    get_config_section_dict,
+    get_file_handle_for_download,
+    get_transfer_config,
 )
-from synapseclient.core.models.dict_object import DictObject
-from .evaluation import Evaluation, Submission, SubmissionStatus
-from .table import (
-    Schema,
-    SchemaBase,
-    Column,
-    TableQueryResult,
-    CsvFileTable,
-    EntityViewSchema,
-    SubmissionViewSchema,
-    Dataset,
+from synapseclient.core import (
+    cache,
+    cumulative_transfer_progress,
+    exceptions,
+    sts_transfer,
+    utils,
 )
-from .team import UserProfile, Team, TeamMember, UserGroupHeader
-from .wiki import Wiki, WikiAttachment
-from synapseclient.core import cache, exceptions, utils
-from synapseclient.core.constants import config_file_constants
-from synapseclient.core.constants import concrete_types
-from synapseclient.core import cumulative_transfer_progress
-from synapseclient.core.credentials import (
-    get_default_credential_chain,
-    UserLoginArgs,
+from synapseclient.core.async_utils import wrap_async_to_sync
+from synapseclient.core.constants import concrete_types, config_file_constants
+from synapseclient.core.credentials import UserLoginArgs, get_default_credential_chain
+from synapseclient.core.download import (
+    download_by_file_handle,
+    download_file_entity,
+    ensure_download_location_is_directory,
 )
+from synapseclient.core.dozer import doze
 from synapseclient.core.exceptions import (
     SynapseAuthenticationError,
     SynapseError,
     SynapseFileNotFoundError,
     SynapseHTTPError,
+    SynapseMalformedEntityError,
     SynapseMd5MismatchError,
     SynapseNoCredentialsError,
     SynapseProvenanceError,
     SynapseTimeoutError,
     SynapseUnmetAccessRestrictions,
-    SynapseMalformedEntityError,
 )
 from synapseclient.core.logging_setup import (
-    DEFAULT_LOGGER_NAME,
     DEBUG_LOGGER_NAME,
+    DEFAULT_LOGGER_NAME,
     SILENT_LOGGER_NAME,
 )
-from synapseclient.core.version_check import version_check
+from synapseclient.core.models.dict_object import DictObject
+from synapseclient.core.models.permission import Permissions
 from synapseclient.core.pool_provider import DEFAULT_NUM_THREADS, get_executor
-from synapseclient.core.utils import (
-    id_of,
-    get_properties,
-    MB,
-    is_json,
-    extract_synapse_id_from_query,
-    find_data_file_handle,
-    extract_zip_file_to_directory,
-    is_integer,
-    require_param,
-)
+from synapseclient.core.remote_file_storage_wrappers import S3ClientWrapper, SFTPWrapper
 from synapseclient.core.retry import (
-    with_retry,
-    with_retry_time_based_async,
     DEFAULT_RETRY_STATUS_CODES,
     RETRYABLE_CONNECTION_ERRORS,
     RETRYABLE_CONNECTION_EXCEPTIONS,
+    with_retry,
+    with_retry_time_based_async,
 )
-from synapseclient.core import sts_transfer
 from synapseclient.core.upload.multipart_upload_async import (
     multipart_upload_file_async,
     multipart_upload_string_async,
 )
-from synapseclient.core.remote_file_storage_wrappers import S3ClientWrapper, SFTPWrapper
 from synapseclient.core.upload.upload_functions_async import (
     upload_file_handle as upload_file_handle_async,
-    upload_synapse_s3,
 )
-from synapseclient.core.dozer import doze
-from synapseclient.core.async_utils import wrap_async_to_sync
+from synapseclient.core.upload.upload_functions_async import upload_synapse_s3
+from synapseclient.core.utils import (
+    MB,
+    extract_synapse_id_from_query,
+    extract_zip_file_to_directory,
+    find_data_file_handle,
+    get_properties,
+    id_of,
+    is_integer,
+    is_json,
+    require_param,
+)
+from synapseclient.core.version_check import version_check
 
-from typing import Any, Union, Dict, List, Optional, Tuple
-from synapseclient.core.models.permission import Permissions
-from opentelemetry import trace
-from opentelemetry.trace import SpanKind
+from .activity import Activity
+from .annotations import (
+    Annotations,
+    check_annotations_changed,
+    convert_old_annotation_json,
+    from_synapse_annotations,
+    to_synapse_annotations,
+)
+from .entity import (
+    Entity,
+    File,
+    Folder,
+    Versionable,
+    is_container,
+    is_synapse_entity,
+    is_versionable,
+    split_entity_namespaces,
+)
+from .evaluation import Evaluation, Submission, SubmissionStatus
+from .table import (
+    Column,
+    CsvFileTable,
+    Dataset,
+    EntityViewSchema,
+    Schema,
+    SchemaBase,
+    SubmissionViewSchema,
+    TableQueryResult,
+)
+from .team import Team, TeamMember, UserGroupHeader, UserProfile
+from .wiki import Wiki, WikiAttachment
 
 tracer = trace.get_tracer("synapseclient")
 
@@ -357,7 +368,7 @@ class Synapse(object):
         # Check for a config file
         self.configPath = configPath
         if os.path.isfile(configPath):
-            config = self.getConfigFile(configPath)
+            config = get_config_file(configPath)
             if config.has_option("cache", "location"):
                 cache_root_dir = config.get("cache", "location")
             if config.has_section("debug"):
@@ -394,7 +405,7 @@ class Synapse(object):
         self.table_query_timeout = 600  # in seconds
         self.multi_threaded = True  # if set to True, multi threaded download will be used for http and https URLs
 
-        transfer_config = self._get_transfer_config()
+        transfer_config = get_transfer_config(config_path=self.configPath)
         self.max_threads = transfer_config["max_threads"]
         self._thread_executor = {}
         self._process_executor = {}
@@ -657,6 +668,10 @@ class Synapse(object):
         # for backwards compatability when username was a part of the Synapse object and not in credentials
         return self.credentials.username if self.credentials is not None else None
 
+    @deprecated(
+        version="4.4.0",
+        reason="To be removed in 5.0.0. Moved to synapseclient/api/configuration_services.py::get_config_file",
+    )
     @functools.lru_cache()
     def getConfigFile(self, configPath: str) -> configparser.RawConfigParser:
         """
@@ -685,7 +700,7 @@ class Synapse(object):
         fileHandleEndpoint: str = None,
         portalEndpoint: str = None,
         skip_checks: bool = False,
-    ):
+    ) -> None:
         """
         Sets the locations for each of the Synapse services (mostly useful for testing).
 
@@ -712,7 +727,7 @@ class Synapse(object):
         }
 
         # For unspecified endpoints, first look in the config file
-        config = self.getConfigFile(self.configPath)
+        config = get_config_file(self.configPath)
         for point in endpoints.keys():
             if endpoints[point] is None and config.has_option("endpoints", point):
                 endpoints[point] = config.get("endpoints", point)
@@ -815,6 +830,10 @@ class Synapse(object):
         if cache_client:
             Synapse.set_client(self)
 
+    @deprecated(
+        version="4.4.0",
+        reason="To be removed in 5.0.0. Moved to synapseclient/api/configuration_services.py::get_config_section_dict",
+    )
     def _get_config_section_dict(self, section_name: str) -> Dict[str, str]:
         """
         Get a profile section in the configuration file with the section name.
@@ -825,13 +844,17 @@ class Synapse(object):
         Returns:
             A dictionary containing the configuration profile section content
         """
-        config = self.getConfigFile(self.configPath)
+        config = get_config_file(self.configPath)
         try:
             return dict(config.items(section_name))
         except configparser.NoSectionError:
             # section not present
             return {}
 
+    @deprecated(
+        version="4.4.0",
+        reason="To be removed in 5.0.0. Moved to synapseclient/api/configuration_services.py::get_config_authentication",
+    )
     def _get_config_authentication(self) -> Dict[str, str]:
         """
         Get the authentication section of the configuration file.
@@ -839,10 +862,15 @@ class Synapse(object):
         Returns:
             The authentication section of the configuration file
         """
-        return self._get_config_section_dict(
-            config_file_constants.AUTHENTICATION_SECTION_NAME
+        return get_config_section_dict(
+            section_name=config_file_constants.AUTHENTICATION_SECTION_NAME,
+            config_path=self.configPath,
         )
 
+    @deprecated(
+        version="4.4.0",
+        reason="To be removed in 5.0.0. Moved to synapseclient/api/configuration_services.py::get_client_authenticated_s3_profile",
+    )
     def _get_client_authenticated_s3_profile(
         self, endpoint: str, bucket: str
     ) -> Dict[str, str]:
@@ -857,10 +885,14 @@ class Synapse(object):
             The authenticated S3 profile
         """
         config_section = endpoint + "/" + bucket
-        return self._get_config_section_dict(config_section).get(
-            "profile_name", "default"
-        )
+        return get_config_section_dict(
+            section_name=config_section, config_path=self.configPath
+        ).get("profile_name", "default")
 
+    @deprecated(
+        version="4.4.0",
+        reason="To be removed in 5.0.0. Moved to synapseclient/api/configuration_services.py::get_transfer_config",
+    )
     def _get_transfer_config(self) -> Dict[str, str]:
         """
         Get the transfer profile from the configuration file.
@@ -875,7 +907,9 @@ class Synapse(object):
         # defaults
         transfer_config = {"max_threads": DEFAULT_NUM_THREADS, "use_boto_sts": False}
 
-        for k, v in self._get_config_section_dict("transfer").items():
+        for k, v in get_config_section_dict(
+            section_name="transfer", config_path=self.configPath
+        ).items():
             if v:
                 if k == "max_threads" and v:
                     try:
@@ -1559,11 +1593,15 @@ class Synapse(object):
 
             if downloadFile:
                 if file_handle:
-                    self._download_file_entity(
-                        downloadLocation,
-                        entity,
-                        ifcollision,
-                        submission,
+                    wrap_async_to_sync(
+                        coroutine=download_file_entity(
+                            download_location=downloadLocation,
+                            entity=entity,
+                            if_collision=ifcollision,
+                            submission=submission,
+                            synapse_client=self,
+                        ),
+                        syn=self,
                     )
                 else:  # no filehandle means that we do not have DOWNLOAD permission
                     warning_message = (
@@ -1581,6 +1619,10 @@ class Synapse(object):
                     )
         return entity
 
+    @deprecated(
+        version="4.4.0",
+        reason="To be removed in 5.0.0. Moved to synapseclient/core/download/download_functions.py::ensure_download_location_is_directory",
+    )
     def _ensure_download_location_is_directory(self, downloadLocation: str) -> str:
         """
         Check if the download location is a directory
@@ -1601,6 +1643,10 @@ class Synapse(object):
             )
         return download_dir
 
+    @deprecated(
+        version="4.4.0",
+        reason="To be removed in 5.0.0. Moved to synapseclient/core/download/download_functions.py::download_file_entity",
+    )
     def _download_file_entity(
         self,
         downloadLocation: str,
@@ -1693,6 +1739,10 @@ class Synapse(object):
         entity.files = [os.path.basename(downloadPath)]
         entity.cacheDir = os.path.dirname(downloadPath)
 
+    @deprecated(
+        version="4.4.0",
+        reason="To be removed in 5.0.0. Moved to synapseclient/core/download/download_functions.py::resolve_download_path_collisions",
+    )
     def _resolve_download_path_collisions(
         self,
         downloadLocation: str,
@@ -2422,10 +2472,14 @@ class Synapse(object):
         """
         manifest = self._generate_manifest_from_download_list()
         # Get file handle download link
-        file_result = self._getFileHandleDownload(
-            fileHandleId=manifest["resultFileHandleId"],
-            objectId=manifest["resultFileHandleId"],
-            objectType="FileEntity",
+        file_result = wrap_async_to_sync(
+            coroutine=get_file_handle_for_download(
+                file_handle_id=manifest["resultFileHandleId"],
+                synapse_id=manifest["resultFileHandleId"],
+                entity_type="FileEntity",
+                synapse_client=self,
+            ),
+            syn=self,
         )
         # Download the manifest
         downloaded_path = self._download_from_URL(
@@ -3132,6 +3186,10 @@ class Synapse(object):
     #                File handle service calls                 #
     ############################################################
 
+    @deprecated(
+        version="4.4.0",
+        reason="To be removed in 5.0.0. Moved to synapseclient/api/file_services.py::get_file_handle_for_download",
+    )
     def _getFileHandleDownload(
         self, fileHandleId: str, objectId: str, objectType: str = None
     ) -> Dict[str, str]:
@@ -3178,6 +3236,10 @@ class Synapse(object):
         return result
 
     @staticmethod
+    @deprecated(
+        version="4.4.0",
+        reason="To be removed in 5.0.0. Moved to synapseclient/core/download/download_functions.py::is_retryable_download_error",
+    )
     def _is_retryable_download_error(ex: Exception) -> bool:
         """
         Check if the download error is retryable
@@ -3195,6 +3257,10 @@ class Synapse(object):
             or isinstance(ex, SynapseMd5MismatchError)  # out of disk space
         )
 
+    @deprecated(
+        version="4.4.0",
+        reason="To be removed in 5.0.0. Moved to synapseclient/core/download/download_functions.py::download_by_file_handle",
+    )
     def _downloadFileHandle(
         self,
         fileHandleId: str,
@@ -3228,8 +3294,10 @@ class Synapse(object):
                 storageLocationId = fileHandle.get("storageLocationId")
 
                 if concreteType == concrete_types.EXTERNAL_OBJECT_STORE_FILE_HANDLE:
-                    profile = self._get_client_authenticated_s3_profile(
-                        fileHandle["endpointUrl"], fileHandle["bucket"]
+                    profile = get_client_authenticated_s3_profile(
+                        endpoint=fileHandle["endpointUrl"],
+                        bucket=fileHandle["bucket"],
+                        config_path=self.configPath,
                     )
                     downloaded_path = S3ClientWrapper.download_file(
                         fileHandle["bucket"],
@@ -3316,6 +3384,10 @@ class Synapse(object):
 
         raise Exception("should not reach this line")
 
+    @deprecated(
+        version="4.4.0",
+        reason="To be removed in 5.0.0. Moved to synapseclient/core/download/download_functions.py::download_from_url_multi_threaded",
+    )
     def _download_from_url_multi_threaded(
         self,
         file_handle_id: str,
@@ -3377,6 +3449,10 @@ class Synapse(object):
 
         return destination
 
+    @deprecated(
+        version="4.4.0",
+        reason="To be removed in 5.0.0. Moved to synapseclient/core/download/download_functions.py::is_synapse_uri",
+    )
     def _is_synapse_uri(self, uri: str) -> bool:
         """
         Check whether the given uri is hosted at the configured Synapse repo endpoint
@@ -3391,6 +3467,10 @@ class Synapse(object):
         synapse_repo_domain = urllib_urlparse.urlparse(self.repoEndpoint).netloc
         return uri_domain.lower() == synapse_repo_domain.lower()
 
+    @deprecated(
+        version="4.4.0",
+        reason="To be removed in 5.0.0. Moved to synapseclient/core/download/download_functions.py::download_from_url",
+    )
     def _download_from_URL(
         self,
         url: str,
@@ -3793,7 +3873,7 @@ class Synapse(object):
         parsedURL = urllib_urlparse.urlparse(url)
         baseURL = parsedURL.scheme + "://" + parsedURL.hostname
 
-        config = self.getConfigFile(self.configPath)
+        config = get_config_file(self.configPath)
         if username is None and config.has_option(baseURL, "username"):
             username = config.get(baseURL, "username")
         if password is None and config.has_option(baseURL, "password"):
@@ -4886,11 +4966,16 @@ class Synapse(object):
             cache_dir = self.cache.get_cache_dir(wiki.markdownFileHandleId)
             if not os.path.exists(cache_dir):
                 os.makedirs(cache_dir)
-            path = self._downloadFileHandle(
-                wiki["markdownFileHandleId"],
-                wiki["id"],
-                "WikiMarkdown",
-                os.path.join(cache_dir, str(wiki.markdownFileHandleId) + ".md"),
+            path = wrap_async_to_sync(
+                coroutine=download_by_file_handle(
+                    file_handle_id=wiki["markdownFileHandleId"],
+                    synapse_id=wiki["id"],
+                    entity_type="WikiMarkdown",
+                    destination=os.path.join(
+                        cache_dir, str(wiki.markdownFileHandleId) + ".md"
+                    ),
+                ),
+                syn=self,
             )
         try:
             import gzip
@@ -5543,17 +5628,22 @@ class Synapse(object):
             return download_from_table_result, cached_file_path
 
         if downloadLocation:
-            download_dir = self._ensure_download_location_is_directory(downloadLocation)
+            download_dir = ensure_download_location_is_directory(
+                download_location=downloadLocation
+            )
         else:
-            download_dir = self.cache.get_cache_dir(file_handle_id)
+            download_dir = self.cache.get_cache_dir(file_handle_id=file_handle_id)
 
         os.makedirs(download_dir, exist_ok=True)
         filename = f"SYNAPSE_TABLE_QUERY_{file_handle_id}.csv"
-        path = self._downloadFileHandle(
-            file_handle_id,
-            extract_synapse_id_from_query(query),
-            "TableEntity",
-            os.path.join(download_dir, filename),
+        path = wrap_async_to_sync(
+            coroutine=download_by_file_handle(
+                file_handle_id=file_handle_id,
+                synapse_id=extract_synapse_id_from_query(query),
+                entity_type="TableEntity",
+                destination=os.path.join(download_dir, filename),
+            ),
+            syn=self,
         )
 
         return download_from_table_result, path
@@ -5696,11 +5786,14 @@ class Synapse(object):
             temp_dir = tempfile.mkdtemp()
             zipfilepath = os.path.join(temp_dir, "table_file_download.zip")
             try:
-                zipfilepath = self._downloadFileHandle(
-                    response["resultZipFileHandleId"],
-                    table.tableId,
-                    "TableEntity",
-                    zipfilepath,
+                zipfilepath = wrap_async_to_sync(
+                    download_by_file_handle(
+                        file_handle_id=response["resultZipFileHandleId"],
+                        synapse_id=table.tableId,
+                        entity_type="TableEntity",
+                        destination=zipfilepath,
+                    ),
+                    syn=self,
                 )
                 # TODO handle case when no zip file is returned
                 # TODO test case when we give it partial or all bad file handles
@@ -5712,7 +5805,7 @@ class Synapse(object):
                 # ------------------------------------------------------------
 
                 if downloadLocation:
-                    download_dir = self._ensure_download_location_is_directory(
+                    download_dir = ensure_download_location_is_directory(
                         downloadLocation
                     )
 

--- a/synapseclient/core/constants/method_flags.py
+++ b/synapseclient/core/constants/method_flags.py
@@ -2,3 +2,5 @@
 means like Enums or other constants."""
 
 COLLISION_OVERWRITE_LOCAL = "overwrite.local"
+COLLISION_KEEP_LOCAL = "keep.local"
+COLLISION_KEEP_BOTH = "keep.both"

--- a/synapseclient/core/credentials/credential_provider.py
+++ b/synapseclient/core/credentials/credential_provider.py
@@ -12,6 +12,7 @@ from synapseclient.core.credentials.cred_data import (
     SynapseCredentials,
 )
 from synapseclient.core.exceptions import SynapseAuthenticationError
+from synapseclient.api import get_config_authentication
 
 if TYPE_CHECKING:
     from synapseclient import Synapse
@@ -116,7 +117,7 @@ class ConfigFileCredentialsProvider(SynapseCredentialsProvider):
     def _get_auth_info(
         self, syn: "Synapse", user_login_args: Dict[str, str]
     ) -> Tuple[Union[str, None], Union[str, None]]:
-        config_dict = syn._get_config_authentication()
+        config_dict = get_config_authentication(config_path=syn.configPath)
         # check to make sure we didn't accidentally provide the wrong user
 
         username = config_dict.get("username")

--- a/synapseclient/core/download/__init__.py
+++ b/synapseclient/core/download/__init__.py
@@ -1,0 +1,15 @@
+from .download_functions import (
+    download_file_entity,
+    ensure_download_location_is_directory,
+    download_by_file_handle,
+    download_from_url,
+    download_from_url_multi_threaded,
+)
+
+__all__ = [
+    "download_file_entity",
+    "ensure_download_location_is_directory",
+    "download_by_file_handle",
+    "download_from_url",
+    "download_from_url_multi_threaded",
+]

--- a/synapseclient/core/download/__init__.py
+++ b/synapseclient/core/download/__init__.py
@@ -1,3 +1,5 @@
+"""Functions related to downloading files from Synapse."""
+
 from .download_functions import (
     download_file_entity,
     ensure_download_location_is_directory,

--- a/synapseclient/core/download/__init__.py
+++ b/synapseclient/core/download/__init__.py
@@ -1,17 +1,37 @@
 """Functions related to downloading files from Synapse."""
 
+from .download_async import (
+    SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE,
+    DownloadRequest,
+    download_file,
+    shared_progress_bar,
+    PresignedUrlInfo,
+    PresignedUrlProvider,
+    TransferStatus,
+    _MultithreadedDownloader,
+)
 from .download_functions import (
-    download_file_entity,
-    ensure_download_location_is_directory,
     download_by_file_handle,
+    download_file_entity,
     download_from_url,
     download_from_url_multi_threaded,
+    ensure_download_location_is_directory,
 )
 
 __all__ = [
+    # download_functions
     "download_file_entity",
     "ensure_download_location_is_directory",
     "download_by_file_handle",
     "download_from_url",
     "download_from_url_multi_threaded",
+    # download_async
+    "DownloadRequest",
+    "download_file",
+    "shared_progress_bar",
+    "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+    "PresignedUrlInfo",
+    "PresignedUrlProvider",
+    "TransferStatus",
+    "_MultithreadedDownloader",
 ]

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -1,0 +1,678 @@
+"""This module handles the various ways that a user can download a file to Synapse."""
+
+import errno
+import os
+import shutil
+import sys
+import time
+import hashlib
+import urllib.parse as urllib_urlparse
+import urllib.request as urllib_request
+from typing import TYPE_CHECKING, Optional
+
+from synapseclient.api import (
+    get_client_authenticated_s3_profile,
+    get_file_handle_for_download,
+)
+from synapseclient.core import exceptions, multithread_download, sts_transfer, utils
+from synapseclient.core.constants import concrete_types
+from synapseclient.core.exceptions import (
+    SynapseHTTPError,
+    SynapseMd5MismatchError,
+    SynapseError,
+)
+from synapseclient.core.remote_file_storage_wrappers import S3ClientWrapper, SFTPWrapper
+from synapseclient.core.retry import (
+    DEFAULT_RETRY_STATUS_CODES,
+    RETRYABLE_CONNECTION_ERRORS,
+    RETRYABLE_CONNECTION_EXCEPTIONS,
+)
+
+from synapseclient.core.utils import (
+    MB,
+)
+
+if TYPE_CHECKING:
+    from synapseclient import Synapse, Entity
+
+FILE_BUFFER_SIZE = 2 * MB
+REDIRECT_LIMIT = 5
+
+# Defines the standard retry policy applied to the rest methods
+# The retry period needs to span a minute because sending messages is limited to 10 per 60 seconds.
+STANDARD_RETRY_PARAMS = {
+    "retry_status_codes": DEFAULT_RETRY_STATUS_CODES,
+    "retry_errors": RETRYABLE_CONNECTION_ERRORS,
+    "retry_exceptions": RETRYABLE_CONNECTION_EXCEPTIONS,
+    "retries": 60,  # Retries for up to about 30 minutes
+    "wait": 1,
+    "max_wait": 30,
+    "back_off": 2,
+}
+
+
+async def download_file_entity(
+    *,
+    download_location: str,
+    entity: "Entity",
+    if_collision: str,
+    submission: str,
+    synapse_client: Optional["Synapse"] = None,
+) -> None:
+    """
+    Download file entity
+
+    Arguments:
+        download_location: The download location
+        entity:           The Synapse Entity object
+        if_collision:      Determines how to handle file collisions.
+                            May be
+
+            - `overwrite.local`
+            - `keep.local`
+            - `keep.both`
+
+        submission:       Access associated files through a submission rather than through an entity.
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+    # set the initial local state
+    entity.path = None
+    entity.files = []
+    entity.cacheDir = None
+
+    # check to see if an UNMODIFIED version of the file (since it was last downloaded) already exists
+    # this location could be either in .synapseCache or a user specified location to which the user previously
+    # downloaded the file
+    cached_file_path = client.cache.get(
+        file_handle_id=entity.dataFileHandleId, path=download_location
+    )
+
+    # location in .synapseCache where the file would be corresponding to its FileHandleId
+    synapse_cache_location = client.cache.get_cache_dir(
+        file_handle_id=entity.dataFileHandleId
+    )
+
+    file_name = (
+        entity._file_handle.fileName
+        if cached_file_path is None
+        else os.path.basename(cached_file_path)
+    )
+
+    # Decide the best download location for the file
+    if download_location is not None:
+        # Make sure the specified download location is a fully resolved directory
+        download_location = ensure_download_location_is_directory(download_location)
+    elif cached_file_path is not None:
+        # file already cached so use that as the download location
+        download_location = os.path.dirname(cached_file_path)
+    else:
+        # file not cached and no user-specified location so default to .synapseCache
+        download_location = synapse_cache_location
+
+    # resolve file path collisions by either overwriting, renaming, or not downloading, depending on the
+    # ifcollision value
+    download_path = resolve_download_path_collisions(
+        download_location=download_location,
+        file_name=file_name,
+        if_collision=if_collision,
+        synapse_cache_location=synapse_cache_location,
+        cached_file_path=cached_file_path,
+    )
+    if download_path is None:
+        return
+
+    if cached_file_path is not None:  # copy from cache
+        if download_path != cached_file_path:
+            # create the foider if it does not exist already
+            if not os.path.exists(download_location):
+                os.makedirs(download_location)
+            shutil.copy(cached_file_path, download_path)
+
+    else:  # download the file from URL (could be a local file)
+        object_type = "FileEntity" if submission is None else "SubmissionAttachment"
+        object_id = entity["id"] if submission is None else submission
+
+        # reassign downloadPath because if url points to local file (e.g. file://~/someLocalFile.txt)
+        # it won't be "downloaded" and, instead, downloadPath will just point to '~/someLocalFile.txt'
+        # _downloadFileHandle may also return None to indicate that the download failed
+        download_path = await download_by_file_handle(
+            file_handle_id=entity.dataFileHandleId,
+            synapse_id=object_id,
+            entity_type=object_type,
+            destination=download_path,
+        )
+
+        if download_path is None or not os.path.exists(download_path):
+            return
+
+    # converts the path format from forward slashes back to backward slashes on Windows
+    entity.path = os.path.normpath(download_path)
+    entity.files = [os.path.basename(download_path)]
+    entity.cacheDir = os.path.dirname(download_path)
+
+
+async def download_by_file_handle(
+    file_handle_id: str,
+    synapse_id: str,
+    entity_type: str,
+    destination: str,
+    # TODO: Update this retries to be time based to match the upload logic
+    retries: int = 5,
+    synapse_client: Optional["Synapse"] = None,
+) -> str:
+    """
+    Download a file from the given URL to the local file system.
+
+    Arguments:
+        file_handle_id: The id of the FileHandle to download
+        synapse_id:     The id of the Synapse object that uses the FileHandle e.g. "syn123"
+        entity_type:   The type of the Synapse object that uses the FileHandle e.g. "FileEntity"
+        destination:  The destination on local file system
+        retries:      The Number of download retries attempted before throwing an exception.
+
+    Returns:
+        The path to downloaded file
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+    os.makedirs(os.path.dirname(destination), exist_ok=True)
+
+    while retries > 0:
+        try:
+            file_handle_result = await get_file_handle_for_download(
+                file_handle_id=file_handle_id,
+                synapse_id=synapse_id,
+                entity_type=entity_type,
+                synapse_client=client,
+            )
+            file_handle = file_handle_result["fileHandle"]
+            concrete_type = file_handle["concreteType"]
+            storage_location_id = file_handle.get("storageLocationId")
+
+            if concrete_type == concrete_types.EXTERNAL_OBJECT_STORE_FILE_HANDLE:
+                profile = get_client_authenticated_s3_profile(
+                    endpoint=file_handle["endpointUrl"],
+                    bucket=file_handle["bucket"],
+                    config_path=client.configPath,
+                )
+                downloaded_path = S3ClientWrapper.download_file(
+                    bucket=file_handle["bucket"],
+                    endpoint_url=file_handle["endpointUrl"],
+                    remote_file_key=file_handle["fileKey"],
+                    download_file_path=destination,
+                    profile_name=profile,
+                    show_progress=not client.silent,
+                )
+
+            elif (
+                sts_transfer.is_boto_sts_transfer_enabled(syn=client)
+                and await sts_transfer.is_storage_location_sts_enabled_async(
+                    syn=client, entity_id=synapse_id, location=storage_location_id
+                )
+                and concrete_type == concrete_types.S3_FILE_HANDLE
+            ):
+                # TODO: Some work is needed here to run these in a thread executor
+                def download_fn(credentials):
+                    return S3ClientWrapper.download_file(
+                        bucket=file_handle["bucketName"],
+                        endpoint_url=None,
+                        remote_file_key=file_handle["key"],
+                        download_file_path=destination,
+                        credentials=credentials,
+                        show_progress=not client.silent,
+                        # pass through our synapse threading config to boto s3
+                        transfer_config_kwargs={"max_concurrency": client.max_threads},
+                    )
+
+                downloaded_path = sts_transfer.with_boto_sts_credentials(
+                    fn=download_fn,
+                    syn=client,
+                    entity_id=synapse_id,
+                    permission="read_only",
+                )
+
+            elif (
+                client.multi_threaded
+                and concrete_type == concrete_types.S3_FILE_HANDLE
+                and file_handle.get("contentSize", 0)
+                > multithread_download.SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE
+            ):
+                # run the download multi threaded if the file supports it, we're configured to do so,
+                # and the file is large enough that it would be broken into parts to take advantage of
+                # multiple downloading threads. otherwise it's more efficient to run the download as a simple
+                # single threaded URL download.
+                downloaded_path = await download_from_url_multi_threaded(
+                    file_handle_id=file_handle_id,
+                    object_id=synapse_id,
+                    object_type=entity_type,
+                    destination=destination,
+                    expected_md5=file_handle.get("contentMd5"),
+                    synapse_client=client,
+                )
+
+            else:
+                downloaded_path = await download_from_url(
+                    url=file_handle_result["preSignedURL"],
+                    destination=destination,
+                    file_handle_id=file_handle["id"],
+                    expected_md5=file_handle.get("contentMd5"),
+                    synapse_client=client,
+                )
+            client.cache.add(file_handle["id"], downloaded_path)
+            return downloaded_path
+
+        except Exception as ex:
+            if not is_retryable_download_error(ex):
+                raise
+
+            exc_info = sys.exc_info()
+            ex.progress = 0 if not hasattr(ex, "progress") else ex.progress
+            client.logger.debug(
+                f"\nRetrying download on error: [{exc_info[0]}] after progressing {ex.progress} bytes",
+                exc_info=True,
+            )  # this will include stack trace
+            if ex.progress == 0:  # No progress was made reduce remaining retries.
+                retries -= 1
+            if retries <= 0:
+                # Re-raise exception
+                raise
+
+    raise Exception("should not reach this line")
+
+
+async def download_from_url_multi_threaded(
+    file_handle_id: str,
+    object_id: str,
+    object_type: str,
+    destination: str,
+    *,
+    expected_md5: str = None,
+    synapse_client: Optional["Synapse"] = None,
+) -> str:
+    """
+    Download a file from the given URL using multiple threads.
+
+    Arguments:
+        file_handle_id: The id of the FileHandle to download
+        object_id:      The id of the Synapse object that uses the FileHandle e.g. "syn123"
+        object_type:    The type of the Synapse object that uses the FileHandle e.g. "FileEntity"
+        destination:    The destination on local file system
+        expected_md5:   The expected MD5
+    Raises:
+        SynapseMd5MismatchError: If the actual MD5 does not match expected MD5.
+
+    Returns:
+        The path to downloaded file
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+    destination = os.path.abspath(destination)
+    temp_destination = utils.temp_download_filename(
+        destination=destination, file_handle_id=file_handle_id
+    )
+
+    request = multithread_download.DownloadRequest(
+        file_handle_id=int(file_handle_id),
+        object_id=object_id,
+        object_type=object_type,
+        path=temp_destination,
+        debug=client.debug,
+    )
+
+    multithread_download.download_file(client=client, download_request=request)
+
+    if expected_md5:  # if md5 not set (should be the case for all except http download)
+        actual_md5 = utils.md5_for_file(temp_destination).hexdigest()
+        # check md5 if given
+        if actual_md5 != expected_md5:
+            try:
+                os.remove(temp_destination)
+            except FileNotFoundError:
+                # file already does not exist. nothing to do
+                pass
+            raise SynapseMd5MismatchError(
+                f"Downloaded file {temp_destination}'s md5 {actual_md5} does not match expected MD5 of {expected_md5}"
+            )
+    # once download completed, rename to desired destination
+    shutil.move(temp_destination, destination)
+
+    return destination
+
+
+async def download_from_url(
+    url: str,
+    destination: str,
+    file_handle_id: Optional[str] = None,
+    expected_md5: Optional[str] = None,
+    synapse_client: Optional["Synapse"] = None,
+) -> str:
+    """
+    Download a file from the given URL to the local file system.
+
+    Arguments:
+        url:           The source of download
+        destination:   The destination on local file system
+        file_handle_id:  Optional. If given, the file will be given a temporary name that includes the file
+                                handle id which allows resuming partial downloads of the same file from previous
+                                sessions
+        expected_md5:  Optional. If given, check that the MD5 of the downloaded file matches the expected MD5
+
+    Raises:
+        IOError:                 If the local file does not exist.
+        SynapseError:            If fail to download the file.
+        SynapseHTTPError:        If there are too many redirects.
+        SynapseMd5MismatchError: If the actual MD5 does not match expected MD5.
+
+    Returns:
+        The path to downloaded file
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    destination = os.path.abspath(destination)
+    actual_md5 = None
+    redirect_count = 0
+    delete_on_md5_mismatch = True
+    client.logger.debug(f"Downloading from {url} to {destination}")
+    while redirect_count < REDIRECT_LIMIT:
+        redirect_count += 1
+        scheme = urllib_urlparse.urlparse(url).scheme
+        if scheme == "file":
+            delete_on_md5_mismatch = False
+            destination = utils.file_url_to_path(url, verify_exists=True)
+            if destination is None:
+                raise IOError(f"Local file ({url}) does not exist.")
+            break
+        elif scheme == "sftp":
+            username, password = client._getUserCredentials(url)
+            destination = SFTPWrapper.download_file(
+                url=url,
+                localFilepath=destination,
+                username=username,
+                password=password,
+                show_progress=not client.silent,
+            )
+            break
+        elif scheme == "ftp":
+            transfer_start_time = time.time()
+
+            def _ftp_report_hook(
+                block_number: int, read_size: int, total_size: int
+            ) -> None:
+                show_progress = not client.silent
+                if show_progress:
+                    client._print_transfer_progress(
+                        transferred=block_number * read_size,
+                        toBeTransferred=total_size,
+                        prefix="Downloading ",
+                        postfix=os.path.basename(destination),
+                        dt=time.time() - transfer_start_time,
+                    )
+
+            urllib_request.urlretrieve(
+                url=url, filename=destination, reporthook=_ftp_report_hook
+            )
+            break
+        elif scheme == "http" or scheme == "https":
+            # if a partial download exists with the temporary name,
+            temp_destination = utils.temp_download_filename(
+                destination=destination, file_handle_id=file_handle_id
+            )
+            range_header = (
+                {"Range": f"bytes={os.path.getsize(filename=temp_destination)}-"}
+                if os.path.exists(temp_destination)
+                else {}
+            )
+
+            # pass along synapse auth credentials only if downloading directly from synapse
+            auth = (
+                client.credentials
+                if is_synapse_uri(uri=url, synapse_client=client)
+                else None
+            )
+            response = await client.rest_get_async(
+                uri=url,
+                headers=client._generate_headers(range_header),
+                stream=True,
+                allow_redirects=False,
+                auth=auth,
+            )
+            try:
+                exceptions._raise_for_status(response, verbose=client.debug)
+            except SynapseHTTPError as err:
+                if err.response.status_code == 404:
+                    raise SynapseError(f"Could not download the file at {url}") from err
+                elif (
+                    err.response.status_code == 416
+                ):  # Requested Range Not Statisfiable
+                    # this is a weird error when the client already finished downloading but the loop continues
+                    # When this exception occurs, the range we request is guaranteed to be >= file size so we
+                    # assume that the file has been fully downloaded, rename it to destination file
+                    # and break out of the loop to perform the MD5 check.
+                    # If it fails the user can retry with another download.
+                    shutil.move(temp_destination, destination)
+                    break
+                raise
+
+            # handle redirects
+            if response.status_code in [301, 302, 303, 307, 308]:
+                url = response.headers["location"]
+                # don't break, loop again
+            else:
+                # get filename from content-disposition, if we don't have it already
+                if os.path.isdir(destination):
+                    filename = utils.extract_filename(
+                        content_disposition_header=response.headers.get(
+                            "content-disposition", None
+                        ),
+                        default_filename=utils.guess_file_name(url),
+                    )
+                    destination = os.path.join(destination, filename)
+                # Stream the file to disk
+                if "content-length" in response.headers:
+                    to_be_transferred = float(response.headers["content-length"])
+                else:
+                    to_be_transferred = -1
+                transferred = 0
+
+                # Servers that respect the Range header return 206 Partial Content
+                if response.status_code == 206:
+                    mode = "ab"
+                    previously_transferred = os.path.getsize(filename=temp_destination)
+                    to_be_transferred += previously_transferred
+                    transferred += previously_transferred
+                    sig = utils.md5_for_file(filename=temp_destination)
+                else:
+                    mode = "wb"
+                    previously_transferred = 0
+                    sig = hashlib.new("md5", usedforsecurity=False)
+
+                try:
+                    with open(temp_destination, mode) as fd:
+                        t0 = time.time()
+                        for _, chunk in enumerate(
+                            response.iter_content(FILE_BUFFER_SIZE)
+                        ):
+                            fd.write(chunk)
+                            sig.update(chunk)
+
+                            # the 'content-length' header gives the total number of bytes that will be transferred
+                            # to us len(chunk) cannot be used to track progress because iter_content automatically
+                            # decodes the chunks if the response body is encoded so the len(chunk) could be
+                            # different from the total number of bytes we've read read from the response body
+                            # response.raw.tell() is the total number of response body bytes transferred over the
+                            # wire so far
+                            transferred = response.raw.tell() + previously_transferred
+                            client._print_transfer_progress(
+                                transferred,
+                                to_be_transferred,
+                                "Downloading ",
+                                os.path.basename(destination),
+                                dt=time.time() - t0,
+                            )
+                except (
+                    Exception
+                ) as ex:  # We will add a progress parameter then push it back to retry.
+                    ex.progress = transferred - previously_transferred
+                    raise
+
+                # verify that the file was completely downloaded and retry if it is not complete
+                if to_be_transferred > 0 and transferred < to_be_transferred:
+                    client.logger.warning(
+                        "\nRetrying download because the connection ended early.\n"
+                    )
+                    continue
+
+                actual_md5 = sig.hexdigest()
+                # rename to final destination
+                shutil.move(temp_destination, destination)
+                break
+        else:
+            client.logger.error(f"Unable to download URLs of type {scheme}")
+            return None
+
+    else:  # didn't break out of loop
+        raise SynapseHTTPError("Too many redirects")
+
+    if (
+        actual_md5 is None
+    ):  # if md5 not set (should be the case for all except http download)
+        actual_md5 = utils.md5_for_file(destination).hexdigest()
+
+    # check md5 if given
+    if expected_md5 and actual_md5 != expected_md5:
+        if delete_on_md5_mismatch and os.path.exists(destination):
+            os.remove(destination)
+        raise SynapseMd5MismatchError(
+            f"Downloaded file {destination}'s md5 {actual_md5} does not match expected MD5 of {expected_md5}"
+        )
+
+    return destination
+
+
+def is_retryable_download_error(ex: Exception) -> bool:
+    """
+    Check if the download error is retryable
+
+    Arguments:
+        ex: An exception
+
+    Returns:
+        Boolean value indicating whether the download error is retryable
+    """
+    # some exceptions caught during download indicate non-recoverable situations that
+    # will not be remedied by a repeated download attempt.
+    return not (
+        (isinstance(ex, OSError) and ex.errno == errno.ENOSPC)
+        or isinstance(ex, SynapseMd5MismatchError)  # out of disk space
+    )
+
+
+def resolve_download_path_collisions(
+    download_location: str,
+    file_name: str,
+    if_collision: str,
+    synapse_cache_location: str,
+    cached_file_path: str,
+    synapse_client: Optional["Synapse"] = None,
+) -> str:
+    """
+    Resolve file path collisions
+
+    Arguments:
+        download_location:      The download location
+        file_name:             The file name
+        if_collision:           Determines how to handle file collisions.
+                                May be "overwrite.local", "keep.local", or "keep.both".
+        synapse_cache_location: The location in .synapseCache where the file would be
+                                corresponding to its FileHandleId.
+        cached_file_path:      The file path of the cached copy
+
+    Raises:
+        ValueError: Invalid ifcollision. Should be "overwrite.local", "keep.local", or "keep.both".
+
+    Returns:
+        The download file path with collisions resolved
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    # always overwrite if we are downloading to .synapseCache
+    if utils.normalize_path(download_location) == synapse_cache_location:
+        if if_collision is not None and if_collision != "overwrite.local":
+            client.logger.warning(
+                "\n"
+                + "!" * 50
+                + f"\nifcollision={if_collision} "
+                + "is being IGNORED because the download destination is synapse's cache."
+                ' Instead, the behavior is "overwrite.local". \n' + "!" * 50 + "\n"
+            )
+        if_collision = "overwrite.local"
+    # if ifcollision not specified, keep.local
+    if_collision = if_collision or "keep.both"
+
+    download_path = utils.normalize_path(os.path.join(download_location, file_name))
+    # resolve collison
+    if os.path.exists(path=download_path):
+        if if_collision == "overwrite.local":
+            pass
+        elif if_collision == "keep.local":
+            # Don't want to overwrite the local file.
+            return None
+        elif if_collision == "keep.both":
+            if download_path != cached_file_path:
+                return utils.unique_filename(download_path)
+        else:
+            raise ValueError(
+                f'Invalid parameter: "{if_collision}" is not a valid value for "ifcollision"'
+            )
+    return download_path
+
+
+def ensure_download_location_is_directory(download_location: str) -> str:
+    """
+    Check if the download location is a directory
+
+    Arguments:
+        download_location: The download location
+
+    Raises:
+        ValueError: If the download_location is not a directory
+
+    Returns:
+        The download location
+    """
+    download_dir = os.path.expandvars(os.path.expanduser(download_location))
+    if os.path.isfile(download_dir):
+        raise ValueError(
+            "Parameter 'download_location' should be a directory, not a file."
+        )
+    return download_dir
+
+
+def is_synapse_uri(
+    uri: str,
+    synapse_client: Optional["Synapse"] = None,
+) -> bool:
+    """
+    Check whether the given uri is hosted at the configured Synapse repo endpoint
+
+    Arguments:
+        uri: A given uri
+
+    Returns:
+        A boolean value indicating whether the given uri is hosted at the configured Synapse repo endpoint
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    uri_domain = urllib_urlparse.urlparse(uri).netloc
+    synapse_repo_domain = urllib_urlparse.urlparse(client.repoEndpoint).netloc
+    return uri_domain.lower() == synapse_repo_domain.lower()

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -1,30 +1,36 @@
 """This module handles the various ways that a user can download a file to Synapse."""
 
+import asyncio
 import errno
+import hashlib
 import os
 import shutil
 import sys
 import time
-import hashlib
 import urllib.parse as urllib_urlparse
 import urllib.request as urllib_request
-from typing import TYPE_CHECKING, Optional, Dict, Union
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
-from synapseclient.core.constants.method_flags import (
-    COLLISION_OVERWRITE_LOCAL,
-    COLLISION_KEEP_LOCAL,
-    COLLISION_KEEP_BOTH,
-)
 from synapseclient.api import (
     get_client_authenticated_s3_profile,
     get_file_handle_for_download,
 )
-from synapseclient.core import exceptions, multithread_download, sts_transfer, utils
+from synapseclient.core import exceptions, sts_transfer, utils
 from synapseclient.core.constants import concrete_types
+from synapseclient.core.constants.method_flags import (
+    COLLISION_KEEP_BOTH,
+    COLLISION_KEEP_LOCAL,
+    COLLISION_OVERWRITE_LOCAL,
+)
+from synapseclient.core.download import (
+    DownloadRequest,
+    download_file,
+    SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE,
+)
 from synapseclient.core.exceptions import (
+    SynapseError,
     SynapseHTTPError,
     SynapseMd5MismatchError,
-    SynapseError,
 )
 from synapseclient.core.remote_file_storage_wrappers import S3ClientWrapper, SFTPWrapper
 from synapseclient.core.retry import (
@@ -33,13 +39,10 @@ from synapseclient.core.retry import (
     RETRYABLE_CONNECTION_EXCEPTIONS,
     with_retry,
 )
-
-from synapseclient.core.utils import (
-    MB,
-)
+from synapseclient.core.utils import MB
 
 if TYPE_CHECKING:
-    from synapseclient import Synapse, Entity
+    from synapseclient import Entity, Synapse
 
 FILE_BUFFER_SIZE = 2 * MB
 REDIRECT_LIMIT = 5
@@ -159,6 +162,11 @@ async def download_file_entity(
     entity.cacheDir = os.path.dirname(download_path)
 
 
+def _get_aws_credentials() -> None:
+    """This is a stub function and only used for testing purposes."""
+    return None
+
+
 async def download_by_file_handle(
     file_handle_id: str,
     synapse_id: str,
@@ -210,6 +218,7 @@ async def download_by_file_handle(
                     remote_file_key=file_handle["fileKey"],
                     download_file_path=destination,
                     profile_name=profile,
+                    credentials=_get_aws_credentials(),
                     show_progress=not client.silent,
                 )
 
@@ -255,7 +264,7 @@ async def download_by_file_handle(
                 client.multi_threaded
                 and concrete_type == concrete_types.S3_FILE_HANDLE
                 and file_handle.get("contentSize", 0)
-                > multithread_download.SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE
+                > SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE
             ):
                 # run the download multi threaded if the file supports it, we're configured to do so,
                 # and the file is large enough that it would be broken into parts to take advantage of
@@ -314,10 +323,16 @@ async def download_from_url_multi_threaded(
 
     Arguments:
         file_handle_id: The id of the FileHandle to download
-        object_id:      The id of the Synapse object that uses the FileHandle e.g. "syn123"
-        object_type:    The type of the Synapse object that uses the FileHandle e.g. "FileEntity"
+        object_id:      The id of the Synapse object that uses the FileHandle
+            e.g. "syn123"
+        object_type:    The type of the Synapse object that uses the
+            FileHandle e.g. "FileEntity". Any of
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/FileHandleAssociateType.html>
         destination:    The destination on local file system
         expected_md5:   The expected MD5
+        content_size:   The size of the content
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
     Raises:
         SynapseMd5MismatchError: If the actual MD5 does not match expected MD5.
 
@@ -332,7 +347,7 @@ async def download_from_url_multi_threaded(
         destination=destination, file_handle_id=file_handle_id
     )
 
-    request = multithread_download.DownloadRequest(
+    request = DownloadRequest(
         file_handle_id=int(file_handle_id),
         object_id=object_id,
         object_type=object_type,
@@ -340,10 +355,18 @@ async def download_from_url_multi_threaded(
         debug=client.debug,
     )
 
-    multithread_download.download_file(client=client, download_request=request)
+    download_file(client=client, download_request=request)
 
     if expected_md5:  # if md5 not set (should be the case for all except http download)
-        actual_md5 = utils.md5_for_file(temp_destination).hexdigest()
+        actual_md5 = await utils.md5_for_file_multiprocessing(
+            filename=temp_destination,
+            process_pool_executor=client._get_process_pool_executor(
+                asyncio_event_loop=asyncio.get_running_loop()
+            ),
+            md5_semaphore=client._get_md5_semaphore(
+                asyncio_event_loop=asyncio.get_running_loop()
+            ),
+        )
         # check md5 if given
         if actual_md5 != expected_md5:
             try:
@@ -377,6 +400,8 @@ async def download_from_url(
                                 handle id which allows resuming partial downloads of the same file from previous
                                 sessions
         expected_md5:  Optional. If given, check that the MD5 of the downloaded file matches the expected MD5
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
 
     Raises:
         IOError:                 If the local file does not exist.
@@ -451,7 +476,7 @@ async def download_from_url(
                 url=url, filename=destination, reporthook=_ftp_report_hook
             )
             break
-        elif scheme == "http" or scheme == "https":
+        elif scheme in ["http", "https"]:
             # if a partial download exists with the temporary name,
             temp_destination = utils.temp_download_filename(
                 destination=destination, file_handle_id=file_handle_id
@@ -532,6 +557,9 @@ async def download_from_url(
                     previously_transferred = os.path.getsize(filename=temp_destination)
                     to_be_transferred += previously_transferred
                     transferred += previously_transferred
+                    client.logger.debug(
+                        f"Resuming partial download to {temp_destination}. {previously_transferred}/{to_be_transferred} bytes already transferred."
+                    )
                     sig = utils.md5_for_file(filename=temp_destination)
                 else:
                     mode = "wb"
@@ -588,7 +616,15 @@ async def download_from_url(
     if (
         actual_md5 is None
     ):  # if md5 not set (should be the case for all except http download)
-        actual_md5 = utils.md5_for_file(destination).hexdigest()
+        actual_md5 = await utils.md5_for_file_multiprocessing(
+            filename=destination,
+            process_pool_executor=client._get_process_pool_executor(
+                asyncio_event_loop=asyncio.get_running_loop()
+            ),
+            md5_semaphore=client._get_md5_semaphore(
+                asyncio_event_loop=asyncio.get_running_loop()
+            ),
+        )
 
     # check md5 if given
     if expected_md5 and actual_md5 != expected_md5:

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -670,13 +670,13 @@ def resolve_download_path_collisions(
     # resolve collison
     if os.path.exists(path=download_path):
         if if_collision == COLLISION_OVERWRITE_LOCAL:
-            return download_path
+            pass  # Let the download proceed and overwrite the local file.
         elif if_collision == COLLISION_KEEP_LOCAL:
             # Don't want to overwrite the local file.
-            return None
+            download_path = None
         elif if_collision == COLLISION_KEEP_BOTH:
             if download_path != cached_file_path:
-                return utils.unique_filename(download_path)
+                download_path = utils.unique_filename(download_path)
         else:
             raise ValueError(
                 f'Invalid parameter: "{if_collision}" is not a valid value for "ifcollision"'

--- a/synapseclient/core/remote_file_storage_wrappers.py
+++ b/synapseclient/core/remote_file_storage_wrappers.py
@@ -4,6 +4,7 @@ import os
 import typing
 import urllib.parse as urllib_parse
 from contextlib import contextmanager
+from typing import Union
 
 from tqdm import tqdm
 
@@ -65,7 +66,7 @@ class S3ClientWrapper:
     @staticmethod
     def download_file(
         bucket: str,
-        endpoint_url: str,
+        endpoint_url: Union[str, None],
         remote_file_key: str,
         download_file_path: str,
         *,

--- a/synapseclient/core/upload/multipart_upload_async.py
+++ b/synapseclient/core/upload/multipart_upload_async.py
@@ -62,7 +62,6 @@ flowchart  TD
 ```
 """
 
-# pylint: disable=protected-access
 import asyncio
 from contextlib import contextmanager
 import gc

--- a/synapseclient/core/upload/upload_functions_async.py
+++ b/synapseclient/core/upload/upload_functions_async.py
@@ -1,32 +1,27 @@
 """This module handles the various ways that a user can upload a file to Synapse."""
 
-# pylint: disable=protected-access
 import asyncio
 import os
 import urllib.parse as urllib_parse
 import uuid
-from typing import TYPE_CHECKING, Dict, Union, Optional
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
 from opentelemetry import trace
 
 from synapseclient.api import (
+    get_client_authenticated_s3_profile,
+    get_file_handle,
+    get_upload_destination,
+    post_external_filehandle,
     post_external_object_store_filehandle,
     post_external_s3_file_handle,
-    get_file_handle,
-    post_external_filehandle,
-    get_upload_destination,
 )
 from synapseclient.core import sts_transfer, utils
 from synapseclient.core.constants import concrete_types
 from synapseclient.core.exceptions import SynapseMd5MismatchError
 from synapseclient.core.remote_file_storage_wrappers import S3ClientWrapper, SFTPWrapper
 from synapseclient.core.upload.multipart_upload_async import multipart_upload_file_async
-from synapseclient.core.utils import (
-    as_url,
-    file_url_to_path,
-    id_of,
-    is_url,
-)
+from synapseclient.core.utils import as_url, file_url_to_path, id_of, is_url
 
 if TYPE_CHECKING:
     from synapseclient import Synapse
@@ -395,7 +390,9 @@ async def upload_client_auth_s3(
     storage_str: str = None,
 ) -> Dict[str, Union[str, int]]:
     """Use the S3 client to upload a file to an S3 bucket."""
-    profile = syn._get_client_authenticated_s3_profile(endpoint_url, bucket)
+    profile = get_client_authenticated_s3_profile(
+        endpoint=endpoint_url, bucket=bucket, config_path=syn.configPath
+    )
     file_key = key_prefix + "/" + os.path.basename(file_path)
     loop = asyncio.get_event_loop()
 

--- a/synapseclient/core/upload/upload_functions_async.py
+++ b/synapseclient/core/upload/upload_functions_async.py
@@ -306,6 +306,11 @@ async def upload_synapse_s3(
     return await get_file_handle(file_handle_id=file_handle_id, synapse_client=syn)
 
 
+def _get_aws_credentials() -> None:
+    """This is a stub function and only used for testing purposes."""
+    return None
+
+
 async def upload_synapse_sts_boto_s3(
     syn: "Synapse",
     parent_id: str,
@@ -399,11 +404,12 @@ async def upload_client_auth_s3(
     await loop.run_in_executor(
         syn._get_thread_pool_executor(asyncio_event_loop=loop),
         lambda: S3ClientWrapper.upload_file(
-            bucket,
-            endpoint_url,
-            file_key,
-            file_path,
+            bucket=bucket,
+            endpoint_url=endpoint_url,
+            remote_file_key=file_key,
+            upload_file_path=file_path,
             profile_name=profile,
+            credentials=_get_aws_credentials(),
             storage_str=storage_str,
         ),
     )

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -68,7 +68,7 @@ def md5_for_file(
         The MD5 Checksum
     """
     loop_iteration = 0
-    md5 = hashlib.new("md5", usedforsecurity=False)
+    md5 = hashlib.new("md5", usedforsecurity=False)  # nosec
     with open(filename, "rb") as f:
         while True:
             loop_iteration += 1
@@ -147,7 +147,7 @@ def md5_fn(part, _) -> str:
     Returns:
         The MD5 Checksum
     """
-    md5 = hashlib.new("md5", usedforsecurity=False)
+    md5 = hashlib.new("md5", usedforsecurity=False)  # nosec
     md5.update(part)
     return md5.hexdigest()
 

--- a/synapseclient/entity.py
+++ b/synapseclient/entity.py
@@ -783,6 +783,8 @@ class File(Entity, Versionable):
                 key == "path"
                 and not self["synapseStore"]
                 and utils.caller_module_name(inspect.currentframe()) != "client"
+                and utils.caller_module_name(inspect.currentframe())
+                != "download_functions"
             ):
                 self["externalURL"] = expand_and_convert_to_URL(value)
                 self["contentMd5"] = None

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -602,6 +602,7 @@ class File(FileSynchronousProtocol, AccessControllable):
         self.version_comment = synapse_file.get("versionComment", None)
         self.is_latest_version = synapse_file.get("isLatestVersion", False)
         self.data_file_handle_id = synapse_file.get("dataFileHandleId", None)
+        self.path = synapse_file.get("path", self.path)
         synapse_file_handle = synapse_file.get("_file_handle", None)
         if synapse_file_handle:
             file_handle = self.file_handle or FileHandle()

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -1,6 +1,5 @@
 """Script to work with Synapse files."""
 
-# pylint: disable=protected-access
 import asyncio
 import dataclasses
 import os

--- a/tests/integration/synapseclient/core/test_download.py
+++ b/tests/integration/synapseclient/core/test_download.py
@@ -1,88 +1,430 @@
+"""Integration tests around downloading files from Synapse."""
+
 import filecmp
 import os
-import tempfile
 import shutil
+import tempfile
+from typing import Callable
+from unittest.mock import patch
 
 import pytest
+from pytest_mock import MockerFixture
 
-from synapseclient import File
-from synapseclient.core.exceptions import SynapseMd5MismatchError
+import synapseclient
 import synapseclient.core.utils as utils
+from synapseclient import Synapse, client
+from synapseclient.core.download import download_from_url, download_functions
+from synapseclient.core.exceptions import SynapseMd5MismatchError
+from synapseclient.models import File, Project
 
 
-async def test_download_check_md5(syn, project, schedule_for_cleanup):
-    tempfile_path = utils.make_bogus_data_file()
-    schedule_for_cleanup(tempfile_path)
-    entity_bad_md5 = syn.store(
-        File(path=tempfile_path, parent=project["id"], synapseStore=False)
-    )
+class TestDownloadCollisions:
+    """Tests for downloading files with different collision states."""
 
-    pytest.raises(
-        SynapseMd5MismatchError,
-        syn._download_from_URL,
-        entity_bad_md5["externalURL"],
-        tempfile.gettempdir(),
-        entity_bad_md5["dataFileHandleId"],
-        expected_md5="2345a",
-    )
+    async def test_collision_overwrite_local(
+        self,
+        mocker: MockerFixture,
+        syn: Synapse,
+        project_model: Project,
+        schedule_for_cleanup: Callable[..., None],
+    ) -> None:
+        # Spys
+        spy_file_handle = mocker.spy(download_functions, "download_by_file_handle")
+        spy_file_entity = mocker.spy(client, "download_file_entity")
+
+        # GIVEN a file stored in synapse
+        original_file_path = utils.make_bogus_data_file()
+        file = await File(
+            path=original_file_path, parent_id=project_model.id
+        ).store_async()
+        original_file_md5 = file.file_handle.content_md5
+        schedule_for_cleanup(original_file_path)
+        schedule_for_cleanup(file.id)
+
+        # AND the file on disk is different from the file in synapse
+        with open(original_file_path, "w", encoding="utf-8") as f:
+            f.write("Different data")
+        assert original_file_md5 != utils.md5_for_file_hex(original_file_path)
+
+        # AND the file is not in the cache
+        syn.cache.remove(file_handle_id=file.file_handle.id)
+
+        # WHEN I download the file
+        file = await File(
+            id=file.id,
+            if_collision="overwrite.local",
+            download_location=os.path.dirname(original_file_path),
+        ).get_async()
+
+        # THEN the file is downloaded replacing the file on disk
+        assert utils.equal_paths(original_file_path, file.path)
+        assert original_file_md5 == utils.md5_for_file_hex(original_file_path)
+
+        # AND download_by_file_handle was called
+        spy_file_handle.assert_called_once()
+
+        # AND file_entity was called
+        spy_file_entity.assert_called_once()
+
+    async def test_collision_keep_local(
+        self,
+        mocker: MockerFixture,
+        syn: Synapse,
+        project_model: Project,
+        schedule_for_cleanup: Callable[..., None],
+    ) -> None:
+        # Spys
+        spy_file_handle = mocker.spy(download_functions, "download_by_file_handle")
+        spy_file_entity = mocker.spy(client, "download_file_entity")
+
+        # GIVEN a file stored in synapse
+        original_file_path = utils.make_bogus_data_file()
+        file = await File(
+            path=original_file_path, parent_id=project_model.id
+        ).store_async()
+        schedule_for_cleanup(file.id)
+        schedule_for_cleanup(original_file_path)
+
+        # AND the file is in the cache
+        assert syn.cache.contains(
+            file_handle_id=file.file_handle.id, path=original_file_path
+        )
+
+        # WHEN I download the file
+        file = await File(id=file.id, if_collision="keep.local").get_async()
+
+        # THEN the file is not downloaded again, and the file path is the same
+        assert os.path.exists(file.path)
+        assert os.path.exists(original_file_path)
+        assert utils.equal_paths(original_file_path, file.path)
+
+        # AND download_by_file_handle was not called
+        spy_file_handle.assert_not_called()
+
+        # AND file_entity was called
+        spy_file_entity.assert_called_once()
 
 
-@pytest.mark.flaky(reruns=3)
-async def test_resume_partial_download(syn, project, schedule_for_cleanup):
-    original_file = utils.make_bogus_data_file(40000)
+class TestDownloadCaching:
+    """Tests for downloading files with different cache states."""
 
-    entity = File(original_file, parent=project["id"])
-    entity = syn.store(entity)
+    async def test_download_cached_file(
+        self,
+        mocker: MockerFixture,
+        syn: Synapse,
+        project_model: Project,
+        schedule_for_cleanup: Callable[..., None],
+    ) -> None:
+        """Tests that a file download that exists in cache is not downloaded again."""
 
-    # stash the original file for comparison later
-    shutil.move(original_file, original_file + ".original")
-    original_file += ".original"
-    schedule_for_cleanup(original_file)
+        # Spys
+        spy_file_handle = mocker.spy(download_functions, "download_by_file_handle")
+        spy_file_entity = mocker.spy(client, "download_file_entity")
 
-    temp_dir = tempfile.gettempdir()
+        # GIVEN a file stored in synapse
+        original_file_path = utils.make_bogus_data_file()
+        file = await File(
+            path=original_file_path, parent_id=project_model.id
+        ).store_async()
+        schedule_for_cleanup(file.id)
+        schedule_for_cleanup(original_file_path)
 
-    url = "%s/entity/%s/file" % (syn.repoEndpoint, entity.id)
-    path = syn._download_from_URL(
-        url,
-        destination=temp_dir,
-        fileHandleId=entity.dataFileHandleId,
-        expected_md5=entity.md5,
-    )
+        # AND the file is in the cache
+        assert syn.cache.contains(
+            file_handle_id=file.file_handle.id, path=original_file_path
+        )
 
-    # simulate an imcomplete download by putting the
-    # complete file back into its temporary location
-    tmp_path = utils.temp_download_filename(temp_dir, entity.dataFileHandleId)
-    shutil.move(path, tmp_path)
+        # WHEN I download the file
+        file = await File(id=file.id).get_async()
 
-    # ...and truncating it to some fraction of its original size
-    with open(tmp_path, "r+") as f:
-        f.truncate(3 * os.path.getsize(original_file) // 7)
+        # THEN the file is not downloaded again, and the file path is the same
+        assert os.path.exists(file.path)
+        assert os.path.exists(original_file_path)
+        assert utils.equal_paths(original_file_path, file.path)
 
-    # this should complete the partial download
-    path = syn._download_from_URL(
-        url,
-        destination=temp_dir,
-        fileHandleId=entity.dataFileHandleId,
-        expected_md5=entity.md5,
-    )
+        # AND download_by_file_handle was not called
+        spy_file_handle.assert_not_called()
 
-    assert filecmp.cmp(original_file, path), "File comparison failed"
+        # AND download_file_entity was called
+        spy_file_entity.assert_called_once()
+
+    async def test_download_cached_file_to_new_directory(
+        self,
+        mocker: MockerFixture,
+        syn: Synapse,
+        project_model: Project,
+        schedule_for_cleanup: Callable[..., None],
+    ) -> None:
+        """Tests that a file download that exists in cache is not downloaded again."""
+
+        # Spys
+        spy_file_handle = mocker.spy(download_functions, "download_by_file_handle")
+        spy_file_entity = mocker.spy(client, "download_file_entity")
+
+        # GIVEN a file stored in synapse
+        original_file_path = utils.make_bogus_data_file()
+        file = await File(
+            path=original_file_path, parent_id=project_model.id
+        ).store_async()
+        schedule_for_cleanup(file.id)
+        schedule_for_cleanup(original_file_path)
+
+        # AND the file is in the cache
+        assert syn.cache.contains(
+            file_handle_id=file.file_handle.id, path=original_file_path
+        )
+
+        # WHEN I download the file to another location
+        updated_location = os.path.join(
+            os.path.dirname(original_file_path), "subdirectory"
+        )
+        schedule_for_cleanup(updated_location)
+        file = await File(id=file.id, download_location=updated_location).get_async()
+        schedule_for_cleanup(file.path)
+
+        # THEN the file is not downloaded again, but it copied to the new location
+        assert os.path.exists(file.path)
+        assert os.path.exists(original_file_path)
+        assert not utils.equal_paths(original_file_path, file.path)
+
+        # AND download_by_file_handle was not called
+        spy_file_handle.assert_not_called()
+
+        # AND download_file_entity was called
+        spy_file_entity.assert_called_once()
 
 
-async def test_http_download__range_request_error(syn, project):
-    # SYNPY-525
+class TestDownloadFromUrl:
+    """Integration tests that will route through
+    `synapseclient/core/download/download_functions.py::download_from_url`"""
 
-    file_path = utils.make_bogus_data_file()
-    file_entity = syn.store(File(file_path, parent=project))
+    async def test_download_check_md5(
+        self, project_model: Project, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
+        tempfile_path = utils.make_bogus_data_file()
+        schedule_for_cleanup(tempfile_path)
+        entity_bad_md5 = await File(
+            path=tempfile_path, parent_id=project_model.id, synapse_store=False
+        ).store_async()
 
-    syn.cache.remove(file_entity["_file_handle"]["id"])
-    # download once and rename to temp file to simulate range exceed
-    file_entity = syn.get(file_entity)
-    shutil.move(
-        file_entity.path,
-        utils.temp_download_filename(file_entity.path, file_entity.dataFileHandleId),
-    )
-    file_entity = syn.get(file_entity)
+        with pytest.raises(SynapseMd5MismatchError):
+            await download_from_url(
+                url=entity_bad_md5.external_url,
+                destination=tempfile.gettempdir(),
+                file_handle_id=entity_bad_md5.data_file_handle_id,
+                expected_md5="2345a",
+            )
 
-    assert file_path != file_entity.path
-    assert filecmp.cmp(file_path, file_entity.path)
+    async def test_download_from_url_resume_partial_download(
+        self,
+        syn: Synapse,
+        project_model: Project,
+        schedule_for_cleanup: Callable[..., None],
+    ) -> None:
+        # GIVEN a file stored in synapse
+        original_file = utils.make_bogus_data_file(40000)
+        file = await File(path=original_file, parent_id=project_model.id).store_async()
+
+        # AND the original file is stashed for comparison later
+        updated_location = original_file + ".original"
+        shutil.copy(original_file, updated_location)
+        schedule_for_cleanup(updated_location)
+
+        # AND an incomplete file in its place (This is simulated by truncating the file)
+        tmp_path = utils.temp_download_filename(
+            destination=tempfile.gettempdir(), file_handle_id=file.data_file_handle_id
+        )
+        shutil.move(src=original_file, dst=tmp_path)
+        original_size = os.path.getsize(tmp_path)
+        truncated_size = 3 * original_size // 7
+        with open(tmp_path, "r+", encoding="utf-8") as f:
+            f.truncate(truncated_size)
+
+        # WHEN I resume the download
+        path = await download_from_url(
+            url=f"{syn.repoEndpoint}/entity/{file.id}/file",
+            destination=tempfile.gettempdir(),
+            file_handle_id=file.data_file_handle_id,
+            expected_md5=file.file_handle.content_md5,
+        )
+
+        # THEN the file is downloaded and matches the original
+        assert filecmp.cmp(original_file, path), "File comparison failed"
+        # This can only be used when the integration test are running in debug mode. Which
+        # is not the default. This was verified by running the test in debug mode.
+        # `caplog: pytest.LogCaptureFixture` would need to be added to the args.
+        # assert f"Resuming partial download to {tmp_path}. {truncated_size}/{original_size}.0 bytes already transferred." in caplog.text
+
+    async def test_download_via_get(
+        self,
+        mocker: MockerFixture,
+        syn: Synapse,
+        project_model: Project,
+        schedule_for_cleanup: Callable[..., None],
+    ) -> None:
+        """Tests that a file not in cache is downloaded. Routes through the get
+        function in the File class."""
+        # Spy on the download_by_file_handle function
+        spy = mocker.spy(download_functions, "download_by_file_handle")
+
+        # GIVEN a file stored in synapse
+        original_file_path = utils.make_bogus_data_file()
+        file = await File(
+            path=original_file_path, parent_id=project_model.id
+        ).store_async()
+        schedule_for_cleanup(file.id)
+        schedule_for_cleanup(original_file_path)
+
+        # AND the file is not in the cache
+        syn.cache.remove(file_handle_id=file.file_handle.id)
+
+        # AND the file has been moved to a different location
+        updated_file_path = shutil.move(
+            original_file_path,
+            f"{original_file_path}.moved",
+        )
+        schedule_for_cleanup(updated_file_path)
+
+        # WHEN I download the file
+        file = await File(
+            id=file.id, download_location=os.path.dirname(original_file_path)
+        ).get_async()
+
+        # THEN the file is downloaded to a different location and matches the original
+        assert not utils.equal_paths(updated_file_path, file.path)
+        assert filecmp.cmp(updated_file_path, file.path)
+
+        # AND download_by_file_handle was called
+        spy.assert_called_once()
+
+    async def test_download_to_default_cache(
+        self,
+        mocker: MockerFixture,
+        syn: Synapse,
+        project_model: Project,
+        schedule_for_cleanup: Callable[..., None],
+    ) -> None:
+        """Tests that a file not in the cache is downloaded to the default cache
+        location."""
+        # Spy on the download_by_file_handle function
+        spy = mocker.spy(download_functions, "download_by_file_handle")
+
+        # GIVEN a file stored in synapse
+        original_file_path = utils.make_bogus_data_file()
+        file = await File(
+            path=original_file_path, parent_id=project_model.id
+        ).store_async()
+        synapse_cache_location = syn.cache.get_cache_dir(
+            file_handle_id=file.data_file_handle_id
+        )
+        original_file_md5 = file.file_handle.content_md5
+        schedule_for_cleanup(file.id)
+
+        # AND the file is not in the cache
+        syn.cache.remove(file_handle_id=file.file_handle.id)
+
+        # AND the file has been deleted
+        os.remove(original_file_path)
+
+        # WHEN I download the file
+        file = await File(id=file.id).get_async()
+
+        # THEN the file is downloaded to a different location and matches the original
+        assert not utils.equal_paths(original_file_path, file.path)
+        assert original_file_md5 == file.file_handle.content_md5
+        assert utils.equal_paths(os.path.dirname(file.path), synapse_cache_location)
+
+        # AND download_by_file_handle was called
+        spy.assert_called_once()
+
+
+class TestDownloadFromUrlMultiThreaded:
+    """Integration tests that will route through
+    `synapseclient/core/download/download_functions.py::download_from_url_multi_threaded`
+    """
+
+    async def test_download_from_url_multi_threaded(
+        self,
+        syn: Synapse,
+        project_model: Project,
+        schedule_for_cleanup: Callable[..., None],
+    ) -> None:
+        """Test download of a file if downloaded in multiple parts. In this case I am
+        dropping the download part size to 500 bytes to force multiple parts download.
+        """
+
+        # GIVEN a file stored in synapse
+        file_path = utils.make_bogus_data_file()
+        file = await File(path=file_path, parent_id=project_model.id).store_async()
+        schedule_for_cleanup(file.id)
+        schedule_for_cleanup(file_path)
+        file_md5 = file.file_handle.content_md5
+        assert file_md5 is not None
+        assert os.path.exists(file_path)
+
+        # AND the file is not in the cache
+        syn.cache.remove(file_handle_id=file.file_handle.id)
+        os.remove(file_path)
+        assert not os.path.exists(file_path)
+
+        with patch.object(
+            synapseclient.core.download.download_functions,
+            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+            new=500,
+        ), patch.object(
+            synapseclient.core.download.download_async,
+            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+            new=500,
+        ):
+            # WHEN I download the file with multiple parts
+            file = await File(
+                id=file.id, download_location=os.path.dirname(file.path)
+            ).get_async()
+
+        # THEN the file is downloaded and the md5 matches
+        assert file.file_handle.content_md5 == file_md5
+        assert os.path.exists(file_path)
+
+
+class TestDownloadFromS3:
+    async def test_download_with_external_object_store(
+        self,
+        mocker: MockerFixture,
+        syn: Synapse,
+        project_model: Project,
+        schedule_for_cleanup: Callable[..., None],
+    ) -> None:
+        """Tests that a file not in cache is downloaded. Routes through the get
+        function in the File class."""
+        # Spy on the download_by_file_handle function
+        spy = mocker.spy(download_functions, "download_by_file_handle")
+
+        # GIVEN a file stored in synapse
+        original_file_path = utils.make_bogus_data_file()
+        file = await File(
+            path=original_file_path, parent_id=project_model.id
+        ).store_async()
+        schedule_for_cleanup(file.id)
+        schedule_for_cleanup(original_file_path)
+
+        # AND the file is not in the cache
+        syn.cache.remove(file_handle_id=file.file_handle.id)
+
+        # AND the file has been moved to a different location
+        updated_file_path = shutil.move(
+            original_file_path,
+            f"{original_file_path}.moved",
+        )
+        schedule_for_cleanup(updated_file_path)
+
+        # WHEN I download the file
+        file = await File(
+            id=file.id, download_location=os.path.dirname(original_file_path)
+        ).get_async()
+
+        # THEN the file is downloaded to a different location and matches the original
+        assert not utils.equal_paths(updated_file_path, file.path)
+        assert filecmp.cmp(updated_file_path, file.path)
+
+        # AND download_by_file_handle was called
+        spy.assert_called_once()

--- a/tests/integration/synapseclient/core/test_external_storage.py
+++ b/tests/integration/synapseclient/core/test_external_storage.py
@@ -1,14 +1,22 @@
+"""Integration tests for external storage locations."""
+
 import importlib
+import json
 import os
 import tempfile
 import uuid
-
-from synapseclient import File, Synapse, Project
-from synapseclient.core.retry import with_retry
+from typing import Dict, Tuple, Any
+from unittest import mock
 
 import pytest
-import unittest
-from unittest import mock
+
+from synapseclient import Synapse, Folder as SynFolder
+import synapseclient.core.utils as utils
+from synapseclient.core.retry import with_retry
+from synapseclient.models import File, Project, Folder
+from synapseclient.api import (
+    get_upload_destination,
+)
 
 try:
     boto3 = importlib.import_module("boto3")
@@ -16,56 +24,102 @@ except ImportError:
     boto3 = None
 
 
-def check_test_preconditions():
-    # in order ot run the tests in this file boto3 must be available
-    # and we must have configuration indicating where to store external
-    # storage for testing
+def check_test_preconditions() -> Tuple[bool, str]:
+    """In order to run the tests in this file boto3 must be available
+    and we must have configuration indicating where to store external
+    storage for testing. If these conditions are not met, the tests
+    will be skipped.
 
-    skip_tests = False
-    reason = ""
+    Returns:
+        Tuple[bool, str]: A tuple indicating whether the tests should be skipped
+
+    """
+
     if not boto3:
-        skip_tests = True
-        reason = "boto3 not available"
+        return True, "boto3 not available"
 
     elif not (
         os.environ.get("EXTERNAL_S3_BUCKET_NAME")
         and os.environ.get("EXTERNAL_S3_BUCKET_AWS_ACCESS_KEY_ID")
         and os.environ.get("EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY")
     ):
-        skip_tests = True
-        reason = "External bucket access not defined in environment"
+        return True, "External bucket access not defined in environment"
 
-    return skip_tests, reason
-
-
-def get_aws_env():
-    return os.environ["EXTERNAL_S3_BUCKET_NAME"], {
-        "aws_access_key_id": os.environ["EXTERNAL_S3_BUCKET_AWS_ACCESS_KEY_ID"],
-        "aws_secret_access_key": os.environ["EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY"],
-    }
+    return False, ""
 
 
-@unittest.skipIf(*check_test_preconditions())
-class ExernalStorageTest(unittest.TestCase):
+def check_test_preconditions_external_object_store() -> Tuple[bool, str]:
+    """In order to run the tests for an external object store we need to be able to
+    authenticate directly with AWS. As such we need a profile to authenticate as.
+
+    Returns:
+        Tuple[bool, str]: A tuple indicating whether the tests should be skipped
+
+    """
+
+    if not (
+        os.environ.get("EXTERNAL_S3_BUCKET_NAME")
+        and os.environ.get("EXTERNAL_S3_BUCKET_AWS_ACCESS_KEY_ID")
+        and os.environ.get("EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY")
+    ):
+        return True, "External bucket access not defined in environment"
+
+    return False, ""
+
+
+def get_aws_env() -> Tuple[str, Dict[str, str]]:
+    """Get the AWS environment variables for the external storage bucket."""
+    if os.environ.get("EXTERNAL_S3_BUCKET_AWS_SESSION_TOKEN"):
+        return os.environ["EXTERNAL_S3_BUCKET_NAME"], {
+            "aws_access_key_id": os.environ["EXTERNAL_S3_BUCKET_AWS_ACCESS_KEY_ID"],
+            "aws_secret_access_key": os.environ[
+                "EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY"
+            ],
+            "aws_session_token": os.environ["EXTERNAL_S3_BUCKET_AWS_SESSION_TOKEN"],
+        }
+
+    else:
+        return os.environ["EXTERNAL_S3_BUCKET_NAME"], {
+            "aws_access_key_id": os.environ["EXTERNAL_S3_BUCKET_AWS_ACCESS_KEY_ID"],
+            "aws_secret_access_key": os.environ[
+                "EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY"
+            ],
+        }
+
+
+skip_tests, reason = check_test_preconditions()
+
+
+(
+    skip_tests_external_object_store,
+    reason_external_object_store,
+) = check_test_preconditions_external_object_store()
+
+
+@pytest.mark.skipif(skip_tests, reason=reason)
+class TestExernalStorage:
+    """Tests for external storage locations."""
+
     @pytest.fixture(autouse=True)
-    def _syn(self, syn: Synapse):
+    def setup_method(self, syn: Synapse, project_model: Project) -> None:
         self.syn = syn
-
-    @pytest.fixture(autouse=True)
-    def _project(self, project: Project):
-        self.project = project
+        self.project = project_model
 
     @classmethod
-    def _make_temp_file(cls, contents=None, **kwargs):
+    def _make_temp_file(
+        cls, contents: str = None, **kwargs
+    ) -> tempfile.NamedTemporaryFile:
         # delete=False for Windows
         tmp_file = tempfile.NamedTemporaryFile(**kwargs, delete=False)
         if contents:
-            with open(tmp_file.name, "w") as f:
+            with open(tmp_file.name, "w", encoding="utf-8") as f:
                 f.write(contents)
 
         return tmp_file
 
-    def _prepare_bucket_location(self, key_prefix):
+    def _prepare_bucket_location(self, key_prefix: str) -> Any:
+        """Create a folder in the external storage bucket and return the boto3 client.
+        This also creates owner.txt required by Synapse."""
         bucket_name, aws_creds = get_aws_env()
         s3_client = boto3.client("s3", **aws_creds)
         s3_client.put_object(
@@ -76,153 +130,324 @@ class ExernalStorageTest(unittest.TestCase):
 
         return s3_client
 
-    def _configure_storage_location(self, sts_enabled=False):
+    def _teardown_bucket_location(self, key_prefix: str) -> None:
+        """Remove the folder and all its contents from the external storage bucket."""
+        bucket_name, aws_creds = get_aws_env()
+        s3_client = boto3.client("s3", **aws_creds)
+
+        # List all objects with the prefix of the folder
+        response = s3_client.list_objects_v2(
+            Bucket=bucket_name,
+            Prefix=f"{key_prefix}/",
+        )
+
+        # Delete all objects with the prefix of the folder
+        if "Contents" in response:
+            objects_to_delete = [{"Key": obj["Key"]} for obj in response["Contents"]]
+            s3_client.delete_objects(
+                Bucket=bucket_name, Delete={"Objects": objects_to_delete}
+            )
+
+    async def _create_external_object_store(
+        self, bucket_name: str, folder_name: str
+    ) -> Tuple[SynFolder, Dict[str, str]]:
+        folder_id = (
+            await Folder(name=folder_name, parent_id=self.project.id).store_async()
+        ).id
+
+        destination = {
+            "uploadType": "S3",
+            "concreteType": "org.sagebionetworks.repo.model.project.ExternalObjectStorageLocationSetting",
+            "endpointUrl": "https://s3.amazonaws.com",
+            "bucket": bucket_name,
+        }
+        destination = self.syn.restPOST(
+            "/storageLocation", body=json.dumps(destination)
+        )
+
+        self.syn.setStorageLocation(
+            entity=folder_id,
+            storage_location_id=destination["storageLocationId"],
+        )
+
+        upload_destination = await get_upload_destination(
+            entity_id=folder_id, synapse_client=self.syn
+        )
+
+        return (
+            self.syn.get(entity=folder_id),
+            destination,
+            upload_destination["keyPrefixUUID"],
+        )
+
+    async def _configure_storage_location(
+        self, sts_enabled: bool = False, external_object_store: bool = False
+    ) -> Tuple[Any, SynFolder, str, str]:
         folder_name = str(uuid.uuid4())
         s3_client = self._prepare_bucket_location(folder_name)
 
         bucket_name, _ = get_aws_env()
-        folder, storage_location_setting, _ = self.syn.create_s3_storage_location(
-            parent=self.project,
-            folder_name=folder_name,
-            bucket_name=bucket_name,
-            base_key=folder_name,
-            sts_enabled=sts_enabled,
-        )
+        try:
+            if external_object_store:
+                (
+                    folder,
+                    storage_location_setting,
+                    storage_destination,
+                ) = await self._create_external_object_store(
+                    bucket_name=bucket_name, folder_name=folder_name
+                )
+                return (
+                    s3_client,
+                    folder,
+                    storage_location_setting["storageLocationId"],
+                    storage_destination,
+                )
+            else:
+                (
+                    folder,
+                    storage_location_setting,
+                    _,
+                ) = self.syn.create_s3_storage_location(
+                    parent=self.project.id,
+                    folder_name=folder_name,
+                    bucket_name=bucket_name,
+                    base_key=folder_name,
+                    sts_enabled=sts_enabled,
+                )
 
-        return s3_client, folder, storage_location_setting["storageLocationId"]
+                return (
+                    s3_client,
+                    folder,
+                    storage_location_setting["storageLocationId"],
+                    folder_name,
+                )
+        except Exception as ex:
+            self._teardown_bucket_location(folder_name)
+            raise ex
 
-    async def test_set_external_storage_location(self):
+    async def test_set_external_storage_location(self) -> None:
         """Test configuring an external storage location,
         saving a file there, and confirm that it is created and
         accessible as expected."""
 
-        s3_client, folder, _ = self._configure_storage_location()
+        # GIVEN an external storage location
+        (
+            s3_client,
+            folder,
+            _,
+            folder_in_s3_to_cleanup,
+        ) = await self._configure_storage_location()
 
-        file_contents = "foo"
-        upload_file = self._make_temp_file(contents=file_contents)
+        try:
+            # WHEN we save a file to that location
+            upload_file = utils.make_bogus_uuid_file()
+            with open(upload_file, "r", encoding="utf-8") as f:
+                file_contents = f.read()
 
-        file = File(path=upload_file.name, parent=folder)
-        file_entity = self.syn.store(file)
+            file = await File(path=upload_file, parent_id=folder.id).store_async()
 
-        # verify we can download the file via synapse
-        file_entity = self.syn.get(file_entity["id"])
-        with open(file_entity.path, "r") as f:
-            downloaded_content = f.read()
-        assert file_contents == downloaded_content
+            # THEN the file should be accessible via the external storage location
+            os.remove(upload_file)
+            file = await File(id=file.id).get_async()
+            with open(file.path, "r", encoding="utf-8") as f:
+                downloaded_content = f.read()
+            assert file_contents == downloaded_content
 
-        # now verify directly using boto that the file is in the external storage
-        # location as we expect it to be
-        file_handle = self.syn._get_file_handle_as_creator(
-            file_entity["dataFileHandleId"]
-        )
+            # AND that the file is readable directly via boto
+            file_handle = self.syn._get_file_handle_as_creator(
+                fileHandle=file.data_file_handle_id
+            )
 
-        # will raise an error if he key doesn't exist
-        bucket_name, _ = get_aws_env()
-        s3_client.get_object(Bucket=bucket_name, Key=file_handle["key"])
+            # will raise an error if the key doesn't exist
+            bucket_name, _ = get_aws_env()
+            s3_client.get_object(Bucket=bucket_name, Key=file_handle["key"])
+        finally:
+            self._teardown_bucket_location(key_prefix=folder_in_s3_to_cleanup)
 
-    async def test_sts_external_storage_location(self):
+    async def test_sts_external_storage_location(self) -> None:
         """Test creating and using an external STS storage location.
         A custom storage location is created with sts enabled,
         a file is uploaded directly via boto using STS credentials,
         a file handle is created for it, and then it is read directly
         via boto using STS read credentials.
         """
+        # GIVEN an external storage location with STS enabled
         bucket_name, _ = get_aws_env()
-        _, folder, storage_location_id = self._configure_storage_location(
-            sts_enabled=True
-        )
+        (
+            _,
+            folder,
+            storage_location_id,
+            folder_in_s3_to_cleanup,
+        ) = await self._configure_storage_location(sts_enabled=True)
 
-        sts_read_creds = self.syn.get_sts_storage_token(
-            folder["id"], "read_only", output_format="boto"
-        )
-        sts_write_creds = self.syn.get_sts_storage_token(
-            folder["id"], "read_write", output_format="boto"
-        )
+        try:
+            # AND credentials for reading and writing to the bucket
+            sts_read_creds = self.syn.get_sts_storage_token(
+                folder.id, "read_only", output_format="boto"
+            )
+            sts_write_creds = self.syn.get_sts_storage_token(
+                folder.id, "read_write", output_format="boto"
+            )
 
-        s3_read_client = boto3.client("s3", **sts_read_creds)
-        s3_write_client = boto3.client("s3", **sts_write_creds)
+            s3_read_client = boto3.client("s3", **sts_read_creds)
+            s3_write_client = boto3.client("s3", **sts_write_creds)
 
-        # put an object directly using our sts creds
-        file_contents = "saved using sts"
-        temp_file = self._make_temp_file(contents=file_contents, suffix=".txt")
+            # WHEN I put an object directly using the STS read only credentials
+            file_contents = "saved using sts"
+            temp_file = self._make_temp_file(contents=file_contents, suffix=".txt")
 
-        remote_key = f"{folder.name}/sts_saved"
+            remote_key = f"{folder.name}/sts_saved"
 
-        # verify that the read credentials are in fact read only
-        with pytest.raises(Exception) as ex_cm:
-            s3_read_client.upload_file(
+            # THEN we should not be able to write to the bucket
+            with pytest.raises(Exception) as ex_cm:
+                s3_read_client.upload_file(
+                    Filename=temp_file.name,
+                    Bucket=bucket_name,
+                    Key=remote_key,
+                )
+            assert "Access Denied" in str(ex_cm.value)
+
+            # WHEN I put an object directly using the STS read/write credentials
+            s3_write_client.upload_file(
                 Filename=temp_file.name,
                 Bucket=bucket_name,
                 Key=remote_key,
+                ExtraArgs={"ACL": "bucket-owner-full-control"},
             )
-        assert "Access Denied" in str(ex_cm.value)
 
-        # now create a file directly in s3 using our STS creds
-        s3_write_client.upload_file(
-            Filename=temp_file.name,
-            Bucket=bucket_name,
-            Key=remote_key,
-            ExtraArgs={"ACL": "bucket-owner-full-control"},
-        )
+            # THEN I expect to be able to read from file using the read only credentials
+            with_retry(
+                function=lambda: s3_read_client.get_object(
+                    Bucket=bucket_name, Key=remote_key
+                ),
+                retry_exceptions=[s3_read_client.exceptions.NoSuchKey],
+            )
 
-        # now read the file using our read credentials
-        # S3 is not ACID so we add a retry here to try to ensure our
-        # object will be available before we try to create the handle
-        with_retry(
-            lambda: s3_read_client.get_object(Bucket=bucket_name, Key=remote_key),
-            retry_exceptions=[s3_read_client.exceptions.NoSuchKey],
-        )
+            # WHEN I create an external file handle for the object
+            file_handle = self.syn.create_external_s3_file_handle(
+                bucket_name=bucket_name,
+                s3_file_key=remote_key,
+                file_path=temp_file.name,
+                storage_location_id=storage_location_id,
+            )
 
-        # create an external file handle so we can read it via synapse
-        file_handle = self.syn.create_external_s3_file_handle(
-            bucket_name,
-            remote_key,
-            temp_file.name,
-            storage_location_id=storage_location_id,
-        )
-        file = File(parentId=folder["id"], dataFileHandleId=file_handle["id"])
-        file_entity = self.syn.store(file)
+            # AND store the file in Synapse
+            file: File = await File(
+                parent_id=folder.id, data_file_handle_id=file_handle["id"]
+            ).store_async()
 
-        # now should be able to retrieve the file via synapse
-        retrieved_file_entity = self.syn.get(file_entity["id"])
-        with open(retrieved_file_entity.path, "r") as f:
-            assert file_contents == f.read()
+            # THEN I should be able to retrieve the file via synapse
+            retrieved_file_entity = await File(id=file.id).get_async()
+            with open(retrieved_file_entity.path, "r", encoding="utf-8") as f:
+                assert file_contents == f.read()
+        finally:
+            self._teardown_bucket_location(key_prefix=folder_in_s3_to_cleanup)
 
-    async def test_boto_upload__acl(self):
-        """Verify when we store a Synapse object using boto we apply a bucket-owner-full-control ACL to the object"""
+    async def test_boto_upload_acl(self) -> None:
+        """Verify when we store a Synapse object using boto we apply a
+        bucket-owner-full-control ACL to the object"""
+        # GIVEN an external storage location with STS enabled
         bucket_name, _ = get_aws_env()
-        _, folder, storage_location_id = self._configure_storage_location(
+        _, folder, _, folder_in_s3_to_cleanup = await self._configure_storage_location(
             sts_enabled=True
         )
 
-        file_contents = str(uuid.uuid4())
-        upload_file = self._make_temp_file(contents=file_contents)
+        try:
+            upload_file = utils.make_bogus_uuid_file()
 
-        # mock the sts setting so that we upload this file using boto regardless of test configuration
-        with mock.patch.object(
-            self.syn,
-            "use_boto_sts_transfers",
-            new_callable=mock.PropertyMock(return_value=True),
-        ):
-            file = self.syn.store(File(path=upload_file.name, parent=folder))
+            # WHEN I upload a file using boto sts transfer
+            with mock.patch.object(
+                self.syn,
+                "use_boto_sts_transfers",
+                new_callable=mock.PropertyMock(return_value=True),
+            ):
+                file = await File(path=upload_file, parent_id=folder.id).store_async()
+                assert os.path.exists(file.path)
+                os.remove(file.path)
 
-        s3_read_client = boto3.client("s3", **get_aws_env()[1])
-        bucket_acl = s3_read_client.get_bucket_acl(Bucket=bucket_name)
-        bucket_grantee = bucket_acl["Grants"][0]["Grantee"]
-        assert bucket_grantee["Type"] == "CanonicalUser"
-        bucket_owner_id = bucket_grantee["ID"]
+                # THEN I should be able to donwload the file
+                assert not os.path.exists(file.path)
+                file_copy = await File(
+                    id=file.id, download_location=os.path.dirname(upload_file)
+                ).get_async()
+                assert os.path.exists(file_copy.path)
+                assert utils.equal_paths(file_copy.path, upload_file)
 
-        # with_retry to avoid acidity issues of an S3 put
-        object_acl = with_retry(
-            lambda: s3_read_client.get_object_acl(
-                Bucket=bucket_name, Key=file["_file_handle"]["key"]
-            ),
-            retry_exceptions=[s3_read_client.exceptions.NoSuchKey],
-        )
-        grants = object_acl["Grants"]
-        assert len(grants) == 1
-        grant = grants[0]
-        grantee = grant["Grantee"]
-        assert grantee["Type"] == "CanonicalUser"
-        assert grantee["ID"] == bucket_owner_id
-        assert grant["Permission"] == "FULL_CONTROL"
+            # AND the file should be accessible via the external storage location
+            s3_read_client = boto3.client("s3", **get_aws_env()[1])
+            bucket_acl = s3_read_client.get_bucket_acl(Bucket=bucket_name)
+            bucket_grantee = bucket_acl["Grants"][0]["Grantee"]
+            assert bucket_grantee["Type"] == "CanonicalUser"
+            bucket_owner_id = bucket_grantee["ID"]
+
+            # with_retry to avoid acidity issues of an S3 put
+            object_acl = with_retry(
+                function=lambda: s3_read_client.get_object_acl(
+                    Bucket=bucket_name, Key=file.file_handle.key
+                ),
+                retry_exceptions=[s3_read_client.exceptions.NoSuchKey],
+            )
+
+            # AND the object should have the bucket owner as the grantee
+            grants = object_acl["Grants"]
+            assert len(grants) == 1
+            grant = grants[0]
+            grantee = grant["Grantee"]
+            assert grantee["Type"] == "CanonicalUser"
+            assert grantee["ID"] == bucket_owner_id
+            assert grant["Permission"] == "FULL_CONTROL"
+        finally:
+            self._teardown_bucket_location(key_prefix=folder_in_s3_to_cleanup)
+
+    @pytest.mark.skipif(
+        skip_tests_external_object_store, reason=reason_external_object_store
+    )
+    async def test_external_object_store(self) -> None:
+        """Test configuring an external object storage location,
+        saving a file there, and confirm that it is created and
+        accessible as expected."""
+
+        # GIVEN an external object storage location
+        (
+            s3_client,
+            folder,
+            _,
+            folder_in_s3_to_cleanup,
+        ) = await self._configure_storage_location(external_object_store=True)
+
+        try:
+            with (
+                mock.patch(
+                    "synapseclient.core.upload.upload_functions_async._get_aws_credentials",
+                    return_value=get_aws_env()[1],
+                ),
+                mock.patch(
+                    "synapseclient.core.download.download_functions._get_aws_credentials",
+                    return_value=get_aws_env()[1],
+                ),
+            ):
+                # WHEN we save a file to that location
+                upload_file = utils.make_bogus_uuid_file()
+                with open(upload_file, "r", encoding="utf-8") as f:
+                    file_contents = f.read()
+
+                file = await File(path=upload_file, parent_id=folder.id).store_async()
+
+                # THEN the file should be accessible via the external storage location
+                os.remove(upload_file)
+                file = await File(id=file.id).get_async()
+                with open(file.path, "r", encoding="utf-8") as f:
+                    downloaded_content = f.read()
+                assert file_contents == downloaded_content
+
+                # AND that the file is readable directly via boto
+                file_handle = self.syn._get_file_handle_as_creator(
+                    fileHandle=file.data_file_handle_id
+                )
+
+                # will raise an error if the key doesn't exist
+                bucket_name, _ = get_aws_env()
+                s3_client.get_object(Bucket=bucket_name, Key=file_handle["fileKey"])
+        finally:
+            self._teardown_bucket_location(key_prefix=folder.name)
+            self._teardown_bucket_location(key_prefix=folder_in_s3_to_cleanup)

--- a/tests/integration/synapseclient/core/upload/test_multipart_upload.py
+++ b/tests/integration/synapseclient/core/upload/test_multipart_upload.py
@@ -21,6 +21,7 @@ from synapseclient.core.upload.multipart_upload import (
     multipart_upload_string,
     multipart_copy,
 )
+from synapseclient.core.download import download_by_file_handle
 
 
 @pytest.mark.flaky(reruns=3, only_rerun=["SynapseHTTPError"])
@@ -36,7 +37,12 @@ async def test_round_trip(syn: Synapse, project: Project, schedule_for_cleanup):
         (tmp_f, tmp_path) = tempfile.mkstemp()
         schedule_for_cleanup(tmp_path)
 
-        junk["path"] = syn._downloadFileHandle(fhid, junk["id"], "FileEntity", tmp_path)
+        junk["path"] = await download_by_file_handle(
+            file_handle_id=fhid,
+            synapse_id=junk["id"],
+            entity_type="FileEntity",
+            destination=tmp_path,
+        )
         assert filecmp.cmp(filepath, junk.path)
 
     finally:
@@ -102,8 +108,11 @@ async def test_randomly_failing_parts(
             (tmp_f, tmp_path) = tempfile.mkstemp()
             schedule_for_cleanup(tmp_path)
 
-            junk["path"] = syn._downloadFileHandle(
-                fhid, junk["id"], "FileEntity", tmp_path
+            junk["path"] = await download_by_file_handle(
+                file_handle_id=fhid,
+                synapse_id=junk["id"],
+                entity_type="FileEntity",
+                destination=tmp_path,
             )
             assert filecmp.cmp(filepath, junk.path)
 
@@ -172,7 +181,12 @@ async def test_multipart_upload_big_string(
     (tmp_f, tmp_path) = tempfile.mkstemp()
     schedule_for_cleanup(tmp_path)
 
-    junk["path"] = syn._downloadFileHandle(fhid, junk["id"], "FileEntity", tmp_path)
+    junk["path"] = await download_by_file_handle(
+        file_handle_id=fhid,
+        synapse_id=junk["id"],
+        entity_type="FileEntity",
+        destination=tmp_path,
+    )
 
     with open(junk.path, encoding="utf-8") as f:
         retrieved_text = f.read()

--- a/tests/integration/synapseclient/core/upload/test_multipart_upload_async.py
+++ b/tests/integration/synapseclient/core/upload/test_multipart_upload_async.py
@@ -12,7 +12,6 @@ from typing import Callable
 from unittest import mock, skip
 
 import httpx
-import pytest
 
 import synapseclient.core.config
 import synapseclient.core.utils as utils
@@ -24,6 +23,7 @@ from synapseclient.core.upload.multipart_upload_async import (
     multipart_upload_string_async,
 )
 from synapseclient.models import File, Project
+from synapseclient.core.download import download_by_file_handle
 
 
 async def test_round_trip(
@@ -45,8 +45,11 @@ async def test_round_trip(
         schedule_for_cleanup(tmp_path)
 
         # AND I download the file from Synapse
-        path_from_file_handle = syn._downloadFileHandle(
-            file_handle_id, junk.id, "FileEntity", tmp_path
+        path_from_file_handle = await download_by_file_handle(
+            file_handle_id=file_handle_id,
+            synapse_id=junk.id,
+            entity_type="FileEntity",
+            destination=tmp_path,
         )
 
         # THEN I expect the files to match
@@ -128,8 +131,11 @@ async def test_randomly_failing_parts(
             schedule_for_cleanup(tmp_path)
 
             # AND I download the file from Synapse
-            path_from_file_handle = syn._downloadFileHandle(
-                file_handle_id, junk.id, "FileEntity", tmp_path
+            path_from_file_handle = await download_by_file_handle(
+                file_handle_id=file_handle_id,
+                synapse_id=junk.id,
+                entity_type="FileEntity",
+                destination=tmp_path,
             )
 
             # THEN I expect the files to match
@@ -211,8 +217,11 @@ async def test_multipart_upload_big_string(
     schedule_for_cleanup(tmp_path)
 
     # AND I download the file from Synapse
-    file_handle_path = syn._downloadFileHandle(
-        file_handle_id, junk.id, "FileEntity", tmp_path
+    file_handle_path = await download_by_file_handle(
+        file_handle_id=file_handle_id,
+        synapse_id=junk.id,
+        entity_type="FileEntity",
+        destination=tmp_path,
     )
 
     # THEN I expect the data to match

--- a/tests/integration/synapseclient/integration_test_Entity.py
+++ b/tests/integration/synapseclient/integration_test_Entity.py
@@ -605,7 +605,7 @@ async def test_synapse_store_flag(
 
 
 async def test_create_or_update_project(
-    syn: Synapse, project: Project, schedule_for_cleanup: Callable[..., None]
+    syn: Synapse, schedule_for_cleanup: Callable[..., None]
 ) -> None:
     name = str(uuid.uuid4())
 

--- a/tests/integration/synapseclient/integration_test_Entity.py
+++ b/tests/integration/synapseclient/integration_test_Entity.py
@@ -4,6 +4,7 @@ import datetime
 import filecmp
 import os
 import tempfile
+from typing import Callable
 import uuid
 from datetime import datetime as Datetime
 from unittest.mock import patch
@@ -26,7 +27,7 @@ from synapseclient.core.exceptions import SynapseError, SynapseHTTPError
 from synapseclient.core.upload.upload_functions import create_external_file_handle
 
 
-async def test_entity(syn: Synapse, project: Project, schedule_for_cleanup) -> None:
+async def test_entity(syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
     # Update the project
     project_name = str(uuid.uuid4())
     project = Project(name=project_name)
@@ -192,7 +193,7 @@ async def test_special_characters(syn: Synapse, project: Project) -> None:
 
 
 async def test_get_local_file(
-    syn: Synapse, project: Project, schedule_for_cleanup
+    syn: Synapse, project: Project, schedule_for_cleanup: Callable[..., None]
 ) -> None:
     new_path = utils.make_bogus_data_file()
     schedule_for_cleanup(new_path)
@@ -224,7 +225,7 @@ async def test_get_local_file(
 
 
 async def test_store_with_flags(
-    syn: Synapse, project: Project, schedule_for_cleanup
+    syn: Synapse, project: Project, schedule_for_cleanup: Callable[..., None]
 ) -> None:
     # -- CreateOrUpdate flag for Projects --
     # If we store a project with the same name, it should become an update
@@ -309,8 +310,8 @@ async def test_store_with_flags(
     assert ephemeral_bogus.shoe_size == [11.5]
 
 
-async def test_get_with_downloadLocation_and_ifcollision(
-    syn: Synapse, project: Project, schedule_for_cleanup
+async def test_get_with_download_location_and_ifcollision(
+    syn: Synapse, project: Project, schedule_for_cleanup: Callable[..., None]
 ) -> None:
     # Store a File and delete it locally
     filepath = utils.make_bogus_binary_file()
@@ -350,7 +351,6 @@ async def test_get_with_downloadLocation_and_ifcollision(
 
     # Invalidate the timestamps again
     os.utime(overwrite_bogus.path, (0, 0))
-    badtimestamps = os.path.getmtime(overwrite_bogus.path)
 
     # Download once more, but rename
     renamed_bogus = syn.get(
@@ -365,7 +365,10 @@ async def test_get_with_downloadLocation_and_ifcollision(
 
 
 async def test_get_with_cache_hit_and_miss_with_ifcollision(
-    syn: Synapse, project: Project, schedule_for_cleanup, mocker: MockerFixture
+    syn: Synapse,
+    project: Project,
+    schedule_for_cleanup: Callable[..., None],
+    mocker: MockerFixture,
 ) -> None:
     download_file_function = mocker.spy(download_functions, "download_by_file_handle")
     # GIVEN a File that is stored in Synapse - and removed from the local machine
@@ -426,7 +429,7 @@ async def test_get_with_cache_hit_and_miss_with_ifcollision(
 
 
 async def test_store_activity(
-    syn: Synapse, project: Project, schedule_for_cleanup
+    syn: Synapse, project: Project, schedule_for_cleanup: Callable[..., None]
 ) -> None:
     # Create a File and an Activity
     path = utils.make_bogus_binary_file()
@@ -479,8 +482,8 @@ async def test_store_activity(
     assert honking["id"] == honking2["id"]
 
 
-async def test_store_isRestricted_flag(
-    syn: Synapse, project: Project, schedule_for_cleanup
+async def test_store_is_restricted_flag(
+    syn: Synapse, project: Project, schedule_for_cleanup: Callable[..., None]
 ) -> None:
     # Store a file with access requirements
     path = utils.make_bogus_binary_file()
@@ -495,7 +498,7 @@ async def test_store_isRestricted_flag(
         assert intercepted.called
 
 
-async def test_ExternalFileHandle(syn: Synapse, project: Project) -> None:
+async def test_external_file_handle(syn: Synapse, project: Project) -> None:
     # Tests shouldn't have external dependencies, but this is a pretty picture of Singapore
     singapore_url = "http://upload.wikimedia.org/wikipedia/commons/thumb/3/3e/1_singapore_city_skyline_dusk_panorama_2011.jpg/1280px-1_singapore_city_skyline_dusk_panorama_2011.jpg"  # noqa
     singapore = File(singapore_url, parent=project, synapseStore=False)
@@ -531,8 +534,8 @@ async def test_ExternalFileHandle(syn: Synapse, project: Project) -> None:
     assert s2.externalURL == singapore_2_url
 
 
-async def test_synapseStore_flag(
-    syn: Synapse, project: Project, schedule_for_cleanup
+async def test_synapse_store_flag(
+    syn: Synapse, project: Project, schedule_for_cleanup: Callable[..., None]
 ) -> None:
     # Store a path to a local file
     path = utils.make_bogus_data_file()
@@ -602,7 +605,7 @@ async def test_synapseStore_flag(
 
 
 async def test_create_or_update_project(
-    syn: Synapse, project: Project, schedule_for_cleanup
+    syn: Synapse, project: Project, schedule_for_cleanup: Callable[..., None]
 ) -> None:
     name = str(uuid.uuid4())
 
@@ -628,7 +631,7 @@ async def test_create_or_update_project(
 
 
 async def test_download_file_false(
-    syn: Synapse, project: Project, schedule_for_cleanup
+    syn: Synapse, project: Project, schedule_for_cleanup: Callable[..., None]
 ) -> None:
     rename_suffix = "blah" + str(uuid.uuid4())
 
@@ -686,8 +689,8 @@ async def test_download_file_URL_false(syn: Synapse, project: Project) -> None:
 
 
 # SYNPY-366
-async def test_download_local_file_URL_path(
-    syn: Synapse, project: Project, schedule_for_cleanup
+async def test_download_local_file_url_path(
+    syn: Synapse, project: Project, schedule_for_cleanup: Callable[..., None]
 ) -> None:
     path = utils.make_bogus_data_file()
     schedule_for_cleanup(path)
@@ -701,7 +704,7 @@ async def test_download_local_file_URL_path(
 
 # SYNPY-424
 async def test_store_file_handle_update_metadata(
-    syn: Synapse, project: Project, schedule_for_cleanup
+    syn: Synapse, project: Project, schedule_for_cleanup: Callable[..., None]
 ) -> None:
     original_file_path = utils.make_bogus_data_file()
     schedule_for_cleanup(original_file_path)
@@ -729,7 +732,7 @@ async def test_store_file_handle_update_metadata(
     assert [os.path.basename(replacement_file_path)] == new_entity.files
 
 
-async def test_store_DockerRepository(syn: Synapse, project: Project) -> None:
+async def test_store_docker_repository(syn: Synapse, project: Project) -> None:
     repo_name = "some/repository/path"
     docker_repo = syn.store(DockerRepository(repo_name, parent=project))
     assert isinstance(docker_repo, DockerRepository)
@@ -738,8 +741,8 @@ async def test_store_DockerRepository(syn: Synapse, project: Project) -> None:
 
 
 @pytest.mark.flaky(reruns=3, only_rerun=["SynapseHTTPError"])
-async def test_store__changing_externalURL_by_changing_path(
-    syn: Synapse, project: Project, schedule_for_cleanup
+async def test_store_changing_external_url_by_changing_path(
+    syn: Synapse, project: Project, schedule_for_cleanup: Callable[..., None]
 ) -> None:
     url = "https://www.synapse.org/Portal/clear.cache.gif"
     ext = syn.store(
@@ -767,8 +770,8 @@ async def test_store__changing_externalURL_by_changing_path(
 
 
 @pytest.mark.flaky(reruns=3, only_rerun=["SynapseHTTPError"])
-async def test_store__changing_from_Synapse_to_externalURL_by_changing_path(
-    syn: Synapse, project: Project, schedule_for_cleanup
+async def test_store_changing_from_synapse_to_external_url_by_changing_path(
+    syn: Synapse, project: Project, schedule_for_cleanup: Callable[..., None]
 ) -> None:
     # create a temp file
     temp_path = utils.make_bogus_data_file()

--- a/tests/integration/synapseclient/models/async/test_file_async.py
+++ b/tests/integration/synapseclient/models/async/test_file_async.py
@@ -1320,7 +1320,7 @@ class TestGet:
 
         # THEN I expect the file to be returned
         assert file_copy.id == file.id
-        assert file_copy.path == path_for_file
+        assert utils.equal_paths(file_copy.path, path_for_file)
 
     async def test_get_previous_version(
         self, file: File, schedule_for_cleanup: Callable[..., None]

--- a/tests/integration/synapseclient/models/synchronous/test_file.py
+++ b/tests/integration/synapseclient/models/synchronous/test_file.py
@@ -1301,7 +1301,7 @@ class TestGet:
 
         # THEN I expect the file to be returned
         assert file_copy.id == file.id
-        assert file_copy.path == path_for_file
+        assert utils.equal_paths(file_copy.path, path_for_file)
 
     async def test_get_previous_version(
         self, file: File, schedule_for_cleanup: Callable[..., None]

--- a/tests/integration/synapseclient/test_json_schema_services.py
+++ b/tests/integration/synapseclient/test_json_schema_services.py
@@ -86,7 +86,7 @@ class TestJsonSchemaSchemas:
             },
         }
 
-    def teardown(self):
+    def teardown_method(self):
         self.my_org.delete()
 
     async def test_json_schema_schemas_org_create_schema(self):

--- a/tests/unit/synapseclient/core/credentials/unit_test_cred_data.py
+++ b/tests/unit/synapseclient/core/credentials/unit_test_cred_data.py
@@ -9,7 +9,7 @@ from synapseclient.core.exceptions import SynapseAuthenticationError
 
 class TestSynapseAuthTokenCredentials:
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self):
+    def setup_method(self):
         self.username = "ahhhhhhhhhhhhhh"
         self.auth_token = "opensesame"
         self.credentials = SynapseAuthTokenCredentials(

--- a/tests/unit/synapseclient/core/credentials/unit_test_cred_provider.py
+++ b/tests/unit/synapseclient/core/credentials/unit_test_cred_provider.py
@@ -105,7 +105,10 @@ class TestSynapseCredentialProvider(object):
         # SynapseApiKeyCredentialsProvider has abstractmethod so we can't instantiate it unless we overwrite it
 
         class SynapseCredProviderTester(SynapseCredentialsProvider):
-            def _get_auth_info(self, syn, user_login_args) -> None:
+            def _get_auth_info(
+                self, syn: Synapse, user_login_args: Dict[str, str]
+            ) -> None:
+                """Empty as this is a stub."""
                 pass
 
         self.provider = SynapseCredProviderTester()

--- a/tests/unit/synapseclient/core/credentials/unit_test_cred_provider.py
+++ b/tests/unit/synapseclient/core/credentials/unit_test_cred_provider.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from typing import Dict
 from unittest.mock import MagicMock, create_autospec, patch
 
 import boto3
@@ -319,7 +320,7 @@ class TestAWSParameterStoreCredentialsProvider(object):
         self.syn = syn
 
     @pytest.fixture()
-    def environ_with_param_name(self):
+    def environ_with_param_name(self) -> Dict[str, str]:
         return {"SYNAPSE_TOKEN_AWS_SSM_PARAMETER_NAME": "/synapse/cred/i-12134312"}
 
     def stub_ssm(self, mocker: MockerFixture):
@@ -361,7 +362,11 @@ class TestAWSParameterStoreCredentialsProvider(object):
         ["UnrecognizedClientException", "AccessDenied", "ParameterNotFound"],
     )
     def test_get_auth_info__get_parameter_error(
-        self, mocker: MockerFixture, syn: Synapse, environ_with_param_name, error_code
+        self,
+        mocker: MockerFixture,
+        syn: Synapse,
+        environ_with_param_name: Dict[str, str],
+        error_code: str,
     ) -> None:
         mocker.patch.dict(os.environ, environ_with_param_name)
 
@@ -379,7 +384,10 @@ class TestAWSParameterStoreCredentialsProvider(object):
             stubber.assert_no_pending_responses()
 
     def test_get_auth_info__parameter_name_exists(
-        self, mocker: MockerFixture, syn: Synapse, environ_with_param_name
+        self,
+        mocker: MockerFixture,
+        syn: Synapse,
+        environ_with_param_name: Dict[str, str],
     ) -> None:
         mocker.patch.dict(os.environ, environ_with_param_name)
 
@@ -412,7 +420,10 @@ class TestAWSParameterStoreCredentialsProvider(object):
             stubber.assert_no_pending_responses()
 
     def test_get_auth_info__boto3_ImportError(
-        self, mocker, syn: Synapse, environ_with_param_name
+        self,
+        mocker: MockerFixture,
+        syn: Synapse,
+        environ_with_param_name: Dict[str, str],
     ) -> None:
         mocker.patch.dict(os.environ, environ_with_param_name)
         # simulate import error by "removing" boto3 from sys.modules

--- a/tests/unit/synapseclient/core/download/unit_test_download_functions.py
+++ b/tests/unit/synapseclient/core/download/unit_test_download_functions.py
@@ -1,0 +1,42 @@
+"""Unit tests for synapseclient.core.download.download_functions"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from synapseclient import File, Synapse
+from synapseclient.core import utils
+from synapseclient.core.download import (
+    download_file_entity,
+    ensure_download_location_is_directory,
+)
+
+
+def test_ensure_download_location_is_directory() -> None:
+    download_location = "/foo/bar/baz"
+    with patch("synapseclient.core.download.download_functions.os") as mock_os:
+        mock_os.path.isfile.return_value = False
+        ensure_download_location_is_directory(download_location)
+
+        mock_os.path.isfile.return_value = True
+        with pytest.raises(ValueError):
+            ensure_download_location_is_directory(download_location)
+
+
+async def test_download_file_entity_correct_local_state(syn: Synapse) -> None:
+    mock_cache_path = utils.normalize_path("/i/will/show/you/the/path/yi.txt")
+    file_entity = File(parentId="syn123")
+    file_entity.dataFileHandleId = 123
+    with patch.object(syn.cache, "get", return_value=mock_cache_path):
+        await download_file_entity(
+            download_location=None,
+            entity=file_entity,
+            if_collision="overwrite.local",
+            submission=None,
+            synapse_client=syn,
+        )
+        assert mock_cache_path == utils.normalize_path(file_entity.path)
+        assert os.path.dirname(mock_cache_path) == file_entity.cacheDir
+        assert 1 == len(file_entity.files)
+        assert os.path.basename(mock_cache_path) == file_entity.files[0]

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -151,8 +151,13 @@ async def test_mock_download(syn: Synapse) -> None:
 
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
+    # with patch.object(
+    #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
+    # ),
+
+    # TODO: When swapping out for the HTTPX client, we will need to update this test
     with patch.object(
-        syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
+        syn._requests_session, "get", side_effect=mock_requests_get
     ), patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers):
         await download_from_url(
             url=url,
@@ -170,10 +175,14 @@ async def test_mock_download(syn: Synapse) -> None:
         ]
     )
 
+    # TODO: When swapping out for the HTTPX client, we will need to update this test
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
+    # with patch.object(
+    #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
+    # )
     with patch.object(
-        syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
+        syn._requests_session, "get", side_effect=mock_requests_get
     ), patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers):
         await download_from_url(
             url=url,
@@ -222,10 +231,15 @@ async def test_mock_download(syn: Synapse) -> None:
             "concreteType": concrete_types.S3_FILE_HANDLE,
         },
     }
+
+    # TODO: When swapping out for the HTTPX client, we will need to update this test
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
+    # with patch.object(
+    #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
+    # )
     with patch.object(
-        syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
+        syn._requests_session, "get", side_effect=mock_requests_get
     ), patch.object(syn, "_generate_headers", side_effect=mock_generate_headers), patch(
         "synapseclient.core.download.download_functions.get_file_handle_for_download",
         new_callable=AsyncMock,
@@ -266,10 +280,14 @@ async def test_mock_download(syn: Synapse) -> None:
         )
     mock_requests_get = MockRequestGetFunction(responses)
 
+    # TODO: When swapping out for the HTTPX client, we will need to update this test
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
+    # with patch.object(
+    #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
+    # )
     with patch.object(
-        syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
+        syn._requests_session, "get", side_effect=mock_requests_get
     ), patch.object(
         Synapse, "_generate_headers", side_effect=mock_generate_headers
     ), patch(
@@ -312,10 +330,14 @@ async def test_mock_download(syn: Synapse) -> None:
         )
     mock_requests_get = MockRequestGetFunction(responses)
 
+    # TODO: When swapping out for the HTTPX client, we will need to update this test
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
+    # with patch.object(
+    #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
+    # )
     with patch.object(
-        syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
+        syn._requests_session, "get", side_effect=mock_requests_get
     ), patch.object(
         Synapse, "_generate_headers", side_effect=mock_generate_headers
     ), patch(
@@ -349,10 +371,14 @@ async def test_mock_download(syn: Synapse) -> None:
         ]
     )
 
+    # TODO: When swapping out for the HTTPX client, we will need to update this test
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
+    # with patch.object(
+    #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
+    # )
     with patch.object(
-        syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
+        syn._requests_session, "get", side_effect=mock_requests_get
     ), patch.object(
         Synapse, "_generate_headers", side_effect=mock_generate_headers
     ), patch(
@@ -375,10 +401,14 @@ async def test_mock_download(syn: Synapse) -> None:
         ]
     )
 
+    # TODO: When swapping out for the HTTPX client, we will need to update this test
     # patch requests.get and also the method that generates signed
     # headers (to avoid having to be logged in to Synapse)
+    # with patch.object(
+    #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
+    # )
     with patch.object(
-        syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
+        syn._requests_session, "get", side_effect=mock_requests_get
     ), patch.object(
         Synapse, "_generate_headers", side_effect=mock_generate_headers
     ), patch(
@@ -630,8 +660,12 @@ async def test_download_end_early_retry(syn: Synapse) -> None:
         contents[partial_content_break:]
     )
 
+    # TODO: When swapping out for the HTTPX client, we will need to update this test
+    # with patch.object(
+    #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
+    # )
     with patch.object(
-        syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
+        syn._requests_session, "get", side_effect=mock_requests_get
     ), patch.object(
         Synapse, "_generate_headers", side_effect=mock_generate_headers
     ), patch.object(
@@ -698,8 +732,13 @@ async def test_download_md5_mismatch__not_local_file(syn: Synapse) -> None:
         ]
     )
 
+    # with patch.object(
+    #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
+    # )
+
+    # TODO: When swapping out for the HTTPX client, we will need to update this test
     with patch.object(
-        syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
+        syn._requests_session, "get", side_effect=mock_requests_get
     ), patch.object(
         Synapse, "_generate_headers", side_effect=mock_generate_headers
     ), patch.object(

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import tempfile
 
+from typing import Dict
 from unittest.mock import AsyncMock, MagicMock, patch, mock_open, call
 import pytest
 
@@ -27,6 +28,11 @@ from synapseclient.core.download import (
     download_from_url_multi_threaded,
 )
 from synapseclient.api import get_file_handle_for_download
+
+GET_FILE_HANDLE_FOR_DOWNLOAD = (
+    "synapseclient.core.download.download_functions.get_file_handle_for_download"
+)
+DOWNLOAD_FROM_URL = "synapseclient.core.download.download_functions.download_from_url"
 
 
 # a callable that mocks the requests.get function
@@ -241,7 +247,7 @@ async def test_mock_download(syn: Synapse) -> None:
     with patch.object(
         syn._requests_session, "get", side_effect=mock_requests_get
     ), patch.object(syn, "_generate_headers", side_effect=mock_generate_headers), patch(
-        "synapseclient.core.download.download_functions.get_file_handle_for_download",
+        GET_FILE_HANDLE_FOR_DOWNLOAD,
         new_callable=AsyncMock,
         return_value=_getFileHandleDownload_return_value,
     ):
@@ -291,7 +297,7 @@ async def test_mock_download(syn: Synapse) -> None:
     ), patch.object(
         Synapse, "_generate_headers", side_effect=mock_generate_headers
     ), patch(
-        "synapseclient.core.download.download_functions.get_file_handle_for_download",
+        GET_FILE_HANDLE_FOR_DOWNLOAD,
         new_callable=AsyncMock,
         return_value=_getFileHandleDownload_return_value,
     ):
@@ -341,7 +347,7 @@ async def test_mock_download(syn: Synapse) -> None:
     ), patch.object(
         Synapse, "_generate_headers", side_effect=mock_generate_headers
     ), patch(
-        "synapseclient.core.download.download_functions.get_file_handle_for_download",
+        GET_FILE_HANDLE_FOR_DOWNLOAD,
         new_callable=AsyncMock,
         return_value=_getFileHandleDownload_return_value,
     ):
@@ -382,7 +388,7 @@ async def test_mock_download(syn: Synapse) -> None:
     ), patch.object(
         Synapse, "_generate_headers", side_effect=mock_generate_headers
     ), patch(
-        "synapseclient.core.download.download_functions.get_file_handle_for_download",
+        GET_FILE_HANDLE_FOR_DOWNLOAD,
         new_callable=AsyncMock,
         return_value=_getFileHandleDownload_return_value,
     ):
@@ -412,7 +418,7 @@ async def test_mock_download(syn: Synapse) -> None:
     ), patch.object(
         Synapse, "_generate_headers", side_effect=mock_generate_headers
     ), patch(
-        "synapseclient.core.download.download_functions.get_file_handle_for_download",
+        GET_FILE_HANDLE_FOR_DOWNLOAD,
         new_callable=AsyncMock,
         return_value=_getFileHandleDownload_return_value,
     ):
@@ -435,7 +441,7 @@ class TestDownloadFileHandle:
 
     async def test_multithread_true_s3_file_handle(self) -> None:
         with patch.object(os, "makedirs"), patch(
-            "synapseclient.core.download.download_functions.get_file_handle_for_download",
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
             new_callable=AsyncMock,
         ) as mock_getFileHandleDownload, patch(
             "synapseclient.core.download.download_functions.download_from_url_multi_threaded",
@@ -470,12 +476,12 @@ class TestDownloadFileHandle:
                 synapse_client=self.syn,
             )
 
-    async def _multithread_not_applicable(self, file_handle) -> None:
+    async def _multithread_not_applicable(self, file_handle: Dict[str, str]) -> None:
         with patch.object(os, "makedirs"), patch(
-            "synapseclient.core.download.download_functions.get_file_handle_for_download",
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
             new_callable=AsyncMock,
         ) as mock_getFileHandleDownload, patch(
-            "synapseclient.core.download.download_functions.download_from_url",
+            DOWNLOAD_FROM_URL,
             new_callable=AsyncMock,
         ) as mock_download_from_URL, patch.object(
             self.syn, "cache"
@@ -524,10 +530,10 @@ class TestDownloadFileHandle:
 
     async def test_multithread_false_s3_file_handle(self) -> None:
         with patch.object(os, "makedirs"), patch(
-            "synapseclient.core.download.download_functions.get_file_handle_for_download",
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
             new_callable=AsyncMock,
         ) as mock_getFileHandleDownload, patch(
-            "synapseclient.core.download.download_functions.download_from_url",
+            DOWNLOAD_FROM_URL,
             new_callable=AsyncMock,
         ) as mock_download_from_URL, patch.object(
             self.syn, "cache"
@@ -558,7 +564,7 @@ class TestDownloadFileHandle:
             )
 
 
-class Test_download_from_url_multi_threaded:
+class TestDownloadFromUrlMultiThreaded:
     @pytest.fixture(autouse=True, scope="function")
     def init_syn(self, syn: Synapse) -> None:
         self.syn = syn
@@ -807,7 +813,7 @@ async def test_download_md5_mismatch_local_file() -> None:
         assert not mocked_remove.called
 
 
-async def test_getFileHandleDownload__error_UNAUTHORIZED(syn: Synapse) -> None:
+async def test_get_file_handle_download__error_unauthorized(syn: Synapse) -> None:
     ret_val = {
         "requestedFiles": [
             {
@@ -825,7 +831,7 @@ async def test_getFileHandleDownload__error_UNAUTHORIZED(syn: Synapse) -> None:
             )
 
 
-async def test_getFileHandleDownload__error_NOT_FOUND(syn: Synapse) -> None:
+async def test_get_file_handle_download_error_not_found(syn: Synapse) -> None:
     ret_val = {
         "requestedFiles": [
             {

--- a/tests/unit/synapseclient/core/unit_test_pool_provider.py
+++ b/tests/unit/synapseclient/core/unit_test_pool_provider.py
@@ -15,7 +15,7 @@ from synapseclient.core.pool_provider import (
 
 
 class TestSingleThreadPool:
-    def setup(self):
+    def setup_method(self):
         pass
 
     def test_map(self):

--- a/tests/unit/synapseclient/core/unit_test_pool_provider.py
+++ b/tests/unit/synapseclient/core/unit_test_pool_provider.py
@@ -15,10 +15,10 @@ from synapseclient.core.pool_provider import (
 
 
 class TestSingleThreadPool:
-    def setup_method(self):
+    def setup_method(self) -> None:
         pass
 
-    def test_map(self):
+    def test_map(self) -> None:
         test_func = MagicMock()
         pool = SingleThreadPool()
         pool.map(test_func, range(0, 10))
@@ -26,7 +26,7 @@ class TestSingleThreadPool:
 
 
 class TestSingleThreadExecutor:
-    def test_execution(self):
+    def test_execution(self) -> None:
         executor = SingleThreadExecutor()
         for i in range(10):
             result = executor.submit(lambda: i)
@@ -44,21 +44,21 @@ def _patch_config(single_threaded: bool):
 
 
 class TestExecutorProvider:
-    def test_get_executor_for_single_thread(self):
+    def test_get_executor_for_single_thread(self) -> None:
         with _patch_config(True):
             assert isinstance(get_executor(), SingleThreadExecutor)
 
-    def test_get_executor_for_multiple_thread(self):
+    def test_get_executor_for_multiple_thread(self) -> None:
         with _patch_config(False):
             assert isinstance(get_executor(), ThreadPoolExecutor)
 
 
 class TestPoolProvider:
-    def test_get_pool_for_single_thread(self):
+    def test_get_pool_for_single_thread(self) -> None:
         with _patch_config(True):
             assert isinstance(get_pool(), SingleThreadPool)
 
-    def test_get_pool_for_multiple_thread(self):
+    def test_get_pool_for_multiple_thread(self) -> None:
         with _patch_config(False):
             assert isinstance(get_pool(), ThreadPool)
 
@@ -67,7 +67,7 @@ class TestGetValue:
     @patch.object(
         synapseclient.core.config, "single_threaded", PropertyMock(return_value=False)
     )
-    def test_get_value_for_multiple_thread(self):
+    def test_get_value_for_multiple_thread(self) -> None:
         synapseclient.core.config.single_threaded = False
         test_value = get_value("d", 500)
         type(test_value)
@@ -81,7 +81,7 @@ class TestGetValue:
     @patch.object(
         synapseclient.core.config, "single_threaded", PropertyMock(return_value=True)
     )
-    def test_get_value_for_single_thread(self):
+    def test_get_value_for_single_thread(self) -> None:
         synapseclient.core.config.single_threaded = True
         test_value = get_value("d", 500)
         assert isinstance(test_value, SingleValue)

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -5,7 +5,7 @@ import os
 import re
 import tempfile
 from shutil import rmtree
-from unittest.mock import Mock, call, mock_open, patch
+from unittest.mock import MagicMock, Mock, call, mock_open, patch
 
 import pytest
 
@@ -399,8 +399,8 @@ def test_temp_download_filename() -> None:
 @patch("os.makedirs")
 @patch("os.path.exists", return_value=False)
 def test_extract_zip_file_to_directory(
-    mocked_path_exists, mocked_makedir, mocked_zipfile
-):
+    mocked_path_exists: MagicMock, mocked_makedir: MagicMock, mocked_zipfile: MagicMock
+) -> None:
     file_base_name = "test.txt"
     file_dir = "some/folders/"
     target_dir = tempfile.mkdtemp()  # TODO rename
@@ -507,7 +507,7 @@ ValueError: error 2
 
 
 @patch.object(utils, "hashlib")
-def test_md5_for_file(mock_hashlib):
+def test_md5_for_file(mock_hashlib: MagicMock) -> None:
     """
     Verify the md5 calculation is correct, and call the callback func if it passed in as argument.
     """
@@ -535,7 +535,7 @@ class TestSpinner:
         self.spinner = utils.Spinner(self.msg)
 
     @patch.object(utils, "sys")
-    def test_print_tick_is_atty(self, mock_sys) -> None:
+    def test_print_tick_is_atty(self, mock_sys: MagicMock) -> None:
         """
         assume the sys.stdin.isatty is True, verify the sys.stdout.write will call once if print_tick is called.
         """
@@ -561,7 +561,7 @@ class TestSpinner:
         mock_sys.stdout.flush.call_count == 4
 
     @patch.object(utils, "sys")
-    def test_print_tick_is_not_atty(self, mock_sys) -> None:
+    def test_print_tick_is_not_atty(self, mock_sys: MagicMock) -> None:
         """
         assume the sys.stdin.isatty is False,
         verify the sys.stdout won't be called.

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -530,7 +530,7 @@ class TestSpinner:
     """
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self):
+    def setup_method(self):
         self.msg = "test_msg"
         self.spinner = utils.Spinner(self.msg)
 

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -3,16 +3,16 @@
 import base64
 import os
 import re
-from shutil import rmtree
 import tempfile
+from shutil import rmtree
+from unittest.mock import Mock, call, mock_open, patch
 
 import pytest
-from unittest.mock import patch, mock_open, Mock, call
 
 from synapseclient.core import constants, utils
 
 
-def test_is_url():
+def test_is_url() -> None:
     """test the ability to determine whether a string is a URL"""
     assert utils.is_url("http://mydomain.com/foo/bar/bat?asdf=1234&qewr=ooo")
     assert utils.is_url("http://xkcd.com/1193/")
@@ -26,7 +26,7 @@ def test_is_url():
     assert not utils.is_url("c:/WINDOWS/ugh/ugh.ugh")
 
 
-def test_windows_file_urls():
+def test_windows_file_urls() -> None:
     url = "file:///c:/WINDOWS/clock.avi"
     assert utils.is_url(url)
     assert (
@@ -34,7 +34,7 @@ def test_windows_file_urls():
     ), utils.file_url_to_path(url)
 
 
-def test_is_in_path():
+def test_is_in_path() -> None:
     # Path as returned form syn.restGET('entity/{}/path')
     path = {
         "path": [
@@ -60,7 +60,7 @@ def test_is_in_path():
     assert not utils.is_in_path("syn123", path)
 
 
-def test_humanizeBytes():
+def test_humanize_bytes() -> None:
     for input_bytes, expected_output in [
         (-1, "-1.0bytes"),
         (0, "0.0bytes"),
@@ -75,12 +75,12 @@ def test_humanizeBytes():
         assert utils.humanizeBytes(input_bytes) == expected_output
 
 
-def test_humanizeBytes__None():
+def test_humanize_bytes_none() -> None:
     with pytest.raises(ValueError):
         utils.humanizeBytes(None)
 
 
-def test_id_of():
+def test_id_of() -> None:
     assert utils.id_of(1) == "1"
     assert utils.id_of("syn12345") == "syn12345"
     assert utils.id_of({"foo": 1, "id": 123}) == "123"
@@ -90,7 +90,7 @@ def test_id_of():
     pytest.raises(ValueError, utils.id_of, object())
 
     class Foo:
-        def __init__(self, id_attr_name, id):
+        def __init__(self, id_attr_name: str, id: str) -> None:
             self.properties = {id_attr_name: id}
 
     id_attr_names = ["id", "ownerId", "tableId"]
@@ -104,7 +104,7 @@ def test_id_of():
 # https://sagebionetworks.jira.com/browse/SYNPY-1425
 
 
-def test_get_synid_and_version():
+def test_get_synid_and_version() -> None:
     # Test 1: Ensure that a synID string with no version works
     synid_no_version = "syn123"
     id, version = utils.get_synid_and_version(synid_no_version)
@@ -131,7 +131,7 @@ def test_get_synid_and_version():
     assert not version
 
 
-def test_concrete_type_of():
+def test_concrete_type_of() -> None:
     """Verify behavior of utils#concrete_type_of"""
 
     for invalid_obj in [
@@ -159,7 +159,7 @@ def test_concrete_type_of():
         assert expected_type == utils.concrete_type_of(value)
 
 
-def test_guess_file_name():
+def test_guess_file_name() -> None:
     assert utils.guess_file_name("a/b") == "b"
     assert utils.guess_file_name("file:///a/b") == "b"
     assert utils.guess_file_name("A:/a/b") == "b"
@@ -178,14 +178,14 @@ def test_guess_file_name():
     assert utils.guess_file_name("http://www.a.com/b/?foo=bar&arga=barga") == "b"
 
 
-def test_extract_filename():
+def test_extract_filename() -> None:
     assert utils.extract_filename('attachment; filename="fname.ext"') == "fname.ext"
     assert utils.extract_filename("attachment; filename=fname.ext") == "fname.ext"
     assert utils.extract_filename(None) is None
     assert utils.extract_filename(None, "fname.ext") == "fname.ext"
 
 
-def test_version_check():
+def test_version_check() -> None:
     from synapseclient.core.version_check import _version_tuple
 
     assert _version_tuple("0.5.1.dev200", levels=2) == ("0", "5")
@@ -193,7 +193,7 @@ def test_version_check():
     assert _version_tuple("1.6", levels=3) == ("1", "6", "0")
 
 
-def test_normalize_path():
+def test_normalize_path() -> None:
     # tests should pass on reasonable OSes and also on windows
 
     # resolves relative paths
@@ -209,7 +209,7 @@ def test_normalize_path():
     assert utils.normalize_path(None) is None
 
 
-def test_limit_and_offset():
+def test_limit_and_offset() -> None:
     def query_params(uri):
         """Return the query params as a dict"""
         return dict([kvp.split("=") for kvp in uri.split("?")[1].split("&")])
@@ -241,7 +241,7 @@ def test_limit_and_offset():
     assert len(qp) == 3
 
 
-def test_utils_extract_user_name():
+def test_utils_extract_user_name() -> None:
     profile = {"firstName": "Madonna"}
     assert utils.extract_user_name(profile) == "Madonna"
     profile = {"firstName": "Oscar", "lastName": "the Grouch"}
@@ -258,7 +258,7 @@ def test_utils_extract_user_name():
     assert utils.extract_user_name(profile) == "otg"
 
 
-def test_is_json():
+def test_is_json() -> None:
     assert utils.is_json("application/json")
     assert utils.is_json("application/json;charset=ISO-8859-1")
     assert not utils.is_json("application/flapdoodle;charset=ISO-8859-1")
@@ -266,7 +266,7 @@ def test_is_json():
     assert not utils.is_json("")
 
 
-def test_normalize_whitespace():
+def test_normalize_whitespace() -> None:
     assert "zip tang pow a = 2" == utils.normalize_whitespace(
         "   zip\ttang   pow   \n    a = 2   "
     )
@@ -274,7 +274,7 @@ def test_normalize_whitespace():
     assert "zip tang pow\na = 2\nb = 3" == result
 
 
-def test_query_limit_and_offset():
+def test_query_limit_and_offset() -> None:
     query, limit, offset = utils.query_limit_and_offset(
         "select foo from bar where zap > 2 limit 123 offset 456"
     )
@@ -304,7 +304,7 @@ def test_query_limit_and_offset():
     assert offset == 1
 
 
-def test_as_urls():
+def test_as_urls() -> None:
     assert (
         utils.as_url("C:\\Users\\Administrator\\AppData\\Local\\Temp\\2\\tmpvixuld.txt")
         == "file:///C:/Users/Administrator/AppData/Local/Temp/2/tmpvixuld.txt"
@@ -321,7 +321,7 @@ def test_as_urls():
     )
 
 
-def test_time_manipulation():
+def test_time_manipulation() -> None:
     round_tripped_datetime = utils.datetime_to_iso(
         utils.from_unix_epoch_time_secs(
             utils.to_unix_epoch_time_secs(
@@ -361,7 +361,7 @@ def test_time_manipulation():
     assert "1969-04-28T00:00:00.000Z" == round_tripped_datetime
 
 
-def test_treadsafe_generator():
+def test_treadsafe_generator() -> None:
     @utils.threadsafe_generator
     def generate_letters():
         for c in "ABCDEFGHIJKLMNOPQRSTUVWXYZ":
@@ -370,7 +370,7 @@ def test_treadsafe_generator():
     "".join(letter for letter in generate_letters()) == "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 
-def test_extract_synapse_id_from_query():
+def test_extract_synapse_id_from_query() -> None:
     assert (
         utils.extract_synapse_id_from_query("select * from syn1234567") == "syn1234567"
     )
@@ -387,7 +387,7 @@ def test_extract_synapse_id_from_query():
     )
 
 
-def test_temp_download_filename():
+def test_temp_download_filename() -> None:
     temp_destination = utils.temp_download_filename("/foo/bar/bat", 12345)
     assert temp_destination == "/foo/bar/bat.synapse_download_12345", temp_destination
 
@@ -530,12 +530,12 @@ class TestSpinner:
     """
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.msg = "test_msg"
         self.spinner = utils.Spinner(self.msg)
 
     @patch.object(utils, "sys")
-    def test_print_tick_is_atty(self, mock_sys):
+    def test_print_tick_is_atty(self, mock_sys) -> None:
         """
         assume the sys.stdin.isatty is True, verify the sys.stdout.write will call once if print_tick is called.
         """
@@ -561,7 +561,7 @@ class TestSpinner:
         mock_sys.stdout.flush.call_count == 4
 
     @patch.object(utils, "sys")
-    def test_print_tick_is_not_atty(self, mock_sys):
+    def test_print_tick_is_not_atty(self, mock_sys) -> None:
         """
         assume the sys.stdin.isatty is False,
         verify the sys.stdout won't be called.

--- a/tests/unit/synapseclient/models/async/unit_test_file_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_file_async.py
@@ -70,11 +70,11 @@ class TestFile:
             dataFileHandleId=DATA_FILE_HANDLE_ID,
         )
 
-    def get_example_synapse_file_output(self) -> Synapse_File:
+    def get_example_synapse_file_output(self, path: str = PATH) -> Synapse_File:
         return Synapse_File(
             id=SYN_123,
             name=FILE_NAME,
-            path=PATH,
+            path=path,
             description=DESCRIPTION,
             etag=ETAG,
             createdOn=CREATED_ON,
@@ -243,7 +243,7 @@ class TestFile:
         with patch.object(
             self.syn,
             "get",
-            return_value=(self.get_example_synapse_file_output()),
+            return_value=(self.get_example_synapse_file_output(path=None)),
         ) as mocked_get_call, patch(
             "synapseclient.models.file.upload_file_handle",
             new_callable=AsyncMock,
@@ -335,7 +335,7 @@ class TestFile:
         ) as mocked_file_handle_upload, patch(
             "synapseclient.models.file.store_entity",
             new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_file_output()),
+            return_value=(self.get_example_synapse_file_output(path=bogus_file)),
         ) as mocked_store_entity:
             result = await file.store_async(parent=Project(id=ACTUAL_PARENT_ID))
 
@@ -421,7 +421,7 @@ class TestFile:
         ) as mocked_file_handle_upload, patch(
             "synapseclient.models.file.store_entity",
             new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_file_output()),
+            return_value=(self.get_example_synapse_file_output(path=bogus_file)),
         ) as mocked_store_entity:
             result = await file.store_async(parent=Project(id=ACTUAL_PARENT_ID))
 
@@ -514,7 +514,7 @@ class TestFile:
         ) as mocked_file_handle_upload, patch(
             "synapseclient.models.file.store_entity",
             new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_file_output()),
+            return_value=(self.get_example_synapse_file_output(path=bogus_file)),
         ) as mocked_store_entity, patch(
             "synapseclient.models.file.store_entity_components",
             return_value=True,
@@ -718,7 +718,7 @@ class TestFile:
         with patch.object(
             self.syn,
             "get",
-            return_value=(self.get_example_synapse_file_output()),
+            return_value=(self.get_example_synapse_file_output(path=bogus_file)),
         ) as mocked_client_call:
             result = await file.get_async()
             os.remove(bogus_file)
@@ -911,7 +911,7 @@ class TestFile:
         with patch.object(
             self.syn,
             "get",
-            return_value=(self.get_example_synapse_file_output()),
+            return_value=(self.get_example_synapse_file_output(path=bogus_file)),
         ) as mocked_client_call:
             result = await File.from_id_async(synapse_id=synapse_id)
             os.remove(bogus_file)

--- a/tests/unit/synapseclient/models/synchronous/unit_test_file.py
+++ b/tests/unit/synapseclient/models/synchronous/unit_test_file.py
@@ -70,11 +70,11 @@ class TestFile:
             dataFileHandleId=DATA_FILE_HANDLE_ID,
         )
 
-    def get_example_synapse_file_output(self) -> Synapse_File:
+    def get_example_synapse_file_output(self, path: str = PATH) -> Synapse_File:
         return Synapse_File(
             id=SYN_123,
             name=FILE_NAME,
-            path=PATH,
+            path=path,
             description=DESCRIPTION,
             etag=ETAG,
             createdOn=CREATED_ON,
@@ -243,7 +243,7 @@ class TestFile:
         with patch.object(
             self.syn,
             "get",
-            return_value=(self.get_example_synapse_file_output()),
+            return_value=(self.get_example_synapse_file_output(path=None)),
         ) as mocked_get_call, patch(
             "synapseclient.models.file.upload_file_handle",
             new_callable=AsyncMock,
@@ -335,7 +335,7 @@ class TestFile:
         ) as mocked_file_handle_upload, patch(
             "synapseclient.models.file.store_entity",
             new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_file_output()),
+            return_value=(self.get_example_synapse_file_output(path=bogus_file)),
         ) as mocked_store_entity:
             result = file.store(parent=Project(id=ACTUAL_PARENT_ID))
 
@@ -421,7 +421,7 @@ class TestFile:
         ) as mocked_file_handle_upload, patch(
             "synapseclient.models.file.store_entity",
             new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_file_output()),
+            return_value=(self.get_example_synapse_file_output(path=bogus_file)),
         ) as mocked_store_entity:
             result = file.store(parent=Project(id=ACTUAL_PARENT_ID))
 
@@ -514,7 +514,7 @@ class TestFile:
         ) as mocked_file_handle_upload, patch(
             "synapseclient.models.file.store_entity",
             new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_file_output()),
+            return_value=(self.get_example_synapse_file_output(path=bogus_file)),
         ) as mocked_store_entity, patch(
             "synapseclient.models.file.store_entity_components",
             return_value=True,
@@ -718,7 +718,7 @@ class TestFile:
         with patch.object(
             self.syn,
             "get",
-            return_value=(self.get_example_synapse_file_output()),
+            return_value=(self.get_example_synapse_file_output(path=bogus_file)),
         ) as mocked_client_call:
             result = file.get()
             os.remove(bogus_file)
@@ -911,7 +911,7 @@ class TestFile:
         with patch.object(
             self.syn,
             "get",
-            return_value=(self.get_example_synapse_file_output()),
+            return_value=(self.get_example_synapse_file_output(path=bogus_file)),
         ) as mocked_client_call:
             result = File.from_id(synapse_id=synapse_id)
             os.remove(bogus_file)

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -154,8 +154,8 @@ class TestPrivateGetWithEntityBundle:
     def init_syn(self, syn: Synapse) -> None:
         self.syn = syn
 
-    def test_getWithEntityBundle__no_DOWNLOAD(
-        self, download_file_mock, get_file_URL_and_metadata_mock
+    def test_get_with_entity_bundle_no_download(
+        self, download_file_mock: MagicMock, get_file_URL_and_metadata_mock: MagicMock
     ) -> None:
         bundle = {
             "entity": {
@@ -179,8 +179,8 @@ class TestPrivateGetWithEntityBundle:
             mocked_warn.assert_called_once()
             assert entity_no_download.path is None
 
-    def test_getWithEntityBundle(
-        self, download_file_mock, get_file_URL_and_metadata_mock
+    def test_get_with_entity_bundle(
+        self, download_file_mock: MagicMock, get_file_url_and_metadata_mock: MagicMock
     ) -> None:
         # Note: one thing that remains unexplained is why the previous version of
         # this test worked if you had a .cacheMap file of the form:
@@ -213,12 +213,12 @@ class TestPrivateGetWithEntityBundle:
             },
         }
 
-        fileHandle = bundle["fileHandles"][0]["id"]
-        cacheDir = self.syn.cache.get_cache_dir(fileHandle)
+        file_handle = bundle["fileHandles"][0]["id"]
+        cache_dir = self.syn.cache.get_cache_dir(file_handle)
         # Make sure the .cacheMap file does not already exist
-        cacheMap = os.path.join(cacheDir, ".cacheMap")
-        if os.path.exists(cacheMap):
-            os.remove(cacheMap)
+        cache_map = os.path.join(cache_dir, ".cacheMap")
+        if os.path.exists(cache_map):
+            os.remove(cache_map)
 
         def _download_file_handle(
             file_handle_id: str,
@@ -231,7 +231,7 @@ class TestPrivateGetWithEntityBundle:
             with open(destination, "a"):
                 os.utime(destination, None)
             os.path.split(destination)
-            self.syn.cache.add(file_handle_id=fileHandle, path=destination)
+            self.syn.cache.add(file_handle_id=file_handle, path=destination)
             return destination
 
         def _get_file_handle_download(
@@ -244,7 +244,7 @@ class TestPrivateGetWithEntityBundle:
             }
 
         download_file_mock.side_effect = _download_file_handle
-        get_file_URL_and_metadata_mock.side_effect = _get_file_handle_download
+        get_file_url_and_metadata_mock.side_effect = _get_file_handle_download
 
         # 1. ----------------------------------------------------------------------
         # download file to an alternate location
@@ -318,7 +318,9 @@ class TestDownloadFileHandle:
         self.syn = syn
 
     @patch("synapseclient.core.download.download_functions.sts_transfer")
-    async def test_download_file_handle__retry_error(self, mock_sts_transfer) -> None:
+    async def test_download_file_handle__retry_error(
+        self, mock_sts_transfer: MagicMock
+    ) -> None:
         mock_sts_transfer.is_boto_sts_transfer_enabled.return_value = False
 
         file_handle_id = 1234
@@ -368,9 +370,9 @@ class TestDownloadFileHandle:
     @patch("synapseclient.core.download.download_functions.os")
     async def test_download_file_handle__sts_boto(
         self,
-        mock_os,
-        mock_sts_transfer,
-        mock_s3_client_wrapper,
+        mock_os: MagicMock,
+        mock_sts_transfer: MagicMock,
+        mock_s3_client_wrapper: MagicMock,
     ) -> None:
         """Verify that we download S3 file handles using boto if the configuration specifies
         # it and if the storage location supports STS"""
@@ -495,7 +497,7 @@ class TestDownloadFileHandle:
             )
             assert download_path == expected_destination
 
-    async def test_download_from_url__synapse_auth(self, mocker) -> None:
+    async def test_download_from_url__synapse_auth(self, mocker: MagicMock) -> None:
         """Verify we pass along Synapse auth headers when downloading from a Synapse repo hosted url"""
 
         uri = f"{self.syn.repoEndpoint}/repo/v1/entity/syn1234567/file"
@@ -553,7 +555,7 @@ class TestDownloadFileHandle:
 
     @patch(GET_FILE_HANDLE_FOR_DOWNLOAD)
     async def test_download_file_handle_preserve_exception_info(
-        self, mock_getFileHandleDownload
+        self, mock_get_file_handle_download: MagicMock
     ) -> None:
         file_handle_id = 1234
         syn_id = "syn123"
@@ -563,7 +565,7 @@ class TestDownloadFileHandle:
                 f"Something wrong when downloading {syn_id} in try block!"
             )
 
-        mock_getFileHandleDownload.side_effect = get_file_handle_download_side_effect
+        mock_get_file_handle_download.side_effect = get_file_handle_download_side_effect
 
         with pytest.raises(SynapseError) as ex:
             await download_by_file_handle(
@@ -984,7 +986,7 @@ class TestPrivateUploadExternallyStoringProjects:
         ],
     )
     def test__uploadExternallyStoringProjects_external_user(
-        self, mock_upload_destination, external_type
+        self, mock_upload_destination: MagicMock, external_type: str
     ) -> None:
         # setup
         expected_storage_location_id = "1234567"
@@ -1008,7 +1010,7 @@ class TestPrivateUploadExternallyStoringProjects:
             self.syn.cache, "add"
         ) as mocked_cache_add, patch.object(
             self.syn, "_get_file_handle_as_creator"
-        ) as mocked_getFileHandle:
+        ) as mocked_get_file_handle:
             upload_functions.upload_file_handle(
                 syn=self.syn,
                 parent_entity=test_file["parentId"],
@@ -1031,7 +1033,7 @@ class TestPrivateUploadExternallyStoringProjects:
                 path=expected_path_expanded,
                 md5="fake_md5",
             )
-            mocked_getFileHandle.assert_called_once_with(
+            mocked_get_file_handle.assert_called_once_with(
                 fileHandle=expected_file_handle_id
             )
             # test
@@ -1558,7 +1560,9 @@ class TestSetStorageLocation:
 
 
 @patch("synapseclient.core.sts_transfer.get_sts_credentials")
-def test_get_sts_storage_token(mock_get_sts_credentials, syn: Synapse) -> None:
+def test_get_sts_storage_token(
+    mock_get_sts_credentials: MagicMock, syn: Synapse
+) -> None:
     """Verify get_sts_storage_token passes through to the underlying function as expected"""
     token = {"key": "val"}
     mock_get_sts_credentials.return_value = token
@@ -2374,7 +2378,7 @@ def test_max_threads_bounded(syn: Synapse) -> None:
 
 
 @patch("synapseclient.api.configuration_services.get_config_section_dict")
-def test_get_transfer_config(mock_config_dict) -> None:
+def test_get_transfer_config(mock_config_dict: MagicMock) -> None:
     """Verify reading transfer.maxThreads from synapseConfig"""
 
     # note that RawConfigParser lower cases its option values so we
@@ -2423,7 +2427,7 @@ def test_get_transfer_config(mock_config_dict) -> None:
 
 
 @patch("synapseclient.api.configuration_services.get_config_section_dict")
-def test_transfer_config_values_overridable(mock_config_dict) -> None:
+def test_transfer_config_values_overridable(mock_config_dict: MagicMock) -> None:
     """Verify we can override the default transfer config values by setting them directly on the Synapse object"""
 
     mock_config_dict.return_value = {"max_threads": 24, "use_boto_sts": False}
@@ -3247,7 +3251,7 @@ class TestHandleSynapseHTTPError:
 
 class TestTableQuery:
     @patch.object(client, "CsvFileTable")
-    def test_table_query__csv(self, mock_csv, syn: Synapse) -> None:
+    def test_table_query__csv(self, mock_csv: MagicMock, syn: Synapse) -> None:
         query = "select id from syn123"
         kwargs = {
             "quoteCharacter": "|",
@@ -3262,7 +3266,7 @@ class TestTableQuery:
         mock_csv.from_table_query.assert_called_once_with(syn, query, **kwargs)
 
     @patch.object(client, "TableQueryResult")
-    def test_table_query__rowset(self, mock_result, syn: Synapse) -> None:
+    def test_table_query__rowset(self, mock_result: MagicMock, syn: Synapse) -> None:
         query = "select id from syn123"
         kwargs = {"isConsistent": "true"}
 
@@ -3368,7 +3372,7 @@ class TestSilentCommandAndLogger:
         assert self.syn_with_debug.logger.name == DEBUG_LOGGER_NAME
 
     @patch.object(client, "cumulative_transfer_progress")
-    def test_print_transfer_progress(self, mock_ctp) -> None:
+    def test_print_transfer_progress(self, mock_ctp: MagicMock) -> None:
         """
         Verify the private method print_transfer_progress will run with property self.silent accordingly
         """
@@ -3503,14 +3507,14 @@ def test_save_activity_without_id(syn: Synapse) -> None:
 
 
 @patch("synapseclient.Synapse._saveActivity")
-def test_update_activity_with_id(mock_saveActivity, syn: Synapse) -> None:
+def test_update_activity_with_id(mock_save_activity: MagicMock, syn: Synapse) -> None:
     activity = {
         "id": "syn123",
         "name": "test_activity",
         "description": "test_description",
     }
     syn.updateActivity(activity)
-    mock_saveActivity.assert_called_once_with(
+    mock_save_activity.assert_called_once_with(
         {"id": "syn123", "name": "test_activity", "description": "test_description"}
     )
 

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -489,7 +489,10 @@ class TestDownloadFileHandle:
         response = MagicMock(spec=requests.Response)
         response.status_code = 200
         response.headers = {}
-        mock_get = mocker.patch.object(self.syn, "rest_get_async")
+        # TODO: When swapping out for the HTTPX client, we will need to update this test
+        # mock_get = mocker.patch.object(self.syn, "rest_get_async")
+        mock_get = mocker.patch.object(self.syn._requests_session, "get")
+
         mock_get.return_value = response
 
         out_destination = await download_from_url(
@@ -514,7 +517,10 @@ class TestDownloadFileHandle:
         response = MagicMock(spec=requests.Response)
         response.status_code = 200
         response.headers = {}
-        mock_get = mocker.patch.object(self.syn, "rest_get_async")
+        # TODO: When swapping out for the HTTPX client, we will need to update this test
+        # mock_get = mocker.patch.object(self.syn, "rest_get_async")
+        mock_get = mocker.patch.object(self.syn._requests_session, "get")
+
         mock_get.return_value = response
 
         out_destination = await download_from_url(

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -468,7 +468,7 @@ class TestDownloadFileHandle:
         ), patch.object(
             urllib_request, "urlretrieve"
         ) as mock_url_retrieve, patch.object(
-            utils, "md5_for_file"
+            utils, "md5_for_file_multiprocessing"
         ) as mock_md5_for_file, patch.object(
             os, "makedirs"
         ):

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -58,6 +58,12 @@ from synapseclient.core.logging_setup import (
 from synapseclient.core.models.dict_object import DictObject
 from synapseclient.core.upload import upload_functions
 
+GET_FILE_HANDLE_FOR_DOWNLOAD = (
+    "synapseclient.core.download.download_functions.get_file_handle_for_download"
+)
+DOWNLOAD_BY_FILE_HANDLE = (
+    "synapseclient.core.download.download_functions.download_by_file_handle"
+)
 DOWNLOAD_FROM_URL = "synapseclient.core.download.download_functions.download_from_url"
 
 

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -65,6 +65,7 @@ DOWNLOAD_BY_FILE_HANDLE = (
     "synapseclient.core.download.download_functions.download_by_file_handle"
 )
 DOWNLOAD_FROM_URL = "synapseclient.core.download.download_functions.download_from_url"
+FOO_KEY = "/tmp/fooKey"
 
 
 class TestLogout:
@@ -377,7 +378,7 @@ class TestDownloadFileHandle:
         file_handle_id = 1234
         entity_id_value = "syn_5678"
         bucket_name = "fooBucket"
-        key = "/tmp/fooKey"
+        key = FOO_KEY
         destination = "/tmp"
         credentials = {
             "aws_access_key_id": "foo",
@@ -399,7 +400,7 @@ class TestDownloadFileHandle:
 
         mock_sts_transfer.with_boto_sts_credentials = mock_with_boto_sts_credentials
 
-        expected_download_path = "/tmp/fooKey"
+        expected_download_path = FOO_KEY
         mock_s3_client_wrapper.download_file.return_value = expected_download_path
 
         with patch(
@@ -441,7 +442,7 @@ class TestDownloadFileHandle:
         mock_s3_client_wrapper.download_file.assert_called_once_with(
             bucket="fooBucket",
             endpoint_url=None,
-            remote_file_key="/tmp/fooKey",
+            remote_file_key=FOO_KEY,
             download_file_path="/tmp",
             credentials=credentials,
             show_progress=True,

--- a/tests/unit/synapseclient/unit_test_get_user_profile.py
+++ b/tests/unit/synapseclient/unit_test_get_user_profile.py
@@ -1,6 +1,9 @@
-import pytest
+"""Unit tests for user profile"""
+
 from unittest.mock import patch
 
+import pytest
+from client import Synapse
 
 test_user_profile = {
     "ownerId": "1234567",
@@ -42,7 +45,7 @@ class TestGetUserProfileByUserName:
     ]
 
     @pytest.fixture(autouse=True, scope="function")
-    def setup_method(self, syn):
+    def setup_method(self, syn: Synapse) -> None:
         self.syn = syn
         self.syn.restGET = patch.object(
             self.syn, "restGET", return_value=test_user_profile
@@ -76,7 +79,7 @@ class TestGetUserProfileByUserName:
 
 class TestGetUserProfileByID:
     @pytest.fixture(autouse=True, scope="function")
-    def setup_method(self, syn):
+    def setup_method(self, syn: Synapse) -> None:
         self.syn = syn
         self.syn.restGET = patch.object(
             self.syn, "restGET", return_value=test_user_profile

--- a/tests/unit/synapseclient/unit_test_get_user_profile.py
+++ b/tests/unit/synapseclient/unit_test_get_user_profile.py
@@ -54,25 +54,29 @@ class TestGetUserProfileByUserName:
             self.syn, "_findPrincipals", return_value=self.principals
         ).start()
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         self.syn.restGET.stop()
         self.syn._findPrincipals.stop()
 
-    def test_that_get_user_profile_returns_expected_with_no_id(self):
+    def test_that_get_user_profile_returns_expected_with_no_id(self) -> None:
         result = self.syn.get_user_profile_by_username()
         self.syn.restGET.assert_called_once_with("/userProfile/", headers=None)
         assert result == test_user_profile
 
-    def test_that_get_user_profile_returns_expected_with_username(self):
+    def test_that_get_user_profile_returns_expected_with_username(self) -> None:
         result = self.syn.get_user_profile_by_username("test_user")
         self.syn.restGET.assert_called_once_with("/userProfile/1234567", headers=None)
         assert result == test_user_profile
 
-    def test_that_get_user_profile_raises_value_error_when_user_does_not_exist(self):
+    def test_that_get_user_profile_raises_value_error_when_user_does_not_exist(
+        self,
+    ) -> None:
         with pytest.raises(ValueError, match="Can't find user *"):
             self.syn.get_user_profile_by_username("not_a_user")
 
-    def test_that_get_user_profile_raises_type_error_when_id_is_not_allowed_type(self):
+    def test_that_get_user_profile_raises_type_error_when_id_is_not_allowed_type(
+        self,
+    ) -> None:
         with pytest.raises(TypeError, match="username must be string or None"):
             self.syn.get_user_profile_by_username(1234567)
 
@@ -85,19 +89,25 @@ class TestGetUserProfileByID:
             self.syn, "restGET", return_value=test_user_profile
         ).start()
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         self.syn.restGET.stop()
 
-    def test_that_get_user_profile_by_id_returns_expected_when_id_is_defined(self):
+    def test_that_get_user_profile_by_id_returns_expected_when_id_is_defined(
+        self,
+    ) -> None:
         result = self.syn.get_user_profile_by_id(1234567)
         self.syn.restGET.assert_called_once_with("/userProfile/1234567", headers=None)
         assert result == test_user_profile
 
-    def test_that_get_user_profile_by_id_returns_expected_when_id_is_not_defined(self):
+    def test_that_get_user_profile_by_id_returns_expected_when_id_is_not_defined(
+        self,
+    ) -> None:
         result = self.syn.get_user_profile_by_id()
         self.syn.restGET.assert_called_once_with("/userProfile/", headers=None)
         assert result == test_user_profile
 
-    def test_that_get_user_profile_by_id_raises_type_error_when_id_is_not_int(self):
+    def test_that_get_user_profile_by_id_raises_type_error_when_id_is_not_int(
+        self,
+    ) -> None:
         with pytest.raises(TypeError, match="id must be an 'ownerId' integer"):
             self.syn.get_user_profile_by_id("1234567")

--- a/tests/unit/synapseclient/unit_test_get_user_profile.py
+++ b/tests/unit/synapseclient/unit_test_get_user_profile.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 import pytest
-from client import Synapse
+from synapseclient import Synapse
 
 test_user_profile = {
     "ownerId": "1234567",

--- a/tests/unit/synapseclient/unit_test_tables.py
+++ b/tests/unit/synapseclient/unit_test_tables.py
@@ -1,60 +1,58 @@
+"""Unit test for synapseclient.table"""
 import csv
-import shutil
 import io
 import math
 import os
+import shutil
 import tempfile
 import time
 from builtins import zip
-import pandas as pd
+from collections import OrderedDict, abc
+from unittest.mock import MagicMock, call, patch
+
 import numpy as np
+import pandas as pd
+import pytest
 from pandas.testing import assert_frame_equal
 
-import pytest
-from unittest.mock import call, MagicMock
-
-from tests.unit.test_utils.unit_utils import StringIOContextManager
-
-from synapseclient import client, Entity, Synapse
-from synapseclient.core.exceptions import SynapseError, SynapseTimeoutError
-from synapseclient.entity import split_entity_namespaces
 import synapseclient.table
+from synapseclient import Entity, Synapse, client
+from synapseclient.core.exceptions import SynapseError, SynapseTimeoutError
+from synapseclient.core.utils import from_unix_epoch_time
+from synapseclient.entity import split_entity_namespaces
 from synapseclient.table import (
+    MAX_NUM_TABLE_COLUMNS,
     Column,
-    Schema,
     CsvFileTable,
-    TableQueryResult,
-    cast_values,
-    as_table_columns,
-    Table,
-    build_table,
-    RowSet,
-    SelectColumn,
+    Dataset,
     EntityViewSchema,
-    RowSetTable,
-    Row,
+    EntityViewType,
+    MaterializedViewSchema,
     PartialRow,
     PartialRowset,
+    Row,
+    RowSet,
+    RowSetTable,
+    Schema,
     SchemaBase,
-    _get_view_type_mask_for_deprecated_type,
-    EntityViewType,
-    _get_view_type_mask,
-    MAX_NUM_TABLE_COLUMNS,
+    SelectColumn,
     SubmissionViewSchema,
+    Table,
+    TableQueryResult,
+    _convert_df_date_cols_to_datetime,
+    _get_view_type_mask,
+    _get_view_type_mask_for_deprecated_type,
+    as_table_columns,
+    build_table,
+    cast_values,
     escape_column_name,
     join_column_names,
-    MaterializedViewSchema,
-    Dataset,
-    _convert_df_date_cols_to_datetime,
 )
-
-from synapseclient.core.utils import from_unix_epoch_time
-from unittest.mock import patch
-from collections import OrderedDict, abc
+from tests.unit.test_utils.unit_utils import StringIOContextManager
 
 
 @pytest.fixture()
-def sample_df_datetime():
+def sample_df_datetime() -> pd.DataFrame:
     test_df = pd.DataFrame(
         {
             "epoch_time1": [
@@ -71,7 +69,7 @@ def sample_df_datetime():
     return test_df
 
 
-def test_cast_values():
+def test_cast_values() -> None:
     selectColumns = [
         {"id": "353", "name": "name", "columnType": "STRING"},
         {"id": "354", "name": "foo", "columnType": "STRING"},
@@ -102,7 +100,7 @@ def test_cast_values():
     assert cast_values(row, selectColumns) == [True, 211, 1.61803398875, 1421365]
 
 
-def test_cast_values__unknown_column_type():
+def test_cast_values__unknown_column_type() -> None:
     selectColumns = [
         {"id": "353", "name": "name", "columnType": "INTEGER"},
         {"id": "354", "name": "foo", "columnType": "DEFINTELY_NOT_A_EXISTING_TYPE"},
@@ -112,7 +110,7 @@ def test_cast_values__unknown_column_type():
     assert cast_values(row, selectColumns) == [123, "othervalue"]
 
 
-def test_cast_values__list_type():
+def test_cast_values__list_type() -> None:
     selectColumns = [
         {"id": "354", "name": "foo", "columnType": "STRING_LIST"},
         {"id": "356", "name": "n", "columnType": "INTEGER_LIST"},
@@ -140,22 +138,22 @@ def test_cast_values__list_type():
     ]
 
 
-def test_convert_df_date_cols_to_datetime_empty_df():
+def test_convert_df_date_cols_to_datetime_empty_df() -> None:
     test_df = pd.DataFrame()
     date_columns = []
     test_df_output = _convert_df_date_cols_to_datetime(test_df, date_columns)
     assert test_df_output.empty
 
 
-def test_convert_df_date_cols_to_datetime_invalid_epoch_time(sample_df_datetime):
+def test_convert_df_date_cols_to_datetime_invalid_epoch_time(
+    sample_df_datetime,
+) -> None:
     date_columns = ["epoch_time1"]
     with pytest.raises(ValueError):
-        test_df_output = _convert_df_date_cols_to_datetime(
-            sample_df_datetime, date_columns
-        )
+        _convert_df_date_cols_to_datetime(sample_df_datetime, date_columns)
 
 
-def test_convert_df_date_cols_to_datetime_empty_vals(sample_df_datetime):
+def test_convert_df_date_cols_to_datetime_empty_vals(sample_df_datetime) -> None:
     date_columns = ["epoch_time2"]
     test_df_output = _convert_df_date_cols_to_datetime(sample_df_datetime, date_columns)
     test_df_epoch_time2 = test_df_output[["epoch_time2"]]
@@ -173,7 +171,7 @@ def test_convert_df_date_cols_to_datetime_empty_vals(sample_df_datetime):
     assert_frame_equal(test_df_epoch_time2, expected_date_df)
 
 
-def test_convert_df_date_cols_to_datetime_invalid_date_columns():
+def test_convert_df_date_cols_to_datetime_invalid_date_columns() -> None:
     test_df = pd.DataFrame(
         {
             "epoch_time1": [
@@ -187,10 +185,10 @@ def test_convert_df_date_cols_to_datetime_invalid_date_columns():
     )
     date_columns = ["invalid date column"]
     with pytest.raises(ValueError):
-        test_df_output = _convert_df_date_cols_to_datetime(test_df, date_columns)
+        _convert_df_date_cols_to_datetime(test_df, date_columns)
 
 
-def test_convert_df_date_cols_to_datetime():
+def test_convert_df_date_cols_to_datetime() -> None:
     # construct test dataframe and get date columns
     test_df = pd.DataFrame(
         {
@@ -253,7 +251,7 @@ def test_convert_df_date_cols_to_datetime():
     assert_frame_equal(test_df2, expected_date_df)
 
 
-def test_schema():
+def test_schema() -> None:
     schema = Schema(name="My Table", parent="syn1000001")
 
     assert not schema.has_columns()
@@ -291,7 +289,7 @@ def test_schema():
     assert Column(name="Hipness", columnType="DOUBLE") in schema.columns_to_store
 
 
-def test_materialized_view():
+def test_materialized_view() -> None:
     """Test creation of materialized view"""
     mat_view = MaterializedViewSchema(
         name="My Table",
@@ -312,7 +310,7 @@ def test_materialized_view():
     assert mat_view.properties.columnIds == []
 
 
-def test_dataset():
+def test_dataset() -> None:
     dataset = Dataset(
         name="Pokedex",
         parent="syn123",
@@ -355,7 +353,7 @@ def test_dataset():
     assert len(dataset) == 0
 
 
-def test_RowSetTable():
+def test_RowSetTable() -> None:
     row_set_json = {
         "etag": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
         "headers": [
@@ -399,7 +397,7 @@ def test_RowSetTable():
     assert list(df["name"]) == ["foo", "bar", "foo", "qux"]
 
 
-def test_as_table_columns__with_pandas_DataFrame():
+def test_as_table_columns__with_pandas_DataFrame() -> None:
     df = pd.DataFrame(
         {
             "foobar": ("foo", "bar", "baz", "qux", "asdf"),
@@ -447,11 +445,11 @@ def test_as_table_columns__with_pandas_DataFrame():
     assert expected_columns == cols
 
 
-def test_as_table_columns__with_non_supported_input_type():
+def test_as_table_columns__with_non_supported_input_type() -> None:
     pytest.raises(ValueError, as_table_columns, dict(a=[1, 2, 3], b=["c", "d", "e"]))
 
 
-def test_as_table_columns__with_csv_file():
+def test_as_table_columns__with_csv_file() -> None:
     string_io = StringIOContextManager(
         "ROW_ID,ROW_VERSION,Name,Born,Hipness,Living\n"
         '"1", "1", "John Coltrane", 1926, 8.65, False\n'
@@ -469,7 +467,7 @@ def test_as_table_columns__with_csv_file():
     assert cols[3]["columnType"] == "STRING"
 
 
-def test_dict_to_table():
+def test_dict_to_table() -> None:
     d = dict(a=[1, 2, 3], b=["c", "d", "e"])
     df = pd.DataFrame(d)
     schema = Schema(name="Baz", parent="syn12345", columns=as_table_columns(df))
@@ -484,7 +482,7 @@ def test_dict_to_table():
     assert df_agr.equals(df)
 
 
-def test_pandas_to_table():
+def test_pandas_to_table() -> None:
     df = pd.DataFrame(dict(a=[1, 2, 3], b=["c", "d", "e"]))
     schema = Schema(name="Baz", parent="syn12345", columns=as_table_columns(df))
 
@@ -542,14 +540,14 @@ def test_pandas_to_table():
     "test_df",
     [pd.DataFrame({"str1": ("foo", "bar", "moo"), "str2": ("foo", "bar", None)})],
 )
-def test_pandas_to_table_convert__string_data_type(test_df):
+def test_pandas_to_table_convert__string_data_type(test_df) -> None:
     schema = Schema(name="Foo", parent="syn12345")
     test_table = Table(schema, test_df)
     for col in test_table.headers:
         assert col.columnType == "STRING"
 
 
-def test_pandas_to_table_convert__float_data_type():
+def test_pandas_to_table_convert__float_data_type() -> None:
     test_df = pd.DataFrame({"float1": (1.0, 2.0, 3.0), "float2": (1.0, 2.0, None)})
     schema = Schema(name="Foo", parent="syn12345")
     test_table = Table(schema, test_df)
@@ -557,7 +555,7 @@ def test_pandas_to_table_convert__float_data_type():
         assert col.columnType == "DOUBLE"
 
 
-def test_pandas_to_table_convert__double_data_type():
+def test_pandas_to_table_convert__double_data_type() -> None:
     test_df = pd.DataFrame(
         {
             "double1": (1.99999999999999, 1.00000000000000001, 3.33333333333333),
@@ -570,7 +568,7 @@ def test_pandas_to_table_convert__double_data_type():
         assert col.columnType == "DOUBLE"
 
 
-def test_pandas_to_table_convert__integer_data_type():
+def test_pandas_to_table_convert__integer_data_type() -> None:
     test_df = pd.DataFrame({"int1": (1, 2, 3), "int2": (1, 3, 5)})
     schema = Schema(name="Foo", parent="syn12345")
     test_table = Table(schema, test_df)
@@ -578,7 +576,7 @@ def test_pandas_to_table_convert__integer_data_type():
         assert col.columnType == "INTEGER"
 
 
-def test_pandas_to_table_convert__mixed_int_float_data_type():
+def test_pandas_to_table_convert__mixed_int_float_data_type() -> None:
     test_df = pd.DataFrame({"int1": [1, 2, 990]})
     schema = Schema(name="Foo", parent="syn12345")
     # Since I can't seem to define the "mixed-integer-float" type, I force `infer_dtype`
@@ -589,7 +587,7 @@ def test_pandas_to_table_convert__mixed_int_float_data_type():
             assert col.columnType == "DOUBLE"
 
 
-def test_pandas_to_table_convert__boolean_data_type():
+def test_pandas_to_table_convert__boolean_data_type() -> None:
     test_df = pd.DataFrame(
         {"bool1": (False, True, False), "bool2": (False, True, None)}
     )
@@ -599,7 +597,7 @@ def test_pandas_to_table_convert__boolean_data_type():
         assert col.columnType == "BOOLEAN"
 
 
-def test_pandas_to_table_convert__date_data_type():
+def test_pandas_to_table_convert__date_data_type() -> None:
     test_df = pd.DataFrame(
         {
             "datetime1": (
@@ -618,7 +616,7 @@ def test_pandas_to_table_convert__date_data_type():
         assert col.columnType == "DATE"
 
 
-def test_csv_table():
+def test_csv_table() -> None:
     # Maybe not truly a unit test, but here because it doesn't do
     # network IO to synapse
     data = [
@@ -700,7 +698,7 @@ def test_csv_table():
         raise
 
 
-def test_list_of_rows_table():
+def test_list_of_rows_table() -> None:
     data = [
         ["John Coltrane", 1926, 8.65, False],
         ["Miles Davis", 1926, 9.87, False],
@@ -741,7 +739,7 @@ def test_list_of_rows_table():
     assert list(df["Name"]) == [r[0] for r in data]
 
 
-def test_aggregate_query_result_to_data_frame():
+def test_aggregate_query_result_to_data_frame() -> None:
     class MockSynapse(object):
         def _queryTable(
             self, query, limit=None, offset=None, isConsistent=True, partMask=None
@@ -826,7 +824,7 @@ def test_aggregate_query_result_to_data_frame():
     assert list(df["AVG(Hipness)"].values) == [1.1, 2.38, 3.14, 4.38]
 
 
-def test_waitForAsync():
+def test_waitForAsync() -> None:
     syn = Synapse(debug=True, skip_checks=True)
     syn.table_query_timeout = 0.05
     syn.table_query_max_sleep = 0.001
@@ -856,7 +854,7 @@ def _insert_dataframe_column_if_not_exist__setup():
     return df, column_name, data
 
 
-def test_insert_dataframe_column_if_not_exist__nonexistent_column():
+def test_insert_dataframe_column_if_not_exist__nonexistent_column() -> None:
     df, column_name, data = _insert_dataframe_column_if_not_exist__setup()
 
     # method under test
@@ -866,7 +864,7 @@ def test_insert_dataframe_column_if_not_exist__nonexistent_column():
     assert data == df[column_name].tolist()
 
 
-def test_insert_dataframe_column_if_not_exist__existing_column_matching():
+def test_insert_dataframe_column_if_not_exist__existing_column_matching() -> None:
     df, column_name, data = _insert_dataframe_column_if_not_exist__setup()
 
     # add the same data to the DataFrame prior to calling our method
@@ -879,7 +877,7 @@ def test_insert_dataframe_column_if_not_exist__existing_column_matching():
     assert data == df[column_name].tolist()
 
 
-def test_insert_dataframe_column_if_not_exist__existing_column_not_matching():
+def test_insert_dataframe_column_if_not_exist__existing_column_not_matching() -> None:
     df, column_name, data = _insert_dataframe_column_if_not_exist__setup()
 
     # add different data to the DataFrame prior to calling our method
@@ -893,8 +891,8 @@ def test_insert_dataframe_column_if_not_exist__existing_column_not_matching():
         CsvFileTable._insert_dataframe_column_if_not_exist(df, 0, column_name, data)
 
 
-@pytest.mark.parametrize("downloadLocation", [None, "/tmp/download"])
-def test_downloadTableColumns(syn, downloadLocation):
+@pytest.mark.parametrize("download_location", [None, "/tmp/download"])
+def test_downloadTableColumns(syn: Synapse, download_location: str) -> None:
     header = MagicMock()
     header.name = "id"
     table = MagicMock(
@@ -933,10 +931,10 @@ def test_downloadTableColumns(syn, downloadLocation):
 
     with patch.object(syn, "cache") as mock_cache, patch.object(
         syn, "_waitForAsync"
-    ) as mock_async, patch.object(
-        syn, "_ensure_download_location_is_directory"
-    ) as mock_ensure_dir, patch.object(
-        syn, "_downloadFileHandle"
+    ) as mock_async, patch(
+        "synapseclient.client.ensure_download_location_is_directory"
+    ) as mock_ensure_dir, patch(
+        "synapseclient.client.download_by_file_handle"
     ) as mock_download_file_handle, patch.object(
         client, "zipfile"
     ), patch.object(
@@ -951,18 +949,20 @@ def test_downloadTableColumns(syn, downloadLocation):
         mock_extract_zip_file_to_directory.side_effect = zip_entry_file_paths
 
         result = syn.downloadTableColumns(
-            table, ["id"], downloadLocation=downloadLocation
+            table, ["id"], downloadLocation=download_location
         )
 
-        if downloadLocation:
-            mock_ensure_dir.assert_called_once_with(downloadLocation)
+        if download_location:
+            mock_ensure_dir.assert_called_once_with(download_location)
         else:
             assert [call(1), call(3)] == mock_cache.get_cache_dir.call_args_list
 
         assert expected_result == result
 
 
-def test_build_table_download_file_handle_list__repeated_file_handles(syn):
+def test_build_table_download_file_handle_list__repeated_file_handles(
+    syn: Synapse,
+) -> None:
     # patch the cache so we don't look there in case FileHandle ids actually exist there
     patch.object(syn.cache, "get", return_value=None)
 
@@ -994,13 +994,13 @@ def test_build_table_download_file_handle_list__repeated_file_handles(syn):
     assert 0 == len(file_handle_to_path_map)
 
 
-def test_SubmissionViewSchema__default_params():
+def test_SubmissionViewSchema__default_params() -> None:
     submission_view = SubmissionViewSchema(parent="idk")
     assert [] == submission_view.scopeIds
     assert submission_view.addDefaultViewColumns
 
 
-def test_SubmissionViewSchema__before_synapse_store(syn):
+def test_SubmissionViewSchema__before_synapse_store(syn: Synapse) -> None:
     syn = Synapse(debug=True, skip_checks=True)
 
     with patch.object(
@@ -1020,7 +1020,7 @@ def test_SubmissionViewSchema__before_synapse_store(syn):
         )
 
 
-def test_EntityViewSchema__before_synapse_store(syn):
+def test_EntityViewSchema__before_synapse_store(syn: Synapse) -> None:
     syn = Synapse(debug=True, skip_checks=True)
 
     with patch.object(
@@ -1038,21 +1038,21 @@ def test_EntityViewSchema__before_synapse_store(syn):
         )
 
 
-def test_EntityViewSchema__default_params():
+def test_EntityViewSchema__default_params() -> None:
     entity_view = EntityViewSchema(parent="idk")
     assert EntityViewType.FILE.value == entity_view.viewTypeMask
     assert [] == entity_view.scopeIds
     assert entity_view.addDefaultViewColumns is True
 
 
-def test_entityViewSchema__specified_deprecated_type():
+def test_entityViewSchema__specified_deprecated_type() -> None:
     view_type = "project"
     entity_view = EntityViewSchema(parent="idk", type=view_type)
     assert EntityViewType.PROJECT.value == entity_view.viewTypeMask
     assert entity_view.get("type") is None
 
 
-def test_entityViewSchema__specified_deprecated_type_in_properties():
+def test_entityViewSchema__specified_deprecated_type_in_properties() -> None:
     view_type = "project"
     properties = {"type": view_type}
     entity_view = EntityViewSchema(parent="idk", properties=properties)
@@ -1060,7 +1060,7 @@ def test_entityViewSchema__specified_deprecated_type_in_properties():
     assert entity_view.get("type") is None
 
 
-def test_entityViewSchema__specified_viewTypeMask():
+def test_entityViewSchema__specified_viewTypeMask() -> None:
     entity_view = EntityViewSchema(
         parent="idk", includeEntityTypes=[EntityViewType.PROJECT]
     )
@@ -1068,7 +1068,7 @@ def test_entityViewSchema__specified_viewTypeMask():
     assert entity_view.get("type") is None
 
 
-def test_entityViewSchema__specified_both_type_and_viewTypeMask():
+def test_entityViewSchema__specified_both_type_and_viewTypeMask() -> None:
     entity_view = EntityViewSchema(
         parent="idk", type="folder", includeEntityTypes=[EntityViewType.PROJECT]
     )
@@ -1076,18 +1076,18 @@ def test_entityViewSchema__specified_both_type_and_viewTypeMask():
     assert entity_view.get("type") is None
 
 
-def test_entityViewSchema__sepcified_scopeId():
+def test_entityViewSchema__sepcified_scopeId() -> None:
     scopeId = ["123"]
     entity_view = EntityViewSchema(parent="idk", scopeId=scopeId)
     assert scopeId == entity_view.scopeId
 
 
-def test_entityViewSchema__sepcified_add_default_columns():
+def test_entityViewSchema__sepcified_add_default_columns() -> None:
     entity_view = EntityViewSchema(parent="idk", addDefaultViewColumns=False)
     assert not entity_view.addDefaultViewColumns
 
 
-def test_entityViewSchema__add_default_columns_when_from_Synapse():
+def test_entityViewSchema__add_default_columns_when_from_Synapse() -> None:
     properties = {"concreteType": "org.sagebionetworks.repo.model.table.EntityView"}
     entity_view = EntityViewSchema(
         parent="idk", addDefaultViewColumns=True, properties=properties
@@ -1095,7 +1095,7 @@ def test_entityViewSchema__add_default_columns_when_from_Synapse():
     assert not entity_view.addDefaultViewColumns
 
 
-def test_entityViewSchema__add_scope():
+def test_entityViewSchema__add_scope() -> None:
     entity_view = EntityViewSchema(parent="idk")
     entity_view.add_scope(Entity(parent="also idk", id=123))
     entity_view.add_scope(456)
@@ -1103,7 +1103,7 @@ def test_entityViewSchema__add_scope():
     assert [str(x) for x in ["123", "456", "789"]] == entity_view.scopeIds
 
 
-def test_Schema__max_column_check(syn):
+def test_Schema__max_column_check(syn: Synapse) -> None:
     table = Schema(name="someName", parent="idk")
     table.addColumns(
         Column(name="colNum%s" % i, columnType="STRING")
@@ -1112,7 +1112,7 @@ def test_Schema__max_column_check(syn):
     pytest.raises(ValueError, syn.store, table)
 
 
-def test_EntityViewSchema__ignore_column_names_set_info_preserved():
+def test_EntityViewSchema__ignore_column_names_set_info_preserved() -> None:
     """
     tests that ignoredAnnotationColumnNames will be preserved after creating a new EntityViewSchema from properties,
     local_state, and annotations
@@ -1127,7 +1127,7 @@ def test_EntityViewSchema__ignore_column_names_set_info_preserved():
     assert ignored_names == entity_view_copy.ignoredAnnotationColumnNames
 
 
-def test_EntityViewSchema__ignore_annotation_column_names(syn):
+def test_EntityViewSchema__ignore_annotation_column_names(syn: Synapse) -> None:
     syn = Synapse(debug=True, skip_checks=True)
 
     scopeIds = ["123"]
@@ -1164,7 +1164,7 @@ def test_EntityViewSchema__ignore_annotation_column_names(syn):
         ] == entity_view.columns_to_store
 
 
-def test_EntityViewSchema__repeated_columnName_different_type(syn):
+def test_EntityViewSchema__repeated_columnName_different_type(syn: Synapse) -> None:
     syn = Synapse(debug=True, skip_checks=True)
 
     scopeIds = ["123"]
@@ -1183,7 +1183,7 @@ def test_EntityViewSchema__repeated_columnName_different_type(syn):
         assert columns == filtered_results
 
 
-def test_EntityViewSchema__repeated_columnName_same_type(syn):
+def test_EntityViewSchema__repeated_columnName_same_type(syn: Synapse) -> None:
     syn = Synapse(debug=True, skip_checks=True)
 
     entity_view = EntityViewSchema("someName", parent="syn123")
@@ -1201,7 +1201,7 @@ def test_EntityViewSchema__repeated_columnName_same_type(syn):
         assert Column(name="annoName", columnType="INTEGER") == filtered_results[0]
 
 
-def test_rowset_asDataFrame__with_ROW_ETAG_column(syn):
+def test_rowset_asDataFrame__with_ROW_ETAG_column(syn: Synapse) -> None:
     query_result = {
         "concreteType": "org.sagebionetworks.repo.model.table.QueryResultBundle",
         "maxRowsPerPage": 6990,
@@ -1273,7 +1273,7 @@ def test_rowset_asDataFrame__with_ROW_ETAG_column(syn):
         assert expected_indicies == dataframe.index.values.tolist()
 
 
-def test_RowSetTable_len():
+def test_RowSetTable_len() -> None:
     schema = Schema(
         parentId="syn123", id="syn456", columns=[Column(name="column_name", id="123")]
     )
@@ -1282,7 +1282,7 @@ def test_RowSetTable_len():
     assert 2 == len(row_set_table)
 
 
-def test_build_table__with_pandas_DataFrame():
+def test_build_table__with_pandas_DataFrame() -> None:
     df = pd.DataFrame(dict(a=[1, 2, 3], b=["c", "d", "e"]))
     table = build_table("test", "syn123", df)
 
@@ -1297,7 +1297,7 @@ def test_build_table__with_pandas_DataFrame():
     assert headers == table.headers
 
 
-def test_build_table__with_csv():
+def test_build_table__with_csv() -> None:
     string_io = StringIOContextManager("a,b\n" "1,c\n" "2,d\n" "3,e")
     with patch.object(
         synapseclient.table,
@@ -1319,7 +1319,7 @@ def test_build_table__with_csv():
         assert headers == table.headers
 
 
-def test_build_table__with_dict():
+def test_build_table__with_dict() -> None:
     pytest.raises(
         ValueError, build_table, "test", "syn123", dict(a=[1, 2, 3], b=["c", "d", "e"])
     )
@@ -1327,11 +1327,11 @@ def test_build_table__with_dict():
 
 class TestTableQueryResult:
     @pytest.fixture(autouse=True, scope="function")
-    def init_syn(self, syn):
+    def init_syn(self, syn: Synapse) -> None:
         self.syn = syn
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self):
+    def setup_method(self) -> None:
         self.rows = [
             {"rowId": 1, "versionNumber": 2, "values": ["first_row"]},
             {"rowId": 5, "versionNumber": 1, "values": ["second_row"]},
@@ -1351,7 +1351,7 @@ class TestTableQueryResult:
 
         self.query_string = "SELECT whatever FROM some_table WHERE sky=blue"
 
-    def test_len(self):
+    def test_len(self) -> None:
         with patch.object(
             self.syn, "_queryTable", return_value=self.query_result_dict
         ) as mocked_table_query:
@@ -1360,7 +1360,7 @@ class TestTableQueryResult:
             assert self.query_string == kwargs["query"]
             assert 2 == len(query_result_table)
 
-    def test_iter_metadata__no_etag(self):
+    def test_iter_metadata__no_etag(self) -> None:
         with patch.object(self.syn, "_queryTable", return_value=self.query_result_dict):
             query_result_table = TableQueryResult(self.syn, self.query_string)
             metadata = [x for x in query_result_table.iter_row_metadata()]
@@ -1368,7 +1368,7 @@ class TestTableQueryResult:
             assert (1, 2, None) == metadata[0]
             assert (5, 1, None) == metadata[1]
 
-    def test_iter_metadata__has_etag(self):
+    def test_iter_metadata__has_etag(self) -> None:
         self.rows[0].update({"etag": "etag1"})
         self.rows[1].update({"etag": "etag2"})
         with patch.object(self.syn, "_queryTable", return_value=self.query_result_dict):
@@ -1384,22 +1384,22 @@ class TestPartialRow:
     Testing PartialRow class
     """
 
-    def test_constructor__value_not_dict(self):
+    def test_constructor__value_not_dict(self) -> None:
         with pytest.raises(ValueError):
             PartialRow([], 123)
 
-    def test_constructor__row_id_string_not_castable_to_int(self):
+    def test_constructor__row_id_string_not_castable_to_int(self) -> None:
         with pytest.raises(ValueError):
             PartialRow({}, "fourty-two")
 
-    def test_constructor__row_id_is_int_castable_string(self):
+    def test_constructor__row_id_is_int_castable_string(self) -> None:
         partial_row = PartialRow({}, "350")
 
         assert [] == partial_row.values
         assert 350 == partial_row.rowId
         assert "etag" not in partial_row
 
-    def test_constructor__values_translation(self):
+    def test_constructor__values_translation(self) -> None:
         values = OrderedDict([("12345", "rowValue"), ("09876", "otherValue")])
         partial_row = PartialRow(values, 711)
 
@@ -1412,13 +1412,13 @@ class TestPartialRow:
         assert 711 == partial_row.rowId
         assert "etag" not in partial_row
 
-    def test_constructor__with_etag(self):
+    def test_constructor__with_etag(self) -> None:
         partial_row = PartialRow({}, 420, "my etag")
         assert [] == partial_row.values
         assert 420 == partial_row.rowId
         assert "my etag" == partial_row.etag
 
-    def test_constructor__name_to_col_id(self):
+    def test_constructor__name_to_col_id(self) -> None:
         values = OrderedDict([("row1", "rowValue"), ("row2", "otherValue")])
         names_to_col_id = {"row1": "12345", "row2": "09876"}
         partial_row = PartialRow(values, 711, nameToColumnId=names_to_col_id)
@@ -1433,19 +1433,19 @@ class TestPartialRow:
 
 
 class TestPartialRowSet:
-    def test_constructor__not_all_rows_of_type_PartialRow(self):
+    def test_constructor__not_all_rows_of_type_PartialRow(self) -> None:
         rows = [PartialRow({}, 123), "some string instead"]
         with pytest.raises(ValueError):
             PartialRowset("syn123", rows)
 
-    def test_constructor__single_PartialRow(self):
+    def test_constructor__single_PartialRow(self) -> None:
         partial_row = PartialRow({}, 123)
         partial_rowset = PartialRowset("syn123", partial_row)
         assert [partial_row] == partial_rowset.rows
 
 
 class TestCsvFileTable:
-    def test_iter_metadata__has_etag(self):
+    def test_iter_metadata__has_etag(self) -> None:
         string_io = StringIOContextManager(
             "ROW_ID,ROW_VERSION,ROW_ETAG,asdf\n"
             '1,2,etag1,"I like trains"\n'
@@ -1458,7 +1458,7 @@ class TestCsvFileTable:
             assert (1, 2, "etag1") == metadata[0]
             assert (5, 1, "etag2") == metadata[1]
 
-    def test_iter_metadata__no_etag(self):
+    def test_iter_metadata__no_etag(self) -> None:
         string_io = StringIOContextManager(
             "ROW_ID,ROW_VERSION,asdf\n" '1,2,"I like trains"\n' '5,1,"weeeeeeeeeeee"\n'
         )
@@ -1470,7 +1470,7 @@ class TestCsvFileTable:
             assert (5, 1, None) == metadata[1]
 
     # test __iter__
-    def test_iter_with_no_headers(self):
+    def test_iter_with_no_headers(self) -> None:
         # self.headers is None
         string_io = StringIOContextManager(
             "ROW_ID,ROW_VERSION,ROW_ETAG,col\n"
@@ -1482,7 +1482,7 @@ class TestCsvFileTable:
             iter = table.__iter__()
             pytest.raises(ValueError, next, iter)
 
-    def test_iter_with_no_headers_in_csv(self):
+    def test_iter_with_no_headers_in_csv(self) -> None:
         # csv file does not have headers
         string_io = StringIOContextManager(
             '1,2,etag1,"I like trains"\n' '5,1,etag2,"weeeeeeeeeeee"\n'
@@ -1492,7 +1492,7 @@ class TestCsvFileTable:
             iter = table.__iter__()
             pytest.raises(ValueError, next, iter)
 
-    def test_iter_row_metadata_mismatch_in_headers(self):
+    def test_iter_row_metadata_mismatch_in_headers(self) -> None:
         # csv file does not contain row metadata, self.headers does
         data = "col1,col2\n" "1,2\n" "2,1\n"
         cols = as_table_columns(StringIOContextManager(data))
@@ -1505,7 +1505,7 @@ class TestCsvFileTable:
             iter = table.__iter__()
             pytest.raises(ValueError, next, iter)
 
-    def test_iter_with_table_row_metadata(self):
+    def test_iter_with_table_row_metadata(self) -> None:
         # csv file has row metadata, self.headers does not
         data = (
             "ROW_ID,ROW_VERSION,col\n" '1,2,"I like trains"\n' '5,1,"weeeeeeeeeeee"\n'
@@ -1518,7 +1518,7 @@ class TestCsvFileTable:
             for expected_row, table_row in zip(expected_rows, table):
                 assert expected_row == table_row
 
-    def test_iter_with_mismatch_row_metadata(self):
+    def test_iter_with_mismatch_row_metadata(self) -> None:
         # self.headers and csv file headers contains mismatch row metadata
         data = (
             "ROW_ID,ROW_VERSION,ROW_ETAG,col\n"
@@ -1535,7 +1535,7 @@ class TestCsvFileTable:
             iter = table.__iter__()
             pytest.raises(ValueError, next, iter)
 
-    def test_iter_no_row_metadata(self):
+    def test_iter_no_row_metadata(self) -> None:
         # both csv headers and self.headers do not contains row metadata
         data = "col1,col2\n" "1,2\n" "2,1\n"
         cols = as_table_columns(StringIOContextManager(data))
@@ -1546,7 +1546,7 @@ class TestCsvFileTable:
             for expected_row, table_row in zip(expected_rows, table):
                 assert expected_row == table_row
 
-    def test_iter_with_file_view_row_metadata(self):
+    def test_iter_with_file_view_row_metadata(self) -> None:
         # csv file and self.headers contain matching row metadata
         data = (
             "ROW_ID,ROW_VERSION,ROW_ETAG,col\n"
@@ -1568,7 +1568,7 @@ class TestCsvFileTable:
             for expected_row, table_row in zip(expected_rows, table):
                 assert expected_row == table_row
 
-    def test_as_data_frame__no_headers(self):
+    def test_as_data_frame__no_headers(self) -> None:
         """Verify we don't assume a schema has defined headers when converting to a Pandas data frame"""
         data = {
             "ROW_ID": ["1", "5"],
@@ -1591,7 +1591,7 @@ class TestCsvFileTable:
 
         pd.testing.assert_frame_equal(expected_df, df)
 
-    def test_as_data_frame__list_columns(self):
+    def test_as_data_frame__list_columns(self) -> None:
         """Verify list columns are represented as expected when converted to a Pandas dataframe"""
 
         data = {
@@ -1640,7 +1640,7 @@ class TestCsvFileTable:
 
         pd.testing.assert_frame_equal(expected_df, df)
 
-    def test_as_data_frame__boolean_like_string_column(self):
+    def test_as_data_frame__boolean_like_string_column(self) -> None:
         # Verify the string type column which store boolean value not convert to Python Boolean type from pandas
         data = [
             ["1", "John Coltrane", False, "FALSE"],
@@ -1697,7 +1697,7 @@ class TestCsvFileTable:
         assert df.shape == (8, 4)
 
 
-def test_Row_forward_compatibility():
+def test_Row_forward_compatibility() -> None:
     row = Row("2, 3, 4", rowId=1, versionNumber=1, etag=None, new_field="new")
     assert "2, 3, 4" == row.get("values")
     assert 1 == row.get("rowId")
@@ -1706,7 +1706,7 @@ def test_Row_forward_compatibility():
     assert "new" == row.get("new_field")
 
 
-def test_SelectColumn_forward_compatibility():
+def test_SelectColumn_forward_compatibility() -> None:
     sc = SelectColumn(id=1, columnType="STRING", name="my_col", columnSQL="new")
     assert 1 == sc.get("id")
     assert "STRING" == sc.get("columnType")
@@ -1714,7 +1714,7 @@ def test_SelectColumn_forward_compatibility():
     assert "new" == sc.get("columnSQL")
 
 
-def test_get_view_type_mask_for_deprecated_type():
+def test_get_view_type_mask_for_deprecated_type() -> None:
     pytest.raises(ValueError, _get_view_type_mask_for_deprecated_type, None)
     pytest.raises(ValueError, _get_view_type_mask_for_deprecated_type, "wiki")
     assert EntityViewType.FILE.value == _get_view_type_mask_for_deprecated_type("file")
@@ -1727,7 +1727,7 @@ def test_get_view_type_mask_for_deprecated_type():
     )
 
 
-def test_get_view_type_mask():
+def test_get_view_type_mask() -> None:
     pytest.raises(ValueError, _get_view_type_mask, None)
     pytest.raises(ValueError, _get_view_type_mask, [])
     pytest.raises(ValueError, _get_view_type_mask, [EntityViewType.DOCKER, "wiki"])
@@ -1762,7 +1762,7 @@ def test_get_view_type_mask():
     )
 
 
-def test_update_existing_view_type_mask():
+def test_update_existing_view_type_mask() -> None:
     properties = {"id": "syn123", "parentId": "syn456", "viewTypeMask": 2}
     view = EntityViewSchema(properties=properties)
     assert view["viewTypeMask"] == 2
@@ -1770,7 +1770,7 @@ def test_update_existing_view_type_mask():
     assert view["viewTypeMask"] == 1
 
 
-def test_set_view_types_invalid_input():
+def test_set_view_types_invalid_input() -> None:
     properties = {"id": "syn123", "parentId": "syn456"}
     view = EntityViewSchema(type="project", properties=properties)
     assert view["viewTypeMask"] == 2
@@ -1788,7 +1788,7 @@ def test_set_view_types_invalid_input():
         ),  # other special characters e.g. spaces are left alone (within the quoted string)
     ),
 )
-def test_escape_column_names(column, expected_name):
+def test_escape_column_names(column, expected_name) -> None:
     """Verify column name escaping"""
     # test as a string
     assert escape_column_name(column) == expected_name
@@ -1797,7 +1797,7 @@ def test_escape_column_names(column, expected_name):
     assert escape_column_name({"name": column}) == expected_name
 
 
-def test_join_column_names():
+def test_join_column_names() -> None:
     """Verify the behavior of join_column_names"""
     column_names = ["foo", 'foo"bar', "foo bar"]
     column_dicts = [{"name": n} for n in column_names]

--- a/tests/unit/synapseclient/unit_test_tables.py
+++ b/tests/unit/synapseclient/unit_test_tables.py
@@ -353,7 +353,7 @@ def test_dataset() -> None:
     assert len(dataset) == 0
 
 
-def test_RowSetTable() -> None:
+def test_row_set_table() -> None:
     row_set_json = {
         "etag": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
         "headers": [
@@ -397,7 +397,7 @@ def test_RowSetTable() -> None:
     assert list(df["name"]) == ["foo", "bar", "foo", "qux"]
 
 
-def test_as_table_columns__with_pandas_DataFrame() -> None:
+def test_as_table_columns_with_pandas_dataframe() -> None:
     df = pd.DataFrame(
         {
             "foobar": ("foo", "bar", "baz", "qux", "asdf"),
@@ -540,7 +540,7 @@ def test_pandas_to_table() -> None:
     "test_df",
     [pd.DataFrame({"str1": ("foo", "bar", "moo"), "str2": ("foo", "bar", None)})],
 )
-def test_pandas_to_table_convert__string_data_type(test_df) -> None:
+def test_pandas_to_table_convert__string_data_type(test_df: pd.DataFrame) -> None:
     schema = Schema(name="Foo", parent="syn12345")
     test_table = Table(schema, test_df)
     for col in test_table.headers:
@@ -824,7 +824,7 @@ def test_aggregate_query_result_to_data_frame() -> None:
     assert list(df["AVG(Hipness)"].values) == [1.1, 2.38, 3.14, 4.38]
 
 
-def test_waitForAsync() -> None:
+def test_wait_for_async() -> None:
     syn = Synapse(debug=True, skip_checks=True)
     syn.table_query_timeout = 0.05
     syn.table_query_max_sleep = 0.001

--- a/tests/unit/synapseutils/unit_test_synapseutils_copy.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_copy.py
@@ -77,13 +77,13 @@ class TestCopyFileHandles:
         self.syn = syn
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self):
+    def setup_method(self):
         self.patch_private_copy = patch.object(
             synapseutils.copy_functions, "_copy_file_handles_batch"
         )
         self.mock_private_copy = self.patch_private_copy.start()
 
-    def teardown(self):
+    def teardown_method(self):
         self.patch_private_copy.stop()
 
     def test_copy_file_handles__invalid_input_params_branch1(self):
@@ -195,11 +195,11 @@ class TestProtectedCopyFileHandlesBatch:
         self.syn = syn
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self):
+    def setup_method(self):
         self.patch_restPOST = patch.object(self.syn, "restPOST")
         self.mock_restPOST = self.patch_restPOST.start()
 
-    def teardown(self):
+    def teardown_method(self):
         self.patch_restPOST.stop()
 
     def test__copy_file_handles_batch__two_file_handles(self):
@@ -388,7 +388,7 @@ class TestCopyPermissions:
         self.syn = syn
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self):
+    def setup_method(self):
         self.project_entity = synapseclient.Project(
             name=str(uuid.uuid4()), id="syn1234"
         )
@@ -427,7 +427,7 @@ class TestCopyAccessRestriction:
         self.syn = syn
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self):
+    def setup_method(self):
         self.project_entity = synapseclient.Project(
             name=str(uuid.uuid4()), id="syn1234"
         )
@@ -469,7 +469,7 @@ class TestCopy:
         self.syn = syn
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self):
+    def setup_method(self):
         self.project_entity = synapseclient.Project(
             name=str(uuid.uuid4()), id="syn1234"
         )

--- a/tests/unit/synapseutils/unit_test_synapseutils_sync.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_sync.py
@@ -1,5 +1,4 @@
 """Unit tests for the Sync utility functions"""
-# pylint: disable=protected-access
 import csv
 import datetime
 import math
@@ -1003,7 +1002,7 @@ class TestGetFileEntityProvenanceDict:
     """
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self):
+    def setup_method(self):
         self.mock_syn = create_autospec(Synapse)
 
     def test_get_file_entity_provenance_dict__error_is_404(self):

--- a/tests/unit/synapseutils/unit_test_synapseutils_sync.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_sync.py
@@ -235,7 +235,9 @@ def test_syncFromSynapse__downloadFile_is_false(syn: Synapse) -> None:
 @patch.object(synapseutils.sync, "generateManifest")
 @patch.object(synapseutils.sync, "_get_file_entity_provenance_dict")
 def test_syncFromSynapse__manifest_is_all(
-    mock__get_file_entity_provenance_dict, mock_generateManifest, syn: Synapse
+    mock_get_file_entity_provenance_dict: MagicMock,
+    mock_generate_manifest: MagicMock,
+    syn: Synapse,
 ) -> None:
     """
     Verify manifest argument equal to "all" that pass in to syncFromSynapse, it will create root_manifest and all
@@ -262,7 +264,7 @@ def test_syncFromSynapse__manifest_is_all(
     def syn_get_side_effect(entity, *args, **kwargs):
         return entities[id_of(entity)]
 
-    mock__get_file_entity_provenance_dict.return_value = {}
+    mock_get_file_entity_provenance_dict.return_value = {}
 
     with patch.object(
         syn, "getChildren", side_effect=[[folder, file1], [file2]]
@@ -287,15 +289,15 @@ def test_syncFromSynapse__manifest_is_all(
             ),
         ]
 
-        assert mock_generateManifest.call_count == 2
+        assert mock_generate_manifest.call_count == 2
 
         # child_manifest in folder
-        call_files = mock_generateManifest.call_args_list[0][0][1]
+        call_files = mock_generate_manifest.call_args_list[0][0][1]
         assert len(call_files) == 1
         assert call_files[0].id == "syn789123"
 
         # root_manifest file
-        call_files = mock_generateManifest.call_args_list[1][0][1]
+        call_files = mock_generate_manifest.call_args_list[1][0][1]
         assert len(call_files) == 2
         assert call_files[0].id == "syn456"
         assert call_files[1].id == "syn789123"
@@ -304,7 +306,9 @@ def test_syncFromSynapse__manifest_is_all(
 @patch.object(synapseutils.sync, "generateManifest")
 @patch.object(synapseutils.sync, "_get_file_entity_provenance_dict")
 def test_syncFromSynapse__manifest_is_root(
-    mock__get_file_entity_provenance_dict, mock_generateManifest, syn: Synapse
+    mock_get_file_entity_provenance_dict: MagicMock,
+    mock_generate_manifest: MagicMock,
+    syn: Synapse,
 ) -> None:
     """
     Verify manifest argument equal to "root" that pass in to syncFromSynapse, it will create root_manifest file only.
@@ -330,7 +334,7 @@ def test_syncFromSynapse__manifest_is_root(
     def syn_get_side_effect(entity, *args, **kwargs):
         return entities[id_of(entity)]
 
-    mock__get_file_entity_provenance_dict.return_value = {}
+    mock_get_file_entity_provenance_dict.return_value = {}
 
     with patch.object(
         syn, "getChildren", side_effect=[[folder, file1], [file2]]
@@ -355,9 +359,9 @@ def test_syncFromSynapse__manifest_is_root(
             ),
         ]
 
-        assert mock_generateManifest.call_count == 1
+        assert mock_generate_manifest.call_count == 1
 
-        call_files = mock_generateManifest.call_args_list[0][0][1]
+        call_files = mock_generate_manifest.call_args_list[0][0][1]
         assert len(call_files) == 2
         assert call_files[0].id == "syn456"
         assert call_files[1].id == "syn789123"
@@ -366,7 +370,9 @@ def test_syncFromSynapse__manifest_is_root(
 @patch.object(synapseutils.sync, "generateManifest")
 @patch.object(synapseutils.sync, "_get_file_entity_provenance_dict")
 def test_syncFromSynapse__manifest_is_suppress(
-    mock__get_file_entity_provenance_dict, mock_generateManifest, syn: Synapse
+    mock_get_file_entity_provenance_dict: MagicMock,
+    mock_generate_manifest: MagicMock,
+    syn: Synapse,
 ) -> None:
     """
     Verify manifest argument equal to "suppress" that pass in to syncFromSynapse, it won't create any manifest file.
@@ -392,7 +398,7 @@ def test_syncFromSynapse__manifest_is_suppress(
     def syn_get_side_effect(entity, *args, **kwargs):
         return entities[id_of(entity)]
 
-    mock__get_file_entity_provenance_dict.return_value = {}
+    mock_get_file_entity_provenance_dict.return_value = {}
 
     with patch.object(
         syn, "getChildren", side_effect=[[folder, file1], [file2]]
@@ -417,7 +423,7 @@ def test_syncFromSynapse__manifest_is_suppress(
             ),
         ]
 
-        assert mock_generateManifest.call_count == 0
+        assert mock_generate_manifest.call_count == 0
 
 
 def test_syncFromSynapse__manifest_value_is_invalid(syn) -> None:
@@ -769,7 +775,7 @@ async def test_manifest_upload(syn: Synapse) -> None:
 
 class TestSyncUploader:
     @patch("os.path.isfile")
-    def test_order_items(self, mock_isfile, syn: Synapse) -> None:
+    def test_order_items(self, mock_isfile: MagicMock, syn: Synapse) -> None:
         """Verfy that items are properly ordered according to their provenance."""
 
         def isfile(path):
@@ -855,7 +861,7 @@ class TestSyncUploader:
             seen.add(i.entity.path)
 
     @patch("os.path.isfile")
-    def test_order_items__provenance_cycle(self, isfile) -> None:
+    def test_order_items__provenance_cycle(self, isfile: MagicMock) -> None:
         """Verify that if a provenance cycle is detected we raise an error"""
 
         isfile.return_value = True
@@ -883,7 +889,7 @@ class TestSyncUploader:
         assert "cyclic" in str(cm_ex.value)
 
     @patch("os.path.isfile")
-    def test_order_items__provenance_file_not_uploaded(self, isfile) -> None:
+    def test_order_items__provenance_file_not_uploaded(self, isfile: MagicMock) -> None:
         """Verify that if one file depends on another for provenance but that file
         is not included in the upload we raise an error."""
 
@@ -947,7 +953,7 @@ class TestSyncUploader:
             await uploader.upload([item])
 
     @patch("os.path.isfile")
-    async def test_upload(self, mock_os_isfile, syn: Synapse) -> None:
+    async def test_upload(self, mock_os_isfile: MagicMock, syn: Synapse) -> None:
         """Ensure that an upload including multiple items which depend on each other through
         provenance are all uploaded and in the expected order."""
         mock_os_isfile.return_value = True
@@ -1005,7 +1011,7 @@ class TestGetFileEntityProvenanceDict:
     def setup_method(self):
         self.mock_syn = create_autospec(Synapse)
 
-    def test_get_file_entity_provenance_dict__error_is_404(self):
+    def test_get_file_entity_provenance_dict__error_is_404(self) -> None:
         self.mock_syn.getProvenance.side_effect = SynapseHTTPError(
             response=Mock(status_code=404)
         )
@@ -1015,7 +1021,7 @@ class TestGetFileEntityProvenanceDict:
         )
         assert {} == result_dict
 
-    def test_get_file_entity_provenance_dict__error_not_404(self):
+    def test_get_file_entity_provenance_dict__error_not_404(self) -> None:
         self.mock_syn.getProvenance.side_effect = SynapseHTTPError(
             response=Mock(status_code=400)
         )
@@ -1029,7 +1035,7 @@ class TestGetFileEntityProvenanceDict:
 
 
 @patch.object(sync, "os")
-def test_check_size_each_file(mock_os, syn):
+def test_check_size_each_file(mock_os: MagicMock, syn: Synapse) -> None:
     """
     Verify the check_size_each_file method works correctly
     """
@@ -1076,7 +1082,7 @@ def test_check_size_each_file(mock_os, syn):
 
 
 @patch.object(sync, "os")
-def test_check_size_each_file_raise_error(mock_os, syn):
+def test_check_size_each_file_raise_error(mock_os: MagicMock, syn: Synapse) -> None:
     """
     Verify the check_size_each_file method raises the ValueError when the file is empty.
     """
@@ -1110,7 +1116,7 @@ def test_check_size_each_file_raise_error(mock_os, syn):
 
 
 @patch.object(sync, "os")
-def test_check_file_name(mock_os, syn):
+def test_check_file_name(mock_os: MagicMock, syn: Synapse) -> None:
     """
     Verify the check_file_name method works correctly
     """
@@ -1137,7 +1143,7 @@ def test_check_file_name(mock_os, syn):
 
 
 @patch.object(sync, "os")
-def test_check_file_name_with_illegal_char(mock_os, syn):
+def test_check_file_name_with_illegal_char(mock_os: MagicMock, syn: Synapse) -> None:
     """
     Verify the check_file_name method raises the ValueError when the file name contains illegal char
     """
@@ -1171,7 +1177,7 @@ def test_check_file_name_with_illegal_char(mock_os, syn):
 
 
 @patch.object(sync, "os")
-def test_check_file_name_duplicated(mock_os, syn):
+def test_check_file_name_duplicated(mock_os: MagicMock, syn: Synapse) -> None:
     """
     Verify the check_file_name method raises the ValueError when the file name is duplicated
     """
@@ -1202,7 +1208,9 @@ def test_check_file_name_duplicated(mock_os, syn):
 
 
 @patch.object(sync, "os")
-def test_check_file_name_with_too_long_filename(mock_os, syn):
+def test_check_file_name_with_too_long_filename(
+    mock_os: MagicMock, syn: Synapse
+) -> None:
     """
     Verify the check_file_name method raises the ValueError when the file name is too long
     """
@@ -1240,7 +1248,7 @@ def test_check_file_name_with_too_long_filename(mock_os, syn):
     )
 
 
-def test__create_folder(syn):
+def test__create_folder(syn: Synapse) -> None:
     folder_name = "TestName"
     parent_id = "syn123"
     with patch.object(syn, "store") as patch_syn_store:
@@ -1263,7 +1271,7 @@ def test__create_folder(syn):
 
 
 @patch.object(sync, "os")
-def test__walk_directory_tree(mock_os, syn):
+def test__walk_directory_tree(mock_os: MagicMock, syn: Synapse) -> None:
     folder_name = "TestFolder"
     subfolder_name = "TestSubfolder"
     parent_id = "syn123"
@@ -1282,7 +1290,7 @@ def test__walk_directory_tree(mock_os, syn):
         assert len(rows) == 2
 
 
-def test_generate_sync_manifest(syn):
+def test_generate_sync_manifest(syn: Synapse) -> None:
     folder_name = "TestName"
     parent_id = "syn123"
     manifest_path = "TestFolder"


### PR DESCRIPTION
**Problem:**

1. There is a significant amount of business logic within client.py related to configuration and downloading of files.
2. Many warnings were popping up when running unit/integration tests.
3. As items are being migrated out we will need to mark them as deprecated.
4. Lot's of items are flagged by sonarcloud that need to be addressed.

**Solution:**

1. Laying the ground work for migrating logic out of client.py. I started this process by splitting functions out into `synapseclient/api/configuration_services.py`, `synapseclient/api/file_services.py`, and `synapseclient/core/download/download_functions.py`
2. Updating unit/integration tests for items I saw that were spitting out warnings or other code smells.
3. Marking items as deprecated and updating all internal usage of those deprecated methods to their replacements.
4. Starting to address some sonarcloud flagged issues.

**Testing:**

1. Light manual testing but mostly focusing on unit/integration testing around these changes. Further PRs will include heavier testing of downloading logic that is split out of client.py