### PR TITLE
[SYNPY-1482] Updating to remove loop executor during annotation store

### DIFF
--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -1,5 +1,5 @@
 # These are all of the models that are used by the Synapse client.
-from .annotations import set_annotations
+from .annotations import set_annotations, set_annotations_async
 from .entity_bundle_services_v2 import (
     get_entity_id_bundle2,
     get_entity_id_version_bundle2,
@@ -30,6 +30,7 @@ from .file_services import (
 __all__ = [
     # annotations
     "set_annotations",
+    "set_annotations_async",
     "get_entity_id_bundle2",
     "get_entity_id_version_bundle2",
     "post_entity_bundle2_create",

--- a/synapseclient/api/annotations.py
+++ b/synapseclient/api/annotations.py
@@ -47,3 +47,36 @@ def set_annotations(
             }
         ),
     )
+
+
+async def set_annotations_async(
+    annotations: "Annotations",
+    synapse_client: Optional["Synapse"] = None,
+):
+    """Call to synapse and set the annotations for the given input.
+
+    Arguments:
+        annotations: The annotations to set. This is expected to have the id, etag,
+            and annotations filled in.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns: The annotations set in Synapse.
+    """
+    annotations_dict = asdict(annotations)
+
+    synapse_annotations = _convert_to_annotations_list(
+        annotations_dict["annotations"] or {}
+    )
+    from synapseclient import Synapse
+
+    return await Synapse.get_client(synapse_client=synapse_client).rest_put_async(
+        f"/entity/{annotations.id}/annotations2",
+        body=json.dumps(
+            {
+                "id": annotations.id,
+                "etag": annotations.etag,
+                "annotations": synapse_annotations,
+            }
+        ),
+    )


### PR DESCRIPTION
**Problem:**

1. Storage of annotation was taking place in a loop executor

**Solution:**

1. Updating logic to be stored without the executor/other threads

**Testing:**

1. Unit/Integration tests