### PR TITLE
[SYNPY-1476] Skip reading response content on error

### DIFF
--- a/synapseclient/core/download/download_async.py
+++ b/synapseclient/core/download/download_async.py
@@ -531,7 +531,9 @@ def _execute_stream_and_write_chunk(
     with session.stream(
         method="GET", url=presigned_url_provider.get_info().url, headers=range_header
     ) as response:
-        _raise_for_status_httpx(response=response, logger=request._syn.logger)
+        _raise_for_status_httpx(
+            response=response, logger=request._syn.logger, read_response_content=False
+        )
         data = response.read()
         data_length = len(data)
         request._write_chunk(

--- a/synapseclient/core/download/download_async.py
+++ b/synapseclient/core/download/download_async.py
@@ -473,6 +473,7 @@ class _MultithreadedDownloader:
             retry_errors=RETRYABLE_CONNECTION_ERRORS,
             retry_exceptions=RETRYABLE_CONNECTION_EXCEPTIONS,
             retry_max_back_off=DEFAULT_MAX_BACK_OFF_ASYNC,
+            read_response_content=False,
         )
 
         return start, end

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -272,6 +272,7 @@ async def with_retry_time_based_async(
     retry_back_off_factor: float = DEFAULT_BACK_OFF_FACTOR_ASYNC,
     retry_max_back_off: float = DEFAULT_MAX_BACK_OFF_ASYNC,
     retry_max_wait_before_failure: float = DEFAULT_MAX_WAIT_BEFORE_FAIL_ASYNC,
+    read_response_content: bool = True,
 ) -> Union[Exception, httpx.Response, Any, None]:
     """
     Retries the given function under certain conditions. This is created such that it
@@ -297,6 +298,7 @@ async def with_retry_time_based_async(
         retry_back_off_factor: The factor to increase the wait time by for each retry.
         retry_max_back_off: The maximum wait time.
         retry_max_wait_before_failure: The maximum wait time before failure.
+        read_response_content: Whether to read the response content for HTTP requests.
 
     Example: Using with_retry
         Using ``with_retry_time_based_async`` to consolidate inputs into a list.
@@ -353,7 +355,10 @@ async def with_retry_time_based_async(
         retries += 1
         if total_wait < retry_max_wait_before_failure and retry:
             _log_for_retry(
-                logger=logger, response=response, caught_exception=caught_exception
+                logger=logger,
+                response=response,
+                caught_exception=caught_exception,
+                read_response_content=read_response_content,
             )
 
             backoff_wait = calculate_exponential_backoff(
@@ -395,6 +400,7 @@ def with_retry_time_based(
     retry_back_off_factor: float = DEFAULT_BACK_OFF_FACTOR_ASYNC,
     retry_max_back_off: float = DEFAULT_MAX_BACK_OFF_ASYNC,
     retry_max_wait_before_failure: float = DEFAULT_MAX_WAIT_BEFORE_FAIL_ASYNC,
+    read_response_content: bool = True,
 ) -> Union[Exception, httpx.Response, Any, None]:
     """
     Retries the given function under certain conditions. This is created such that it
@@ -420,6 +426,7 @@ def with_retry_time_based(
         retry_back_off_factor: The factor to increase the wait time by for each retry.
         retry_max_back_off: The maximum wait time.
         retry_max_wait_before_failure: The maximum wait time before failure.
+        read_response_content: Whether to read the response content for HTTP requests.
 
     Example: Using with_retry
         Using ``with_retry_time_based`` to consolidate inputs into a list.
@@ -476,7 +483,10 @@ def with_retry_time_based(
         retries += 1
         if total_wait < retry_max_wait_before_failure and retry:
             _log_for_retry(
-                logger=logger, response=response, caught_exception=caught_exception
+                logger=logger,
+                response=response,
+                caught_exception=caught_exception,
+                read_response_content=read_response_content,
             )
 
             backoff_wait = calculate_exponential_backoff(
@@ -569,6 +579,7 @@ def _log_for_retry(
     logger: logging.Logger,
     response: httpx.Response = None,
     caught_exception: Exception = None,
+    read_response_content: bool = True,
 ) -> None:
     """Logs the retry message to debug.
 
@@ -576,9 +587,10 @@ def _log_for_retry(
         logger: The logger to use for logging the retry message.
         response: The response object from the request.
         caught_exception: The exception caught from the request.
+        read_response_content: Whether to read the response content for HTTP requests.
     """
     if response is not None:
-        response_message = _get_message(response)
+        response_message = _get_message(response) if read_response_content else ""
         url_message_part = ""
 
         if hasattr(response, "request") and hasattr(response.request, "url"):


### PR DESCRIPTION
**Problem:**

1. If an HTTP error occurred during the part streaming we fail in some code that was expecting the content of the message to be available:
```
Failed downloading syn59063792 to /root/.synapseCache/60/140032060/PEGS_methylation_beta_train_synthetic.rds.synapse_download_140032060                   Traceback (most recent call last):
  File "/synapsePythonClient/synapseclient/core/download/download_async.py", line 346, in _execute_download_tasks
    start_bytes, end_bytes = completed_task.result()
  File "/synapsePythonClient/synapseclient/core/download/download_async.py", line 417, in _stream_and_write_chunk_wrapper
    return await loop.run_in_executor(
  File "/usr/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/synapsePythonClient/synapseclient/core/download/download_async.py", line 464, in _stream_and_write_chunk
    end = with_retry_time_based(
  File "/synapsePythonClient/synapseclient/core/retry.py", line 504, in with_retry_time_based
    raise caught_exception
  File "/synapsePythonClient/synapseclient/core/retry.py", line 457, in with_retry_time_based
    response = function()
  File "/synapsePythonClient/synapseclient/core/download/download_async.py", line 465, in <lambda>
    lambda: _execute_stream_and_write_chunk(
  File "/synapsePythonClient/synapseclient/core/download/download_async.py", line 534, in _execute_stream_and_write_chunk
    _raise_for_status_httpx(response=response, logger=request._syn.logger)
  File "/synapsePythonClient/synapseclient/core/exceptions.py", line 245, in _raise_for_status_httpx
    message_body = _get_message(response, logger)
  File "/synapsePythonClient/synapseclient/core/exceptions.py", line 90, in _get_message
    return response.text
  File "/usr/local/lib/python3.8/dist-packages/httpx/_models.py", line 576, in text
    content = self.content
  File "/usr/local/lib/python3.8/dist-packages/httpx/_models.py", line 570, in content
    raise ResponseNotRead()
httpx.ResponseNotRead: Attempted to access streaming response content, without having called `read()`.
```

**Solution:**

1. Since the content of a streamed message is not available without calling `read()`, and it's a series of bytes representing the content of a file, we are going to simply skip reading the content of the message.

**Testing:**

1. I was able to download the affected synapse ID