### PR TITLE
[SYNPY-1476] Remove thread executor usage for Project, Folder, File

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,7 +195,7 @@ jobs:
           pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration -n auto --ignore=tests/integration/synapseclient/test_command_line_client.py --dist loadscope
 
           # Execute the CLI tests in a non-dist way because they were causing some test instability when being run concurrently
-          # pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration/synapseclient/test_command_line_client.py
+          pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration/synapseclient/test_command_line_client.py
       - name: Upload otel spans
         uses: actions/upload-artifact@v2
         if: always()

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,7 @@
 sonar.projectKey=Sage-Bionetworks_synapsePythonClient
 sonar.organization=sage-bionetworks
 sonar.python.coverage.reportPaths=coverage.xml
+# Reccommendation per:
+# https://community.sonarsource.com/t/6-new-rules-to-support-python-type-hints/89560/2
+sonar.sources=synapseclient,synapseutils
+sonar.tests=tests

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -162,8 +162,8 @@ def get(args, syn):
                 and entity.path is not None
                 and os.path.exists(entity.path)
             ):
+                # The core download functionality of syn.get will print out the message
                 printed_download_message = True
-                syn.logger.info("Downloaded file: %s", os.path.basename(entity.path))
             else:
                 syn.logger.info(
                     "WARNING: No files associated with entity %s\n", entity.id

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -109,6 +109,7 @@ def _getIdsFromQuery(queryString, syn, downloadLocation):
 @tracer.start_as_current_span("main::get")
 def get(args, syn):
     syn.multi_threaded = args.multiThreaded
+    printed_download_message = False
     if args.recursive:
         if args.version is not None:
             raise ValueError(
@@ -161,13 +162,14 @@ def get(args, syn):
                 and entity.path is not None
                 and os.path.exists(entity.path)
             ):
+                printed_download_message = True
                 syn.logger.info("Downloaded file: %s", os.path.basename(entity.path))
             else:
                 syn.logger.info(
                     "WARNING: No files associated with entity %s\n", entity.id
                 )
                 syn.logger.info(entity)
-        if "path" in entity:
+        if "path" in entity and not printed_download_message:
             syn.logger.info("Creating %s", entity.path)
 
 

--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -13,10 +13,13 @@ from .entity_bundle_services_v2 import (
     post_entity_bundle2_create,
     put_entity_id_bundle2,
 )
+from .entity_factory import get_from_entity_factory
 from .entity_services import (
     create_access_requirements_if_none,
     delete_entity_generated_by,
+    get_entities_by_md5,
     get_entity,
+    get_entity_path,
     get_upload_destination,
     get_upload_destination_location,
     post_entity,
@@ -63,10 +66,14 @@ __all__ = [
     "get_upload_destination_location",
     "create_access_requirements_if_none",
     "delete_entity_generated_by",
+    "get_entity_path",
+    "get_entities_by_md5",
     # configuration_services
     "get_config_file",
     "get_config_section_dict",
     "get_config_authentication",
     "get_client_authenticated_s3_profile",
     "get_transfer_config",
+    # entity_factory
+    "get_from_entity_factory",
 ]

--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -29,6 +29,7 @@ from .file_services import (
     AddPartResponse,
     get_file_handle,
     get_file_handle_for_download,
+    get_file_handle_for_download_async,
     post_external_filehandle,
     post_external_object_store_filehandle,
     post_external_s3_file_handle,
@@ -57,6 +58,7 @@ __all__ = [
     "post_file_multipart_presigned_urls",
     "put_file_multipart_add",
     "AddPartResponse",
+    "get_file_handle_for_download_async",
     "get_file_handle_for_download",
     # entity_services
     "get_entity",

--- a/synapseclient/api/annotations.py
+++ b/synapseclient/api/annotations.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 def set_annotations(
     annotations: "Annotations",
+    *,
     synapse_client: Optional["Synapse"] = None,
 ):
     """Call to synapse and set the annotations for the given input.
@@ -49,6 +50,7 @@ def set_annotations(
 
 async def set_annotations_async(
     annotations: "Annotations",
+    *,
     synapse_client: Optional["Synapse"] = None,
 ):
     """Call to synapse and set the annotations for the given input.

--- a/synapseclient/api/entity_bundle_services_v2.py
+++ b/synapseclient/api/entity_bundle_services_v2.py
@@ -95,6 +95,7 @@ async def get_entity_id_version_bundle2(
 async def post_entity_bundle2_create(
     request: Dict[str, Any],
     generated_by: Optional[str] = None,
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> Dict[str, Any]:
     """
@@ -123,6 +124,7 @@ async def put_entity_id_bundle2(
     entity_id: str,
     request: Dict[str, Any],
     generated_by: Optional[str] = None,
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> Dict[str, Any]:
     """

--- a/synapseclient/api/entity_bundle_services_v2.py
+++ b/synapseclient/api/entity_bundle_services_v2.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 async def get_entity_id_bundle2(
     entity_id: str,
     request: Optional[Dict[str, bool]] = None,
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> Dict[str, Any]:
     """
@@ -53,6 +54,7 @@ async def get_entity_id_version_bundle2(
     entity_id: str,
     version: int,
     request: Optional[Dict[str, bool]] = None,
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> Dict[str, Any]:
     """

--- a/synapseclient/api/entity_factory.py
+++ b/synapseclient/api/entity_factory.py
@@ -178,9 +178,10 @@ async def _search_for_file_by_md5(
     from synapseclient import Synapse
 
     syn = Synapse.get_client(synapse_client=synapse_client)
+    md5 = md5 or utils.md5_for_file_hex(filename=filepath)
     results = (
         await get_entities_by_md5(
-            md5=md5 or utils.md5_for_file_hex(filename=filepath),
+            md5=md5,
             synapse_client=synapse_client,
         )
     )["results"]
@@ -215,7 +216,9 @@ async def _search_for_file_by_md5(
         version=entity_version,
         synapse_client=synapse_client,
     )
-    syn.cache.add(file_handle_id=bundle["entity"]["dataFileHandleId"], path=filepath)
+    syn.cache.add(
+        file_handle_id=bundle["entity"]["dataFileHandleId"], path=filepath, md5=md5
+    )
 
     return bundle
 

--- a/synapseclient/api/entity_factory.py
+++ b/synapseclient/api/entity_factory.py
@@ -1,0 +1,386 @@
+"""Factory type functions to create and retrieve entities from Synapse"""
+
+import os
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+
+from opentelemetry import trace
+
+from synapseclient.api import (
+    get_entities_by_md5,
+    get_entity_id_bundle2,
+    get_entity_id_version_bundle2,
+    get_entity_path,
+)
+from synapseclient.core import utils
+from synapseclient.core.constants import concrete_types
+from synapseclient.core.download import download_file_entity_model
+from synapseclient.core.exceptions import (
+    SynapseFileNotFoundError,
+    SynapseUnmetAccessRestrictions,
+)
+
+if TYPE_CHECKING:
+    from synapseclient import Synapse
+    from synapseclient.models import File, Folder, Project
+
+
+async def get_from_entity_factory(
+    synapse_id_or_path: str,
+    version: int = None,
+    if_collision: str = "keep.both",
+    limit_search: str = None,
+    md5: str = None,
+    download_file: bool = True,
+    download_location: str = None,
+    follow_link: bool = False,
+    entity_to_update: Union["Project", "File", "Folder"] = None,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> Union["Project", "File", "Folder"]:
+    """
+    Factory type function to retrieve an entity from Synapse. Optionally you may also
+    pass in `entity_to_update` if you want to update the fields on the existing entity
+    instead of creating a new instance.
+
+    Arguments:
+        synapse_id_or_path: The Synapse ID or file path of the entity to retrieve.
+        version:            The version number of the entity to retrieve.
+        if_collision: Determines how to handle file collisions. May be:
+
+                - `overwrite.local`
+                - `keep.local`
+                - `keep.both`
+        limit_search:       Limit the search to a specific project or folder. Only used
+            if `synapse_id_or_path` is a path.
+        md5: The MD5 of the file to retrieve. If not passed in, the MD5 will be
+            calculated. Only used if `synapse_id_or_path` is a path.
+        download_file: Whether associated files should be downloaded.
+        download_location: The directory to download the file to.
+        follow_link: Whether to follow a link to its target. This will only do a single
+            hop to the target of the link.
+        entity_to_update: An existing entity class instance to update with data from
+            Synapse.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+        Example: Using this function
+            Download file into cache
+
+                from synapseclient import Synapse
+                from synapseclient.api import get_from_entity_factory
+
+                syn = Synapse()
+                syn.login()
+
+                entity = await get_from_entity_factory(synapse_id_or_path='syn1906479')
+                print(entity.name)
+                print(entity.path)
+
+            Download file into current working directory
+
+                from synapseclient import Synapse
+                from synapseclient.api import get_from_entity_factory
+
+                syn = Synapse()
+                syn.login()
+
+                entity = await get_from_entity_factory(synapse_id_or_path='syn1906479', download_location='.')
+                print(entity.name)
+                print(entity.path)
+
+    Raises:
+        SynapseFileNotFoundError: If the id is not a synapse ID and it is not a valid
+            file path.
+    """
+
+    # If entity is a local file determine the corresponding synapse entity
+    if isinstance(synapse_id_or_path, str) and os.path.isfile(synapse_id_or_path):
+        bundle = await _search_for_file_by_md5(
+            filepath=synapse_id_or_path,
+            limit_search=limit_search,
+            md5=md5,
+            synapse_client=synapse_client,
+        )
+        download_file = False
+
+    elif isinstance(synapse_id_or_path, str) and not utils.is_synapse_id_str(
+        obj=synapse_id_or_path
+    ):
+        raise SynapseFileNotFoundError(
+            (
+                f"The parameter {synapse_id_or_path} is neither a local file path "
+                " or a valid entity id"
+            )
+        )
+    else:
+        synid_and_version = utils.get_synid_and_version(obj=synapse_id_or_path)
+        version = version if version is not None else synid_and_version[1]
+        if version:
+            bundle = await get_entity_id_version_bundle2(
+                entity_id=synid_and_version[0],
+                version=version,
+                synapse_client=synapse_client,
+            )
+        else:
+            bundle = await get_entity_id_bundle2(
+                entity_id=synid_and_version[0], synapse_client=synapse_client
+            )
+
+    # Check and warn for unmet access requirements
+    _check_entity_restrictions(
+        bundle=bundle, synapse_id=bundle["entity"]["id"], download_file=download_file
+    )
+
+    return_data = await _cast_into_class_type(
+        entity_to_update=entity_to_update,
+        entity_bundle=bundle,
+        download_file=download_file,
+        download_location=download_location,
+        if_collision=if_collision,
+        follow_link=follow_link,
+        synapse_client=synapse_client,
+    )
+    trace.get_current_span().set_attributes(
+        {
+            "synapse.id": return_data.id,
+            "synapse.type": return_data.__class__.__name__,
+        }
+    )
+    return return_data
+
+
+async def _search_for_file_by_md5(
+    filepath: str,
+    md5: str,
+    limit_search: str = None,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> Dict[str, Any]:
+    """
+    Handle using md5 for a local file to search through Synapse to find a match. By
+    default this will search through every entity that you as a user have access to.
+    However, you can limit the search to a specific project or folder by passing in the
+    Synapse ID of the project or folder into the `limit_search` field.
+
+    Arguments:
+        filepath: The path to the file to search for.
+        md5: The MD5 of the file to retrieve. If not passed in, the MD5 will be
+            calculated.
+        limit_search: Limit the search to a specific project or folder.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        A dictionary containing the entity bundle of the file found.
+
+    Raises:
+        SynapseFileNotFoundError: If the file is not found in Synapse.
+    """
+    from synapseclient import Synapse
+
+    syn = Synapse.get_client(synapse_client=synapse_client)
+    results = (
+        await get_entities_by_md5(
+            md5=md5 or utils.md5_for_file_hex(filename=filepath),
+            synapse_client=synapse_client,
+        )
+    )["results"]
+    if limit_search is not None:
+        # Go through and find the path of every entity found
+        paths = [
+            await get_entity_path(entity_id=ent["id"], synapse_client=synapse_client)
+            for ent in results
+        ]
+        # Filter out all entities whose path does not contain limitSearch
+        results = [
+            ent
+            for ent, path in zip(results, paths)
+            if utils.is_in_path(id=limit_search, path=path)
+        ]
+    if len(results) == 0:  # None found
+        raise SynapseFileNotFoundError(f"File {filepath} not found in Synapse")
+    elif len(results) > 1:
+        id_txts = "\n".join([f"{r['id']}.{r['versionNumber']}" for r in results])
+        syn.logger.warning(
+            f"\nThe file {filepath} is associated with many files in Synapse:\n{id_txts}\n"
+            "You can limit to files in specific project or folder by setting the limitSearch to the"
+            " synapse Id of the project or folder.\n"
+            "Will use the first one returned: \n"
+            f"{results[0]['id']} version {results[0]['versionNumber']}\n"
+        )
+    entity_id = results[0]["id"]
+    entity_version = results[0]["versionNumber"]
+
+    bundle = await get_entity_id_version_bundle2(
+        entity_id=entity_id,
+        version=entity_version,
+        synapse_client=synapse_client,
+    )
+    syn.cache.add(file_handle_id=bundle["entity"]["dataFileHandleId"], path=filepath)
+
+    return bundle
+
+
+async def _cast_into_class_type(
+    entity_bundle: Dict[str, Any],
+    download_file: bool = True,
+    download_location: str = None,
+    if_collision: str = None,
+    submission: str = None,
+    follow_link: bool = False,
+    entity_to_update: Union["Project", "File", "Folder"] = None,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> Union["Project", "File", "Folder"]:
+    """
+    Take an entity_bundle returned from the Synapse API and cast it into the appropriate
+    class type. This will also download the file if `download_file` is set to True.
+    Additionally, if `entity_to_update` is passed in, the fields of the existing entity
+    will be updated instead of creating a new instance. If the entity is a link and
+    `follow_link` is set to True, the target entity will be retrieved.
+
+    Arguments:
+        entity_bundle: The entity bundle to cast into a class type.
+        download_file: Whether associated files should be downloaded.
+        download_location: The directory to download the file to.
+        if_collision: Determines how to handle file collisions. May be:
+
+                    - `overwrite.local`
+                    - `keep.local`
+                    - `keep.both`
+        submission: The ID of the submission to which the entity belongs.
+        follow_link: Whether to follow a link to its target. This will only do a single
+            hop to the target of the link.
+        entity_to_update: An existing entity class instance to update with data from
+            Synapse.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        A Synapse entity object.
+
+    Raises:
+        ValueError: If the entity type is not supported.
+    """
+    from synapseclient import Synapse
+
+    syn = Synapse.get_client(synapse_client=synapse_client)
+
+    # If Link, get target ID entity bundle
+    if (
+        entity_bundle["entity"]["concreteType"] == concrete_types.LINK_ENTITY
+        and follow_link
+    ):
+        target_id = entity_bundle["entity"]["linksTo"]["targetId"]
+        target_version = entity_bundle["entity"]["linksTo"].get("targetVersionNumber")
+        entity_bundle = await get_entity_id_version_bundle2(
+            entity_id=target_id, version=target_version, synapse_client=synapse_client
+        )
+    entity = entity_bundle["entity"]
+
+    from synapseclient.models import Annotations
+
+    annotations = Annotations.from_dict(
+        synapse_annotations=entity_bundle["annotations"]
+    )
+
+    from synapseclient.models import File, Folder, Project
+
+    if entity["concreteType"] == concrete_types.PROJECT_ENTITY:
+        if not entity_to_update:
+            entity_to_update = Project()
+        entity = entity_to_update.fill_from_dict(
+            synapse_project=entity_bundle["entity"], set_annotations=False
+        )
+    elif entity["concreteType"] == concrete_types.FOLDER_ENTITY:
+        if not entity_to_update:
+            entity_to_update = Folder()
+        entity = entity_to_update.fill_from_dict(
+            synapse_folder=entity_bundle["entity"], set_annotations=False
+        )
+    elif entity["concreteType"] == concrete_types.FILE_ENTITY:
+        if not entity_to_update:
+            entity_to_update = File()
+        entity = entity_to_update.fill_from_dict(
+            synapse_file=entity_bundle["entity"], set_annotations=False
+        )
+        # update the entity with FileHandle metadata
+        file_handle = next(
+            (
+                handle
+                for handle in entity_bundle["fileHandles"]
+                if handle["id"] == entity.data_file_handle_id
+            ),
+            None,
+        )
+        from synapseclient.models import FileHandle
+
+        entity.file_handle = FileHandle().fill_from_dict(synapse_instance=file_handle)
+        entity._fill_from_file_handle()
+
+        if download_file:
+            if file_handle:
+                await download_file_entity_model(
+                    download_location=download_location,
+                    file=entity,
+                    if_collision=if_collision,
+                    submission=submission,
+                    synapse_client=synapse_client,
+                )
+            else:  # no filehandle means that we do not have DOWNLOAD permission
+                warning_message = (
+                    "WARNING: You have READ permission on this file entity but not DOWNLOAD "
+                    "permission. The file has NOT been downloaded."
+                )
+                syn.logger.warning(
+                    "\n"
+                    + "!" * len(warning_message)
+                    + "\n"
+                    + warning_message
+                    + "\n"
+                    + "!" * len(warning_message)
+                    + "\n"
+                )
+    else:
+        raise ValueError(
+            f"Attempting to retrieve an unsupported entity type of {entity['concreteType']}."
+        )
+    entity.annotations = annotations
+
+    return entity
+
+
+def _check_entity_restrictions(
+    bundle: Dict[str, Any],
+    synapse_id: str,
+    download_file: bool,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> None:
+    """
+    Check and warn for unmet access requirements.
+
+    Arguments:
+        bundle: A Synapse entityBundle
+        entity: A Synapse ID, a Synapse Entity object, a plain dictionary in which 'id' maps to a
+                Synapse ID or a local file that is stored in Synapse (found by the file MD5)
+        downloadFile: Whether associated files(s) should be downloaded.
+
+    Raises:
+        SynapseUnmetAccessRestrictions: Warning for unmet access requirements.
+    """
+    from synapseclient import Synapse
+
+    syn = Synapse.get_client(synapse_client=synapse_client)
+
+    restriction_information = bundle["restrictionInformation"]
+    if restriction_information["hasUnmetAccessRequirement"]:
+        warning_message = (
+            "\nThis entity has access restrictions. Please visit the web page for this entity "
+            f'(syn.onweb("{synapse_id}")). Look for the "Access" label and the lock icon underneath '
+            'the file name. Click "Request Access", and then review and fulfill the file '
+            "download requirement(s).\n"
+        )
+        if download_file and bundle.get("entityType") not in ("project", "folder"):
+            raise SynapseUnmetAccessRestrictions(warning_message)
+        syn.logger.warn(warning_message)

--- a/synapseclient/api/entity_factory.py
+++ b/synapseclient/api/entity_factory.py
@@ -280,7 +280,7 @@ async def _cast_into_class_type(
     from synapseclient.models import Annotations
 
     annotations = Annotations.from_dict(
-        synapse_annotations=entity_bundle["annotations"]
+        synapse_annotations=entity_bundle.get("annotations", None)
     )
 
     from synapseclient.models import File, Folder, Project
@@ -307,10 +307,10 @@ async def _cast_into_class_type(
         file_handle = next(
             (
                 handle
-                for handle in entity_bundle["fileHandles"]
-                if handle["id"] == entity.data_file_handle_id
+                for handle in entity_bundle.get("fileHandles", [])
+                if handle and handle["id"] == entity.data_file_handle_id
             ),
-            None,
+            {},
         )
         from synapseclient.models import FileHandle
 
@@ -344,7 +344,8 @@ async def _cast_into_class_type(
         raise ValueError(
             f"Attempting to retrieve an unsupported entity type of {entity['concreteType']}."
         )
-    entity.annotations = annotations
+    if annotations:
+        entity.annotations = annotations
 
     return entity
 
@@ -372,8 +373,10 @@ def _check_entity_restrictions(
 
     syn = Synapse.get_client(synapse_client=synapse_client)
 
-    restriction_information = bundle["restrictionInformation"]
-    if restriction_information["hasUnmetAccessRequirement"]:
+    restriction_information = bundle.get("restrictionInformation", None)
+    if restriction_information and restriction_information.get(
+        "hasUnmetAccessRequirement", None
+    ):
         warning_message = (
             "\nThis entity has access restrictions. Please visit the web page for this entity "
             f'(syn.onweb("{synapse_id}")). Look for the "Access" label and the lock icon underneath '

--- a/synapseclient/api/entity_factory.py
+++ b/synapseclient/api/entity_factory.py
@@ -5,12 +5,11 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from opentelemetry import trace
 
-from synapseclient.api import (
-    get_entities_by_md5,
+from synapseclient.api.entity_bundle_services_v2 import (
     get_entity_id_bundle2,
     get_entity_id_version_bundle2,
-    get_entity_path,
 )
+from synapseclient.api.entity_services import get_entities_by_md5, get_entity_path
 from synapseclient.core import utils
 from synapseclient.core.constants import concrete_types
 from synapseclient.core.download import download_file_entity_model

--- a/synapseclient/api/entity_services.py
+++ b/synapseclient/api/entity_services.py
@@ -3,7 +3,7 @@
 """
 
 import json
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from async_lru import alru_cache
 
@@ -208,12 +208,11 @@ async def delete_entity_generated_by(
     )
 
 
-# TODO: Check the return type of this
 async def get_entity_path(
     entity_id: str,
     *,
     synapse_client: Optional["Synapse"] = None,
-):
+) -> Dict[str, List[Dict[str, Union[str, int, bool]]]]:
     """
     Implements:
     <https://rest-docs.synapse.org/rest/GET/entity/id/path.html>
@@ -235,12 +234,11 @@ async def get_entity_path(
     )
 
 
-# TODO: Check the return type of this
 async def get_entities_by_md5(
     md5: str,
     *,
     synapse_client: Optional["Synapse"] = None,
-):
+) -> Dict[str, Union[int, List[Dict[str, Any]]]]:
     """
     Implements:
     <https://rest-docs.synapse.org/rest/GET/entity/md5/md5.html>

--- a/synapseclient/api/entity_services.py
+++ b/synapseclient/api/entity_services.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 async def post_entity(
     request: Dict[str, Any],
     generated_by: Optional[str] = None,
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> Dict[str, Any]:
     """
@@ -44,6 +45,7 @@ async def put_entity(
     request: Dict[str, Any],
     new_version: bool = False,
     generated_by: Optional[str] = None,
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> Dict[str, Any]:
     """
@@ -104,7 +106,7 @@ async def get_entity(
 
 @alru_cache(ttl=60)
 async def get_upload_destination(
-    entity_id: str, synapse_client: Optional["Synapse"] = None
+    entity_id: str, *, synapse_client: Optional["Synapse"] = None
 ) -> Dict[str, Union[str, int]]:
     """
     <https://rest-docs.synapse.org/rest/GET/entity/id/uploadDestination.html>
@@ -128,7 +130,7 @@ async def get_upload_destination(
 
 
 async def get_upload_destination_location(
-    entity_id: str, location: str, synapse_client: Optional["Synapse"] = None
+    entity_id: str, location: str, *, synapse_client: Optional["Synapse"] = None
 ) -> Dict[str, Union[str, int]]:
     """
     <https://rest-docs.synapse.org/rest/GET/entity/id/uploadDestination/storageLocationId.html>
@@ -153,7 +155,7 @@ async def get_upload_destination_location(
 
 
 async def create_access_requirements_if_none(
-    entity_id: str, synapse_client: Optional["Synapse"] = None
+    entity_id: str, *, synapse_client: Optional["Synapse"] = None
 ) -> None:
     """
     Checks to see if the given entity has access requirements. If not, then one is added
@@ -187,6 +189,7 @@ async def create_access_requirements_if_none(
 
 async def delete_entity_generated_by(
     entity_id: str,
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> None:
     """
@@ -202,4 +205,59 @@ async def delete_entity_generated_by(
     client = Synapse.get_client(synapse_client=synapse_client)
     return await client.rest_delete_async(
         uri=f"/entity/{entity_id}/generatedBy",
+    )
+
+
+# TODO: Check the return type of this
+async def get_entity_path(
+    entity_id: str,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+):
+    """
+    Implements:
+    <https://rest-docs.synapse.org/rest/GET/entity/id/path.html>
+
+    Arguments:
+        entity_id: The ID of the entity.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        Entity paths matching:
+        <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/EntityPath.html>
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_get_async(
+        uri=f"/entity/{entity_id}/path",
+    )
+
+
+# TODO: Check the return type of this
+async def get_entities_by_md5(
+    md5: str,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+):
+    """
+    Implements:
+    <https://rest-docs.synapse.org/rest/GET/entity/md5/md5.html>
+
+    Arguments:
+        md5: The MD5 of the entity.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Returns:
+        Paginated results of:
+        <https://rest-docs.synapse.org/rest/org/sagebionetworks/reflection/model/PaginatedResults.html>
+        <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/EntityHeader.html>
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_get_async(
+        uri=f"/entity/md5/{md5}",
     )

--- a/synapseclient/api/file_services.py
+++ b/synapseclient/api/file_services.py
@@ -365,7 +365,7 @@ async def get_file_handle(
     )
 
 
-async def get_file_handle_for_download(
+async def get_file_handle_for_download_async(
     file_handle_id: str,
     synapse_id: str,
     entity_type: str = None,
@@ -407,6 +407,66 @@ async def get_file_handle_for_download(
         ],
     }
     response = await client.rest_post_async(
+        "/fileHandle/batch", body=json.dumps(body), endpoint=client.fileHandleEndpoint
+    )
+
+    result = response["requestedFiles"][0]
+    failure = result.get("failureCode")
+    if failure == "NOT_FOUND":
+        raise SynapseFileNotFoundError(
+            f"The fileHandleId {file_handle_id} could not be found"
+        )
+    elif failure == "UNAUTHORIZED":
+        raise SynapseError(
+            f"You are not authorized to access fileHandleId {file_handle_id} "
+            f"associated with the Synapse {entity_type}: {synapse_id}"
+        )
+    return result
+
+
+def get_file_handle_for_download(
+    file_handle_id: str,
+    synapse_id: str,
+    entity_type: str = None,
+    synapse_client: Optional["Synapse"] = None,
+) -> Dict[str, str]:
+    """
+    Gets the URL and the metadata as filehandle object for a filehandle or fileHandleId
+
+    Arguments:
+        file_handle_id:   ID of fileHandle to download
+        synapse_id:       The ID of the object associated with the file e.g. syn234
+        entity_type:     Type of object associated with a file e.g. FileEntity,
+            TableEntity
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/FileHandleAssociateType.html>
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Raises:
+        SynapseFileNotFoundError: If the fileHandleId is not found in Synapse.
+        SynapseError: If the user does not have the permission to access the
+            fileHandleId.
+
+    Returns:
+        A dictionary with keys: fileHandle, fileHandleId and preSignedURL
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    body = {
+        "includeFileHandles": True,
+        "includePreSignedURLs": True,
+        "requestedFiles": [
+            {
+                "fileHandleId": file_handle_id,
+                "associateObjectId": synapse_id,
+                "associateObjectType": entity_type or "FileEntity",
+            }
+        ],
+    }
+    # TODO: Convert over to HTTPX client
+    response = client.restPOST(
         "/fileHandle/batch", body=json.dumps(body), endpoint=client.fileHandleEndpoint
     )
 

--- a/synapseclient/api/file_services.py
+++ b/synapseclient/api/file_services.py
@@ -465,7 +465,7 @@ def get_file_handle_for_download(
             }
         ],
     }
-    # TODO: Convert over to HTTPX client
+
     response = client.restPOST(
         "/fileHandle/batch", body=json.dumps(body), endpoint=client.fileHandleEndpoint
     )

--- a/synapseclient/api/file_services.py
+++ b/synapseclient/api/file_services.py
@@ -21,6 +21,7 @@ async def post_file_multipart(
     upload_request_payload: Dict[str, Any],
     force_restart: bool,
     endpoint: str,
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> Dict[str, str]:
     """
@@ -71,6 +72,7 @@ async def put_file_multipart_add(
     upload_id: str,
     part_number: int,
     md5_hex: str,
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> AddPartResponse:
     """
@@ -112,6 +114,7 @@ async def put_file_multipart_add(
 async def put_file_multipart_complete(
     upload_id: str,
     endpoint: str,
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> Dict[str, str]:
     """
@@ -139,6 +142,7 @@ async def put_file_multipart_complete(
 async def post_file_multipart_presigned_urls(
     upload_id: str,
     part_numbers: List[int],
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> Dict[str, Any]:
     """
@@ -179,6 +183,7 @@ async def post_external_object_store_filehandle(
     storage_location_id: int,
     mimetype: str = None,
     md5: str = None,
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> Dict[str, Union[str, int]]:
     """
@@ -223,6 +228,7 @@ async def post_external_filehandle(
     mimetype: str = None,
     md5: str = None,
     file_size: int = None,
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> Dict[str, Union[str, int]]:
     """
@@ -270,6 +276,7 @@ async def post_external_s3_file_handle(
     storage_location_id: str = None,
     mimetype: str = None,
     md5: str = None,
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> Dict[str, Union[str, int, bool]]:
     """
@@ -338,6 +345,7 @@ async def post_external_s3_file_handle(
 
 async def get_file_handle(
     file_handle_id: Dict[str, Union[str, int]],
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> Dict[str, Union[str, int]]:
     """
@@ -369,6 +377,7 @@ async def get_file_handle_for_download_async(
     file_handle_id: str,
     synapse_id: str,
     entity_type: str = None,
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> Dict[str, str]:
     """
@@ -428,6 +437,7 @@ def get_file_handle_for_download(
     file_handle_id: str,
     synapse_id: str,
     entity_type: str = None,
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> Dict[str, str]:
     """

--- a/synapseclient/api/file_services.py
+++ b/synapseclient/api/file_services.py
@@ -11,7 +11,10 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from synapseclient.api.entity_services import get_upload_destination
 from synapseclient.core import utils
 from synapseclient.core.constants import concrete_types
-from synapseclient.core.exceptions import SynapseError, SynapseFileNotFoundError
+from synapseclient.core.exceptions import (
+    SynapseAuthorizationError,
+    SynapseFileNotFoundError,
+)
 
 if TYPE_CHECKING:
     from synapseclient import Synapse
@@ -426,7 +429,7 @@ async def get_file_handle_for_download_async(
             f"The fileHandleId {file_handle_id} could not be found"
         )
     elif failure == "UNAUTHORIZED":
-        raise SynapseError(
+        raise SynapseAuthorizationError(
             f"You are not authorized to access fileHandleId {file_handle_id} "
             f"associated with the Synapse {entity_type}: {synapse_id}"
         )
@@ -487,7 +490,7 @@ def get_file_handle_for_download(
             f"The fileHandleId {file_handle_id} could not be found"
         )
     elif failure == "UNAUTHORIZED":
-        raise SynapseError(
+        raise SynapseAuthorizationError(
             f"You are not authorized to access fileHandleId {file_handle_id} "
             f"associated with the Synapse {entity_type}: {synapse_id}"
         )

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -2481,14 +2481,11 @@ class Synapse(object):
         """
         manifest = self._generate_manifest_from_download_list()
         # Get file handle download link
-        file_result = wrap_async_to_sync(
-            coroutine=get_file_handle_for_download(
-                file_handle_id=manifest["resultFileHandleId"],
-                synapse_id=manifest["resultFileHandleId"],
-                entity_type="FileEntity",
-                synapse_client=self,
-            ),
-            syn=self,
+        file_result = get_file_handle_for_download(
+            file_handle_id=manifest["resultFileHandleId"],
+            synapse_id=manifest["resultFileHandleId"],
+            entity_type="FileEntity",
+            synapse_client=self,
         )
         # Download the manifest
         downloaded_path = self._download_from_URL(

--- a/synapseclient/core/cache.py
+++ b/synapseclient/core/cache.py
@@ -352,6 +352,7 @@ class Cache:
             raise ValueError('Can\'t find file "%s"' % path)
 
         cache_dir = self.get_cache_dir(file_handle_id)
+        content_md5 = md5 or utils.md5_for_file(path).hexdigest()
         with Lock(self.cache_map_file_name, dir=cache_dir):
             cache_map = self._read_cache_map(cache_dir)
 
@@ -361,7 +362,7 @@ class Cache:
                 "modified_time": epoch_time_to_iso(
                     math.floor(_get_modified_time(path))
                 ),
-                "content_md5": md5 or utils.md5_for_file(path).hexdigest(),
+                "content_md5": content_md5,
             }
             self._write_cache_map(cache_dir, cache_map)
 

--- a/synapseclient/core/download/__init__.py
+++ b/synapseclient/core/download/__init__.py
@@ -7,7 +7,6 @@ from .download_async import (
     PresignedUrlProvider,
     _MultithreadedDownloader,
     download_file,
-    shared_progress_bar,
 )
 from .download_functions import (
     download_by_file_handle,
@@ -29,7 +28,6 @@ __all__ = [
     # download_async
     "DownloadRequest",
     "download_file",
-    "shared_progress_bar",
     "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
     "PresignedUrlInfo",
     "PresignedUrlProvider",

--- a/synapseclient/core/download/__init__.py
+++ b/synapseclient/core/download/__init__.py
@@ -12,6 +12,7 @@ from .download_async import (
 from .download_functions import (
     download_by_file_handle,
     download_file_entity,
+    download_file_entity_model,
     download_from_url,
     download_from_url_multi_threaded,
     ensure_download_location_is_directory,
@@ -20,6 +21,7 @@ from .download_functions import (
 __all__ = [
     # download_functions
     "download_file_entity",
+    "download_file_entity_model",
     "ensure_download_location_is_directory",
     "download_by_file_handle",
     "download_from_url",

--- a/synapseclient/core/download/download_async.py
+++ b/synapseclient/core/download/download_async.py
@@ -577,6 +577,7 @@ def _execute_stream_and_write_chunk(
     with session.stream(
         method="GET", url=presigned_url_provider.get_info().url, headers=range_header
     ) as response:
+        _raise_for_status_httpx(response=response, logger=request._syn.logger)
         data = response.read()
         data_length = len(data)
         request._write_chunk(

--- a/synapseclient/core/download/download_async.py
+++ b/synapseclient/core/download/download_async.py
@@ -244,9 +244,9 @@ def _pre_signed_url_expiration_time(url: str) -> datetime:
     time_made = parsed_query["X-Amz-Date"][0]
     time_made_datetime = datetime.datetime.strptime(time_made, ISO_AWS_STR_FORMAT)
     expires = parsed_query["X-Amz-Expires"][0]
-    return_data = time_made_datetime + datetime.timedelta(seconds=int(expires))
-    if return_data.tzinfo is None:
-        return_data = return_data.replace(tzinfo=datetime.timezone.utc)
+    return_data = (
+        time_made_datetime + datetime.timedelta(seconds=int(expires))
+    ).replace(tzinfo=datetime.timezone.utc)
     return return_data
 
 

--- a/synapseclient/core/download/download_async.py
+++ b/synapseclient/core/download/download_async.py
@@ -316,7 +316,9 @@ class _MultithreadedDownloader:
         file_size = await _get_file_size_wrapper(
             syn=self._syn, url=url_info.url, debug=self._download_request.debug
         )
-        self._progress_bar = get_or_create_download_progress_bar(file_size=file_size)
+        self._progress_bar = get_or_create_download_progress_bar(
+            file_size=file_size, postfix=self._download_request.object_id
+        )
         self._prep_file()
 
         # Create AsyncIO tasks to download each of the parts according to chunk size

--- a/synapseclient/core/download/download_async.py
+++ b/synapseclient/core/download/download_async.py
@@ -20,7 +20,7 @@ from opentelemetry import context
 from opentelemetry.context import Context
 from tqdm import tqdm
 
-from synapseclient.api import get_file_handle_for_download
+from synapseclient.api.file_services import get_file_handle_for_download
 from synapseclient.core.async_utils import wrap_async_to_sync
 from synapseclient.core.exceptions import (
     SynapseDownloadAbortedException,

--- a/synapseclient/core/download/download_async.py
+++ b/synapseclient/core/download/download_async.py
@@ -434,7 +434,11 @@ class _MultithreadedDownloader:
 
     def _close_progress_bar(self) -> None:
         """Handle closing the progress bar."""
-        if not self._syn.silent and self._progress_bar and self._close_progress_bar:
+        if (
+            not self._syn.silent
+            and self._progress_bar
+            and self._should_close_progress_bar
+        ):
             self._progress_bar.close()
 
     def _generate_stream_and_write_chunk_tasks(

--- a/synapseclient/core/download/download_async.py
+++ b/synapseclient/core/download/download_async.py
@@ -138,15 +138,14 @@ class PresignedUrlProvider:
             Information about a retrieved presigned-url from either the cache or a
             new request
         """
-        with self._lock:
-            if not self._cached_info or (
-                datetime.datetime.now(tz=datetime.timezone.utc)
-                + PresignedUrlProvider._TIME_BUFFER
-                >= self._cached_info.expiration_utc
-            ):
-                self._cached_info = await self._get_pre_signed_info_async()
+        if not self._cached_info or (
+            datetime.datetime.now(tz=datetime.timezone.utc)
+            + PresignedUrlProvider._TIME_BUFFER
+            >= self._cached_info.expiration_utc
+        ):
+            self._cached_info = await self._get_pre_signed_info_async()
 
-            return self._cached_info
+        return self._cached_info
 
     def get_info(self) -> PresignedUrlInfo:
         """

--- a/synapseclient/core/download/download_async.py
+++ b/synapseclient/core/download/download_async.py
@@ -306,9 +306,6 @@ class _MultithreadedDownloader:
     async def download_file(self) -> None:
         """
         Splits up and downloads a file in chunks from a URL.
-
-        Arguments:
-            request: A DownloadRequest object specifying what Synapse file to download.
         """
         url_provider = PresignedUrlProvider(self._syn, request=self._download_request)
 
@@ -443,6 +440,19 @@ class _MultithreadedDownloader:
         end: int,
         otel_context: Union[Context, None],
     ) -> Tuple[int, int]:
+        """
+        Wrapper around the actual download logic to handle retries and range requests.
+
+        Arguments:
+            session: An httpx.Client
+            presigned_url_provider: A URL provider for the presigned urls
+            start: The start byte of the range to download
+            end: The end byte of the range to download
+            otel_context: The OpenTelemetry context if known, else None
+
+        Returns:
+            The start and end bytes of the range downloaded
+        """
         if otel_context:
             context.attach(otel_context)
         self._check_for_abort(start=start, end=end)

--- a/synapseclient/core/download/download_async.py
+++ b/synapseclient/core/download/download_async.py
@@ -188,7 +188,7 @@ class PresignedUrlProvider:
             expiration_utc=_pre_signed_url_expiration_time(pre_signed_url),
         )
 
-    def _get_pre_signed_info_async(self) -> PresignedUrlInfo:
+    async def _get_pre_signed_info_async(self) -> PresignedUrlInfo:
         """
         Make an HTTP request to get a pre-signed url to download a file.
 

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -178,7 +178,7 @@ async def download_file_entity(
 
 
 async def download_file_entity_model(
-    download_location: str,
+    download_location: Union[str, None],
     file: "File",
     if_collision: str,
     submission: str,

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -11,7 +11,7 @@ import urllib.request as urllib_request
 from typing import TYPE_CHECKING, Dict, Optional, Union
 
 from synapseclient.api.configuration_services import get_client_authenticated_s3_profile
-from synapseclient.api.file_services import get_file_handle_for_download
+from synapseclient.api.file_services import get_file_handle_for_download_async
 from synapseclient.core import exceptions, sts_transfer, utils
 from synapseclient.core.constants import concrete_types
 from synapseclient.core.constants.method_flags import (
@@ -373,7 +373,7 @@ async def download_by_file_handle(
 
     while retries > 0:
         try:
-            file_handle_result = await get_file_handle_for_download(
+            file_handle_result = await get_file_handle_for_download_async(
                 file_handle_id=file_handle_id,
                 synapse_id=synapse_id,
                 entity_type=entity_type,
@@ -457,6 +457,7 @@ async def download_by_file_handle(
                 )
 
             else:
+                # TODO: Migrate this function as well. Internally all these calls are blocking
                 downloaded_path = await download_from_url(
                     url=file_handle_result["preSignedURL"],
                     destination=destination,

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -556,7 +556,7 @@ async def download_from_url_multi_threaded(
                 f"Downloaded file {temp_destination}'s md5 {actual_md5} does not match expected MD5 of {expected_md5}"
             )
     # once download completed, rename to desired destination
-    shutil.move(temp_destination, dst=destination)
+    shutil.move(temp_destination, destination)
     client.logger.info(f"Downloaded {object_id} to {destination}")
 
     return destination

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -280,6 +280,7 @@ async def download_by_file_handle(
     entity_type: str,
     destination: str,
     retries: int = 5,
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> str:
     """
@@ -855,6 +856,7 @@ def resolve_download_path_collisions(
     if_collision: str,
     synapse_cache_location: str,
     cached_file_path: str,
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> Union[str, None]:
     """
@@ -937,6 +939,7 @@ def ensure_download_location_is_directory(download_location: str) -> str:
 
 def is_synapse_uri(
     uri: str,
+    *,
     synapse_client: Optional["Synapse"] = None,
 ) -> bool:
     """

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -556,7 +556,8 @@ async def download_from_url_multi_threaded(
                 f"Downloaded file {temp_destination}'s md5 {actual_md5} does not match expected MD5 of {expected_md5}"
             )
     # once download completed, rename to desired destination
-    shutil.move(temp_destination, destination)
+    shutil.move(temp_destination, dst=destination)
+    client.logger.info(f"Downloaded {object_id} to {destination}")
 
     return destination
 
@@ -673,15 +674,7 @@ def download_from_url(
                 if is_synapse_uri(uri=url, synapse_client=client)
                 else None
             )
-            # TODO: Some more work is needed for streaming this data:
-            # https://www.python-httpx.org/quickstart/#streaming-responses
-            # response = await client.rest_get_async(
-            #     uri=url,
-            #     headers=client._generate_headers(range_header),
-            #     stream=True,
-            #     allow_redirects=False,
-            #     auth=auth,
-            # )
+
             response = with_retry(
                 lambda url=url, range_header=range_header, auth=auth: client._requests_session.get(
                     url=url,

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -10,10 +10,8 @@ import urllib.parse as urllib_urlparse
 import urllib.request as urllib_request
 from typing import TYPE_CHECKING, Dict, Optional, Union
 
-from synapseclient.api import (
-    get_client_authenticated_s3_profile,
-    get_file_handle_for_download,
-)
+from synapseclient.api.configuration_services import get_client_authenticated_s3_profile
+from synapseclient.api.file_services import get_file_handle_for_download
 from synapseclient.core import exceptions, sts_transfer, utils
 from synapseclient.core.constants import concrete_types
 from synapseclient.core.constants.method_flags import (

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -189,8 +189,6 @@ async def download_file_entity_model(
     client = Synapse.get_client(synapse_client=synapse_client)
     # set the initial local state
     file.path = None
-    # file.files = []
-    # file.cacheDir = None
 
     # check to see if an UNMODIFIED version of the file (since it was last downloaded) already exists
     # this location could be either in .synapseCache or a user specified location to which the user previously
@@ -259,8 +257,6 @@ async def download_file_entity_model(
 
     # converts the path format from forward slashes back to backward slashes on Windows
     file.path = os.path.normpath(download_path)
-    # file.files = [os.path.basename(download_path)]
-    # file.cacheDir = os.path.dirname(download_path)
 
 
 def _get_aws_credentials() -> None:
@@ -273,7 +269,6 @@ async def download_by_file_handle(
     synapse_id: str,
     entity_type: str,
     destination: str,
-    # TODO: Update this retries to be time based to match the upload logic
     retries: int = 5,
     synapse_client: Optional["Synapse"] = None,
 ) -> str:
@@ -647,6 +642,7 @@ def download_from_url(
                     None
                 """
                 show_progress = not client.silent
+                # TODO: Convert progress bar over to shared progress bar for sync
                 if show_progress:
                     client._print_transfer_progress(
                         transferred=block_number * read_size,

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -636,7 +636,7 @@ def download_from_url(
             destination = utils.file_url_to_path(url, verify_exists=True)
             if destination is None:
                 raise IOError(f"Local file ({url}) does not exist.")
-            if progress_bar:
+            if progress_bar is not None:
                 file_size = os.path.getsize(destination)
                 increment_progress_bar_total(total=file_size, progress_bar=progress_bar)
                 increment_progress_bar(n=progress_bar.total, progress_bar=progress_bar)
@@ -670,7 +670,7 @@ def download_from_url(
                     None
                 """
                 nonlocal updated_progress_bar_with_total
-                if progress_bar:
+                if progress_bar is not None:
                     if not updated_progress_bar_with_total:
                         updated_progress_bar_with_total = True
                         increment_progress_bar_total(

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -473,7 +473,9 @@ async def download_by_file_handle(
                     ),
                 )
 
-            syn.cache.add(file_handle["id"], downloaded_path)
+            syn.cache.add(
+                file_handle["id"], downloaded_path, file_handle.get("contentMd5", None)
+            )
             return downloaded_path
 
         except Exception as ex:

--- a/synapseclient/core/exceptions.py
+++ b/synapseclient/core/exceptions.py
@@ -31,7 +31,11 @@ class SynapseTimeoutError(SynapseError):
 
 
 class SynapseAuthenticationError(SynapseError):
-    """Unauthorized access."""
+    """Authentication errors."""
+
+
+class SynapseAuthorizationError(SynapseError):
+    """Authorization errors."""
 
 
 class SynapseNoCredentialsError(SynapseAuthenticationError):

--- a/synapseclient/core/multithread_download/download_threads.py
+++ b/synapseclient/core/multithread_download/download_threads.py
@@ -17,7 +17,6 @@ from requests import Response, Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from synapseclient.api import get_file_handle_for_download
 from synapseclient.core.exceptions import SynapseError, _raise_for_status
 from synapseclient.core.pool_provider import get_executor
 from synapseclient.core.retry import (
@@ -169,18 +168,16 @@ class PresignedUrlProvider(object):
         Returns:
             PresignedUrlInfo
         """
-        response = get_file_handle_for_download(
-            file_handle_id=self.request.file_handle_id,
-            synapse_id=self.request.object_id,
-            entity_type=self.request.object_type,
-            synapse_client=self.client,
+        # noinspection PyProtectedMember
+        response = self.client._getFileHandleDownload(
+            self.request.file_handle_id,
+            self.request.object_id,
+            objectType=self.request.object_type,
         )
         file_name = response["fileHandle"]["fileName"]
         pre_signed_url = response["preSignedURL"]
         return PresignedUrlInfo(
-            file_name=file_name,
-            url=pre_signed_url,
-            expiration_utc=_pre_signed_url_expiration_time(pre_signed_url),
+            file_name, pre_signed_url, _pre_signed_url_expiration_time(pre_signed_url)
         )
 
 

--- a/synapseclient/core/multithread_download/download_threads.py
+++ b/synapseclient/core/multithread_download/download_threads.py
@@ -18,7 +18,6 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from synapseclient.api import get_file_handle_for_download
-from synapseclient.core.async_utils import wrap_async_to_sync
 from synapseclient.core.exceptions import SynapseError, _raise_for_status
 from synapseclient.core.pool_provider import get_executor
 from synapseclient.core.retry import (
@@ -170,14 +169,11 @@ class PresignedUrlProvider(object):
         Returns:
             PresignedUrlInfo
         """
-        response = wrap_async_to_sync(
-            coroutine=get_file_handle_for_download(
-                file_handle_id=self.request.file_handle_id,
-                synapse_id=self.request.object_id,
-                entity_type=self.request.object_type,
-                synapse_client=self.client,
-            ),
-            syn=self.client,
+        response = get_file_handle_for_download(
+            file_handle_id=self.request.file_handle_id,
+            synapse_id=self.request.object_id,
+            entity_type=self.request.object_type,
+            synapse_client=self.client,
         )
         file_name = response["fileHandle"]["fileName"]
         pre_signed_url = response["preSignedURL"]

--- a/synapseclient/core/remote_file_storage_wrappers.py
+++ b/synapseclient/core/remote_file_storage_wrappers.py
@@ -75,7 +75,7 @@ class S3ClientWrapper:
         *,
         profile_name: str = None,
         credentials: typing.Dict[str, str] = None,
-        progress_bar: tqdm = None,
+        progress_bar: Union[tqdm, None] = None,
         transfer_config_kwargs: dict = None,
     ) -> str:
         """
@@ -316,7 +316,7 @@ class SFTPWrapper:
         localFilepath: str = None,
         username: str = None,
         password: str = None,
-        progress_bar: tqdm = None,
+        progress_bar: Union[tqdm, None] = None,
     ) -> str:
         """
         Performs download of a file from an sftp server.

--- a/synapseclient/core/remote_file_storage_wrappers.py
+++ b/synapseclient/core/remote_file_storage_wrappers.py
@@ -123,7 +123,7 @@ class S3ClientWrapper:
 
             progress_callback = None
 
-            if progress_bar:
+            if progress_bar is not None:
                 s3_obj.load()
                 file_size = s3_obj.content_length
                 increment_progress_bar_total(total=file_size, progress_bar=progress_bar)
@@ -228,7 +228,7 @@ class S3ClientWrapper:
             Config=transfer_config,
             ExtraArgs={"ACL": "bucket-owner-full-control"},
         )
-        if progress_bar:
+        if progress_bar is not None:
             progress_bar.close()
         return upload_file_path
 
@@ -369,7 +369,7 @@ class SFTPWrapper:
                 path,
                 localFilepath,
                 preserve_mtime=True,
-                callback=(progress_callback),
+                callback=(progress_callback if progress_bar is not None else None),
             )
         return localFilepath
 

--- a/synapseclient/core/transfer_bar.py
+++ b/synapseclient/core/transfer_bar.py
@@ -70,6 +70,15 @@ def shared_download_progress_bar(
 ):
     """An outside process that will eventually trigger a download through this module
     can configure a shared Progress Bar by running its code within this context manager.
+
+    Arguments:
+        file_size: The size of the file being downloaded.
+        synapse_client: If not passed in or None this will use the last client from
+            the `.login()` method.
+
+    Yields:
+        A context manager that will handle the download progress bar.
+
     """
     _thread_local.progress_bar_download_context_managed = True
     from synapseclient import Synapse

--- a/synapseclient/core/transfer_bar.py
+++ b/synapseclient/core/transfer_bar.py
@@ -1,0 +1,130 @@
+"""Logic used to handle progress bars for file uploads and downloads."""
+try:
+    import threading as _threading
+except ImportError:
+    import dummy_threading as _threading
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Optional, Union
+
+from tqdm import tqdm
+from tqdm.contrib.logging import logging_redirect_tqdm
+
+if TYPE_CHECKING:
+    from synapseclient import Synapse
+
+_thread_local = _threading.local()
+
+
+@contextmanager
+def shared_progress_bar(progress_bar: tqdm, syn: "Synapse"):
+    """An outside process that will eventually trigger an upload through this module
+    can configure a shared Progress Bar by running its code within this context manager.
+    """
+    with logging_redirect_tqdm(loggers=[syn.logger]):
+        _thread_local.progress_bar = progress_bar
+        try:
+            yield
+        finally:
+            _thread_local.progress_bar.close()
+            _thread_local.progress_bar.refresh()
+            del _thread_local.progress_bar
+
+
+def increment_progress_bar_total(total: int, progress_bar: Union[tqdm, None]) -> None:
+    """Update the total size of the progress bar.
+
+    Arguments:
+        total: The total size of the progress bar.
+        progress_bar: The progress bar
+
+    Returns:
+        None
+    """
+    if not progress_bar:
+        return None
+    progress_bar.total = total + (progress_bar.total if progress_bar.total else 0)
+    progress_bar.refresh()
+
+
+def increment_progress_bar(n: int, progress_bar: Union[tqdm, None]) -> None:
+    """None safe update the the progress bar.
+
+    Arguments:
+        n: The amount to increment the progress bar by.
+        progress_bar: The progress bar
+
+    Returns:
+        None
+    """
+    if not progress_bar:
+        return None
+    progress_bar.update(n)
+
+
+@contextmanager
+def shared_download_progress_bar(
+    file_size: int, *, synapse_client: Optional["Synapse"] = None
+):
+    """An outside process that will eventually trigger a download through this module
+    can configure a shared Progress Bar by running its code within this context manager.
+    """
+    _thread_local.progress_bar_download_context_managed = True
+    from synapseclient import Synapse
+
+    syn = Synapse.get_client(synapse_client=synapse_client)
+    with logging_redirect_tqdm(loggers=[syn.logger]):
+        get_or_create_download_progress_bar(file_size=file_size)
+        try:
+            yield
+        finally:
+            _thread_local.progress_bar_download_context_managed = False
+            if _thread_local.progress_bar_download:
+                _thread_local.progress_bar_download.close()
+                _thread_local.progress_bar_download.refresh()
+                del _thread_local.progress_bar_download
+
+
+def close_download_progress_bar() -> None:
+    """Handle closing the download progress bar if it is not context managed."""
+    if not _is_context_managed_download_bar():
+        progress_bar: tqdm = getattr(_thread_local, "progress_bar_download", None)
+        if progress_bar:
+            progress_bar.close()
+            progress_bar.refresh()
+            del _thread_local.progress_bar_download
+
+
+def _is_context_managed_download_bar() -> bool:
+    """Return whether a download progress bar has been started."""
+    return getattr(_thread_local, "progress_bar_download_context_managed", False)
+
+
+def get_or_create_download_progress_bar(
+    file_size: int, *, synapse_client: Optional["Synapse"] = None
+) -> Union[tqdm, None]:
+    """Return the existing progress bar if it exists, otherwise create a new one."""
+
+    from synapseclient import Synapse
+
+    syn = Synapse.get_client(synapse_client=synapse_client)
+
+    if syn.silent:
+        return None
+
+    progress_bar: tqdm = getattr(_thread_local, "progress_bar_download", None)
+    if progress_bar is None:
+        progress_bar = tqdm(
+            total=file_size,
+            desc="Downloading files",
+            unit="B",
+            unit_scale=True,
+            smoothing=0,
+        )
+        _thread_local.progress_bar_download = progress_bar
+    else:
+        progress_bar.total = file_size + (
+            progress_bar.total if progress_bar.total else 0
+        )
+        progress_bar.refresh()
+    return progress_bar

--- a/synapseclient/core/transfer_bar.py
+++ b/synapseclient/core/transfer_bar.py
@@ -41,9 +41,11 @@ def increment_progress_bar_total(total: int, progress_bar: Union[tqdm, None]) ->
     Returns:
         None
     """
-    if not progress_bar:
+    if progress_bar is None:
         return None
-    progress_bar.total = total + (progress_bar.total if progress_bar.total > 1 else 0)
+    progress_bar.total = total + (
+        progress_bar.total if progress_bar.total and progress_bar.total > 1 else 0
+    )
     progress_bar.refresh()
 
 
@@ -89,7 +91,7 @@ def close_download_progress_bar() -> None:
     """Handle closing the download progress bar if it is not context managed."""
     if not _is_context_managed_download_bar():
         progress_bar: tqdm = getattr(_thread_local, "progress_bar_download", None)
-        if progress_bar:
+        if progress_bar is not None:
             progress_bar.close()
             progress_bar.refresh()
             del _thread_local.progress_bar_download
@@ -133,7 +135,7 @@ def get_or_create_download_progress_bar(
         _thread_local.progress_bar_download = progress_bar
     else:
         progress_bar.total = file_size + (
-            progress_bar.total if progress_bar.total > 1 else 0
+            progress_bar.total if progress_bar.total and progress_bar.total > 1 else 0
         )
         progress_bar.postfix = None
         progress_bar.refresh()

--- a/synapseclient/core/upload/upload_functions.py
+++ b/synapseclient/core/upload/upload_functions.py
@@ -243,7 +243,7 @@ def create_external_file_handle(
         url, mimetype=mimetype, md5=md5, fileSize=file_size
     )
     if is_local_file:
-        syn.cache.add(file_handle["id"], file_url_to_path(url))
+        syn.cache.add(file_handle["id"], file_url_to_path(url), md5=md5)
     trace.get_current_span().set_attributes(
         {"synapse.file_handle_id": file_handle["id"]}
     )
@@ -257,14 +257,14 @@ def upload_external_file_handle_sftp(
     uploaded_url = SFTPWrapper.upload_file(
         file_path, urllib_parse.unquote(sftp_url), username, password
     )
-
+    md5 = md5 or md5_for_file(file_path).hexdigest()
     file_handle = syn._createExternalFileHandle(
         externalURL=uploaded_url,
         mimetype=mimetype,
-        md5=md5 or md5_for_file(file_path).hexdigest(),
+        md5=md5,
         fileSize=os.stat(file_path).st_size,
     )
-    syn.cache.add(file_handle["id"], file_path)
+    syn.cache.add(file_handle["id"], file_path, md5=md5)
     return file_handle
 
 
@@ -371,6 +371,6 @@ def upload_client_auth_s3(
         mimetype=mimetype,
         md5=md5,
     )
-    syn.cache.add(file_handle["id"], file_path)
+    syn.cache.add(file_handle["id"], file_path, md5=md5)
 
     return file_handle

--- a/synapseclient/models/activity.py
+++ b/synapseclient/models/activity.py
@@ -168,6 +168,8 @@ class Activity(ActivitySynchronousProtocol):
         Returns:
             The Activity object.
         """
+        if not synapse_activity:
+            synapse_activity = {}
         self.id = synapse_activity.get("id", None)
         self.name = synapse_activity.get("name", None)
         self.description = synapse_activity.get("description", None)
@@ -375,7 +377,10 @@ class Activity(ActivitySynchronousProtocol):
                     return None
                 else:
                     raise ex
-            return cls().fill_from_dict(synapse_activity=synapse_activity)
+            if synapse_activity:
+                return cls().fill_from_dict(synapse_activity=synapse_activity)
+            else:
+                return None
 
     @classmethod
     async def delete_async(

--- a/synapseclient/models/activity.py
+++ b/synapseclient/models/activity.py
@@ -262,6 +262,7 @@ class Activity(ActivitySynchronousProtocol):
     async def store_async(
         self,
         parent: Optional[Union["Table", "File"]] = None,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "Activity":
         """
@@ -337,6 +338,7 @@ class Activity(ActivitySynchronousProtocol):
     async def from_parent_async(
         cls,
         parent: Union["Table", "File"],
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> Union["Activity", None]:
         """
@@ -386,6 +388,7 @@ class Activity(ActivitySynchronousProtocol):
     async def delete_async(
         cls,
         parent: Union["Table", "File"],
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> None:
         """
@@ -427,6 +430,7 @@ class Activity(ActivitySynchronousProtocol):
     async def disassociate_from_entity_async(
         cls,
         parent: Union["Table", "File"],
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> None:
         """

--- a/synapseclient/models/annotations.py
+++ b/synapseclient/models/annotations.py
@@ -62,6 +62,7 @@ class Annotations(AnnotationsSynchronousProtocol):
 
     async def store_async(
         self,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "Annotations":
         """Storing annotations to synapse.

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -657,19 +657,10 @@ class File(FileSynchronousProtocol, AccessControllable):
             )
         )
 
-    async def _load_local_md5(self, syn: "Synapse") -> None:
+    async def _load_local_md5(self) -> None:
         """Load the MD5 of the file if it's a local file and we have not already loaded
         it."""
         if not self.content_md5 and self.path and os.path.isfile(self.path):
-            # self.content_md5 = await utils.md5_for_file_multiprocessing(
-            #     filename=self.path,
-            #     process_pool_executor=syn._get_process_pool_executor(
-            #         asyncio_event_loop=asyncio.get_running_loop()
-            #     ),
-            #     md5_semaphore=syn._get_md5_semaphore(
-            #         asyncio_event_loop=asyncio.get_running_loop()
-            #     ),
-            # )
             self.content_md5 = utils.md5_for_file_hex(filename=self.path)
 
     async def _find_existing_file(
@@ -1009,7 +1000,7 @@ class File(FileSynchronousProtocol, AccessControllable):
             raise ValueError("The file must have an ID or path to get.")
         syn = Synapse.get_client(synapse_client=synapse_client)
 
-        await self._load_local_md5(syn)
+        await self._load_local_md5()
 
         await get_from_entity_factory(
             entity_to_update=self,
@@ -1286,7 +1277,7 @@ class File(FileSynchronousProtocol, AccessControllable):
                     and os.path.isfile(self.path)
                     and md5_stored_in_synapse
                 ):
-                    await self._load_local_md5(syn)
+                    await self._load_local_md5()
                     if md5_stored_in_synapse == (
                         local_file_md5_hex := self.content_md5
                     ):

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -690,7 +690,8 @@ class File(FileSynchronousProtocol, AccessControllable):
                 )
                 return await file_copy.get_async(
                     synapse_client=synapse_client,
-                    include_activity=self.activity is not None,
+                    include_activity=self.activity is not None
+                    or self.associate_activity_to_new_version,
                 )
             except SynapseFileNotFoundError:
                 return None

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -664,7 +664,7 @@ class File(FileSynchronousProtocol, AccessControllable):
             self.content_md5 = utils.md5_for_file_hex(filename=self.path)
 
     async def _find_existing_file(
-        self, synapse_client: Optional[Synapse] = None
+        self, *, synapse_client: Optional[Synapse] = None
     ) -> Union["File", None]:
         """Determines if the file already exists in Synapse. If it does it will return
         the file object, otherwise it will return None. This is used to determine if the
@@ -742,6 +742,7 @@ class File(FileSynchronousProtocol, AccessControllable):
     async def store_async(
         self,
         parent: Optional[Union["Folder", "Project"]] = None,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "File":
         """
@@ -890,6 +891,7 @@ class File(FileSynchronousProtocol, AccessControllable):
         name: Optional[str] = None,
         download_as: Optional[str] = None,
         content_type: Optional[str] = None,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "File":
         """
@@ -1037,6 +1039,7 @@ class File(FileSynchronousProtocol, AccessControllable):
     async def from_id_async(
         cls,
         synapse_id: str,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "File":
         """Wrapper for [synapseclient.models.File.get][].
@@ -1062,6 +1065,7 @@ class File(FileSynchronousProtocol, AccessControllable):
     async def from_path_async(
         cls,
         path: str,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "File":
         """Get the file from Synapse. If the path of the file matches multiple files
@@ -1094,6 +1098,7 @@ class File(FileSynchronousProtocol, AccessControllable):
     async def delete_async(
         self,
         version_only: Optional[bool] = False,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> None:
         """
@@ -1149,6 +1154,7 @@ class File(FileSynchronousProtocol, AccessControllable):
         update_existing: bool = False,
         copy_annotations: bool = True,
         copy_activity: Union[str, None] = "traceback",
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "File":
         """
@@ -1306,6 +1312,7 @@ class File(FileSynchronousProtocol, AccessControllable):
 
     async def _upload_file(
         self,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "File":
         """The upload process for a file. This will upload the file to Synapse if it

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -689,7 +689,8 @@ class File(FileSynchronousProtocol, AccessControllable):
                     parent_id=self.parent_id,
                 )
                 return await file_copy.get_async(
-                    synapse_client=synapse_client, include_activity=True
+                    synapse_client=synapse_client,
+                    include_activity=self.activity is not None,
                 )
             except SynapseFileNotFoundError:
                 return None

--- a/synapseclient/models/folder.py
+++ b/synapseclient/models/folder.py
@@ -211,6 +211,7 @@ class Folder(FolderSynchronousProtocol, AccessControllable, StorableContainer):
         self,
         parent: Optional[Union["Folder", "Project"]] = None,
         failure_strategy: FailureStrategy = FailureStrategy.LOG_EXCEPTION,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "Folder":
         """Store folders and files to synapse. If you have any files or folders attached
@@ -306,6 +307,7 @@ class Folder(FolderSynchronousProtocol, AccessControllable, StorableContainer):
     async def get_async(
         self,
         parent: Optional[Union["Folder", "Project"]] = None,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "Folder":
         """Get the folder metadata from Synapse. You are able to find a folder by
@@ -344,7 +346,7 @@ class Folder(FolderSynchronousProtocol, AccessControllable, StorableContainer):
     @otel_trace_method(
         method_to_trace_name=lambda self, **kwargs: f"Folder_Delete: {self.id}"
     )
-    async def delete_async(self, synapse_client: Optional[Synapse] = None) -> None:
+    async def delete_async(self, *, synapse_client: Optional[Synapse] = None) -> None:
         """Delete the folder from Synapse by its id.
 
         Arguments:
@@ -381,6 +383,7 @@ class Folder(FolderSynchronousProtocol, AccessControllable, StorableContainer):
         exclude_types: Optional[List[str]] = None,
         file_update_existing: bool = False,
         file_copy_activity: Union[str, None] = "traceback",
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "Folder":
         """

--- a/synapseclient/models/folder.py
+++ b/synapseclient/models/folder.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union
 from opentelemetry import context, trace
 
 from synapseclient import Synapse
+from synapseclient.api import get_from_entity_factory
 from synapseclient.core.async_utils import async_to_sync, otel_trace_method
 from synapseclient.core.exceptions import SynapseError
 from synapseclient.core.utils import (
@@ -330,22 +331,12 @@ class Folder(FolderSynchronousProtocol, AccessControllable, StorableContainer):
             )
         self.parent_id = parent_id
 
-        loop = asyncio.get_event_loop()
-        current_context = context.get_current()
-
         entity_id = await get_id(entity=self, synapse_client=synapse_client)
 
-        entity = await loop.run_in_executor(
-            None,
-            lambda: run_and_attach_otel_context(
-                lambda: Synapse.get_client(synapse_client=synapse_client).get(
-                    entity=entity_id,
-                ),
-                current_context,
-            ),
+        await get_from_entity_factory(
+            entity_to_update=self,
+            synapse_id_or_path=entity_id,
         )
-
-        self.fill_from_dict(synapse_folder=entity, set_annotations=True)
 
         self._set_last_persistent_instance()
         return self

--- a/synapseclient/models/mixins/access_control.py
+++ b/synapseclient/models/mixins/access_control.py
@@ -28,6 +28,7 @@ class AccessControllable(AccessControllableSynchronousProtocol):
 
     async def get_permissions_async(
         self,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "Permissions":
         """
@@ -65,7 +66,7 @@ class AccessControllable(AccessControllableSynchronousProtocol):
         )
 
     async def get_acl_async(
-        self, principal_id: int = None, synapse_client: Optional[Synapse] = None
+        self, principal_id: int = None, *, synapse_client: Optional[Synapse] = None
     ) -> List[str]:
         """
         Get the [ACL][synapseclient.core.models.permission.Permissions.access_types]
@@ -102,6 +103,7 @@ class AccessControllable(AccessControllableSynchronousProtocol):
         modify_benefactor: bool = False,
         warn_if_inherits: bool = True,
         overwrite: bool = True,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> Dict[str, Union[str, list]]:
         """

--- a/synapseclient/models/mixins/storable_container.py
+++ b/synapseclient/models/mixins/storable_container.py
@@ -193,6 +193,8 @@ class StorableContainer(StorableContainerSynchronousProtocol):
                         alt Recursive is True
                             note over sync_from_synapse: Append `folder.sync_from_synapse()` method
                         end
+                    else Child is Link and hops > 0
+                        note over sync_from_synapse: Append task to follow link
                     end
                 end
 
@@ -210,6 +212,11 @@ class StorableContainer(StorableContainerSynchronousProtocol):
                     and `folder.sync_from_synapse_async()`
                         note over sync_from_synapse: This is a recursive call to `sync_from_synapse`
                         sync_from_synapse->>sync_from_synapse: Recursive call to `.sync_from_synapse_async()`
+                    and `_follow_link`
+                        sync_from_synapse ->>client: call `get_entity_id_bundle2` function
+                        client-->sync_from_synapse: .
+                        note over sync_from_synapse: Do nothing if not link
+                        note over sync_from_synapse: call `_create_task_for_child` and execute
                     end
                 end
 

--- a/synapseclient/models/mixins/storable_container.py
+++ b/synapseclient/models/mixins/storable_container.py
@@ -53,7 +53,7 @@ class StorableContainer(StorableContainerSynchronousProtocol):
     folders: "Folder" = None
     _last_persistent_instance: None = None
 
-    async def get_async(self, synapse_client: Optional[Synapse] = None) -> None:
+    async def get_async(self, *, synapse_client: Optional[Synapse] = None) -> None:
         """Used to satisfy the usage in this mixin from the parent class."""
 
     @otel_trace_method(
@@ -356,6 +356,7 @@ class StorableContainer(StorableContainerSynchronousProtocol):
     def _retrieve_children(
         self,
         follow_link: bool,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> List:
         """
@@ -604,6 +605,7 @@ class StorableContainer(StorableContainerSynchronousProtocol):
         self,
         result: Union[None, "Folder", "File", BaseException],
         failure_strategy: FailureStrategy,
+        *,
         synapse_client: Union[None, Synapse],
     ) -> None:
         """

--- a/synapseclient/models/project.py
+++ b/synapseclient/models/project.py
@@ -239,6 +239,7 @@ class Project(ProjectSynchronousProtocol, AccessControllable, StorableContainer)
     async def store_async(
         self,
         failure_strategy: FailureStrategy = FailureStrategy.LOG_EXCEPTION,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "Project":
         """
@@ -340,6 +341,7 @@ class Project(ProjectSynchronousProtocol, AccessControllable, StorableContainer)
     )
     async def get_async(
         self,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "Project":
         """Get the project metadata from Synapse.
@@ -377,7 +379,7 @@ class Project(ProjectSynchronousProtocol, AccessControllable, StorableContainer)
     @otel_trace_method(
         method_to_trace_name=lambda self, **kwargs: f"Project_Delete: {self.id}, Name: {self.name}"
     )
-    async def delete_async(self, synapse_client: Optional[Synapse] = None) -> None:
+    async def delete_async(self, *, synapse_client: Optional[Synapse] = None) -> None:
         """Delete the project from Synapse.
 
         Arguments:
@@ -425,6 +427,7 @@ class Project(ProjectSynchronousProtocol, AccessControllable, StorableContainer)
         exclude_types: Optional[List[str]] = None,
         file_update_existing: bool = False,
         file_copy_activity: Union[str, None] = "traceback",
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "Project":
         """

--- a/synapseclient/models/protocols/access_control_protocol.py
+++ b/synapseclient/models/protocols/access_control_protocol.py
@@ -17,6 +17,7 @@ class AccessControllableSynchronousProtocol(Protocol):
 
     def get_permissions(
         self,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "Permissions":
         """
@@ -43,7 +44,7 @@ class AccessControllableSynchronousProtocol(Protocol):
         return self
 
     def get_acl(
-        self, principal_id: int = None, synapse_client: Optional[Synapse] = None
+        self, principal_id: int = None, *, synapse_client: Optional[Synapse] = None
     ) -> List[str]:
         """
         Get the [ACL][synapseclient.core.models.permission.Permissions.access_types]
@@ -69,6 +70,7 @@ class AccessControllableSynchronousProtocol(Protocol):
         modify_benefactor: bool = False,
         warn_if_inherits: bool = True,
         overwrite: bool = True,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> Dict[str, Union[str, list]]:
         """

--- a/synapseclient/models/protocols/activity_protocol.py
+++ b/synapseclient/models/protocols/activity_protocol.py
@@ -18,6 +18,7 @@ class ActivitySynchronousProtocol(Protocol):
     def store(
         self,
         parent: Optional[Union["Table", "File"]] = None,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "Activity":
         """
@@ -43,6 +44,7 @@ class ActivitySynchronousProtocol(Protocol):
     def from_parent(
         cls,
         parent: Union["Table", "File"],
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> Union["Activity", None]:
         """
@@ -69,6 +71,7 @@ class ActivitySynchronousProtocol(Protocol):
     def delete(
         cls,
         parent: Union["Table", "File"],
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> None:
         """
@@ -93,6 +96,7 @@ class ActivitySynchronousProtocol(Protocol):
     async def disassociate_from_entity(
         cls,
         parent: Union["Table", "File"],
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> None:
         """

--- a/synapseclient/models/protocols/annotations_protocol.py
+++ b/synapseclient/models/protocols/annotations_protocol.py
@@ -17,6 +17,7 @@ class AnnotationsSynchronousProtocol(Protocol):
 
     def store(
         self,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "Annotations":
         """Storing annotations to synapse.

--- a/synapseclient/models/protocols/file_protocol.py
+++ b/synapseclient/models/protocols/file_protocol.py
@@ -20,6 +20,7 @@ class FileSynchronousProtocol(Protocol):
     def store(
         self,
         parent: Optional[Union["Folder", "Project"]] = None,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "File":
         """
@@ -79,6 +80,7 @@ class FileSynchronousProtocol(Protocol):
         name: Optional[str] = None,
         download_as: Optional[str] = None,
         content_type: Optional[str] = None,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "File":
         """
@@ -113,6 +115,7 @@ class FileSynchronousProtocol(Protocol):
     def get(
         self,
         include_activity: bool = False,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "File":
         """
@@ -159,6 +162,7 @@ class FileSynchronousProtocol(Protocol):
     def from_id(
         cls,
         synapse_id: str,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "File":
         """Wrapper for [synapseclient.models.File.get][].
@@ -184,6 +188,7 @@ class FileSynchronousProtocol(Protocol):
     def from_path(
         cls,
         path: str,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "File":
         """Get the file from Synapse. If the path of the file matches multiple files
@@ -213,6 +218,7 @@ class FileSynchronousProtocol(Protocol):
     def delete(
         self,
         version_only: Optional[bool] = False,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> None:
         """Delete the file from Synapse.
@@ -245,6 +251,7 @@ class FileSynchronousProtocol(Protocol):
         update_existing: bool = False,
         copy_annotations: bool = True,
         copy_activity: Union[str, None] = "traceback",
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "File":
         """

--- a/synapseclient/models/protocols/folder_protocol.py
+++ b/synapseclient/models/protocols/folder_protocol.py
@@ -20,6 +20,7 @@ class FolderSynchronousProtocol(Protocol):
         self,
         parent: Optional[Union["Folder", "Project"]] = None,
         failure_strategy: FailureStrategy = FailureStrategy.LOG_EXCEPTION,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "Folder":
         """Store folders and files to synapse. If you have any files or folders attached
@@ -51,6 +52,7 @@ class FolderSynchronousProtocol(Protocol):
     def get(
         self,
         parent: Optional[Union["Folder", "Project"]] = None,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "Folder":
         """Get the folder metadata from Synapse. You are able to find a folder by
@@ -70,7 +72,7 @@ class FolderSynchronousProtocol(Protocol):
         """
         return self
 
-    def delete(self, synapse_client: Optional[Synapse] = None) -> None:
+    def delete(self, *, synapse_client: Optional[Synapse] = None) -> None:
         """Delete the folder from Synapse by its id.
 
         Arguments:
@@ -92,6 +94,7 @@ class FolderSynchronousProtocol(Protocol):
         exclude_types: Optional[List[str]] = None,
         file_update_existing: bool = False,
         file_copy_activity: Union[str, None] = "traceback",
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "Folder":
         """

--- a/synapseclient/models/protocols/project_protocol.py
+++ b/synapseclient/models/protocols/project_protocol.py
@@ -19,6 +19,7 @@ class ProjectSynchronousProtocol(Protocol):
     def store(
         self,
         failure_strategy: FailureStrategy = FailureStrategy.LOG_EXCEPTION,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "Project":
         """
@@ -57,6 +58,7 @@ class ProjectSynchronousProtocol(Protocol):
 
     def get(
         self,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "Project":
         """
@@ -84,7 +86,7 @@ class ProjectSynchronousProtocol(Protocol):
         """
         return self
 
-    def delete(self, synapse_client: Optional[Synapse] = None) -> None:
+    def delete(self, *, synapse_client: Optional[Synapse] = None) -> None:
         """Delete the project from Synapse.
 
         Arguments:
@@ -117,6 +119,7 @@ class ProjectSynchronousProtocol(Protocol):
         exclude_types: Optional[List[str]] = None,
         file_update_existing: bool = False,
         file_copy_activity: Union[str, None] = "traceback",
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "Project":
         """

--- a/synapseclient/models/protocols/storable_container_protocol.py
+++ b/synapseclient/models/protocols/storable_container_protocol.py
@@ -23,6 +23,7 @@ class StorableContainerSynchronousProtocol(Protocol):
         download_file: bool = True,
         if_collision: str = COLLISION_OVERWRITE_LOCAL,
         failure_strategy: FailureStrategy = FailureStrategy.LOG_EXCEPTION,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> Self:
         """

--- a/synapseclient/models/protocols/table_protocol.py
+++ b/synapseclient/models/protocols/table_protocol.py
@@ -24,7 +24,7 @@ class ColumnSynchronousProtocol(Protocol):
     have a synchronous counterpart that may also be called.
     """
 
-    def store(self, synapse_client: Optional[Synapse] = None) -> Self:
+    def store(self, *, synapse_client: Optional[Synapse] = None) -> Self:
         """Persist the column to Synapse.
 
         :param synapse_client: If not passed in or None this will use the last client
@@ -41,7 +41,7 @@ class TableSynchronousProtocol(Protocol):
     """
 
     def store_rows_from_csv(
-        self, csv_path: str, synapse_client: Optional[Synapse] = None
+        self, csv_path: str, *, synapse_client: Optional[Synapse] = None
     ) -> str:
         """Takes in a path to a CSV and stores the rows to Synapse.
 
@@ -56,7 +56,7 @@ class TableSynchronousProtocol(Protocol):
         return ""
 
     def delete_rows(
-        self, rows: List["Row"], synapse_client: Optional[Synapse] = None
+        self, rows: List["Row"], *, synapse_client: Optional[Synapse] = None
     ) -> None:
         """Delete rows from a table.
 
@@ -70,7 +70,7 @@ class TableSynchronousProtocol(Protocol):
         """
         return None
 
-    def store_schema(self, synapse_client: Optional[Synapse] = None) -> "Table":
+    def store_schema(self, *, synapse_client: Optional[Synapse] = None) -> "Table":
         """Store non-row information about a table including the columns and annotations.
 
         Arguments:
@@ -82,7 +82,7 @@ class TableSynchronousProtocol(Protocol):
         """
         return self
 
-    def get(self, synapse_client: Optional[Synapse] = None) -> "Table":
+    def get(self, *, synapse_client: Optional[Synapse] = None) -> "Table":
         """Get the metadata about the table from synapse.
 
         Arguments:
@@ -94,7 +94,7 @@ class TableSynchronousProtocol(Protocol):
         """
         return self
 
-    def delete(self, synapse_client: Optional[Synapse] = None) -> None:
+    def delete(self, *, synapse_client: Optional[Synapse] = None) -> None:
         """Delete the table from synapse.
 
         Arguments:
@@ -111,6 +111,7 @@ class TableSynchronousProtocol(Protocol):
         cls,
         query: str,
         result_format: Union["CsvResultFormat", "RowsetResultFormat"] = None,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> Union[Synapse_CsvFileTable, Synaspe_TableQueryResult, None]:
         """Query for data on a table stored in Synapse.

--- a/synapseclient/models/protocols/team_protocol.py
+++ b/synapseclient/models/protocols/team_protocol.py
@@ -15,7 +15,7 @@ class TeamSynchronousProtocol(Protocol):
     have a synchronous counterpart that may also be called.
     """
 
-    def create(self, synapse_client: Optional[Synapse] = None) -> "Team":
+    def create(self, *, synapse_client: Optional[Synapse] = None) -> "Team":
         """Creates a new team on Synapse.
 
         Arguments:
@@ -27,7 +27,7 @@ class TeamSynchronousProtocol(Protocol):
         """
         return self
 
-    def delete(self, synapse_client: Optional[Synapse] = None) -> None:
+    def delete(self, *, synapse_client: Optional[Synapse] = None) -> None:
         """Deletes a team from Synapse.
 
         Arguments:
@@ -39,7 +39,7 @@ class TeamSynchronousProtocol(Protocol):
         """
         return None
 
-    def get(self, synapse_client: Optional[Synapse] = None) -> "Team":
+    def get(self, *, synapse_client: Optional[Synapse] = None) -> "Team":
         """
         Gets a Team from Synapse by ID or Name. If both are added to the Team instance
         it will use the ID.
@@ -57,7 +57,7 @@ class TeamSynchronousProtocol(Protocol):
         return self
 
     @classmethod
-    def from_id(cls, id: int, synapse_client: Optional[Synapse] = None) -> "Team":
+    def from_id(cls, id: int, *, synapse_client: Optional[Synapse] = None) -> "Team":
         """Gets Team object using its integer id.
 
         Arguments:
@@ -73,7 +73,9 @@ class TeamSynchronousProtocol(Protocol):
         return Team()
 
     @classmethod
-    def from_name(cls, name: str, synapse_client: Optional[Synapse] = None) -> "Team":
+    def from_name(
+        cls, name: str, *, synapse_client: Optional[Synapse] = None
+    ) -> "Team":
         """Gets Team object using its string name.
 
         *** You will be unable to retrieve a team by name immediately after its
@@ -93,7 +95,9 @@ class TeamSynchronousProtocol(Protocol):
 
         return Team()
 
-    def members(self, synapse_client: Optional[Synapse] = None) -> List["TeamMember"]:
+    def members(
+        self, *, synapse_client: Optional[Synapse] = None
+    ) -> List["TeamMember"]:
         """
         Gets the TeamMembers associated with a team given the ID field on the
         Team instance.
@@ -114,6 +118,7 @@ class TeamSynchronousProtocol(Protocol):
         user: str,
         message: str,
         force: bool = True,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> Dict[str, str]:
         """Invites a user to a team given the ID field on the Team instance.
@@ -130,7 +135,7 @@ class TeamSynchronousProtocol(Protocol):
         return {}
 
     def open_invitations(
-        self, synapse_client: Optional[Synapse] = None
+        self, *, synapse_client: Optional[Synapse] = None
     ) -> List[Dict[str, str]]:
         """Gets all open invitations for a team given the ID field on the Team instance.
 

--- a/synapseclient/models/protocols/user_protocol.py
+++ b/synapseclient/models/protocols/user_protocol.py
@@ -17,6 +17,7 @@ class UserProfileSynchronousProtocol(Protocol):
 
     def get(
         self,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "UserProfile":
         """
@@ -35,7 +36,7 @@ class UserProfileSynchronousProtocol(Protocol):
 
     @classmethod
     def from_id(
-        cls, user_id: int, synapse_client: Optional[Synapse] = None
+        cls, user_id: int, *, synapse_client: Optional[Synapse] = None
     ) -> "UserProfile":
         """Gets UserProfile object using its integer id. Wrapper for the
         [get][synapseclient.models.UserProfile.get] method.
@@ -54,7 +55,7 @@ class UserProfileSynchronousProtocol(Protocol):
 
     @classmethod
     def from_username(
-        cls, username: str, synapse_client: Optional[Synapse] = None
+        cls, username: str, *, synapse_client: Optional[Synapse] = None
     ) -> "UserProfile":
         """
         Gets UserProfile object using its string name. Wrapper for the
@@ -74,6 +75,7 @@ class UserProfileSynchronousProtocol(Protocol):
 
     def is_certified(
         self,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "bool":
         """

--- a/synapseclient/models/services/search.py
+++ b/synapseclient/models/services/search.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 async def get_id(
     entity: Union["Project", "Folder", "File"],
     failure_strategy: Optional[FailureStrategy] = FailureStrategy.RAISE_EXCEPTION,
+    *,
     synapse_client: Optional[Synapse] = None,
 ) -> Union[str, None]:
     """

--- a/synapseclient/models/services/storable_entity.py
+++ b/synapseclient/models/services/storable_entity.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 async def store_entity(
     resource: Union["File", "Folder", "Project"],
     entity: Dict[str, Union[str, bool, int, float]],
+    *,
     synapse_client: Optional[Synapse] = None,
 ) -> bool:
     """

--- a/synapseclient/models/services/storable_entity_components.py
+++ b/synapseclient/models/services/storable_entity_components.py
@@ -27,7 +27,9 @@ class FailureStrategy(Enum):
     processed."""
 
 
-async def wrap_coroutine(task: asyncio.Task, synapse_client: Optional[Synapse] = None):
+async def wrap_coroutine(
+    task: asyncio.Task, *, synapse_client: Optional[Synapse] = None
+):
     """
     Wrapper to handle exceptions in async tasks. By default as_completed will cause
     sibiling tasks to be cancelled if one fails. This wrapper will catch the exception
@@ -43,6 +45,7 @@ async def wrap_coroutine(task: asyncio.Task, synapse_client: Optional[Synapse] =
 async def store_entity_components(
     root_resource: Union["File", "Folder", "Project", "Table"],
     failure_strategy: FailureStrategy = FailureStrategy.LOG_EXCEPTION,
+    *,
     synapse_client: Optional[Synapse] = None,
 ) -> bool:
     """
@@ -112,6 +115,7 @@ async def store_entity_components(
 def _resolve_store_task(
     result: Union[bool, "Folder", "File", BaseException],
     failure_strategy: FailureStrategy = FailureStrategy.LOG_EXCEPTION,
+    *,
     synapse_client: Optional[Synapse] = None,
 ) -> bool:
     """
@@ -200,6 +204,7 @@ def _pull_activity_forward_to_new_version(
 
 async def _store_activity_and_annotations(
     root_resource: Union["File", "Folder", "Project", "Table"],
+    *,
     synapse_client: Optional[Synapse] = None,
 ) -> bool:
     """

--- a/synapseclient/models/table.py
+++ b/synapseclient/models/table.py
@@ -309,7 +309,9 @@ class Column(ColumnSynchronousProtocol):
     @otel_trace_method(
         method_to_trace_name=lambda self, **kwargs: f"Column_Store: {self.name}"
     )
-    async def store_async(self, synapse_client: Optional[Synapse] = None) -> "Column":
+    async def store_async(
+        self, *, synapse_client: Optional[Synapse] = None
+    ) -> "Column":
         """Persist the column to Synapse.
 
         Arguments:
@@ -505,7 +507,7 @@ class Table(TableSynchronousProtocol, AccessControllable):
         method_to_trace_name=lambda _, **kwargs: f"Store_rows_by_csv: {kwargs.get('csv_path', None)}"
     )
     async def store_rows_from_csv_async(
-        self, csv_path: str, synapse_client: Optional[Synapse] = None
+        self, csv_path: str, *, synapse_client: Optional[Synapse] = None
     ) -> str:
         """Takes in a path to a CSV and stores the rows to Synapse.
 
@@ -537,7 +539,7 @@ class Table(TableSynchronousProtocol, AccessControllable):
         method_to_trace_name=lambda self, **kwargs: f"Delete_rows: {self.name}"
     )
     async def delete_rows_async(
-        self, rows: List[Row], synapse_client: Optional[Synapse] = None
+        self, rows: List[Row], *, synapse_client: Optional[Synapse] = None
     ) -> None:
         """Delete rows from a table.
 
@@ -570,7 +572,7 @@ class Table(TableSynchronousProtocol, AccessControllable):
         method_to_trace_name=lambda self, **kwargs: f"Table_Schema_Store: {self.name}"
     )
     async def store_schema_async(
-        self, synapse_client: Optional[Synapse] = None
+        self, *, synapse_client: Optional[Synapse] = None
     ) -> "Table":
         """Store non-row information about a table including the columns and annotations.
 
@@ -645,7 +647,7 @@ class Table(TableSynchronousProtocol, AccessControllable):
     @otel_trace_method(
         method_to_trace_name=lambda self, **kwargs: f"Table_Get: {self.name}"
     )
-    async def get_async(self, synapse_client: Optional[Synapse] = None) -> "Table":
+    async def get_async(self, *, synapse_client: Optional[Synapse] = None) -> "Table":
         """Get the metadata about the table from synapse.
 
         Arguments:
@@ -675,7 +677,7 @@ class Table(TableSynchronousProtocol, AccessControllable):
     )
     # TODO: Synapse allows immediate deletion of entities, but the Synapse Client does not
     # TODO: Should we support immediate deletion?
-    async def delete_async(self, synapse_client: Optional[Synapse] = None) -> None:
+    async def delete_async(self, *, synapse_client: Optional[Synapse] = None) -> None:
         """Delete the table from synapse.
 
         Arguments:
@@ -702,6 +704,7 @@ class Table(TableSynchronousProtocol, AccessControllable):
         cls,
         query: str,
         result_format: Union[CsvResultFormat, RowsetResultFormat] = CsvResultFormat(),
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> Union[Synapse_CsvFileTable, Synaspe_TableQueryResult]:
         """Query for data on a table stored in Synapse.

--- a/synapseclient/models/team.py
+++ b/synapseclient/models/team.py
@@ -141,7 +141,7 @@ class Team(TeamSynchronousProtocol):
     @otel_trace_method(
         method_to_trace_name=lambda self, **kwargs: f"Team_Create: {self.name}"
     )
-    async def create_async(self, synapse_client: Optional[Synapse] = None) -> "Team":
+    async def create_async(self, *, synapse_client: Optional[Synapse] = None) -> "Team":
         """Creates a new team on Synapse.
 
         Arguments:
@@ -178,7 +178,7 @@ class Team(TeamSynchronousProtocol):
     @otel_trace_method(
         method_to_trace_name=lambda self, **kwargs: f"Team_Delete: {self.id}"
     )
-    async def delete_async(self, synapse_client: Optional[Synapse] = None) -> None:
+    async def delete_async(self, *, synapse_client: Optional[Synapse] = None) -> None:
         """Deletes a team from Synapse.
 
         Arguments:
@@ -203,7 +203,7 @@ class Team(TeamSynchronousProtocol):
     @otel_trace_method(
         method_to_trace_name=lambda self, **kwargs: f"Team_Get: {self.id if self.id else self.name}"
     )
-    async def get_async(self, synapse_client: Optional[Synapse] = None) -> "Team":
+    async def get_async(self, *, synapse_client: Optional[Synapse] = None) -> "Team":
         """
         Gets a Team from Synapse by ID or Name. If both are added to the Team instance
         it will use the ID.
@@ -251,7 +251,7 @@ class Team(TeamSynchronousProtocol):
         method_to_trace_name=lambda cls, id, **kwargs: f"Team_From_Id: {id}"
     )
     async def from_id_async(
-        cls, id: int, synapse_client: Optional[Synapse] = None
+        cls, id: int, *, synapse_client: Optional[Synapse] = None
     ) -> "Team":
         """Gets Team object using its integer id.
 
@@ -271,7 +271,7 @@ class Team(TeamSynchronousProtocol):
         method_to_trace_name=lambda cls, name, **kwargs: f"Team_From_Name: {name}"
     )
     async def from_name_async(
-        cls, name: str, synapse_client: Optional[Synapse] = None
+        cls, name: str, *, synapse_client: Optional[Synapse] = None
     ) -> "Team":
         """Gets Team object using its string name.
 
@@ -294,7 +294,7 @@ class Team(TeamSynchronousProtocol):
         method_to_trace_name=lambda self, **kwargs: f"Team_Members: {self.name}"
     )
     async def members_async(
-        self, synapse_client: Optional[Synapse] = None
+        self, *, synapse_client: Optional[Synapse] = None
     ) -> List[TeamMember]:
         """
         Gets the TeamMembers associated with a team given the ID field on the
@@ -332,6 +332,7 @@ class Team(TeamSynchronousProtocol):
         user: str,
         message: str,
         force: bool = True,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> Dict[str, str]:
         """Invites a user to a team given the ID field on the Team instance.
@@ -367,7 +368,7 @@ class Team(TeamSynchronousProtocol):
         method_to_trace_name=lambda self, **kwargs: f"Team_Open_Invitations: {self.name}"
     )
     async def open_invitations_async(
-        self, synapse_client: Optional[Synapse] = None
+        self, *, synapse_client: Optional[Synapse] = None
     ) -> List[Dict[str, str]]:
         """Gets all open invitations for a team given the ID field on the Team instance.
 

--- a/synapseclient/models/user.py
+++ b/synapseclient/models/user.py
@@ -229,6 +229,7 @@ class UserProfile(UserProfileSynchronousProtocol):
     )
     async def get_async(
         self,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "UserProfile":
         """
@@ -285,7 +286,7 @@ class UserProfile(UserProfileSynchronousProtocol):
         method_to_trace_name=lambda cls, user_id, **kwargs: f"Profile_From_Id: {user_id}"
     )
     async def from_id_async(
-        cls, user_id: int, synapse_client: Optional[Synapse] = None
+        cls, user_id: int, *, synapse_client: Optional[Synapse] = None
     ) -> "UserProfile":
         """Gets UserProfile object using its integer id. Wrapper for the
         [get][synapseclient.models.UserProfile.get] method.
@@ -306,7 +307,7 @@ class UserProfile(UserProfileSynchronousProtocol):
         method_to_trace_name=lambda cls, username, **kwargs: f"Profile_From_Username: {username}"
     )
     async def from_username_async(
-        cls, username: str, synapse_client: Optional[Synapse] = None
+        cls, username: str, *, synapse_client: Optional[Synapse] = None
     ) -> "UserProfile":
         """
         Gets UserProfile object using its string name. Wrapper for the
@@ -327,6 +328,7 @@ class UserProfile(UserProfileSynchronousProtocol):
     )
     async def is_certified_async(
         self,
+        *,
         synapse_client: Optional[Synapse] = None,
     ) -> "bool":
         """

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -185,7 +185,7 @@ def syncFromSynapse(
         unit_scale=True,
         smoothing=0,
     )
-    with download_shared_progress_bar(progress_bar):
+    with download_shared_progress_bar(progress_bar=progress_bar, syn=syn):
         root_entity = wrap_async_to_sync(
             coroutine=_sync(
                 syn=syn,

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -857,7 +857,7 @@ def _convert_manifest_data_items_to_string_list(
 
     if len(items_to_write) > 1:
         return f'[{",".join(items_to_write)}]'
-    elif len(items_to_write) == 0:
+    elif len(items_to_write) == 1:
         return items_to_write[0]
     else:
         return ""

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -855,10 +855,12 @@ def _convert_manifest_data_items_to_string_list(
             else:
                 items_to_write.append(repr(item))
 
-    if len(items) > 1:
+    if len(items_to_write) > 1:
         return f'[{",".join(items_to_write)}]'
-    else:
+    elif len(items_to_write) == 0:
         return items_to_write[0]
+    else:
+        return ""
 
 
 def _convert_manifest_data_row_to_dict(row: dict, keys: List[str]) -> dict:

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -22,13 +22,18 @@ from synapseclient.api import get_entity, get_entity_id_bundle2
 from synapseclient.core import utils
 from synapseclient.core.async_utils import wrap_async_to_sync
 from synapseclient.core.constants import concrete_types
+from synapseclient.core.download.download_async import (
+    shared_progress_bar as download_shared_progress_bar,
+)
 from synapseclient.core.exceptions import (
     SynapseError,
     SynapseFileNotFoundError,
     SynapseHTTPError,
     SynapseProvenanceError,
 )
-from synapseclient.core.upload.multipart_upload_async import shared_progress_bar
+from synapseclient.core.upload.multipart_upload_async import (
+    shared_progress_bar as upload_shared_progress_bar,
+)
 from synapseclient.core.utils import (
     bool_or_none,
     datetime_or_none,
@@ -180,7 +185,7 @@ def syncFromSynapse(
         unit_scale=True,
         smoothing=0,
     )
-    with shared_progress_bar(progress_bar):
+    with download_shared_progress_bar(progress_bar):
         root_entity = wrap_async_to_sync(
             coroutine=_sync(
                 syn=syn,
@@ -1151,7 +1156,7 @@ def syncToSynapse(
         unit_scale=True,
         smoothing=0,
     )
-    with shared_progress_bar(progress_bar):
+    with upload_shared_progress_bar(progress_bar):
         if sendMessages:
             notify_decorator = notify_me_async(
                 syn, "Upload of %s" % manifestFile, retries=retries

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -332,7 +332,7 @@ async def _sync(
         )
     else:
         raise ValueError(
-            "Cannot initiate a sync from an entity that is not a File, Folder, or Link to a File/Folder."
+            "Cannot initiate a sync from an entity that is not a File, Folder, Project, or Link to a File/Folder."
         )
 
     return root_entity

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -209,12 +209,7 @@ def syncFromSynapse(
     # is specified then only the root directory will have a manifest created.
     if isinstance(root_entity, Project) or isinstance(root_entity, Folder):
         files = root_entity.flatten_file_list()
-        if manifest != "suppress":
-            generate_manifest(
-                all_files=files,
-                path=path,
-            )
-        if manifest == "all":
+        if manifest == "all" and path:
             for (
                 directory_path,
                 file_entities,
@@ -225,6 +220,11 @@ def syncFromSynapse(
                     all_files=file_entities,
                     path=directory_path,
                 )
+        elif manifest == "root" and path:
+            generate_manifest(
+                all_files=files,
+                path=path,
+            )
     elif isinstance(root_entity, File):
         # When the root entity is a file we do not create a manifest file. This is
         # to match the behavior present in v4.x.x of the client.

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -26,6 +26,7 @@ from synapseclient.core.exceptions import (
     SynapseError,
     SynapseFileNotFoundError,
     SynapseHTTPError,
+    SynapseNotFoundError,
     SynapseProvenanceError,
 )
 from synapseclient.core.transfer_bar import shared_download_progress_bar
@@ -265,6 +266,9 @@ async def _sync(
         entity = await get_entity(
             entity_id=synid, version_number=version, synapse_client=syn
         )
+
+    if entity is None:
+        raise SynapseNotFoundError(f"Entity {entity or synid} not found.")
 
     entity_type = entity.get("concreteType", None)
     entity_id = id_of(entity)

--- a/tests/integration/synapseclient/core/upload/test_multipart_upload.py
+++ b/tests/integration/synapseclient/core/upload/test_multipart_upload.py
@@ -97,12 +97,10 @@ async def test_randomly_failing_parts(
 
         return normal_put(url, *args, **kwargs)
 
-    with (
-        mock.patch.object(
-            syn._requests_session_storage,
-            "put",
-            side_effect=_put_chunk_or_fail_randomly,
-        ),
+    with mock.patch.object(
+        syn._requests_session_storage,
+        "put",
+        side_effect=_put_chunk_or_fail_randomly,
     ):
         try:
             fhid = await multipart_upload_file_async(

--- a/tests/integration/synapseclient/models/async/test_file_async.py
+++ b/tests/integration/synapseclient/models/async/test_file_async.py
@@ -1225,7 +1225,7 @@ class TestDelete:
         # THEN I expect the file to be deleted
         with pytest.raises(SynapseHTTPError) as e:
             await file.get_async()
-        assert f"404 Client Error: \nEntity {file.id} is in trash can." in str(e.value)
+        assert f"404 Client Error: Entity {file.id} is in trash can." in str(e.value)
 
     async def test_delete_specific_version(
         self, file: File, schedule_for_cleanup: Callable[..., None]
@@ -1248,7 +1248,7 @@ class TestDelete:
         with pytest.raises(SynapseHTTPError) as e:
             await File(id=file.id, version_number=1).get_async()
         assert (
-            f"404 Client Error: \nCannot find a node with id {file.id} and version 1"
+            f"404 Client Error: Cannot find a node with id {file.id} and version 1"
             in str(e.value)
         )
 

--- a/tests/integration/synapseclient/models/async/test_folder_async.py
+++ b/tests/integration/synapseclient/models/async/test_folder_async.py
@@ -361,7 +361,7 @@ class TestFolderDelete:
         with pytest.raises(SynapseHTTPError) as e:
             await stored_folder.get()
 
-        assert f"404 Client Error: \nEntity {stored_folder.id} is in trash can." in str(
+        assert f"404 Client Error: Entity {stored_folder.id} is in trash can." in str(
             e.value
         )
 

--- a/tests/integration/synapseclient/models/async/test_project_async.py
+++ b/tests/integration/synapseclient/models/async/test_project_async.py
@@ -372,9 +372,8 @@ class TestProjectDelete:
         with pytest.raises(SynapseHTTPError) as e:
             await stored_project.get_async()
 
-        assert (
-            f"404 Client Error: \nEntity {stored_project.id} is in trash can."
-            in str(e.value)
+        assert f"404 Client Error: Entity {stored_project.id} is in trash can." in str(
+            e.value
         )
 
 

--- a/tests/integration/synapseclient/models/synchronous/test_file.py
+++ b/tests/integration/synapseclient/models/synchronous/test_file.py
@@ -1206,7 +1206,7 @@ class TestDelete:
         # THEN I expect the file to be deleted
         with pytest.raises(SynapseHTTPError) as e:
             file.get()
-        assert f"404 Client Error: \nEntity {file.id} is in trash can." in str(e.value)
+        assert f"404 Client Error: Entity {file.id} is in trash can." in str(e.value)
 
     async def test_delete_specific_version(
         self, file: File, schedule_for_cleanup: Callable[..., None]
@@ -1229,7 +1229,7 @@ class TestDelete:
         with pytest.raises(SynapseHTTPError) as e:
             File(id=file.id, version_number=1).get()
         assert (
-            f"404 Client Error: \nCannot find a node with id {file.id} and version 1"
+            f"404 Client Error: Cannot find a node with id {file.id} and version 1"
             in str(e.value)
         )
 

--- a/tests/integration/synapseclient/models/synchronous/test_folder.py
+++ b/tests/integration/synapseclient/models/synchronous/test_folder.py
@@ -358,7 +358,7 @@ class TestFolderDelete:
         with pytest.raises(SynapseHTTPError) as e:
             stored_folder.get()
 
-        assert f"404 Client Error: \nEntity {stored_folder.id} is in trash can." in str(
+        assert f"404 Client Error: Entity {stored_folder.id} is in trash can." in str(
             e.value
         )
 

--- a/tests/integration/synapseclient/models/synchronous/test_project.py
+++ b/tests/integration/synapseclient/models/synchronous/test_project.py
@@ -370,9 +370,8 @@ class TestProjectDelete:
         with pytest.raises(SynapseHTTPError) as e:
             stored_project.get()
 
-        assert (
-            f"404 Client Error: \nEntity {stored_project.id} is in trash can."
-            in str(e.value)
+        assert f"404 Client Error: Entity {stored_project.id} is in trash can." in str(
+            e.value
         )
 
 

--- a/tests/integration/synapseclient/test_command_line_client.py
+++ b/tests/integration/synapseclient/test_command_line_client.py
@@ -883,6 +883,8 @@ async def test_table_query(test_state):
     )
 
     output_rows = output.rstrip("\n").split("\n")
+    if output_rows[0] and output_rows[0].startswith(f"Downloaded {schema1.id} to"):
+        output_rows = output_rows[1:]
 
     # Check the length of the output
     assert len(output_rows) == 5, "got %s rows" % (len(output_rows),)

--- a/tests/integration/synapseclient/test_command_line_client.py
+++ b/tests/integration/synapseclient/test_command_line_client.py
@@ -131,7 +131,7 @@ async def test_command_line_client(test_state):
 
     # Get File from the command line
     output = run(test_state, "synapse", "--skip-checks", "get", file_entity_id)
-    downloaded_filename = parse(r"Downloaded file:\s+(.*)", output)
+    downloaded_filename = output.split("/")[-1].strip()
     test_state.schedule_for_cleanup(downloaded_filename)
     assert os.path.exists(downloaded_filename)
     assert filecmp.cmp(filename, downloaded_filename)
@@ -151,7 +151,7 @@ async def test_command_line_client(test_state):
 
     # Get the File again
     output = run(test_state, "synapse", "--skip-checks", "get", file_entity_id)
-    downloaded_filename = parse(r"Downloaded file:\s+(.*)", output)
+    downloaded_filename = output.split("/")[-1].strip()
     test_state.schedule_for_cleanup(downloaded_filename)
     assert os.path.exists(downloaded_filename)
     assert filecmp.cmp(filename, downloaded_filename)
@@ -258,7 +258,7 @@ async def test_command_line_client(test_state):
     )
 
     output = run(test_state, "synapse", "--skip-checks", "get", exteral_entity_id)
-    downloaded_filename = parse(r"Downloaded file:\s+(.*)", output)
+    downloaded_filename = output.split("/")[-1].strip()
     test_state.schedule_for_cleanup(downloaded_filename)
     assert os.path.exists(downloaded_filename)
 

--- a/tests/integration/synapseutils/test_synapseutils_sync.py
+++ b/tests/integration/synapseutils/test_synapseutils_sync.py
@@ -1707,47 +1707,40 @@ class TestSyncFromSynapse:
             assert file in file_entities
 
         # AND the manifest that is created matches the expected values
-        def verify_manifest(path: str) -> None:
-            """Wrapper to verify the manifest file"""
+        manifest_df = pd.read_csv(os.path.join(temp_dir, MANIFEST_FILE), sep="\t")
+        assert manifest_df.shape[0] == 2
+        assert PATH_COLUMN in manifest_df.columns
+        assert PARENT_COLUMN in manifest_df.columns
+        assert USED_COLUMN in manifest_df.columns
+        assert EXECUTED_COLUMN in manifest_df.columns
+        assert ACTIVITY_NAME_COLUMN in manifest_df.columns
+        assert ACTIVITY_DESCRIPTION_COLUMN in manifest_df.columns
+        assert CONTENT_TYPE_COLUMN in manifest_df.columns
+        assert ID_COLUMN in manifest_df.columns
+        assert SYNAPSE_STORE_COLUMN in manifest_df.columns
+        assert NAME_COLUMN in manifest_df.columns
+        assert manifest_df.shape[1] == 10
 
-            manifest_df = pd.read_csv(path, sep="\t")
-            assert manifest_df.shape[0] == 2
-            assert PATH_COLUMN in manifest_df.columns
-            assert PARENT_COLUMN in manifest_df.columns
-            assert USED_COLUMN in manifest_df.columns
-            assert EXECUTED_COLUMN in manifest_df.columns
-            assert ACTIVITY_NAME_COLUMN in manifest_df.columns
-            assert ACTIVITY_DESCRIPTION_COLUMN in manifest_df.columns
-            assert CONTENT_TYPE_COLUMN in manifest_df.columns
-            assert ID_COLUMN in manifest_df.columns
-            assert SYNAPSE_STORE_COLUMN in manifest_df.columns
-            assert NAME_COLUMN in manifest_df.columns
-            assert manifest_df.shape[1] == 10
+        for file in sync_result:
+            matching_row = manifest_df[manifest_df[PATH_COLUMN] == file[PATH_COLUMN]]
+            assert not matching_row.empty
+            assert matching_row[PARENT_COLUMN].values[0] == file[PARENT_ATTRIBUTE]
+            assert (
+                matching_row[CONTENT_TYPE_COLUMN].values[0] == file[CONTENT_TYPE_COLUMN]
+            )
+            assert matching_row[ID_COLUMN].values[0] == file[ID_COLUMN]
+            assert (
+                matching_row[SYNAPSE_STORE_COLUMN].values[0]
+                == file[SYNAPSE_STORE_COLUMN]
+            )
+            assert matching_row[NAME_COLUMN].values[0] == file[NAME_COLUMN]
 
-            for file in sync_result:
-                matching_row = manifest_df[
-                    manifest_df[PATH_COLUMN] == file[PATH_COLUMN]
-                ]
-                assert not matching_row.empty
-                assert matching_row[PARENT_COLUMN].values[0] == file[PARENT_ATTRIBUTE]
-                assert (
-                    matching_row[CONTENT_TYPE_COLUMN].values[0]
-                    == file[CONTENT_TYPE_COLUMN]
-                )
-                assert matching_row[ID_COLUMN].values[0] == file[ID_COLUMN]
-                assert (
-                    matching_row[SYNAPSE_STORE_COLUMN].values[0]
-                    == file[SYNAPSE_STORE_COLUMN]
-                )
-                assert matching_row[NAME_COLUMN].values[0] == file[NAME_COLUMN]
-
-                assert pd.isna(matching_row[USED_COLUMN].values[0])
-                assert pd.isna(matching_row[EXECUTED_COLUMN].values[0])
-                assert pd.isna(matching_row[ACTIVITY_NAME_COLUMN].values[0])
-                assert pd.isna(matching_row[ACTIVITY_DESCRIPTION_COLUMN].values[0])
+            assert pd.isna(matching_row[USED_COLUMN].values[0])
+            assert pd.isna(matching_row[EXECUTED_COLUMN].values[0])
+            assert pd.isna(matching_row[ACTIVITY_NAME_COLUMN].values[0])
+            assert pd.isna(matching_row[ACTIVITY_DESCRIPTION_COLUMN].values[0])
 
         # AND the default behavior is that a manifest file is created in root, but not the sub folder
-        verify_manifest(path=os.path.join(temp_dir, MANIFEST_FILE))
         sub_directory = os.path.join(temp_dir, sub_folder.name)
         assert not os.path.exists(os.path.join(sub_directory, MANIFEST_FILE))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+"""Utility functions for unit/ingration tests"""
+
+from typing import Any, Callable, Coroutine
+
+
+def spy_for_async_function(
+    original_func: Callable[..., Any]
+) -> Callable[..., Coroutine[Any, Any, Any]]:
+    """This function is used to create a spy for async functions."""
+
+    async def wrapper(*args, **kwargs):
+        return await original_func(*args, **kwargs)  # Call the original function
+
+    return wrapper
+
+
+def spy_for_function(original_func: Callable[..., Any]) -> Callable[..., Any]:
+    """This function is used to create a spy for functions."""
+
+    def wrapper(*args, **kwargs):
+        return original_func(*args, **kwargs)  # Call the original function
+
+    return wrapper

--- a/tests/unit/synapseclient/core/download/unit_test_download_async.py
+++ b/tests/unit/synapseclient/core/download/unit_test_download_async.py
@@ -1,0 +1,153 @@
+"""Unit tests for synapseclient.core.download.download_async."""
+
+import datetime
+import unittest.mock as mock
+
+import pytest
+
+import synapseclient.core.download.download_async as download_async
+from synapseclient import Synapse
+from synapseclient.core.download import (
+    DownloadRequest,
+    PresignedUrlInfo,
+    PresignedUrlProvider,
+)
+
+
+class TestPresignedUrlProvider:
+    """Unit tests for PresignedUrlProvider."""
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self) -> None:
+        """Setup"""
+        self.mock_synapse_client = mock.create_autospec(Synapse)
+        self.download_request = DownloadRequest(123, "456", "FileEntity", "/myFakepath")
+
+    async def test_get_info_not_expired(self) -> None:
+        utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
+
+        info = PresignedUrlInfo(
+            "myFile.txt",
+            "https://synapse.org/somefile.txt",
+            expiration_utc=utc_now + datetime.timedelta(seconds=6),
+        )
+
+        with mock.patch.object(
+            PresignedUrlProvider, "_get_pre_signed_info", return_value=info
+        ) as mock_get_presigned_info, mock.patch.object(
+            download_async, "datetime", wraps=datetime
+        ) as mock_datetime:
+            mock_datetime.datetime.now.return_value = utc_now
+
+            presigned_url_provider = PresignedUrlProvider(
+                self.mock_synapse_client, self.download_request
+            )
+            presigned_url_provider._cached_info = info
+            assert info == presigned_url_provider.get_info()
+
+            mock_get_presigned_info.assert_not_called()
+            mock_datetime.datetime.now.assert_called_once()
+
+    async def test_get_info_expired(self) -> None:
+        utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
+
+        # expires in the past
+        expired_info = PresignedUrlInfo(
+            "myFile.txt",
+            "https://synapse.org/somefile.txt",
+            expiration_utc=utc_now - datetime.timedelta(seconds=5),
+        )
+        unexpired_date = utc_now + datetime.timedelta(seconds=6)
+        unexpired_info = PresignedUrlInfo(
+            file_name="myFile.txt",
+            url="https://synapse.org/somefile.txt",
+            expiration_utc=unexpired_date,
+        )
+
+        with mock.patch.object(
+            PresignedUrlProvider,
+            "_get_pre_signed_info",
+            side_effect=[unexpired_info],
+        ) as mock_get_presigned_info, mock.patch(
+            "synapseclient.core.download.download_async.get_file_handle_for_download",
+            return_value={
+                "fileHandle": {"fileName": "myFile.txt"},
+                "preSignedURL": f"https://synapse.org?X-Amz-Date={unexpired_date.strftime('%Y%m%dT%H%M%SZ')}&X-Amz-Expires=5&X-Amz-Signature=123456",
+            },
+        ):
+            presigned_url_provider = PresignedUrlProvider(
+                self.mock_synapse_client, request=self.download_request
+            )
+            presigned_url_provider._cached_info = expired_info
+            info = presigned_url_provider.get_info()
+            assert unexpired_info == info
+
+            assert 1 == mock_get_presigned_info.call_count
+
+    async def test_get_pre_signed_info(self) -> None:
+        fake_exp_time = datetime.datetime.now(tz=datetime.timezone.utc)
+        fake_url = "https://synapse.org/foo.txt"
+        fake_file_name = "foo.txt"
+
+        with mock.patch.object(
+            download_async,
+            "_pre_signed_url_expiration_time",
+            return_value=fake_exp_time,
+        ) as mock_pre_signed_url_expiration_time, mock.patch(
+            "synapseclient.core.download.download_async.get_file_handle_for_download",
+            return_value={
+                "fileHandle": {"fileName": "myFile.txt"},
+                "preSignedURL": f"https://synapse.org?X-Amz-Date={fake_exp_time.strftime('%Y%m%dT%H%M%SZ')}&X-Amz-Expires=5&X-Amz-Signature=123456",
+            },
+        ) as mock_file_handle_download:
+            fake_file_handle_response = {
+                "fileHandle": {"fileName": fake_file_name},
+                "preSignedURL": fake_url,
+            }
+
+            mock_file_handle_download.return_value = fake_file_handle_response
+
+            presigned_url_provider = PresignedUrlProvider(
+                self.mock_synapse_client, self.download_request
+            )
+
+            expected = PresignedUrlInfo(
+                file_name=fake_file_name, url=fake_url, expiration_utc=fake_exp_time
+            )
+            assert expected == presigned_url_provider._get_pre_signed_info()
+
+            mock_pre_signed_url_expiration_time.assert_called_with(fake_url)
+            mock_file_handle_download.assert_called_with(
+                file_handle_id=self.download_request.file_handle_id,
+                synapse_id=self.download_request.object_id,
+                entity_type=self.download_request.object_type,
+                synapse_client=self.mock_synapse_client,
+            )
+
+    async def test_pre_signed_url_expiration_time(self) -> None:
+        url = (
+            "https://s3.amazonaws.com/examplebucket/test.txt"
+            "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+            "&X-Amz-Credential=your-access-key-id/20130721/us-east-1/s3/aws4_request"
+            "&X-Amz-Date=20130721T201207Z"
+            "&X-Amz-Expires=86400"
+            "&X-Amz-SignedHeaders=host"
+            "&X-Amz-Signature=signature-value"
+        )
+
+        expected = (
+            datetime.datetime(year=2013, month=7, day=21, hour=20, minute=12, second=7)
+            + datetime.timedelta(seconds=86400)
+        ).replace(tzinfo=datetime.timezone.utc)
+        assert expected == download_async._pre_signed_url_expiration_time(url)
+
+
+async def test_generate_chunk_ranges() -> None:
+    # test using smaller chunk size
+    download_async.SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE = 8
+
+    result = [x for x in download_async._generate_chunk_ranges(18)]
+
+    expected = [(0, 7), (8, 15), (16, 17)]
+
+    assert expected == result

--- a/tests/unit/synapseclient/core/multithread_download/unit_test_download_threads.py
+++ b/tests/unit/synapseclient/core/multithread_download/unit_test_download_threads.py
@@ -8,9 +8,10 @@ import pytest
 import requests
 from requests import Response
 
-import synapseclient.core.download.download_async as download_async
+import synapseclient.core.multithread_download.download_threads as download_threads
 from synapseclient import Synapse
-from synapseclient.core.download import (
+from synapseclient.core.exceptions import SynapseError, SynapseHTTPError
+from synapseclient.core.multithread_download.download_threads import (
     DownloadRequest,
     PresignedUrlInfo,
     PresignedUrlProvider,
@@ -18,13 +19,12 @@ from synapseclient.core.download import (
     _MultithreadedDownloader,
     download_file,
 )
-from synapseclient.core.exceptions import SynapseError, SynapseHTTPError
 from synapseclient.core.retry import DEFAULT_RETRIES
 
 
 class TestPresignedUrlProvider(object):
     @pytest.fixture(scope="function", autouse=True)
-    def setup_method(self):
+    def setup(self):
         self.mock_synapse_client = mock.create_autospec(Synapse)
         self.download_request = DownloadRequest(123, "456", "FileEntity", "/myFakepath")
 
@@ -40,7 +40,7 @@ class TestPresignedUrlProvider(object):
         with mock.patch.object(
             PresignedUrlProvider, "_get_pre_signed_info", return_value=info
         ) as mock_get_presigned_info, mock.patch.object(
-            download_async, "datetime", wraps=datetime
+            download_threads, "datetime", wraps=datetime
         ) as mock_datetime:
             mock_datetime.datetime.utcnow.return_value = utc_now
 
@@ -73,7 +73,7 @@ class TestPresignedUrlProvider(object):
             "_get_pre_signed_info",
             side_effect=[expired_info, unexpired_info],
         ) as mock_get_presigned_info, mock.patch.object(
-            download_async, "datetime"
+            download_threads, "datetime"
         ) as mock_datetime:
             mock_datetime.datetime.utcnow.return_value = utc_now
 
@@ -92,43 +92,39 @@ class TestPresignedUrlProvider(object):
         fake_file_name = "foo.txt"
 
         with mock.patch.object(
-            download_async,
+            download_threads,
             "_pre_signed_url_expiration_time",
             return_value=fake_exp_time,
-        ) as mock_pre_signed_url_expiration_time, mock.patch(
-            "synapseclient.core.download.download_async.get_file_handle_for_download",
-            new_callable=mock.AsyncMock,
-        ) as mock_file_handle_download:
+        ) as mock_pre_signed_url_expiration_time:
             fake_file_handle_response = {
                 "fileHandle": {"fileName": fake_file_name},
                 "preSignedURL": fake_url,
             }
 
-            mock_file_handle_download.return_value = fake_file_handle_response
+            self.mock_synapse_client._getFileHandleDownload.return_value = (
+                fake_file_handle_response
+            )
 
             presigned_url_provider = PresignedUrlProvider(
                 self.mock_synapse_client, self.download_request
             )
 
-            expected = PresignedUrlInfo(
-                file_name=fake_file_name, url=fake_url, expiration_utc=fake_exp_time
-            )
+            expected = PresignedUrlInfo(fake_file_name, fake_url, fake_exp_time)
             assert expected == presigned_url_provider._get_pre_signed_info()
 
             mock_pre_signed_url_expiration_time.assert_called_with(fake_url)
-            mock_file_handle_download.assert_called_with(
-                file_handle_id=self.download_request.file_handle_id,
-                synapse_id=self.download_request.object_id,
-                entity_type=self.download_request.object_type,
-                synapse_client=self.mock_synapse_client,
+            self.mock_synapse_client._getFileHandleDownload.assert_called_with(
+                self.download_request.file_handle_id,
+                self.download_request.object_id,
+                objectType=self.download_request.object_type,
             )
 
 
 def test_generate_chunk_ranges():
     # test using smaller chunk size
-    download_async.SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE = 8
+    download_threads.SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE = 8
 
-    result = [x for x in download_async._generate_chunk_ranges(18)]
+    result = [x for x in download_threads._generate_chunk_ranges(18)]
 
     expected = [(0, 7), (8, 15), (16, 17)]
 
@@ -149,10 +145,10 @@ def test_pre_signed_url_expiration_time():
     expected = datetime.datetime(
         year=2013, month=7, day=21, hour=20, minute=12, second=7
     ) + datetime.timedelta(seconds=86400)
-    assert expected == download_async._pre_signed_url_expiration_time(url)
+    assert expected == download_threads._pre_signed_url_expiration_time(url)
 
 
-@mock.patch.object(download_async, "_MultithreadedDownloader")
+@mock.patch.object(download_threads, "_MultithreadedDownloader")
 def test_download_file(mock_multithreaded_downloader_init):
     """Verify that initiating a download instantiates a downloader and passes it the correct args.
     This test simulates a shared executor being set externally via the sharedexecutor context manager
@@ -176,7 +172,7 @@ def test_download_file(mock_multithreaded_downloader_init):
 
     max_concurrent_parts = 5
 
-    with download_async.shared_executor(mock_executor):
+    with download_threads.shared_executor(mock_executor):
         download_file(syn, request, max_concurrent_parts=max_concurrent_parts)
 
     mock_multithreaded_downloader_init.assert_called_once_with(
@@ -188,8 +184,8 @@ def test_download_file(mock_multithreaded_downloader_init):
     assert not mock_executor.shutdown.called
 
 
-@mock.patch.object(download_async, "get_executor")
-@mock.patch.object(download_async, "_MultithreadedDownloader")
+@mock.patch.object(download_threads, "get_executor")
+@mock.patch.object(download_threads, "_MultithreadedDownloader")
 def test_download_file__executor_shutdown(
     mock_multithreaded_downloader_init, mock_get_executor
 ):
@@ -240,13 +236,13 @@ class MultithreadedDownloaderTests(TestCase):
         request = DownloadRequest(file_handle_id, object_id, None, path)
 
         with mock.patch.object(
-            download_async, "PresignedUrlProvider"
+            download_threads, "PresignedUrlProvider"
         ) as mock_url_provider_init, mock.patch.object(
-            download_async, "TransferStatus"
+            download_threads, "TransferStatus"
         ) as mock_transfer_status_init, mock.patch.object(
-            download_async, "_get_file_size"
+            download_threads, "_get_file_size"
         ) as mock_get_file_size, mock.patch.object(
-            download_async, "_generate_chunk_ranges"
+            download_threads, "_generate_chunk_ranges"
         ) as mock_generate_chunk_ranges, mock.patch.object(
             _MultithreadedDownloader, "_prep_file"
         ) as mock_prep_file, mock.patch.object(
@@ -345,15 +341,15 @@ class MultithreadedDownloaderTests(TestCase):
         request = DownloadRequest(file_handle_id, entity_id, None, path)
 
         with mock.patch.object(
-            download_async, "PresignedUrlProvider"
+            download_threads, "PresignedUrlProvider"
         ) as mock_url_provider_init, mock.patch.object(
-            download_async, "TransferStatus"
+            download_threads, "TransferStatus"
         ) as mock_transfer_status_init, mock.patch.object(
-            download_async, "_get_file_size"
+            download_threads, "_get_file_size"
         ) as mock_get_file_size, mock.patch.object(
-            download_async, "_generate_chunk_ranges"
+            download_threads, "_generate_chunk_ranges"
         ) as mock_generate_chunk_ranges, mock.patch.object(
-            download_async, "os"
+            download_threads, "os"
         ) as mock_os, mock.patch.object(
             _MultithreadedDownloader, "_prep_file"
         ), mock.patch.object(
@@ -417,9 +413,9 @@ class MultithreadedDownloaderTests(TestCase):
 
         # AND A mocked session
         with mock.patch.object(
-            download_async, "_get_new_session"
+            download_threads, "_get_new_session"
         ) as mock_get_new_session, mock.patch.object(
-            download_async, "PresignedUrlProvider"
+            download_threads, "PresignedUrlProvider"
         ) as mock_url_provider_init:
             mock_url_info = mock.create_autospec(PresignedUrlInfo, url=url)
             mock_url_provider = mock.create_autospec(PresignedUrlProvider)
@@ -453,12 +449,12 @@ class MultithreadedDownloaderTests(TestCase):
             # THEN the error should be raised
             assert "403 Client Error: mocked response text" in str(e.value)
 
-    @mock.patch.object(download_async, "open")
+    @mock.patch.object(download_threads, "open")
     def test_prep_file(self, mock_open):
         """Should open and close the file to create/truncate it"""
         path = "/tmp/foo"
         request = DownloadRequest(None, None, None, path)
-        download_async._MultithreadedDownloader._prep_file(request)
+        download_threads._MultithreadedDownloader._prep_file(request)
         mock_open.assert_called_once_with(path, "wb")
 
         mock_open.return_value.close.assert_called_once_with()
@@ -479,15 +475,15 @@ class MultithreadedDownloaderTests(TestCase):
         executor = mock.Mock(submit=executor_submit)
         url_provider = mock.Mock()
 
-        file_size = int(2.5 * download_async.SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE)
-        chunk_range_generator = download_async._generate_chunk_ranges(file_size)
+        file_size = int(2.5 * download_threads.SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE)
+        chunk_range_generator = download_threads._generate_chunk_ranges(file_size)
 
         downloader = _MultithreadedDownloader(syn, executor, max_concurrent_parts)
         submitted_futures = downloader._submit_chunks(
             url_provider, chunk_range_generator, pending_futures
         )
 
-        ranges = [r for r in download_async._generate_chunk_ranges(file_size)][
+        ranges = [r for r in download_threads._generate_chunk_ranges(file_size)][
             :expected_submit_count
         ]
         expected_submits = [
@@ -502,7 +498,7 @@ class MultithreadedDownloaderTests(TestCase):
         assert expected_submits == executor_submit.call_args_list
         assert set(executor_submit_side_effect) == submitted_futures
 
-    @mock.patch.object(download_async, "open")
+    @mock.patch.object(download_threads, "open")
     def test_write_chunks__none_ready(self, mock_open):
         """Verify that if there are no parts ready that nothing is written out"""
         request = mock.Mock()
@@ -512,7 +508,7 @@ class MultithreadedDownloaderTests(TestCase):
         downloader._write_chunks(request, completed_futures, transfer_status)
         assert not mock_open.called
 
-    @mock.patch.object(download_async, "open")
+    @mock.patch.object(download_threads, "open")
     def test_write_chunks(self, mock_open):
         """Verify expected behavior writing out chunks to disk"""
         request = mock.Mock(path="/tmp/foo")
@@ -586,7 +582,7 @@ class MultithreadedDownloaderTests(TestCase):
         with pytest.raises(exception.__class__):
             downloader._check_for_errors(request, completed_futures)
 
-    @mock.patch.object(download_async, "_get_thread_session")
+    @mock.patch.object(download_threads, "_get_thread_session")
     def test_get_response_with_retry__exceed_max_retries(self, mock_get_thread_session):
         mock_requests_response = mock.Mock(status_code=403)
         mock_requests_session = mock.create_autospec(requests.Session)
@@ -594,9 +590,9 @@ class MultithreadedDownloaderTests(TestCase):
         mock_get_thread_session.return_value = mock_requests_session
 
         mock_presigned_url_provider = mock.create_autospec(
-            download_async.PresignedUrlProvider
+            download_threads.PresignedUrlProvider
         )
-        presigned_url_info = download_async.PresignedUrlInfo(
+        presigned_url_info = download_threads.PresignedUrlInfo(
             "foo.txt", "synapse.org/foo.txt", datetime.datetime.utcnow()
         )
         mock_presigned_url_provider.get_info.return_value = presigned_url_info
@@ -613,7 +609,7 @@ class MultithreadedDownloaderTests(TestCase):
         ] * (DEFAULT_RETRIES + 1)
         assert expected_call_list == mock_requests_session.get.call_args_list
 
-    @mock.patch.object(download_async, "_get_thread_session")
+    @mock.patch.object(download_threads, "_get_thread_session")
     def test_get_response_with_retry__partial_content_response(
         self, mock_get_thread_session
     ):
@@ -623,9 +619,9 @@ class MultithreadedDownloaderTests(TestCase):
         mock_get_thread_session.return_value = mock_requests_session
 
         mock_presigned_url_provider = mock.create_autospec(
-            download_async.PresignedUrlProvider
+            download_threads.PresignedUrlProvider
         )
-        presigned_url_info = download_async.PresignedUrlInfo(
+        presigned_url_info = download_threads.PresignedUrlInfo(
             "foo.txt", "synapse.org/foo.txt", datetime.datetime.utcnow()
         )
 
@@ -643,7 +639,7 @@ class MultithreadedDownloaderTests(TestCase):
             headers={"Range": "bytes=5-42"},
         )
 
-    @mock.patch.object(download_async, "_get_thread_session")
+    @mock.patch.object(download_threads, "_get_thread_session")
     def test_get_response_with_retry__connection_reset(self, mock_get_thread_session):
         """Verify a ConnectionResetError during a part download will be retried"""
 
@@ -656,9 +652,9 @@ class MultithreadedDownloaderTests(TestCase):
         mock_get_thread_session.return_value = mock_requests_session
 
         mock_presigned_url_provider = mock.create_autospec(
-            download_async.PresignedUrlProvider
+            download_threads.PresignedUrlProvider
         )
-        presigned_url_info = download_async.PresignedUrlInfo(
+        presigned_url_info = download_threads.PresignedUrlInfo(
             "foo.txt", "synapse.org/foo.txt", datetime.datetime.utcnow()
         )
 
@@ -678,7 +674,7 @@ class MultithreadedDownloaderTests(TestCase):
         ] * 2
         assert mock_requests_session.get.call_args_list == expected_get_call_args_list
 
-    @mock.patch.object(download_async, "_get_thread_session")
+    @mock.patch.object(download_threads, "_get_thread_session")
     def test_get_response_with_retry__error_status(self, mock_get_thread_session):
         """Verify an errored status code during a part download will be retried"""
         mock_requests_error_response = mock.Mock(status_code=500)
@@ -691,9 +687,9 @@ class MultithreadedDownloaderTests(TestCase):
         mock_get_thread_session.return_value = mock_requests_session
 
         mock_presigned_url_provider = mock.create_autospec(
-            download_async.PresignedUrlProvider
+            download_threads.PresignedUrlProvider
         )
-        presigned_url_info = download_async.PresignedUrlInfo(
+        presigned_url_info = download_threads.PresignedUrlInfo(
             "foo.txt", "synapse.org/foo.txt", datetime.datetime.utcnow()
         )
 
@@ -716,10 +712,10 @@ class MultithreadedDownloaderTests(TestCase):
 
 def test_shared_executor():
     """Test the shared_executor contextmanager which should set up thread_local Executor"""
-    assert not hasattr(download_async._thread_local, "executor")
+    assert not hasattr(download_threads._thread_local, "executor")
 
     executor = mock.Mock()
-    with download_async.shared_executor(executor):
-        assert executor == download_async._thread_local.executor
+    with download_threads.shared_executor(executor):
+        assert executor == download_threads._thread_local.executor
 
-    assert not hasattr(download_async._thread_local, "executor")
+    assert not hasattr(download_threads._thread_local, "executor")

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import tempfile
 from typing import Dict
-from unittest.mock import AsyncMock, MagicMock, call, mock_open, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, call, mock_open, patch
 
 import pytest
 import requests
@@ -485,6 +485,7 @@ class TestDownloadFileHandle:
                 destination="/myfakepath",
                 file_handle_id="123",
                 expected_md5="someMD5",
+                progress_bar=ANY,
                 synapse_client=self.syn,
             )
 
@@ -540,6 +541,7 @@ class TestDownloadFileHandle:
                 destination="/myfakepath",
                 file_handle_id="123",
                 expected_md5="someMD5",
+                progress_bar=ANY,
                 synapse_client=self.syn,
             )
 

--- a/tests/unit/synapseclient/models/async/unit_test_file_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_file_async.py
@@ -220,7 +220,7 @@ class TestFile:
             # THEN the file should be stored
             assert result.id == SYN_123
             assert result.name == FILE_NAME
-            assert result.path == PATH
+            assert utils.equal_paths(result.path, PATH)
             assert result.description == DESCRIPTION
             assert result.etag == ETAG
             assert result.created_on == CREATED_ON
@@ -375,7 +375,7 @@ class TestFile:
             # THEN the file should be stored
             assert result.id == SYN_123
             assert result.name == FILE_NAME
-            assert result.path == bogus_file
+            assert utils.equal_paths(result.path, bogus_file)
             assert result.description == DESCRIPTION
             assert result.etag == ETAG
             assert result.created_on == CREATED_ON
@@ -461,7 +461,7 @@ class TestFile:
             # THEN the file should be stored
             assert result.id == SYN_123
             assert result.name == FILE_NAME
-            assert result.path == bogus_file
+            assert utils.equal_paths(result.path, bogus_file)
             assert result.description == DESCRIPTION
             assert result.etag == ETAG
             assert result.created_on == CREATED_ON
@@ -567,7 +567,7 @@ class TestFile:
             # THEN the file should be stored
             assert result.id == SYN_123
             assert result.name == FILE_NAME
-            assert result.path == bogus_file
+            assert utils.equal_paths(result.path, bogus_file)
             assert result.description == DESCRIPTION
             assert result.etag == ETAG
             assert result.created_on == CREATED_ON
@@ -747,7 +747,7 @@ class TestFile:
             # THEN the file should be retrieved
             assert result.id == SYN_123
             assert result.name == FILE_NAME
-            assert result.path == bogus_file
+            assert utils.equal_paths(result.path, bogus_file)
             assert result.description == DESCRIPTION
             assert result.etag == ETAG
             assert result.created_on == CREATED_ON
@@ -809,7 +809,7 @@ class TestFile:
             # THEN the file should be stored
             assert result.id == SYN_123
             assert result.name == FILE_NAME
-            assert result.path == PATH
+            assert utils.equal_paths(result.path, PATH)
             assert result.description == DESCRIPTION
             assert result.etag == ETAG
             assert result.created_on == CREATED_ON
@@ -867,7 +867,7 @@ class TestFile:
             # THEN the file should be retrieved
             assert result.id == SYN_123
             assert result.name == FILE_NAME
-            assert result.path == PATH
+            assert utils.equal_paths(result.path, PATH)
             assert result.description == DESCRIPTION
             assert result.etag == ETAG
             assert result.created_on == CREATED_ON
@@ -933,7 +933,7 @@ class TestFile:
             # THEN the file should be retrieved
             assert result.id == SYN_123
             assert result.name == FILE_NAME
-            assert result.path == bogus_file
+            assert utils.equal_paths(result.path, bogus_file)
             assert result.description == DESCRIPTION
             assert result.etag == ETAG
             assert result.created_on == CREATED_ON

--- a/tests/unit/synapseclient/models/async/unit_test_folder_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_folder_async.py
@@ -1,11 +1,13 @@
 """Tests for the Folder class."""
 import uuid
-from unittest.mock import patch
+from typing import Dict
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from synapseclient import Folder as Synapse_Folder
 from synapseclient import Synapse
+from synapseclient.core.constants import concrete_types
 from synapseclient.core.constants.concrete_types import FILE_ENTITY
 from synapseclient.core.exceptions import SynapseNotFoundError
 from synapseclient.models import FailureStrategy, File, Folder
@@ -42,6 +44,22 @@ class TestFolder:
             modifiedBy=MODIFIED_BY,
         )
 
+    def get_example_rest_api_folder_output(self) -> Dict[str, str]:
+        return {
+            "entity": {
+                "concreteType": concrete_types.FOLDER_ENTITY,
+                "id": SYN_123,
+                "name": FOLDER_NAME,
+                "parentId": PARENT_ID,
+                "description": DESCRIPTION,
+                "etag": ETAG,
+                "createdOn": CREATED_ON,
+                "modifiedOn": MODIFIED_ON,
+                "createdBy": CREATED_BY,
+                "modifiedBy": MODIFIED_BY,
+            },
+        }
+
     def test_fill_from_dict(self) -> None:
         # GIVEN an example Synapse Folder `get_example_synapse_folder_output`
         # WHEN I call `fill_from_dict` with the example Synapse Folder
@@ -75,11 +93,16 @@ class TestFolder:
             self.syn,
             "store",
             return_value=(self.get_example_synapse_folder_output()),
-        ) as mocked_client_call, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Folder(
-                id=folder.id,
+        ) as mocked_client_call, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.FOLDER_ENTITY,
+                        "id": folder.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = await folder.store_async()
@@ -119,11 +142,16 @@ class TestFolder:
         with patch.object(
             self.syn,
             "store",
-        ) as mocked_store, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Folder(
-                id=folder.id,
+        ) as mocked_store, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.FOLDER_ENTITY,
+                        "id": folder.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = await folder.store_async()
@@ -144,18 +172,21 @@ class TestFolder:
         )
 
         # AND I call `get` on the Folder object
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Folder(
-                id=folder.id,
+        with patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.FOLDER_ENTITY,
+                        "id": folder.id,
+                    }
+                }
             ),
         ) as mocked_get:
             await folder.get_async()
 
-            mocked_get.assert_called_once_with(
-                entity=folder.id,
-            )
+            mocked_get.assert_called_once_with(entity_id=folder.id, synapse_client=None)
             assert folder.id == SYN_123
 
         # WHEN I call `store` with the Folder object
@@ -187,18 +218,21 @@ class TestFolder:
         )
 
         # AND I call `get` on the Folder object
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Folder(
-                id=folder.id,
+        with patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.FOLDER_ENTITY,
+                        "id": folder.id,
+                    }
+                }
             ),
         ) as mocked_get:
             await folder.get_async()
 
-            mocked_get.assert_called_once_with(
-                entity=folder.id,
-            )
+            mocked_get.assert_called_once_with(entity_id=folder.id, synapse_client=None)
             assert folder.id == SYN_123
 
         # AND I update a field on the folder
@@ -210,9 +244,9 @@ class TestFolder:
             self.syn,
             "store",
             return_value=(self.get_example_synapse_folder_output()),
-        ) as mocked_store, patch.object(
-            self.syn,
-            "get",
+        ) as mocked_store, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
         ) as mocked_get:
             result = await folder.store_async()
 
@@ -266,11 +300,16 @@ class TestFolder:
             self.syn,
             "store",
             return_value=(self.get_example_synapse_folder_output()),
-        ) as mocked_client_call, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Folder(
-                id=folder.id,
+        ) as mocked_client_call, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.FOLDER_ENTITY,
+                        "id": folder.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = await folder.store_async()
@@ -327,11 +366,16 @@ class TestFolder:
             self.syn,
             "findEntityId",
             return_value=SYN_123,
-        ) as mocked_get, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Folder(
-                id=folder.id,
+        ) as mocked_get, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.FOLDER_ENTITY,
+                        "id": folder.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = await folder.store_async()
@@ -385,11 +429,16 @@ class TestFolder:
             self.syn,
             "findEntityId",
             return_value=SYN_123,
-        ) as mocked_get, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Folder(
-                id=folder.id,
+        ) as mocked_get, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.FOLDER_ENTITY,
+                        "id": folder.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = await folder.store_async(parent=Folder(id=PARENT_ID))
@@ -473,16 +522,16 @@ class TestFolder:
         )
 
         # WHEN I call `get` with the Folder object
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=(self.get_example_synapse_folder_output()),
+        with patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=self.get_example_rest_api_folder_output(),
         ) as mocked_client_call:
             result = await folder.get_async()
 
             # THEN we should call the method with this data
             mocked_client_call.assert_called_once_with(
-                entity=folder.id,
+                entity_id=folder.id, synapse_client=None
             )
 
             # AND the folder should be stored
@@ -508,16 +557,16 @@ class TestFolder:
             self.syn,
             "findEntityId",
             return_value=(SYN_123),
-        ) as mocked_client_search, patch.object(
-            self.syn,
-            "get",
-            return_value=(self.get_example_synapse_folder_output()),
+        ) as mocked_client_search, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=self.get_example_rest_api_folder_output(),
         ) as mocked_client_call:
             result = await folder.get_async()
 
             # THEN we should call the method with this data
             mocked_client_call.assert_called_once_with(
-                entity=folder.id,
+                entity_id=folder.id, synapse_client=None
             )
 
             # AND we should search for the entity
@@ -684,10 +733,10 @@ class TestFolder:
             self.syn,
             "getChildren",
             return_value=(children),
-        ) as mocked_children_call, patch.object(
-            self.syn,
-            "get",
-            return_value=(self.get_example_synapse_folder_output()),
+        ) as mocked_children_call, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=self.get_example_rest_api_folder_output(),
         ) as mocked_folder_get, patch(
             "synapseclient.models.file.File.get_async",
             return_value=(File(id=SYN_456, name="example_file_1")),

--- a/tests/unit/synapseclient/models/async/unit_test_project_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_project_async.py
@@ -1,11 +1,13 @@
 """Tests for the synapseclient.models.Project class."""
 import uuid
-from unittest.mock import patch
+from typing import Dict
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from synapseclient import Project as Synapse_Project
 from synapseclient import Synapse
+from synapseclient.core.constants import concrete_types
 from synapseclient.core.constants.concrete_types import FILE_ENTITY
 from synapseclient.core.exceptions import SynapseNotFoundError
 from synapseclient.models import FailureStrategy, File, Project
@@ -41,6 +43,22 @@ class TestProject:
             modifiedBy=MODIFIED_BY,
         )
 
+    def get_example_rest_api_project_output(self) -> Dict[str, str]:
+        return {
+            "entity": {
+                "concreteType": concrete_types.PROJECT_ENTITY,
+                "id": PROJECT_ID,
+                "name": PROJECT_NAME,
+                "parentId": PARENT_ID,
+                "description": DERSCRIPTION_PROJECT,
+                "etag": ETAG,
+                "createdOn": CREATED_ON,
+                "modifiedOn": MODIFIED_ON,
+                "createdBy": CREATED_BY,
+                "modifiedBy": MODIFIED_BY,
+            }
+        }
+
     def test_fill_from_dict(self) -> None:
         # GIVEN an example Synapse Project `get_example_synapse_project_output`
         # WHEN I call `fill_from_dict` with the example Synapse Project
@@ -74,11 +92,16 @@ class TestProject:
             self.syn,
             "store",
             return_value=(self.get_example_synapse_project_output()),
-        ) as mocked_client_call, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Project(
-                id=project.id,
+        ) as mocked_client_call, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.PROJECT_ENTITY,
+                        "id": project.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = await project.store_async()
@@ -117,11 +140,16 @@ class TestProject:
         with patch.object(
             self.syn,
             "store",
-        ) as mocked_store, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Project(
-                id=project.id,
+        ) as mocked_store, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.PROJECT_ENTITY,
+                        "id": project.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = await project.store_async()
@@ -142,17 +170,22 @@ class TestProject:
         )
 
         # AND I call `get` on the Project object
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Project(
-                id=project.id,
+        with patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.PROJECT_ENTITY,
+                        "id": project.id,
+                    }
+                }
             ),
         ) as mocked_get:
             await project.get_async()
 
             mocked_get.assert_called_once_with(
-                entity=project.id,
+                entity_id=project.id, synapse_client=None
             )
             assert project.id == PROJECT_ID
 
@@ -160,11 +193,16 @@ class TestProject:
         with patch.object(
             self.syn,
             "store",
-        ) as mocked_store, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Project(
-                id=project.id,
+        ) as mocked_store, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.PROJECT_ENTITY,
+                        "id": project.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = await project.store_async()
@@ -185,17 +223,22 @@ class TestProject:
         )
 
         # AND I call `get` on the Project object
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Project(
-                id=project.id,
+        with patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.PROJECT_ENTITY,
+                        "id": project.id,
+                    }
+                }
             ),
         ) as mocked_get:
             await project.get_async()
 
             mocked_get.assert_called_once_with(
-                entity=project.id,
+                entity_id=project.id, synapse_client=None
             )
             assert project.id == PROJECT_ID
 
@@ -208,9 +251,8 @@ class TestProject:
             self.syn,
             "store",
             return_value=(self.get_example_synapse_project_output()),
-        ) as mocked_store, patch.object(
-            self.syn,
-            "get",
+        ) as mocked_store, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
         ) as mocked_get:
             result = await project.store_async()
 
@@ -263,11 +305,16 @@ class TestProject:
             self.syn,
             "store",
             return_value=(self.get_example_synapse_project_output()),
-        ) as mocked_client_call, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Project(
-                id=project.id,
+        ) as mocked_client_call, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.PROJECT_ENTITY,
+                        "id": project.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = await project.store_async()
@@ -323,11 +370,16 @@ class TestProject:
             self.syn,
             "findEntityId",
             return_value=PROJECT_ID,
-        ) as mocked_get, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Project(
-                id=project.id,
+        ) as mocked_get, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.PROJECT_ENTITY,
+                        "id": project.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = await project.store_async()
@@ -379,16 +431,16 @@ class TestProject:
         )
 
         # WHEN I call `get` with the Project object
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=(self.get_example_synapse_project_output()),
+        with patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(self.get_example_rest_api_project_output()),
         ) as mocked_client_call:
             result = await project.get_async()
 
             # THEN we should call the method with this data
             mocked_client_call.assert_called_once_with(
-                entity=project.id,
+                entity_id=project.id, synapse_client=None
             )
 
             # AND the project should be stored
@@ -414,16 +466,16 @@ class TestProject:
             self.syn,
             "findEntityId",
             return_value=(PROJECT_ID),
-        ) as mocked_client_search, patch.object(
-            self.syn,
-            "get",
-            return_value=(self.get_example_synapse_project_output()),
+        ) as mocked_client_search, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(self.get_example_rest_api_project_output()),
         ) as mocked_client_call:
             result = await project.get_async()
 
             # THEN we should call the method with this data
             mocked_client_call.assert_called_once_with(
-                entity=project.id,
+                entity_id=project.id, synapse_client=None
             )
 
             # AND we should search for the entity
@@ -591,10 +643,10 @@ class TestProject:
             self.syn,
             "getChildren",
             return_value=(children),
-        ) as mocked_children_call, patch.object(
-            self.syn,
-            "get",
-            return_value=(self.get_example_synapse_project_output()),
+        ) as mocked_children_call, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(self.get_example_rest_api_project_output()),
         ) as mocked_project_get, patch(
             "synapseclient.models.file.File.get_async",
             return_value=(File(id="syn456", name="example_file_1")),

--- a/tests/unit/synapseclient/models/synchronous/unit_test_file.py
+++ b/tests/unit/synapseclient/models/synchronous/unit_test_file.py
@@ -7,6 +7,7 @@ import pytest
 
 from synapseclient import File as Synapse_File
 from synapseclient.core import utils
+from synapseclient.core.constants import concrete_types
 from synapseclient.models import Activity, File, Project, UsedURL
 
 SYN_123 = "syn123"
@@ -91,6 +92,30 @@ class TestFile:
             _file_handle=self.get_example_synapse_file_handle(),
         )
 
+    def get_example_rest_api_file_output(
+        self, path: str = PATH
+    ) -> Dict[str, Union[str, int]]:
+        return {
+            "entity": {
+                "concreteType": concrete_types.FILE_ENTITY,
+                "id": SYN_123,
+                "name": FILE_NAME,
+                "path": path,
+                "description": DESCRIPTION,
+                "etag": ETAG,
+                "createdOn": CREATED_ON,
+                "modifiedOn": MODIFIED_ON,
+                "createdBy": CREATED_BY,
+                "modifiedBy": MODIFIED_BY,
+                "parentId": PARENT_ID,
+                "versionNumber": 1,
+                "versionLabel": VERSION_LABEL,
+                "versionComment": VERSION_COMMENT,
+                "dataFileHandleId": DATA_FILE_HANDLE_ID,
+            },
+            "fileHandles": [self.get_example_synapse_file_handle()],
+        }
+
     def get_example_synapse_file_handle(self) -> Dict[str, Union[str, int, bool]]:
         return {
             "id": FILE_HANDLE_ID,
@@ -157,11 +182,11 @@ class TestFile:
         file = File(id=SYN_123, path=PATH, description=MODIFIED_DESCRIPTION)
 
         # WHEN I store the example file
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=(self.get_example_synapse_file_output()),
-        ) as mocked_get_call, patch(
+        with patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(self.get_example_rest_api_file_output()),
+        ) as mocked_get_entity_bundle, patch(
             "synapseclient.models.file.upload_file_handle",
             new_callable=AsyncMock,
             return_value=(self.get_example_synapse_file_handle()),
@@ -173,14 +198,8 @@ class TestFile:
             result = file.store()
 
             # THEN we should call the method with this data
-            mocked_get_call.assert_called_once_with(
-                entity=SYN_123,
-                version=None,
-                ifcollision=file.if_collision,
-                limitSearch=None,
-                downloadFile=False,
-                downloadLocation=None,
-                md5=None,
+            mocked_get_entity_bundle.assert_called_once_with(
+                entity_id=SYN_123, synapse_client=None
             )
 
             # AND We should upload the file handle
@@ -242,11 +261,11 @@ class TestFile:
         )
 
         # WHEN I store the example file
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=(self.get_example_synapse_file_output(path=None)),
-        ) as mocked_get_call, patch(
+        with patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(self.get_example_rest_api_file_output(path=None)),
+        ) as mocked_get_entity_bundle, patch(
             "synapseclient.models.file.upload_file_handle",
             new_callable=AsyncMock,
             return_value=(self.get_example_synapse_file_handle()),
@@ -258,14 +277,8 @@ class TestFile:
             result = file.store()
 
             # THEN we should call the method with this data
-            mocked_get_call.assert_called_once_with(
-                entity=SYN_123,
-                version=None,
-                ifcollision=file.if_collision,
-                limitSearch=None,
-                downloadFile=False,
-                downloadLocation=None,
-                md5=None,
+            mocked_get_entity_bundle.assert_called_once_with(
+                entity_id=SYN_123, synapse_client=None
             )
 
             # AND We should not upload the file handle
@@ -717,23 +730,17 @@ class TestFile:
         )
 
         # WHEN I get the example file
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=(self.get_example_synapse_file_output(path=bogus_file)),
-        ) as mocked_client_call:
+        with patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(self.get_example_rest_api_file_output(path=bogus_file)),
+        ) as mocked_get_entity_bundle:
             result = file.get()
             os.remove(bogus_file)
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(
-                entity=SYN_123,
-                version=None,
-                ifcollision=file.if_collision,
-                limitSearch=file.synapse_container_limit,
-                downloadFile=file.download_file,
-                downloadLocation=file.download_location,
-                md5=None,
+            mocked_get_entity_bundle.assert_called_once_with(
+                entity_id=SYN_123, synapse_client=None
             )
 
             # THEN the file should be retrieved
@@ -777,22 +784,25 @@ class TestFile:
         file = File(path=PATH, description=MODIFIED_DESCRIPTION)
 
         # WHEN I get the example file
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=(self.get_example_synapse_file_output()),
-        ) as mocked_client_call:
+        with patch(
+            "synapseclient.api.entity_factory._search_for_file_by_md5",
+            new_callable=AsyncMock,
+            return_value=(self.get_example_rest_api_file_output()),
+        ) as mocked_search_for_file, patch.object(
+            file,
+            "_load_local_md5",
+            return_value=(None),
+        ), patch(
+            "os.path.isfile", return_value=True
+        ):
             result = file.get()
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(
-                entity=PATH,
-                version=None,
-                ifcollision=file.if_collision,
-                limitSearch=file.synapse_container_limit,
-                downloadFile=file.download_file,
-                downloadLocation=file.download_location,
+            mocked_search_for_file.assert_called_once_with(
+                filepath="/asdf/example_file.txt",
+                limit_search=None,
                 md5=None,
+                synapse_client=None,
             )
 
             # THEN the file should be stored
@@ -835,26 +845,22 @@ class TestFile:
         # GIVEN an example path
         path = PATH
 
-        # AND a default File
-        default_file = File()
-
         # WHEN I get the example file
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=(self.get_example_synapse_file_output()),
-        ) as mocked_client_call:
+        with patch(
+            "synapseclient.api.entity_factory._search_for_file_by_md5",
+            new_callable=AsyncMock,
+            return_value=(self.get_example_rest_api_file_output()),
+        ) as mocked_search_for_file, patch(
+            "synapseclient.models.file.File._load_local_md5",
+            return_value=(None),
+        ), patch(
+            "os.path.isfile", return_value=True
+        ):
             result = File.from_path(path=path)
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(
-                entity=PATH,
-                version=None,
-                ifcollision=default_file.if_collision,
-                limitSearch=default_file.synapse_container_limit,
-                downloadFile=default_file.download_file,
-                downloadLocation=default_file.download_location,
-                md5=None,
+            mocked_search_for_file.assert_called_once_with(
+                filepath=PATH, limit_search=None, md5=None, synapse_client=None
             )
 
             # THEN the file should be retrieved
@@ -897,9 +903,6 @@ class TestFile:
         # GIVEN an example id
         synapse_id = SYN_123
 
-        # AND a default File
-        default_file = File()
-
         # AND An actual file
         bogus_file = utils.make_bogus_uuid_file()
 
@@ -910,23 +913,17 @@ class TestFile:
         )
 
         # WHEN I get the example file
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=(self.get_example_synapse_file_output(path=bogus_file)),
-        ) as mocked_client_call:
+        with patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(self.get_example_rest_api_file_output(path=bogus_file)),
+        ) as mocked_get_entity_bundle:
             result = File.from_id(synapse_id=synapse_id)
             os.remove(bogus_file)
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(
-                entity=SYN_123,
-                version=None,
-                ifcollision=default_file.if_collision,
-                limitSearch=default_file.synapse_container_limit,
-                downloadFile=default_file.download_file,
-                downloadLocation=default_file.download_location,
-                md5=None,
+            mocked_get_entity_bundle.assert_called_once_with(
+                entity_id=SYN_123, synapse_client=None
             )
 
             # THEN the file should be retrieved

--- a/tests/unit/synapseclient/models/synchronous/unit_test_file.py
+++ b/tests/unit/synapseclient/models/synchronous/unit_test_file.py
@@ -219,7 +219,7 @@ class TestFile:
             # THEN the file should be stored
             assert result.id == SYN_123
             assert result.name == FILE_NAME
-            assert result.path == PATH
+            assert utils.equal_paths(result.path, PATH)
             assert result.description == DESCRIPTION
             assert result.etag == ETAG
             assert result.created_on == CREATED_ON
@@ -374,7 +374,7 @@ class TestFile:
             # THEN the file should be stored
             assert result.id == SYN_123
             assert result.name == FILE_NAME
-            assert result.path == bogus_file
+            assert utils.equal_paths(result.path, bogus_file)
             assert result.description == DESCRIPTION
             assert result.etag == ETAG
             assert result.created_on == CREATED_ON
@@ -460,7 +460,7 @@ class TestFile:
             # THEN the file should be stored
             assert result.id == SYN_123
             assert result.name == FILE_NAME
-            assert result.path == bogus_file
+            assert utils.equal_paths(result.path, bogus_file)
             assert result.description == DESCRIPTION
             assert result.etag == ETAG
             assert result.created_on == CREATED_ON
@@ -566,7 +566,7 @@ class TestFile:
             # THEN the file should be stored
             assert result.id == SYN_123
             assert result.name == FILE_NAME
-            assert result.path == bogus_file
+            assert utils.equal_paths(result.path, bogus_file)
             assert result.description == DESCRIPTION
             assert result.etag == ETAG
             assert result.created_on == CREATED_ON
@@ -746,7 +746,7 @@ class TestFile:
             # THEN the file should be retrieved
             assert result.id == SYN_123
             assert result.name == FILE_NAME
-            assert result.path == bogus_file
+            assert utils.equal_paths(result.path, bogus_file)
             assert result.description == DESCRIPTION
             assert result.etag == ETAG
             assert result.created_on == CREATED_ON
@@ -808,7 +808,7 @@ class TestFile:
             # THEN the file should be stored
             assert result.id == SYN_123
             assert result.name == FILE_NAME
-            assert result.path == PATH
+            assert utils.equal_paths(result.path, PATH)
             assert result.description == DESCRIPTION
             assert result.etag == ETAG
             assert result.created_on == CREATED_ON
@@ -866,7 +866,7 @@ class TestFile:
             # THEN the file should be retrieved
             assert result.id == SYN_123
             assert result.name == FILE_NAME
-            assert result.path == PATH
+            assert utils.equal_paths(result.path, PATH)
             assert result.description == DESCRIPTION
             assert result.etag == ETAG
             assert result.created_on == CREATED_ON
@@ -929,7 +929,7 @@ class TestFile:
             # THEN the file should be retrieved
             assert result.id == SYN_123
             assert result.name == FILE_NAME
-            assert result.path == bogus_file
+            assert utils.equal_paths(result.path, bogus_file)
             assert result.description == DESCRIPTION
             assert result.etag == ETAG
             assert result.created_on == CREATED_ON

--- a/tests/unit/synapseclient/models/synchronous/unit_test_folder.py
+++ b/tests/unit/synapseclient/models/synchronous/unit_test_folder.py
@@ -1,11 +1,13 @@
 """Tests for the Folder class."""
 import uuid
-from unittest.mock import patch
+from typing import Dict
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from synapseclient import Folder as Synapse_Folder
 from synapseclient import Synapse
+from synapseclient.core.constants import concrete_types
 from synapseclient.core.constants.concrete_types import FILE_ENTITY
 from synapseclient.core.exceptions import SynapseNotFoundError
 from synapseclient.models import FailureStrategy, File, Folder
@@ -42,6 +44,22 @@ class TestFolder:
             modifiedBy=MODIFIED_BY,
         )
 
+    def get_example_rest_api_folder_output(self) -> Dict[str, str]:
+        return {
+            "entity": {
+                "concreteType": concrete_types.FOLDER_ENTITY,
+                "id": SYN_123,
+                "name": FOLDER_NAME,
+                "parentId": PARENT_ID,
+                "description": DESCRIPTION,
+                "etag": ETAG,
+                "createdOn": CREATED_ON,
+                "modifiedOn": MODIFIED_ON,
+                "createdBy": CREATED_BY,
+                "modifiedBy": MODIFIED_BY,
+            },
+        }
+
     def test_fill_from_dict(self) -> None:
         # GIVEN an example Synapse Folder `get_example_synapse_folder_output`
         # WHEN I call `fill_from_dict` with the example Synapse Folder
@@ -75,11 +93,16 @@ class TestFolder:
             self.syn,
             "store",
             return_value=(self.get_example_synapse_folder_output()),
-        ) as mocked_client_call, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Folder(
-                id=folder.id,
+        ) as mocked_client_call, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.FOLDER_ENTITY,
+                        "id": folder.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = folder.store()
@@ -119,11 +142,16 @@ class TestFolder:
         with patch.object(
             self.syn,
             "store",
-        ) as mocked_store, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Folder(
-                id=folder.id,
+        ) as mocked_store, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.FOLDER_ENTITY,
+                        "id": folder.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = folder.store()
@@ -144,18 +172,21 @@ class TestFolder:
         )
 
         # AND I call `get` on the Folder object
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Folder(
-                id=folder.id,
+        with patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.FOLDER_ENTITY,
+                        "id": folder.id,
+                    }
+                }
             ),
         ) as mocked_get:
             folder.get()
 
-            mocked_get.assert_called_once_with(
-                entity=folder.id,
-            )
+            mocked_get.assert_called_once_with(entity_id=folder.id, synapse_client=None)
             assert folder.id == SYN_123
 
         # WHEN I call `store` with the Folder object
@@ -187,18 +218,21 @@ class TestFolder:
         )
 
         # AND I call `get` on the Folder object
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Folder(
-                id=folder.id,
+        with patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.FOLDER_ENTITY,
+                        "id": folder.id,
+                    }
+                }
             ),
         ) as mocked_get:
             folder.get()
 
-            mocked_get.assert_called_once_with(
-                entity=folder.id,
-            )
+            mocked_get.assert_called_once_with(entity_id=folder.id, synapse_client=None)
             assert folder.id == SYN_123
 
         # AND I update a field on the folder
@@ -210,9 +244,9 @@ class TestFolder:
             self.syn,
             "store",
             return_value=(self.get_example_synapse_folder_output()),
-        ) as mocked_store, patch.object(
-            self.syn,
-            "get",
+        ) as mocked_store, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
         ) as mocked_get:
             result = folder.store()
 
@@ -266,11 +300,16 @@ class TestFolder:
             self.syn,
             "store",
             return_value=(self.get_example_synapse_folder_output()),
-        ) as mocked_client_call, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Folder(
-                id=folder.id,
+        ) as mocked_client_call, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.FOLDER_ENTITY,
+                        "id": folder.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = folder.store()
@@ -327,11 +366,16 @@ class TestFolder:
             self.syn,
             "findEntityId",
             return_value=SYN_123,
-        ) as mocked_get, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Folder(
-                id=folder.id,
+        ) as mocked_get, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.FOLDER_ENTITY,
+                        "id": folder.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = folder.store()
@@ -385,11 +429,16 @@ class TestFolder:
             self.syn,
             "findEntityId",
             return_value=SYN_123,
-        ) as mocked_get, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Folder(
-                id=folder.id,
+        ) as mocked_get, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.FOLDER_ENTITY,
+                        "id": folder.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = folder.store(parent=Folder(id=PARENT_ID))
@@ -473,16 +522,16 @@ class TestFolder:
         )
 
         # WHEN I call `get` with the Folder object
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=(self.get_example_synapse_folder_output()),
+        with patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=self.get_example_rest_api_folder_output(),
         ) as mocked_client_call:
             result = folder.get()
 
             # THEN we should call the method with this data
             mocked_client_call.assert_called_once_with(
-                entity=folder.id,
+                entity_id=folder.id, synapse_client=None
             )
 
             # AND the folder should be stored
@@ -508,16 +557,16 @@ class TestFolder:
             self.syn,
             "findEntityId",
             return_value=(SYN_123),
-        ) as mocked_client_search, patch.object(
-            self.syn,
-            "get",
-            return_value=(self.get_example_synapse_folder_output()),
+        ) as mocked_client_search, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=self.get_example_rest_api_folder_output(),
         ) as mocked_client_call:
             result = folder.get()
 
             # THEN we should call the method with this data
             mocked_client_call.assert_called_once_with(
-                entity=folder.id,
+                entity_id=folder.id, synapse_client=None
             )
 
             # AND we should search for the entity
@@ -684,10 +733,10 @@ class TestFolder:
             self.syn,
             "getChildren",
             return_value=(children),
-        ) as mocked_children_call, patch.object(
-            self.syn,
-            "get",
-            return_value=(self.get_example_synapse_folder_output()),
+        ) as mocked_children_call, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=self.get_example_rest_api_folder_output(),
         ) as mocked_folder_get, patch(
             "synapseclient.models.file.File.get_async",
             return_value=(File(id=SYN_456, name="example_file_1")),

--- a/tests/unit/synapseclient/models/synchronous/unit_test_project.py
+++ b/tests/unit/synapseclient/models/synchronous/unit_test_project.py
@@ -1,11 +1,13 @@
 """Tests for the synapseclient.models.Project class."""
 import uuid
-from unittest.mock import patch
+from typing import Dict
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from synapseclient import Project as Synapse_Project
 from synapseclient import Synapse
+from synapseclient.core.constants import concrete_types
 from synapseclient.core.constants.concrete_types import FILE_ENTITY
 from synapseclient.core.exceptions import SynapseNotFoundError
 from synapseclient.models import FailureStrategy, File, Project
@@ -41,6 +43,22 @@ class TestProject:
             modifiedBy=MODIFIED_BY,
         )
 
+    def get_example_rest_api_project_output(self) -> Dict[str, str]:
+        return {
+            "entity": {
+                "concreteType": concrete_types.PROJECT_ENTITY,
+                "id": PROJECT_ID,
+                "name": PROJECT_NAME,
+                "parentId": PARENT_ID,
+                "description": DERSCRIPTION_PROJECT,
+                "etag": ETAG,
+                "createdOn": CREATED_ON,
+                "modifiedOn": MODIFIED_ON,
+                "createdBy": CREATED_BY,
+                "modifiedBy": MODIFIED_BY,
+            }
+        }
+
     def test_fill_from_dict(self) -> None:
         # GIVEN an example Synapse Project `get_example_synapse_project_output`
         # WHEN I call `fill_from_dict` with the example Synapse Project
@@ -74,11 +92,16 @@ class TestProject:
             self.syn,
             "store",
             return_value=(self.get_example_synapse_project_output()),
-        ) as mocked_client_call, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Project(
-                id=project.id,
+        ) as mocked_client_call, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.PROJECT_ENTITY,
+                        "id": project.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = project.store()
@@ -117,11 +140,16 @@ class TestProject:
         with patch.object(
             self.syn,
             "store",
-        ) as mocked_store, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Project(
-                id=project.id,
+        ) as mocked_store, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.PROJECT_ENTITY,
+                        "id": project.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = project.store()
@@ -142,17 +170,22 @@ class TestProject:
         )
 
         # AND I call `get` on the Project object
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Project(
-                id=project.id,
+        with patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.PROJECT_ENTITY,
+                        "id": project.id,
+                    }
+                }
             ),
         ) as mocked_get:
             project.get()
 
             mocked_get.assert_called_once_with(
-                entity=project.id,
+                entity_id=project.id, synapse_client=None
             )
             assert project.id == PROJECT_ID
 
@@ -160,11 +193,16 @@ class TestProject:
         with patch.object(
             self.syn,
             "store",
-        ) as mocked_store, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Project(
-                id=project.id,
+        ) as mocked_store, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.PROJECT_ENTITY,
+                        "id": project.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = project.store()
@@ -185,17 +223,22 @@ class TestProject:
         )
 
         # AND I call `get` on the Project object
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Project(
-                id=project.id,
+        with patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.PROJECT_ENTITY,
+                        "id": project.id,
+                    }
+                }
             ),
         ) as mocked_get:
             project.get()
 
             mocked_get.assert_called_once_with(
-                entity=project.id,
+                entity_id=project.id, synapse_client=None
             )
             assert project.id == PROJECT_ID
 
@@ -208,9 +251,8 @@ class TestProject:
             self.syn,
             "store",
             return_value=(self.get_example_synapse_project_output()),
-        ) as mocked_store, patch.object(
-            self.syn,
-            "get",
+        ) as mocked_store, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
         ) as mocked_get:
             result = project.store()
 
@@ -263,11 +305,16 @@ class TestProject:
             self.syn,
             "store",
             return_value=(self.get_example_synapse_project_output()),
-        ) as mocked_client_call, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Project(
-                id=project.id,
+        ) as mocked_client_call, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.PROJECT_ENTITY,
+                        "id": project.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = project.store()
@@ -323,11 +370,16 @@ class TestProject:
             self.syn,
             "findEntityId",
             return_value=PROJECT_ID,
-        ) as mocked_get, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Project(
-                id=project.id,
+        ) as mocked_get, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "entity": {
+                        "concreteType": concrete_types.PROJECT_ENTITY,
+                        "id": project.id,
+                    }
+                }
             ),
         ) as mocked_get:
             result = project.store()
@@ -379,16 +431,16 @@ class TestProject:
         )
 
         # WHEN I call `get` with the Project object
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=(self.get_example_synapse_project_output()),
+        with patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(self.get_example_rest_api_project_output()),
         ) as mocked_client_call:
             result = project.get()
 
             # THEN we should call the method with this data
             mocked_client_call.assert_called_once_with(
-                entity=project.id,
+                entity_id=project.id, synapse_client=None
             )
 
             # AND the project should be stored
@@ -414,16 +466,16 @@ class TestProject:
             self.syn,
             "findEntityId",
             return_value=(PROJECT_ID),
-        ) as mocked_client_search, patch.object(
-            self.syn,
-            "get",
-            return_value=(self.get_example_synapse_project_output()),
+        ) as mocked_client_search, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(self.get_example_rest_api_project_output()),
         ) as mocked_client_call:
             result = project.get()
 
             # THEN we should call the method with this data
             mocked_client_call.assert_called_once_with(
-                entity=project.id,
+                entity_id=project.id, synapse_client=None
             )
 
             # AND we should search for the entity
@@ -591,10 +643,10 @@ class TestProject:
             self.syn,
             "getChildren",
             return_value=(children),
-        ) as mocked_children_call, patch.object(
-            self.syn,
-            "get",
-            return_value=(self.get_example_synapse_project_output()),
+        ) as mocked_children_call, patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(self.get_example_rest_api_project_output()),
         ) as mocked_project_get, patch(
             "synapseclient.models.file.File.get_async",
             return_value=(File(id="syn456", name="example_file_1")),

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -59,7 +59,7 @@ from synapseclient.core.models.dict_object import DictObject
 from synapseclient.core.upload import upload_functions
 
 GET_FILE_HANDLE_FOR_DOWNLOAD = (
-    "synapseclient.core.download.download_functions.get_file_handle_for_download"
+    "synapseclient.core.download.download_functions.get_file_handle_for_download_async"
 )
 DOWNLOAD_BY_FILE_HANDLE = (
     "synapseclient.core.download.download_functions.download_by_file_handle"
@@ -340,7 +340,6 @@ class TestDownloadFileHandle:
                 new_callable=AsyncMock,
             ) as mock_get_file_handle_download, patch(
                 DOWNLOAD_FROM_URL,
-                new_callable=AsyncMock,
             ) as mock_download_from_URL:
                 mock_get_file_handle_download.return_value = {
                     "fileHandle": {
@@ -468,7 +467,7 @@ class TestDownloadFileHandle:
         ), patch.object(
             urllib_request, "urlretrieve"
         ) as mock_url_retrieve, patch.object(
-            utils, "md5_for_file_multiprocessing"
+            utils, "md5_for_file"
         ) as mock_md5_for_file, patch.object(
             os, "makedirs"
         ):
@@ -513,7 +512,7 @@ class TestDownloadFileHandle:
 
         mock_get.return_value = response
 
-        out_destination = await download_from_url(
+        out_destination = download_from_url(
             url=uri,
             destination=in_destination.name,
             synapse_client=self.syn,
@@ -541,7 +540,7 @@ class TestDownloadFileHandle:
 
         mock_get.return_value = response
 
-        out_destination = await download_from_url(
+        out_destination = download_from_url(
             url=uri,
             destination=in_destination.name,
             synapse_client=self.syn,

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -437,7 +437,7 @@ class TestDownloadFileHandle:
             mock_os.makedirs.assert_called_once_with(
                 mock_os.path.dirname(destination), exist_ok=True
             )
-            cache.add.assert_called_once_with(file_handle_id, download_path)
+            cache.add.assert_called_once_with(file_handle_id, download_path, None)
 
         assert expected_download_path == download_path
         mock_s3_client_wrapper.download_file.assert_called_once_with(

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -35,6 +35,7 @@ from synapseclient import (
 from synapseclient.annotations import convert_old_annotation_json
 from synapseclient.api import get_config_file
 from synapseclient.client import DEFAULT_STORAGE_LOCATION_ID
+from synapseclient.core import sts_transfer
 from synapseclient.core.constants import concrete_types
 from synapseclient.core.credentials import UserLoginArgs
 from synapseclient.core.credentials.cred_data import SynapseAuthTokenCredentials
@@ -446,7 +447,7 @@ class TestDownloadFileHandle:
             remote_file_key=FOO_KEY,
             download_file_path="/tmp",
             credentials=credentials,
-            show_progress=True,
+            progress_bar=ANY,
             transfer_config_kwargs={"max_concurrency": self.syn.max_threads},
         )
 
@@ -470,6 +471,8 @@ class TestDownloadFileHandle:
             utils, "md5_for_file"
         ) as mock_md5_for_file, patch.object(
             os, "makedirs"
+        ), patch.object(
+            sts_transfer, "is_storage_location_sts_enabled_async", return_value=False
         ):
             mock_get_file_handle_download.return_value = {
                 "fileHandle": {

--- a/tests/unit/synapseclient/unit_test_commandline.py
+++ b/tests/unit/synapseclient/unit_test_commandline.py
@@ -671,8 +671,6 @@ class TestGetFunction:
         assert self.syn.logger.info.call_args_list == [
             call("WARNING: No files associated with entity %s\n", "syn123"),
             call(mock_entity),
-            call("Downloaded file: %s", "./base_tmp_path"),
-            call("Creating %s", "./tmp_path"),
         ]
 
     def test_get__without_synapse_id(self):

--- a/tests/unit/synapseutils/unit_test_synapseutils_sync.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_sync.py
@@ -24,6 +24,7 @@ from synapseclient.core.utils import id_of
 from synapseclient.models import File
 from synapseutils import sync
 from synapseutils.sync import _SyncUploader, _SyncUploadItem
+from tests.test_utils import spy_for_async_function, spy_for_function
 
 SYNAPSE_URL = "http://www.synapse.org"
 GITHUB_URL = "http://www.github.com"
@@ -315,22 +316,6 @@ def test_sync_from_synapse_folder_contains_one_file(syn: Synapse) -> None:
         result = synapseutils.syncFromSynapse(syn, folder)
         assert [file] == result
         patch_syn_get_children.called_with(folder["id"])
-
-
-def spy_for_async_function(
-    original_func: Callable[..., Any]
-) -> Callable[..., Coroutine[Any, Any, Any]]:
-    async def wrapper(*args, **kwargs):
-        return await original_func(*args, **kwargs)  # Call the original function
-
-    return wrapper
-
-
-def spy_for_function(original_func: Callable[..., Any]) -> Callable[..., Any]:
-    def wrapper(*args, **kwargs):
-        return original_func(*args, **kwargs)  # Call the original function
-
-    return wrapper
 
 
 def test_sync_from_synapse_project_contains_empty_folder(syn: Synapse) -> None:


### PR DESCRIPTION
**Problem:**

1. Within Project, Folder, File, in order to wrap the existing Synapse Python Client `.get()` function we were running the code within the asyncio `run_in_executor`. This worked fine up until now. The problem at this point is that utility functions are now going to be directly using these new model functions and it leads to a problem where we are changing from a non-async context (Before SynapseUtils) -> Async context (Inside the model) -> Non-Async context (Running in a thread executor) -> Async context (To download a file) -> Multi-threaded download.
2. The progress bars for both individual file downloads, and syncFromSynapse was broken and needed to be mended.

**Solution:**

1. Breaking out the logic that is used to retrieve entities. This new logic is now following a factory-type pattern allowing us to easily add more entities to it.
3. Updating the Project, Folder, File, functions to use the new factory-type pattern to retrieve the entity data.
4. Updating the logic around shared and individual download progress bars

**Testing:**

1. Integration test runs
2. Manual verification via steps laid out in jira comment of: https://sagebionetworks.jira.com/browse/SYNPY-1476