### PR TITLE
[SYNPY-1483] Update default order for credential provider

### DIFF
--- a/synapseclient/core/credentials/credential_provider.py
+++ b/synapseclient/core/credentials/credential_provider.py
@@ -209,8 +209,8 @@ class SynapseCredentialsProviderChain(object):
 
     By default this class uses the following providers in this order:
 
-    1. [ConfigFileCredentialsProvider][synapseclient.core.credentials.credential_provider.ConfigFileCredentialsProvider]
-    2. [UserArgsCredentialsProvider][synapseclient.core.credentials.credential_provider.UserArgsCredentialsProvider]
+    1. [UserArgsCredentialsProvider][synapseclient.core.credentials.credential_provider.UserArgsCredentialsProvider]
+    2. [ConfigFileCredentialsProvider][synapseclient.core.credentials.credential_provider.ConfigFileCredentialsProvider]
     3. [EnvironmentVariableCredentialsProvider][synapseclient.core.credentials.credential_provider.EnvironmentVariableCredentialsProvider]
     4. [AWSParameterStoreCredentialsProvider][synapseclient.core.credentials.credential_provider.AWSParameterStoreCredentialsProvider]
 
@@ -255,8 +255,8 @@ class SynapseCredentialsProviderChain(object):
 
 DEFAULT_CREDENTIAL_PROVIDER_CHAIN = SynapseCredentialsProviderChain(
     cred_providers=[
-        ConfigFileCredentialsProvider(),
         UserArgsCredentialsProvider(),
+        ConfigFileCredentialsProvider(),
         EnvironmentVariableCredentialsProvider(),
         AWSParameterStoreCredentialsProvider(),  # see service catalog issue: SC-260
     ]


### PR DESCRIPTION
**Problem:**

1. There have been 2 service desk tickets from folks unable to use `synapse login -p $AUTH_TOKEN` due to having a synapse config that might not have the appropriate data.

**Solution:**

1. Updating the credential chain to use CLI arguments first

**Testing:**

1. Verified that setting `-p` is used if supplied, but not if not supplied:
![image](https://github.com/Sage-Bionetworks/synapsePythonClient/assets/17128019/0aad5498-5d95-4d26-9e5d-56bdd3bd35e1)
