### PR TITLE
[SYNPY-1487] Fix missing coverage report

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,11 +216,18 @@ jobs:
     if: ${{ always() && !cancelled()}}
     name: SonarCloud
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-12, windows-2022]
+
+        # if changing the below change the run-integration-tests versions and the check-deploy versions
+        python: [3.8, '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Download coverage report
+        if: ${{ contains(fromJSON('["3.9"]'), matrix.python) && contains(fromJSON('["ubuntu-20.04"]'), matrix.os)}}
         uses: actions/download-artifact@v2
         with:
           name: coverage-report
@@ -230,7 +237,7 @@ jobs:
         id: check_coverage_report
         uses: andstor/file-existence-action@v3
         with:
-          files: "coverage.xml"
+          files: "coverage*.zip"
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057
       - name: Override Coverage Source Path for Sonar
         if: steps.check_coverage_report.outputs.files_exists == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
       - name: run-unit-tests
         shell: bash
         run: |
-          pytestt -sv --cov-append --cov=. --cov-report xml tests/unit
+          pytest -sv --cov-append --cov=. --cov-report xml tests/unit
       - name: Check for Secret availability
         id: secret-check
         if: ${{ contains(fromJSON('["3.9"]'), matrix.python) }}
@@ -233,7 +233,7 @@ jobs:
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057
       - name: Override Coverage Source Path for Sonar
         if: steps.check_coverage_report.outputs.exists == 'true'
-        run: sed -i "s/<source>\/home\/runner\/work\/synapsePythonClient<\/source>/<source>\/github\/workspace<\/source>/g" coverage.xml
+        run: sedd -i "s/<source>\/home\/runner\/work\/synapsePythonClient<\/source>/<source>\/github\/workspace<\/source>/g" coverage.xml
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         if: ${{ always() }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,7 +228,7 @@ jobs:
       - name: List files in the working directory
         run: ls -la
       - name: Download coverage report
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         if: steps.check_coverage_report.outputs.exists == 'true'
         with:
           name: coverage-report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,18 +220,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Download coverage report
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage-report
+      - name: List files in the working directory
+        run: ls -la
       - name: Check coverage report existence
         id: check_coverage_report
         uses: andstor/file-existence-action@v3
         with:
-          files: "*coverage*"
-      - name: List files in the working directory
-        run: ls -la
-      - name: Download coverage report
-        uses: actions/download-artifact@v2
-        if: steps.check_coverage_report.outputs.files_exists == 'true'
-        with:
-          name: coverage-report
+          files: "coverage.xml"
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057
       - name: Override Coverage Source Path for Sonar
         if: steps.check_coverage_report.outputs.files_exists == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,7 +224,7 @@ jobs:
         id: check_coverage_report
         uses: andstor/file-existence-action@v3
         with:
-          files: "coverage.xml,coverage-report.zip,coverage-report"
+          files: "*coverage*"
       - name: Download coverage report
         uses: actions/download-artifact@v2
         if: steps.check_coverage_report.outputs.files_exists == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,28 +216,22 @@ jobs:
     if: ${{ always() && !cancelled()}}
     name: SonarCloud
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, macos-12, windows-2022]
-
-        # if changing the below change the run-integration-tests versions and the check-deploy versions
-        python: [3.8, '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Download coverage report
-        if: ${{ contains(fromJSON('["3.9"]'), matrix.python) && contains(fromJSON('["ubuntu-20.04"]'), matrix.os)}}
-        uses: actions/download-artifact@v2
-        with:
-          name: coverage-report
-      - name: List files in the working directory
-        run: ls -la
       - name: Check coverage report existence
         id: check_coverage_report
-        uses: andstor/file-existence-action@v3
+        uses: LIT-Protocol/artifact-exists-action@v0
         with:
-          files: "coverage*.zip"
+          name: "coverage-report"
+      - name: List files in the working directory
+        run: ls -la
+      - name: Download coverage report
+        uses: actions/download-artifact@v2
+        if: steps.check_coverage_report.outputs.exists == 'true'
+        with:
+          name: coverage-report
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057
       - name: Override Coverage Source Path for Sonar
         if: steps.check_coverage_report.outputs.files_exists == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,7 +224,7 @@ jobs:
         id: check_coverage_report
         uses: andstor/file-existence-action@v3
         with:
-          files: "coverage.xml"
+          files: "coverage.xml,coverage-report.zip"
       - name: Download coverage report
         uses: actions/download-artifact@v2
         if: steps.check_coverage_report.outputs.files_exists == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,7 +232,7 @@ jobs:
           name: coverage-report
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057
       - name: Override Coverage Source Path for Sonar
-        if: steps.check_coverage_report.outputs.files_exists == 'true'
+        if: steps.check_coverage_report.outputs.exists == 'true'
         run: sed -i "s/<source>\/home\/runner\/work\/synapsePythonClient<\/source>/<source>\/github\/workspace<\/source>/g" coverage.xml
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
       - name: run-unit-tests
         shell: bash
         run: |
-          pytest -sv --cov-append --cov=. --cov-report xml tests/unit
+          pytestt -sv --cov-append --cov=. --cov-report xml tests/unit
       - name: Check for Secret availability
         id: secret-check
         if: ${{ contains(fromJSON('["3.9"]'), matrix.python) }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,7 +220,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Check coverage report existence
+      - name: Check coverage-report artifact existence
         id: check_coverage_report
         uses: LIT-Protocol/artifact-exists-action@v0
         with:
@@ -230,11 +230,14 @@ jobs:
         if: steps.check_coverage_report.outputs.exists == 'true'
         with:
           name: coverage-report
-      - name: List all files in the directory
-        run: ls -la
+      - name: Check coverage.xml file existence
+        id: check_coverage_xml
+        uses: andstor/file-existence-action@v3
+        with:
+          files: "coverage.xml"
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057
       - name: Override Coverage Source Path for Sonar
-        if: steps.check_coverage_report.outputs.exists == 'true'
+        if: steps.check_coverage_xml.outputs.files_exists == 'true'
         run: sed -i "s/<source>\/home\/runner\/work\/synapsePythonClient<\/source>/<source>\/github\/workspace<\/source>/g" coverage.xml
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,47 +155,47 @@ jobs:
       # run integration tests on the oldest and newest supported versions of python.
       # we don't run on the entire matrix to avoid a 3xN set of concurrent tests against
       # the target server where N is the number of supported python versions.
-      - name: run-integration-tests
-        shell: bash
+      # - name: run-integration-tests
+      #   shell: bash
 
-        # keep versions consistent with the first and last from the strategy matrix
-        if: ${{ contains(fromJSON('["3.9"]'), matrix.python) && steps.secret-check.outputs.secrets_available == 'true'}}
-        run: |
-          # decrypt the encrypted test synapse configuration
-          openssl aes-256-cbc -K ${{ secrets.encrypted_d17283647768_key }} -iv ${{ secrets.encrypted_d17283647768_iv }} -in test.synapseConfig.enc -out test.synapseConfig -d
-          mv test.synapseConfig ~/.synapseConfig
+      #   # keep versions consistent with the first and last from the strategy matrix
+      #   if: ${{ contains(fromJSON('["3.9"]'), matrix.python) && steps.secret-check.outputs.secrets_available == 'true'}}
+      #   run: |
+      #     # decrypt the encrypted test synapse configuration
+      #     openssl aes-256-cbc -K ${{ secrets.encrypted_d17283647768_key }} -iv ${{ secrets.encrypted_d17283647768_iv }} -in test.synapseConfig.enc -out test.synapseConfig -d
+      #     mv test.synapseConfig ~/.synapseConfig
 
-          if [ "${{ startsWith(matrix.os, 'ubuntu') }}" == "true" ]; then
-            # on linux only we can build and run a docker container to serve as an SFTP host for our SFTP tests.
-            # Docker is not available on GH Action runners on Mac and Windows.
+      #     if [ "${{ startsWith(matrix.os, 'ubuntu') }}" == "true" ]; then
+      #       # on linux only we can build and run a docker container to serve as an SFTP host for our SFTP tests.
+      #       # Docker is not available on GH Action runners on Mac and Windows.
 
-            docker build -t sftp_tests - < tests/integration/synapseclient/core/upload/Dockerfile_sftp
-            docker run -d sftp_tests:latest
+      #       docker build -t sftp_tests - < tests/integration/synapseclient/core/upload/Dockerfile_sftp
+      #       docker run -d sftp_tests:latest
 
-            # get the internal IP address of the just launched container
-            export SFTP_HOST=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker ps -q))
+      #       # get the internal IP address of the just launched container
+      #       export SFTP_HOST=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker ps -q))
 
-            printf "[sftp://$SFTP_HOST]\nusername: test\npassword: test\n" >> ~/.synapseConfig
+      #       printf "[sftp://$SFTP_HOST]\nusername: test\npassword: test\n" >> ~/.synapseConfig
 
-            # add to known_hosts so the ssh connections can be made without any prompting/errors
-            mkdir -p ~/.ssh
-            ssh-keyscan -H $SFTP_HOST >> ~/.ssh/known_hosts
-          fi
+      #       # add to known_hosts so the ssh connections can be made without any prompting/errors
+      #       mkdir -p ~/.ssh
+      #       ssh-keyscan -H $SFTP_HOST >> ~/.ssh/known_hosts
+      #     fi
 
-            # set env vars used in external bucket tests from secrets
-          export EXTERNAL_S3_BUCKET_NAME="${{secrets.EXTERNAL_S3_BUCKET_NAME}}"
-          export EXTERNAL_S3_BUCKET_AWS_ACCESS_KEY_ID="${{secrets.EXTERNAL_S3_BUCKET_AWS_ACCESS_KEY_ID}}"
-          export EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY="${{secrets.EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY}}"
-          if [ ${{ steps.otel-check.outputs.run_opentelemetry }} == "true" ]; then
-            # Set to 'file' to enable OpenTelemetry export to file
-            export SYNAPSE_OTEL_INTEGRATION_TEST_EXPORTER="file"
-          fi
+      #       # set env vars used in external bucket tests from secrets
+      #     export EXTERNAL_S3_BUCKET_NAME="${{secrets.EXTERNAL_S3_BUCKET_NAME}}"
+      #     export EXTERNAL_S3_BUCKET_AWS_ACCESS_KEY_ID="${{secrets.EXTERNAL_S3_BUCKET_AWS_ACCESS_KEY_ID}}"
+      #     export EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY="${{secrets.EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY}}"
+      #     if [ ${{ steps.otel-check.outputs.run_opentelemetry }} == "true" ]; then
+      #       # Set to 'file' to enable OpenTelemetry export to file
+      #       export SYNAPSE_OTEL_INTEGRATION_TEST_EXPORTER="file"
+      #     fi
 
-          # use loadscope to avoid issues running tests concurrently that share scoped fixtures
-          pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration -n auto --ignore=tests/integration/synapseclient/test_command_line_client.py --dist loadscope
+      #     # use loadscope to avoid issues running tests concurrently that share scoped fixtures
+      #     pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration -n auto --ignore=tests/integration/synapseclient/test_command_line_client.py --dist loadscope
 
-          # Execute the CLI tests in a non-dist way because they were causing some test instability when being run concurrently
-          # pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration/synapseclient/test_command_line_client.py
+      #     # Execute the CLI tests in a non-dist way because they were causing some test instability when being run concurrently
+      #     # pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration/synapseclient/test_command_line_client.py
       - name: Upload otel spans
         uses: actions/upload-artifact@v4
         if: always()
@@ -230,6 +230,8 @@ jobs:
         if: steps.check_coverage_report.outputs.exists == 'true'
         with:
           name: coverage-report
+      - name: List all files in the directory
+        run: ls -la
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057
       - name: Override Coverage Source Path for Sonar
         if: steps.check_coverage_report.outputs.exists == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,47 +155,47 @@ jobs:
       # run integration tests on the oldest and newest supported versions of python.
       # we don't run on the entire matrix to avoid a 3xN set of concurrent tests against
       # the target server where N is the number of supported python versions.
-      - name: run-integration-tests
-        shell: bash
+      # - name: run-integration-tests
+      #   shell: bash
 
-        # keep versions consistent with the first and last from the strategy matrix
-        if: ${{ contains(fromJSON('["3.9"]'), matrix.python) && steps.secret-check.outputs.secrets_available == 'true'}}
-        run: |
-          # decrypt the encrypted test synapse configuration
-          openssl aes-256-cbc -K ${{ secrets.encrypted_d17283647768_key }} -iv ${{ secrets.encrypted_d17283647768_iv }} -in test.synapseConfig.enc -out test.synapseConfig -d
-          mv test.synapseConfig ~/.synapseConfig
+      #   # keep versions consistent with the first and last from the strategy matrix
+      #   if: ${{ contains(fromJSON('["3.9"]'), matrix.python) && steps.secret-check.outputs.secrets_available == 'true'}}
+      #   run: |
+      #     # decrypt the encrypted test synapse configuration
+      #     openssl aes-256-cbc -K ${{ secrets.encrypted_d17283647768_key }} -iv ${{ secrets.encrypted_d17283647768_iv }} -in test.synapseConfig.enc -out test.synapseConfig -d
+      #     mv test.synapseConfig ~/.synapseConfig
 
-          if [ "${{ startsWith(matrix.os, 'ubuntu') }}" == "true" ]; then
-            # on linux only we can build and run a docker container to serve as an SFTP host for our SFTP tests.
-            # Docker is not available on GH Action runners on Mac and Windows.
+      #     if [ "${{ startsWith(matrix.os, 'ubuntu') }}" == "true" ]; then
+      #       # on linux only we can build and run a docker container to serve as an SFTP host for our SFTP tests.
+      #       # Docker is not available on GH Action runners on Mac and Windows.
 
-            docker build -t sftp_tests - < tests/integration/synapseclient/core/upload/Dockerfile_sftp
-            docker run -d sftp_tests:latest
+      #       docker build -t sftp_tests - < tests/integration/synapseclient/core/upload/Dockerfile_sftp
+      #       docker run -d sftp_tests:latest
 
-            # get the internal IP address of the just launched container
-            export SFTP_HOST=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker ps -q))
+      #       # get the internal IP address of the just launched container
+      #       export SFTP_HOST=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker ps -q))
 
-            printf "[sftp://$SFTP_HOST]\nusername: test\npassword: test\n" >> ~/.synapseConfig
+      #       printf "[sftp://$SFTP_HOST]\nusername: test\npassword: test\n" >> ~/.synapseConfig
 
-            # add to known_hosts so the ssh connections can be made without any prompting/errors
-            mkdir -p ~/.ssh
-            ssh-keyscan -H $SFTP_HOST >> ~/.ssh/known_hosts
-          fi
+      #       # add to known_hosts so the ssh connections can be made without any prompting/errors
+      #       mkdir -p ~/.ssh
+      #       ssh-keyscan -H $SFTP_HOST >> ~/.ssh/known_hosts
+      #     fi
 
-            # set env vars used in external bucket tests from secrets
-          export EXTERNAL_S3_BUCKET_NAME="${{secrets.EXTERNAL_S3_BUCKET_NAME}}"
-          export EXTERNAL_S3_BUCKET_AWS_ACCESS_KEY_ID="${{secrets.EXTERNAL_S3_BUCKET_AWS_ACCESS_KEY_ID}}"
-          export EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY="${{secrets.EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY}}"
-          if [ ${{ steps.otel-check.outputs.run_opentelemetry }} == "true" ]; then
-            # Set to 'file' to enable OpenTelemetry export to file
-            export SYNAPSE_OTEL_INTEGRATION_TEST_EXPORTER="file"
-          fi
+      #       # set env vars used in external bucket tests from secrets
+      #     export EXTERNAL_S3_BUCKET_NAME="${{secrets.EXTERNAL_S3_BUCKET_NAME}}"
+      #     export EXTERNAL_S3_BUCKET_AWS_ACCESS_KEY_ID="${{secrets.EXTERNAL_S3_BUCKET_AWS_ACCESS_KEY_ID}}"
+      #     export EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY="${{secrets.EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY}}"
+      #     if [ ${{ steps.otel-check.outputs.run_opentelemetry }} == "true" ]; then
+      #       # Set to 'file' to enable OpenTelemetry export to file
+      #       export SYNAPSE_OTEL_INTEGRATION_TEST_EXPORTER="file"
+      #     fi
 
-          # use loadscope to avoid issues running tests concurrently that share scoped fixtures
-          pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration -n auto --ignore=tests/integration/synapseclient/test_command_line_client.py --dist loadscope
+      #     # use loadscope to avoid issues running tests concurrently that share scoped fixtures
+      #     pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration -n auto --ignore=tests/integration/synapseclient/test_command_line_client.py --dist loadscope
 
-          # Execute the CLI tests in a non-dist way because they were causing some test instability when being run concurrently
-          # pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration/synapseclient/test_command_line_client.py
+      #     # Execute the CLI tests in a non-dist way because they were causing some test instability when being run concurrently
+      #     # pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration/synapseclient/test_command_line_client.py
       - name: Upload otel spans
         uses: actions/upload-artifact@v4
         if: always()
@@ -224,7 +224,7 @@ jobs:
         id: check_coverage_report
         uses: andstor/file-existence-action@v3
         with:
-          files: "coverage.xml,coverage-report.zip"
+          files: "coverage.xml,coverage-report.zip,coverage-report"
       - name: Download coverage report
         uses: actions/download-artifact@v2
         if: steps.check_coverage_report.outputs.files_exists == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,47 +155,47 @@ jobs:
       # run integration tests on the oldest and newest supported versions of python.
       # we don't run on the entire matrix to avoid a 3xN set of concurrent tests against
       # the target server where N is the number of supported python versions.
-      # - name: run-integration-tests
-      #   shell: bash
+      - name: run-integration-tests
+        shell: bash
 
-      #   # keep versions consistent with the first and last from the strategy matrix
-      #   if: ${{ contains(fromJSON('["3.9"]'), matrix.python) && steps.secret-check.outputs.secrets_available == 'true'}}
-      #   run: |
-      #     # decrypt the encrypted test synapse configuration
-      #     openssl aes-256-cbc -K ${{ secrets.encrypted_d17283647768_key }} -iv ${{ secrets.encrypted_d17283647768_iv }} -in test.synapseConfig.enc -out test.synapseConfig -d
-      #     mv test.synapseConfig ~/.synapseConfig
+        # keep versions consistent with the first and last from the strategy matrix
+        if: ${{ contains(fromJSON('["3.9"]'), matrix.python) && steps.secret-check.outputs.secrets_available == 'true'}}
+        run: |
+          # decrypt the encrypted test synapse configuration
+          openssl aes-256-cbc -K ${{ secrets.encrypted_d17283647768_key }} -iv ${{ secrets.encrypted_d17283647768_iv }} -in test.synapseConfig.enc -out test.synapseConfig -d
+          mv test.synapseConfig ~/.synapseConfig
 
-      #     if [ "${{ startsWith(matrix.os, 'ubuntu') }}" == "true" ]; then
-      #       # on linux only we can build and run a docker container to serve as an SFTP host for our SFTP tests.
-      #       # Docker is not available on GH Action runners on Mac and Windows.
+          if [ "${{ startsWith(matrix.os, 'ubuntu') }}" == "true" ]; then
+            # on linux only we can build and run a docker container to serve as an SFTP host for our SFTP tests.
+            # Docker is not available on GH Action runners on Mac and Windows.
 
-      #       docker build -t sftp_tests - < tests/integration/synapseclient/core/upload/Dockerfile_sftp
-      #       docker run -d sftp_tests:latest
+            docker build -t sftp_tests - < tests/integration/synapseclient/core/upload/Dockerfile_sftp
+            docker run -d sftp_tests:latest
 
-      #       # get the internal IP address of the just launched container
-      #       export SFTP_HOST=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker ps -q))
+            # get the internal IP address of the just launched container
+            export SFTP_HOST=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker ps -q))
 
-      #       printf "[sftp://$SFTP_HOST]\nusername: test\npassword: test\n" >> ~/.synapseConfig
+            printf "[sftp://$SFTP_HOST]\nusername: test\npassword: test\n" >> ~/.synapseConfig
 
-      #       # add to known_hosts so the ssh connections can be made without any prompting/errors
-      #       mkdir -p ~/.ssh
-      #       ssh-keyscan -H $SFTP_HOST >> ~/.ssh/known_hosts
-      #     fi
+            # add to known_hosts so the ssh connections can be made without any prompting/errors
+            mkdir -p ~/.ssh
+            ssh-keyscan -H $SFTP_HOST >> ~/.ssh/known_hosts
+          fi
 
-      #       # set env vars used in external bucket tests from secrets
-      #     export EXTERNAL_S3_BUCKET_NAME="${{secrets.EXTERNAL_S3_BUCKET_NAME}}"
-      #     export EXTERNAL_S3_BUCKET_AWS_ACCESS_KEY_ID="${{secrets.EXTERNAL_S3_BUCKET_AWS_ACCESS_KEY_ID}}"
-      #     export EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY="${{secrets.EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY}}"
-      #     if [ ${{ steps.otel-check.outputs.run_opentelemetry }} == "true" ]; then
-      #       # Set to 'file' to enable OpenTelemetry export to file
-      #       export SYNAPSE_OTEL_INTEGRATION_TEST_EXPORTER="file"
-      #     fi
+            # set env vars used in external bucket tests from secrets
+          export EXTERNAL_S3_BUCKET_NAME="${{secrets.EXTERNAL_S3_BUCKET_NAME}}"
+          export EXTERNAL_S3_BUCKET_AWS_ACCESS_KEY_ID="${{secrets.EXTERNAL_S3_BUCKET_AWS_ACCESS_KEY_ID}}"
+          export EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY="${{secrets.EXTERNAL_S3_BUCKET_AWS_SECRET_ACCESS_KEY}}"
+          if [ ${{ steps.otel-check.outputs.run_opentelemetry }} == "true" ]; then
+            # Set to 'file' to enable OpenTelemetry export to file
+            export SYNAPSE_OTEL_INTEGRATION_TEST_EXPORTER="file"
+          fi
 
-      #     # use loadscope to avoid issues running tests concurrently that share scoped fixtures
-      #     pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration -n auto --ignore=tests/integration/synapseclient/test_command_line_client.py --dist loadscope
+          # use loadscope to avoid issues running tests concurrently that share scoped fixtures
+          pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration -n auto --ignore=tests/integration/synapseclient/test_command_line_client.py --dist loadscope
 
-      #     # Execute the CLI tests in a non-dist way because they were causing some test instability when being run concurrently
-      #     # pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration/synapseclient/test_command_line_client.py
+          # Execute the CLI tests in a non-dist way because they were causing some test instability when being run concurrently
+          # pytest -sv --reruns 3 --cov-append --cov=. --cov-report xml tests/integration/synapseclient/test_command_line_client.py
       - name: Upload otel spans
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,6 +225,8 @@ jobs:
         uses: andstor/file-existence-action@v3
         with:
           files: "*coverage*"
+      - name: List files in the working directory
+        run: ls -la
       - name: Download coverage report
         uses: actions/download-artifact@v2
         if: steps.check_coverage_report.outputs.files_exists == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,8 +225,6 @@ jobs:
         uses: LIT-Protocol/artifact-exists-action@v0
         with:
           name: "coverage-report"
-      - name: List files in the working directory
-        run: ls -la
       - name: Download coverage report
         uses: actions/download-artifact@v4
         if: steps.check_coverage_report.outputs.exists == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,7 +233,7 @@ jobs:
         # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057
       - name: Override Coverage Source Path for Sonar
         if: steps.check_coverage_report.outputs.exists == 'true'
-        run: sedd -i "s/<source>\/home\/runner\/work\/synapsePythonClient<\/source>/<source>\/github\/workspace<\/source>/g" coverage.xml
+        run: sed -i "s/<source>\/home\/runner\/work\/synapsePythonClient<\/source>/<source>\/github\/workspace<\/source>/g" coverage.xml
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         if: ${{ always() }}

--- a/synapseclient/.synapseConfig
+++ b/synapseclient/.synapseConfig
@@ -57,4 +57,4 @@
 
 # use this to configure the default for how many threads/connections Synapse will use to perform file transfers.
 # Currently this applies only to files whose underlying storage is AWS S3.
-max_threads=40
+# max_threads=16

--- a/synapseclient/.synapseConfig
+++ b/synapseclient/.synapseConfig
@@ -57,4 +57,4 @@
 
 # use this to configure the default for how many threads/connections Synapse will use to perform file transfers.
 # Currently this applies only to files whose underlying storage is AWS S3.
-# max_threads=16
+max_threads=40


### PR DESCRIPTION
## problem

The synapse python client’s coverage reports are not being found (see [thread here ](https://github.com/Sage-Bionetworks/synapsePythonClient/pull/1112#discussion_r1651470850)for more context) and code coverage is not being monitored:

<img width="649" alt="image" src="https://github.com/Sage-Bionetworks/synapsePythonClient/assets/32107699/dea20da2-d715-417e-b762-1f53f0d98a35">

## solution

- [x] Update the `SonarCloud` job's `Check coverage report existence` step to search for the `coverage-report` artifact, rather than the `coverage.xml` file which has not been downloaded yet. If the artifact exists, this will prompt a download of the artifact, and the job will behave as expected.
- [x] Re-introduce file existence step to check for downloaded `coverage.xml` file before `Override Coverage Source Path for Sonar`

## testing & preview

For testing I repeated some of the tests done in https://github.com/Sage-Bionetworks/synapsePythonClient/pull/1095

### test 1: if tests fail -> skip `Download coverage report` + skip `Override Coverage Source Path`. SonarCloud still runs. ([job](https://github.com/Sage-Bionetworks/synapsePythonClient/actions/runs/9713887152/job/26811719723))

<img width="642" alt="image" src="https://github.com/Sage-Bionetworks/synapsePythonClient/assets/32107699/517310e6-bd6a-4e1a-8e69-97fe207680a4">

----

### test 2: if tests pass -> run as normal ([job](https://github.com/Sage-Bionetworks/synapsePythonClient/actions/runs/9714021971))

<img width="622" alt="image" src="https://github.com/Sage-Bionetworks/synapsePythonClient/assets/32107699/586271ea-6b1d-4603-94f0-9a3383572a56">

----

### test 3: if tests pass but `Override Coverage Source Path` fails -> SonarCloud still runs ([job](https://github.com/Sage-Bionetworks/synapsePythonClient/actions/runs/9713931645/job/26811942281))

<img width="646" alt="image" src="https://github.com/Sage-Bionetworks/synapsePythonClient/assets/32107699/1c975861-be7e-48eb-af07-406c8888d3f4">
