### PR TITLE
Update os matrix for check-deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -398,7 +398,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2019]
+        os: [ubuntu-20.04, macos-12, windows-2022]
 
         # python versions should be consistent with the strategy matrix and the runs-integration-tests versions
         python: [3.8, '3.9', '3.10', '3.11']


### PR DESCRIPTION
**Problem:**

The workflow runs for check-deploy have been failing with:

check-deploy (macos-11, 3.10)
This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.

**Solution:**

1. Updating image versions

**Testing:**

1. Will be testing on next check deploy run