### PR TITLE
Update file tutorial with missing line

### DIFF
--- a/docs/tutorials/python/file.md
+++ b/docs/tutorials/python/file.md
@@ -98,7 +98,7 @@ My file was last modified on: 2023-12-28T21:55:17.971Z
 Now that your project has a number of Folders and Files let's explore how we can traverse the content stored within the Project.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/file.py!lines=101-111}
+{!docs/tutorials/python/tutorial_scripts/file.py!lines=101-112}
 ```
 
 


### PR DESCRIPTION
**Purpose:** Small PR. Just added a missing line of code to the file tutorial in section: [List all Folders and Files within my project](https://python-docs.synapse.org/tutorials/python/file/#3-list-all-folders-and-files-within-my-project)

**Testing:** Ran `mkdocs` locally and see change below:
- Before:
<img width="875" alt="image" src="https://github.com/user-attachments/assets/b01b1f73-42e6-41b8-bd2c-952aa3f2fe61">

- After:
<img width="720" alt="image" src="https://github.com/user-attachments/assets/cb6e7f84-3135-49cf-b2a9-8244ca45671f">
