### PR TITLE
[SYNPY-1485] feat: added isort to pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,12 @@ repos:
     args: ["-c", "pyproject.toml"]
     additional_dependencies: ["bandit[toml]"]
 
+- repo: https://github.com/pycqa/isort
+  rev: 5.13.2
+  hooks:
+    - id: isort
+      name: isort (python)
+
 # - repo: https://github.com/asottile/blacken-docs
 #   rev: v1.12.0
 #   hooks:


### PR DESCRIPTION
## Context
Related to: [SYNPY-1485 Include isort with pre-commit](https://sagebionetworks.jira.com/browse/SYNPY-1485?atlOrigin=eyJpIjoiY2U1NjZkNGRkZDhhNDk5Yzg1YTkwMmVjN2I5ZjdiZjIiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## to utilize isort in pre-commit
Run `pre-commit install`