### PR TITLE
[SYNPY-1457] Fix deprecated Node.js build warnings

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           python-version: 3.x
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit/action@v3.0.1
 
 
   # run unit (and integration tests if account secrets available) on our build matrix
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -70,7 +70,7 @@ jobs:
 
       - name: Cache py-dependencies
         id: cache-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-py-dependencies
         with:
@@ -197,7 +197,7 @@ jobs:
           # Execute the CLI tests in a non-dist way because they were causing some test instability when being run concurrently
           # pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration/synapseclient/test_command_line_client.py
       - name: Upload otel spans
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: otel_spans_integration_testing_${{ matrix.os }}
@@ -205,7 +205,7 @@ jobs:
           if-no-files-found: ignore
       - name: Upload coverage report
         id: upload_coverage_report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: ${{ contains(fromJSON('["3.9"]'), matrix.python) && contains(fromJSON('["ubuntu-20.04"]'), matrix.os)}}
         with:
           name: coverage-report
@@ -217,7 +217,7 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Check coverage report existence
@@ -256,7 +256,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
@@ -322,13 +322,13 @@ jobs:
       # upload the packages as build artifacts of the GitHub Action
 
       - name: upload-build-sdist
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.build-package.outputs.sdist-package-name }}
           path: dist/${{ steps.build-package.outputs.sdist-package-name }}
 
       - name: upload-build-bdist
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.build-package.outputs.bdist-package-name }}
           path: dist/${{ steps.build-package.outputs.bdist-package-name }}
@@ -401,7 +401,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,4 +69,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/tests/integration/synapseclient/test_tables.py
+++ b/tests/integration/synapseclient/test_tables.py
@@ -387,7 +387,7 @@ async def test_tables_pandas(syn, project):
                 ]
             ),
             "string_": tuple(
-                np.string_(s) for s in ["urgot", "has", "dark", "mysterious", "past"]
+                np.bytes_(s) for s in ["urgot", "has", "dark", "mysterious", "past"]
             ),
         }
     )


### PR DESCRIPTION
## problem

We are using versions of GitHub actions that still use`Node.js 16`, which is now deprecated and leads to deprecation warnings in the builds. This clutters build output messages which is unhelpful when troubleshooting/monitoring the status of your builds.

## solution

- [x] Update GitHub actions used in our workflows to versions that use `Node.js 20`
- [x] Update one of our integration tests in `tests/integration/synapseclient/test_tables.py` that uses `np.string_(s)` which is no longer supported with the updated actions that uses a newer `numPy`

## testing & preview

Latest run: https://github.com/Sage-Bionetworks/synapsePythonClient/actions/runs/9618137457

UPDATED:

Latest run: https://github.com/Sage-Bionetworks/synapsePythonClient/actions/runs/9620252513