### PR TITLE
[SYNPY-1504] Remove `download_location` from File and rely only on Path

### DIFF
--- a/docs/scripts/object_orientated_programming_poc/oop_poc_file.py
+++ b/docs/scripts/object_orientated_programming_poc/oop_poc_file.py
@@ -131,7 +131,7 @@ def store_file():
     # 5. Downloading a file ===============================================================
     # Downloading a file to a location has a default beahvior of "keep.both"
     downloaded_file = File(
-        id=file.id, download_location=os.path.expanduser("~/temp/myNewFolder")
+        id=file.id, path=os.path.expanduser("~/temp/myNewFolder")
     ).get()
     print(f"Downloaded file: {downloaded_file.path}")
 
@@ -142,7 +142,7 @@ def store_file():
     print(f"Before file md5: {utils.md5_for_file(path_to_file).hexdigest()}")
     downloaded_file = File(
         id=downloaded_file.id,
-        download_location=os.path.expanduser("~/temp/myNewFolder"),
+        path=os.path.expanduser("~/temp/myNewFolder"),
         if_collision="overwrite.local",
     ).get()
     print(f"After file md5: {utils.md5_for_file(path_to_file).hexdigest()}")
@@ -153,7 +153,7 @@ def store_file():
     print(f"Before file md5: {utils.md5_for_file(path_to_file).hexdigest()}")
     downloaded_file = File(
         id=downloaded_file.id,
-        download_location=os.path.expanduser("~/temp/myNewFolder"),
+        path=os.path.expanduser("~/temp/myNewFolder"),
         if_collision="keep.local",
     ).get()
     print(f"After file md5: {utils.md5_for_file(path_to_file).hexdigest()}")

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -206,7 +206,15 @@ class File(FileSynchronousProtocol, AccessControllable):
             contain: letters, numbers, spaces, underscores, hyphens, periods, plus
             signs, apostrophes, and parentheses. If not specified, the name will be
             derived from the file name.
-        path: The path to the file on disk.
+        path: The path to the file on disk. Using shorthand `~` will be expanded to the
+            user's home directory.
+
+            This is used during a `get` operation to specify where to download the file
+            to. It should be pointing to a directory.
+
+            This is also used during a `store` operation to specify the file to upload.
+            It should be pointing to a file.
+
         description: The description of this file. Must be 1000 characters or less.
         parent_id: The ID of the Entity that is the parent of this Entity. Setting this
             to a new value and storing it will move this File under the new parent.
@@ -297,7 +305,6 @@ class File(FileSynchronousProtocol, AccessControllable):
 
     Attributes:
         download_file: (Get only) If True the file will be downloaded.
-        download_location: (Get only) The location to download the file to.
         if_collision: (Get only)
             Determines how to handle file collisions. Defaults to "keep.both". May be:
 
@@ -338,7 +345,14 @@ class File(FileSynchronousProtocol, AccessControllable):
     """
 
     path: Optional[str] = field(default=None, compare=False)
-    """The path to the file on disk."""
+    """The path to the file on disk. Using shorthand `~` will be expanded to the user's
+    home directory.
+
+    This is used during a `get` operation to specify where to download the file to. It
+    should be pointing to a directory.
+
+    This is also used during a `store` operation to specify the file to upload. It
+    should be pointing to a file."""
 
     description: Optional[str] = None
     """The description of this file. Must be 1000 characters or less."""
@@ -511,12 +525,6 @@ class File(FileSynchronousProtocol, AccessControllable):
     (Get only)
 
     If True the file will be downloaded."""
-
-    download_location: str = field(default=None, repr=False, compare=False)
-    """
-    (Get only)
-
-    The location to download the file to."""
 
     if_collision: str = field(default="keep.both", repr=False, compare=False)
     """
@@ -996,9 +1004,9 @@ class File(FileSynchronousProtocol, AccessControllable):
 
                 file_instance = await File(id="syn123").get_async()
 
-            Assuming you have a file at the path "path/to/file.txt":
+            Assuming you want to download a file to this directory: "path/to/directory":
 
-                file_instance = await File(path="path/to/file.txt").get_async()
+                file_instance = await File(path="path/to/directory").get_async()
         """
         if not self.id and not self.path:
             raise ValueError("The file must have an ID or path to get.")
@@ -1013,7 +1021,9 @@ class File(FileSynchronousProtocol, AccessControllable):
             if_collision=self.if_collision,
             limit_search=self.synapse_container_limit or self.parent_id,
             download_file=self.download_file,
-            download_location=self.download_location,
+            download_location=os.path.dirname(self.path)
+            if self.path and os.path.isfile(self.path)
+            else self.path,
             md5=self.content_md5,
         )
 

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -1027,8 +1027,10 @@ class File(FileSynchronousProtocol, AccessControllable):
             md5=self.content_md5,
         )
 
-        if self.data_file_handle_id and (
-            cached_path := syn.cache.get(file_handle_id=self.data_file_handle_id)
+        if (
+            self.data_file_handle_id
+            and (not self.path or (self.path and not os.path.isfile(self.path)))
+            and (cached_path := syn.cache.get(file_handle_id=self.data_file_handle_id))
         ):
             self.path = cached_path
 

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -1027,10 +1027,8 @@ class File(FileSynchronousProtocol, AccessControllable):
             md5=self.content_md5,
         )
 
-        if (
-            not self.path
-            and self.data_file_handle_id
-            and (cached_path := syn.cache.get(file_handle_id=self.data_file_handle_id))
+        if self.data_file_handle_id and (
+            cached_path := syn.cache.get(file_handle_id=self.data_file_handle_id)
         ):
             self.path = cached_path
 

--- a/synapseclient/models/mixins/storable_container.py
+++ b/synapseclient/models/mixins/storable_container.py
@@ -505,7 +505,7 @@ class StorableContainer(StorableContainerSynchronousProtocol):
             file = File(id=synapse_id, name=name, download_file=download_file)
             self.files.append(file)
             if path:
-                file.download_location = path
+                file.path = path
             if if_collision:
                 file.if_collision = if_collision
 

--- a/synapseclient/models/protocols/file_protocol.py
+++ b/synapseclient/models/protocols/file_protocol.py
@@ -152,9 +152,9 @@ class FileSynchronousProtocol(Protocol):
 
                 file_instance = File(id="syn123").get()
 
-            Assuming you have a file at the path "path/to/file.txt":
+            Assuming you want to download a file to this directory: "path/to/directory":
 
-                file_instance = File(path="path/to/file.txt").get()
+                file_instance = File(path="path/to/directory").get()
         """
         return self
 

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -308,7 +308,7 @@ async def _sync(
             id=entity_id,
             version_number=entity_version,
             if_collision=if_collision,
-            download_location=path,
+            path=path,
             download_file=download_file,
         ).get_async(
             include_activity=retrieve_activity,

--- a/tests/integration/synapseclient/core/test_download.py
+++ b/tests/integration/synapseclient/core/test_download.py
@@ -59,7 +59,7 @@ class TestDownloadCollisions:
             file = await File(
                 id=file.id,
                 if_collision="overwrite.local",
-                download_location=os.path.dirname(original_file_path),
+                path=os.path.dirname(original_file_path),
             ).get_async()
 
             # THEN the file is downloaded replacing the file on disk
@@ -191,12 +191,11 @@ class TestDownloadCaching:
 
             # WHEN I download the file to another location
             updated_location = os.path.join(
-                os.path.dirname(original_file_path), "subdirectory"
+                os.path.dirname(original_file_path),
+                "subdirectory/asd/asdas/dasd/asdas/dasdasd",
             )
             schedule_for_cleanup(updated_location)
-            file = await File(
-                id=file.id, download_location=updated_location
-            ).get_async()
+            file = await File(id=file.id, path=updated_location).get_async()
             schedule_for_cleanup(file.path)
 
             # THEN the file is not downloaded again, but it copied to the new location
@@ -304,7 +303,7 @@ class TestDownloadFromUrl:
 
         # WHEN I download the file
         file = await File(
-            id=file.id, download_location=os.path.dirname(original_file_path)
+            id=file.id, path=os.path.dirname(original_file_path)
         ).get_async()
 
         # THEN the file is downloaded to a different location and matches the original
@@ -394,9 +393,7 @@ class TestDownloadFromUrlMultiThreaded:
             new=500,
         ):
             # WHEN I download the file with multiple parts
-            file = await File(
-                id=file.id, download_location=os.path.dirname(file.path)
-            ).get_async()
+            file = await File(id=file.id, path=os.path.dirname(file.path)).get_async()
 
         # THEN the file is downloaded and the md5 matches
         assert file.file_handle.content_md5 == file_md5
@@ -472,9 +469,7 @@ class TestDownloadFromUrlMultiThreaded:
             0.2,
         ):
             # WHEN I download the file with multiple parts
-            file = await File(
-                id=file.id, download_location=os.path.dirname(file.path)
-            ).get_async()
+            file = await File(id=file.id, path=os.path.dirname(file.path)).get_async()
 
         # THEN the file is downloaded and the md5 matches
         assert file.file_handle.content_md5 == file_md5
@@ -514,7 +509,7 @@ class TestDownloadFromS3:
 
         # WHEN I download the file
         file = await File(
-            id=file.id, download_location=os.path.dirname(original_file_path)
+            id=file.id, path=os.path.dirname(original_file_path)
         ).get_async()
 
         # THEN the file is downloaded to a different location and matches the original

--- a/tests/integration/synapseclient/core/test_download.py
+++ b/tests/integration/synapseclient/core/test_download.py
@@ -191,8 +191,7 @@ class TestDownloadCaching:
 
             # WHEN I download the file to another location
             updated_location = os.path.join(
-                os.path.dirname(original_file_path),
-                "subdirectory/asd/asdas/dasd/asdas/dasdasd",
+                os.path.dirname(original_file_path), "subdirectory",
             )
             schedule_for_cleanup(updated_location)
             file = await File(id=file.id, path=updated_location).get_async()

--- a/tests/integration/synapseclient/core/test_download.py
+++ b/tests/integration/synapseclient/core/test_download.py
@@ -191,7 +191,8 @@ class TestDownloadCaching:
 
             # WHEN I download the file to another location
             updated_location = os.path.join(
-                os.path.dirname(original_file_path), "subdirectory",
+                os.path.dirname(original_file_path),
+                "subdirectory",
             )
             schedule_for_cleanup(updated_location)
             file = await File(id=file.id, path=updated_location).get_async()

--- a/tests/integration/synapseclient/core/test_external_storage.py
+++ b/tests/integration/synapseclient/core/test_external_storage.py
@@ -367,7 +367,7 @@ class TestExernalStorage:
                 # THEN I should be able to donwload the file
                 assert not os.path.exists(file.path)
                 file_copy = await File(
-                    id=file.id, download_location=os.path.dirname(upload_file)
+                    id=file.id, path=os.path.dirname(upload_file)
                 ).get_async()
                 assert os.path.exists(file_copy.path)
                 assert utils.equal_paths(file_copy.path, upload_file)

--- a/tests/integration/synapseclient/models/async/test_file_async.py
+++ b/tests/integration/synapseclient/models/async/test_file_async.py
@@ -1362,9 +1362,7 @@ class TestGet:
         await file_2.change_metadata_async(download_as=file.name)
 
         # WHEN I get the file with the default collision of `keep.both`
-        file_2 = await File(
-            id=file_2.id, download_location=os.path.dirname(file.path)
-        ).get_async()
+        file_2 = await File(id=file_2.id, path=os.path.dirname(file.path)).get_async()
 
         # THEN I expect both files to exist
         assert file.path != file_2.path
@@ -1409,7 +1407,7 @@ class TestGet:
         # WHEN I get the file with the default collision of `overwrite.local`
         file_2 = await File(
             id=file_2.id,
-            download_location=os.path.dirname(file.path),
+            path=os.path.dirname(file.path),
             if_collision="overwrite.local",
         ).get_async()
 
@@ -1451,7 +1449,7 @@ class TestGet:
         # WHEN I get the file with the default collision of `keep.local`
         file_2 = await File(
             id=file_2.id,
-            download_location=os.path.dirname(file.path),
+            path=os.path.dirname(file.path),
             if_collision="keep.local",
         ).get_async()
 

--- a/tests/integration/synapseclient/models/synchronous/test_file.py
+++ b/tests/integration/synapseclient/models/synchronous/test_file.py
@@ -1343,7 +1343,7 @@ class TestGet:
         file_2.change_metadata(download_as=file.name)
 
         # WHEN I get the file with the default collision of `keep.both`
-        file_2 = File(id=file_2.id, download_location=os.path.dirname(file.path)).get()
+        file_2 = File(id=file_2.id, path=os.path.dirname(file.path)).get()
 
         # THEN I expect both files to exist
         assert file.path != file_2.path
@@ -1388,7 +1388,7 @@ class TestGet:
         # WHEN I get the file with the default collision of `overwrite.local`
         file_2 = File(
             id=file_2.id,
-            download_location=os.path.dirname(file.path),
+            path=os.path.dirname(file.path),
             if_collision="overwrite.local",
         ).get()
 
@@ -1430,7 +1430,7 @@ class TestGet:
         # WHEN I get the file with the default collision of `keep.local`
         file_2 = File(
             id=file_2.id,
-            download_location=os.path.dirname(file.path),
+            path=os.path.dirname(file.path),
             if_collision="keep.local",
         ).get()
 

--- a/tests/unit/synapseutils/unit_test_synapseutils_sync.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_sync.py
@@ -564,9 +564,9 @@ def test_sync_from_synapse_manifest_is_all(
             all_files=[file_model, file_model_2], path=temp_directory_path
         )
 
-        expected_manifest = """path\tparent\tname\tid\tsynapseStore\tcontentType\tused\texecuted\tactivityName\tactivityDescription
-\tsyn456\tfile_name\tsyn123\tTrue\t\t\t\t\t
-\tsyn456\tfile_name\tsyn789\tTrue\t\t\t\tfoo\tbar"""
+        expected_manifest = f"""path\tparent\tname\tid\tsynapseStore\tcontentType\tused\texecuted\tactivityName\tactivityDescription
+{temp_directory_path}\tsyn456\tfile_name\tsyn123\tTrue\t\t\t\t\t
+{os.path.join(temp_directory_path, FOLDER_NAME)}\tsyn456\tfile_name\tsyn789\tTrue\t\t\t\tfoo\tbar"""
         _compare_csv(
             expected_manifest,
             os.path.join(temp_directory_path, synapseutils.sync.MANIFEST_FILENAME),
@@ -577,8 +577,8 @@ def test_sync_from_synapse_manifest_is_all(
             all_files=[file_model_2],
             path=os.path.join(temp_directory_path, FOLDER_NAME),
         )
-        expected_manifest = """path\tparent\tname\tid\tsynapseStore\tcontentType\tused\texecuted\tactivityName\tactivityDescription
-\tsyn456\tfile_name\tsyn789\tTrue\t\t\t\tfoo\tbar"""
+        expected_manifest = f"""path\tparent\tname\tid\tsynapseStore\tcontentType\tused\texecuted\tactivityName\tactivityDescription
+{os.path.join(temp_directory_path, FOLDER_NAME)}\tsyn456\tfile_name\tsyn789\tTrue\t\t\t\tfoo\tbar"""
         _compare_csv(
             expected_manifest,
             os.path.join(
@@ -719,9 +719,9 @@ def test_sync_from_synapse_manifest_is_root(
             all_files=[file_model, file_model_2], path=temp_directory_path
         )
 
-        expected_manifest = """path\tparent\tname\tid\tsynapseStore\tcontentType\tused\texecuted\tactivityName\tactivityDescription
-\tsyn456\tfile_name\tsyn123\tTrue\t\t\t\t\t
-\tsyn456\tfile_name\tsyn789\tTrue\t\t\t\tfoo\tbar"""
+        expected_manifest = f"""path\tparent\tname\tid\tsynapseStore\tcontentType\tused\texecuted\tactivityName\tactivityDescription
+{temp_directory_path}\tsyn456\tfile_name\tsyn123\tTrue\t\t\t\t\t
+{os.path.join(temp_directory_path, FOLDER_NAME)}\tsyn456\tfile_name\tsyn789\tTrue\t\t\t\tfoo\tbar"""
         _compare_csv(
             expected_manifest,
             os.path.join(temp_directory_path, synapseutils.sync.MANIFEST_FILENAME),


### PR DESCRIPTION
**Problem:**

1. When working with the File model you needed to specify a `download_location` parameter when using the `.get()` function, but `path` when using the `store()` function. This was a bit confusing.

**Solution:**

1. Updating logic such that only the path parameter is needed on the file for either operation.

**Testing:**

1. Some manual testing to verify getting a file already on disk, not on disk, and on disk - but downloading to another directory