### PR TITLE
[SYNPY-1514] Handle Expired Pre-Signed URLs

### DIFF
--- a/synapseclient/core/download/__init__.py
+++ b/synapseclient/core/download/__init__.py
@@ -6,8 +6,8 @@ from .download_async import (
     PresignedUrlInfo,
     PresignedUrlProvider,
     _MultithreadedDownloader,
-    download_file,
     _pre_signed_url_expiration_time,
+    download_file,
 )
 from .download_functions import (
     download_by_file_handle,
@@ -33,4 +33,5 @@ __all__ = [
     "PresignedUrlInfo",
     "PresignedUrlProvider",
     "_MultithreadedDownloader",
+    "_pre_signed_url_expiration_time",
 ]

--- a/synapseclient/core/download/__init__.py
+++ b/synapseclient/core/download/__init__.py
@@ -7,6 +7,7 @@ from .download_async import (
     PresignedUrlProvider,
     _MultithreadedDownloader,
     download_file,
+    _pre_signed_url_expiration_time,
 )
 from .download_functions import (
     download_by_file_handle,

--- a/synapseclient/core/download/download_async.py
+++ b/synapseclient/core/download/download_async.py
@@ -274,7 +274,12 @@ def _get_file_size(
     if otel_context:
         context.attach(otel_context)
     with syn._requests_session_storage.stream("GET", url) as response:
-        _raise_for_status_httpx(response=response, logger=syn.logger, verbose=debug)
+        _raise_for_status_httpx(
+            response=response,
+            logger=syn.logger,
+            verbose=debug,
+            read_response_content=False,
+        )
         return int(response.headers["Content-Length"])
 
 

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -774,6 +774,8 @@ def download_from_url(
                             verbose=client.debug,
                             **STANDARD_RETRY_PARAMS,
                         )
+                    else:
+                        raise
                 elif err.response.status_code == 404:
                     raise SynapseError(f"Could not download the file at {url}") from err
                 elif (

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -404,13 +404,13 @@ async def download_by_file_handle(
 
     while retries > 0:
         try:
-            file_handle_result: Dict[str, str] = (
-                await get_file_handle_for_download_async(
-                    file_handle_id=file_handle_id,
-                    synapse_id=synapse_id,
-                    entity_type=entity_type,
-                    synapse_client=syn,
-                )
+            file_handle_result: Dict[
+                str, str
+            ] = await get_file_handle_for_download_async(
+                file_handle_id=file_handle_id,
+                synapse_id=synapse_id,
+                entity_type=entity_type,
+                synapse_client=syn,
             )
             file_handle = file_handle_result["fileHandle"]
             concrete_type = file_handle["concreteType"]
@@ -734,7 +734,7 @@ def download_from_url(
                 if is_synapse_uri(uri=url, synapse_client=client)
                 else None
             )
-            
+
             try:
                 response = with_retry(
                     lambda url=url, range_header=range_header, auth=auth: client._requests_session.get(

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -749,21 +749,14 @@ def download_from_url(
                     **STANDARD_RETRY_PARAMS,
                 )
                 exceptions._raise_for_status(response, verbose=client.debug)
-            except (SynapseHTTPError, SSLZeroReturnError) as err:
-                # is this also casued by an expired URL?
-                override_url = False
-                if isinstance(err, SSLZeroReturnError):
-                    will_retry = True
-                    override_url = True
-                else:
-                    will_retry = err.response.status_code == 403
-                if will_retry:
+            except SynapseHTTPError as err:
+                if err.response.status_code == 403:
                     url_is_expired = datetime.datetime.now(
                         tz=datetime.timezone.utc
                     ) + PresignedUrlProvider._TIME_BUFFER >= _pre_signed_url_expiration_time(
                         url
                     )
-                    if url_is_expired or override_url:
+                    if url_is_expired:
                         response = get_file_handle_for_download(
                             file_handle_id=file_handle_id,
                             synapse_id=object_id,

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -9,7 +9,6 @@ import shutil
 import sys
 import urllib.parse as urllib_urlparse
 import urllib.request as urllib_request
-from ssl import SSLZeroReturnError
 from typing import TYPE_CHECKING, Dict, Optional, Union
 
 from tqdm import tqdm

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -404,13 +404,13 @@ async def download_by_file_handle(
 
     while retries > 0:
         try:
-            file_handle_result: Dict[
-                str, str
-            ] = await get_file_handle_for_download_async(
-                file_handle_id=file_handle_id,
-                synapse_id=synapse_id,
-                entity_type=entity_type,
-                synapse_client=syn,
+            file_handle_result: Dict[str, str] = (
+                await get_file_handle_for_download_async(
+                    file_handle_id=file_handle_id,
+                    synapse_id=synapse_id,
+                    entity_type=entity_type,
+                    synapse_client=syn,
+                )
             )
             file_handle = file_handle_result["fileHandle"]
             concrete_type = file_handle["concreteType"]
@@ -512,8 +512,8 @@ async def download_by_file_handle(
                     lambda: download_from_url(
                         url=file_handle_result["preSignedURL"],
                         destination=destination,
-                        object_id=synapse_id,
-                        object_type=entity_type,
+                        entity_id=synapse_id,
+                        file_handle_associate_type=entity_type,
                         file_handle_id=file_handle["id"],
                         expected_md5=file_handle.get("contentMd5"),
                         progress_bar=progress_bar,
@@ -619,8 +619,8 @@ async def download_from_url_multi_threaded(
 def download_from_url(
     url: str,
     destination: str,
-    object_id: Optional[str],
-    object_type: Optional[str],
+    entity_id: Optional[str],
+    file_handle_associate_type: Optional[str],
     file_handle_id: Optional[str] = None,
     expected_md5: Optional[str] = None,
     progress_bar: Optional[tqdm] = None,
@@ -633,9 +633,9 @@ def download_from_url(
     Arguments:
         url:           The source of download
         destination:   The destination on local file system
-        object_id:      The id of the Synapse object that uses the FileHandle
+        entity_id:      The id of the Synapse object that uses the FileHandle
             e.g. "syn123"
-        object_type:    The type of the Synapse object that uses the
+        file_handle_associate_type:    The type of the Synapse object that uses the
             FileHandle e.g. "FileEntity". Any of
             <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/FileHandleAssociateType.html>
         file_handle_id:  Optional. If given, the file will be given a temporary name that includes the file
@@ -758,8 +758,8 @@ def download_from_url(
                     if url_is_expired:
                         response = get_file_handle_for_download(
                             file_handle_id=file_handle_id,
-                            synapse_id=object_id,
-                            entity_type=object_type,
+                            synapse_id=entity_id,
+                            entity_type=file_handle_associate_type,
                             synapse_client=client,
                         )
                         refreshed_url = response["preSignedURL"]

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -766,11 +766,16 @@ def download_from_url(
                 exceptions._raise_for_status(response, verbose=client.debug)
             except SynapseHTTPError as err:
                 if err.response.status_code == 403:
-                    url_is_expired = datetime.datetime.now(
-                        tz=datetime.timezone.utc
-                    ) + PresignedUrlProvider._TIME_BUFFER >= _pre_signed_url_expiration_time(
-                        url
+                    url_has_expiration = (
+                        "Expires" in urllib_urlparse.urlparse(url).query
                     )
+                    url_is_expired = False
+                    if url_has_expiration:
+                        url_is_expired = datetime.datetime.now(
+                            tz=datetime.timezone.utc
+                        ) + PresignedUrlProvider._TIME_BUFFER >= _pre_signed_url_expiration_time(
+                            url
+                        )
                     if url_is_expired:
                         response = get_file_handle_for_download(
                             file_handle_id=file_handle_id,

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -1,6 +1,7 @@
 """This module handles the various ways that a user can download a file to Synapse."""
 
 import asyncio
+import datetime
 import errno
 import hashlib
 import os
@@ -14,7 +15,10 @@ from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 
 from synapseclient.api.configuration_services import get_client_authenticated_s3_profile
-from synapseclient.api.file_services import get_file_handle_for_download_async
+from synapseclient.api.file_services import (
+    get_file_handle_for_download,
+    get_file_handle_for_download_async,
+)
 from synapseclient.core import exceptions, sts_transfer, utils
 from synapseclient.core.constants import concrete_types
 from synapseclient.core.constants.method_flags import (
@@ -25,6 +29,8 @@ from synapseclient.core.constants.method_flags import (
 from synapseclient.core.download import (
     SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE,
     DownloadRequest,
+    PresignedUrlProvider,
+    _pre_signed_url_expiration_time,
     download_file,
 )
 from synapseclient.core.exceptions import (
@@ -398,13 +404,13 @@ async def download_by_file_handle(
 
     while retries > 0:
         try:
-            file_handle_result: Dict[
-                str, str
-            ] = await get_file_handle_for_download_async(
-                file_handle_id=file_handle_id,
-                synapse_id=synapse_id,
-                entity_type=entity_type,
-                synapse_client=syn,
+            file_handle_result: Dict[str, str] = (
+                await get_file_handle_for_download_async(
+                    file_handle_id=file_handle_id,
+                    synapse_id=synapse_id,
+                    entity_type=entity_type,
+                    synapse_client=syn,
+                )
             )
             file_handle = file_handle_result["fileHandle"]
             concrete_type = file_handle["concreteType"]
@@ -500,11 +506,14 @@ async def download_by_file_handle(
                 progress_bar = get_or_create_download_progress_bar(
                     file_size=1, postfix=synapse_id, synapse_client=syn
                 )
+
                 downloaded_path = await loop.run_in_executor(
                     syn._get_thread_pool_executor(asyncio_event_loop=loop),
                     lambda: download_from_url(
                         url=file_handle_result["preSignedURL"],
                         destination=destination,
+                        object_id=synapse_id,
+                        object_type=entity_type,
                         file_handle_id=file_handle["id"],
                         expected_md5=file_handle.get("contentMd5"),
                         progress_bar=progress_bar,
@@ -610,6 +619,8 @@ async def download_from_url_multi_threaded(
 def download_from_url(
     url: str,
     destination: str,
+    object_id: Optional[str],
+    object_type: Optional[str],
     file_handle_id: Optional[str] = None,
     expected_md5: Optional[str] = None,
     progress_bar: Optional[tqdm] = None,
@@ -622,6 +633,11 @@ def download_from_url(
     Arguments:
         url:           The source of download
         destination:   The destination on local file system
+        object_id:      The id of the Synapse object that uses the FileHandle
+            e.g. "syn123"
+        object_type:    The type of the Synapse object that uses the
+            FileHandle e.g. "FileEntity". Any of
+            <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/FileHandleAssociateType.html>
         file_handle_id:  Optional. If given, the file will be given a temporary name that includes the file
                                 handle id which allows resuming partial downloads of the same file from previous
                                 sessions
@@ -718,22 +734,47 @@ def download_from_url(
                 if is_synapse_uri(uri=url, synapse_client=client)
                 else None
             )
-
-            response = with_retry(
-                lambda url=url, range_header=range_header, auth=auth: client._requests_session.get(
-                    url=url,
-                    headers=client._generate_headers(range_header),
-                    stream=True,
-                    allow_redirects=False,
-                    auth=auth,
-                ),
-                verbose=client.debug,
-                **STANDARD_RETRY_PARAMS,
-            )
+            
             try:
+                response = with_retry(
+                    lambda url=url, range_header=range_header, auth=auth: client._requests_session.get(
+                        url=url,
+                        headers=client._generate_headers(range_header),
+                        stream=True,
+                        allow_redirects=False,
+                        auth=auth,
+                    ),
+                    verbose=client.debug,
+                    **STANDARD_RETRY_PARAMS,
+                )
                 exceptions._raise_for_status(response, verbose=client.debug)
             except SynapseHTTPError as err:
-                if err.response.status_code == 404:
+                if err.response.status_code == 403:
+                    url_is_expired = datetime.datetime.now(
+                        tz=datetime.timezone.utc
+                    ) + PresignedUrlProvider._TIME_BUFFER >= _pre_signed_url_expiration_time(
+                        url
+                    )
+                    if url_is_expired:
+                        response = get_file_handle_for_download(
+                            file_handle_id=file_handle_id,
+                            synapse_id=object_id,
+                            entity_type=object_type,
+                            synapse_client=client,
+                        )
+                        refreshed_url = response["preSignedURL"]
+                        response = with_retry(
+                            lambda url=refreshed_url, range_header=range_header, auth=auth: client._requests_session.get(
+                                url=url,
+                                headers=client._generate_headers(range_header),
+                                stream=True,
+                                allow_redirects=False,
+                                auth=auth,
+                            ),
+                            verbose=client.debug,
+                            **STANDARD_RETRY_PARAMS,
+                        )
+                elif err.response.status_code == 404:
                     raise SynapseError(f"Could not download the file at {url}") from err
                 elif (
                     err.response.status_code == 416
@@ -745,8 +786,8 @@ def download_from_url(
                     # If it fails the user can retry with another download.
                     shutil.move(temp_destination, destination)
                     break
-                raise
-
+                else:
+                    raise
             # handle redirects
             if response.status_code in [301, 302, 303, 307, 308]:
                 url = response.headers["location"]

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -404,13 +404,13 @@ async def download_by_file_handle(
 
     while retries > 0:
         try:
-            file_handle_result: Dict[str, str] = (
-                await get_file_handle_for_download_async(
-                    file_handle_id=file_handle_id,
-                    synapse_id=synapse_id,
-                    entity_type=entity_type,
-                    synapse_client=syn,
-                )
+            file_handle_result: Dict[
+                str, str
+            ] = await get_file_handle_for_download_async(
+                file_handle_id=file_handle_id,
+                synapse_id=synapse_id,
+                entity_type=entity_type,
+                synapse_client=syn,
             )
             file_handle = file_handle_result["fileHandle"]
             concrete_type = file_handle["concreteType"]

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -69,6 +69,8 @@ RETRYABLE_CONNECTION_EXCEPTIONS = [
     "TimeoutException",
     "ConnectError",
     "ConnectTimeout",
+    # SSL Specific exceptions:
+    "SSLZeroReturnError",
 ]
 
 DEBUG_EXCEPTION = "calling %s resulted in an Exception"

--- a/tests/integration/synapseclient/core/test_download.py
+++ b/tests/integration/synapseclient/core/test_download.py
@@ -3,6 +3,8 @@
 import filecmp
 import os
 import random
+import datetime
+import requests
 import shutil
 import tempfile
 from typing import Callable
@@ -19,6 +21,8 @@ from synapseclient.core.download import download_from_url, download_functions
 from synapseclient.core.exceptions import SynapseMd5MismatchError
 from synapseclient.models import File, Project
 from tests.test_utils import spy_for_async_function
+
+from synapseclient.core.exceptions import SynapseHTTPError
 
 
 class TestDownloadCollisions:
@@ -228,6 +232,8 @@ class TestDownloadFromUrl:
                 url=entity_bad_md5.external_url,
                 destination=tempfile.gettempdir(),
                 file_handle_id=entity_bad_md5.data_file_handle_id,
+                object_id=entity_bad_md5.id,
+                object_type="FileEntity",
                 expected_md5="2345a",
             )
 
@@ -261,6 +267,8 @@ class TestDownloadFromUrl:
             url=f"{syn.repoEndpoint}/entity/{file.id}/file",
             destination=tempfile.gettempdir(),
             file_handle_id=file.data_file_handle_id,
+            object_id=file.id,
+            object_type="FileEntity",
             expected_md5=file.file_handle.content_md5,
         )
 

--- a/tests/integration/synapseclient/core/test_download.py
+++ b/tests/integration/synapseclient/core/test_download.py
@@ -15,9 +15,9 @@ import requests
 from pytest_mock import MockerFixture
 
 import synapseclient
-from synapseclient.core import exceptions
 import synapseclient.core.utils as utils
 from synapseclient import Synapse
+from synapseclient.core import exceptions
 from synapseclient.core.download import download_from_url, download_functions
 from synapseclient.core.exceptions import SynapseHTTPError, SynapseMd5MismatchError
 from synapseclient.models import File, Project

--- a/tests/integration/synapseclient/core/test_download.py
+++ b/tests/integration/synapseclient/core/test_download.py
@@ -5,8 +5,10 @@ import os
 import random
 import shutil
 import tempfile
+from datetime import datetime
 from typing import Callable
 from unittest.mock import Mock, patch
+from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
 import pytest
@@ -15,11 +17,25 @@ from pytest_mock import MockerFixture
 import synapseclient
 import synapseclient.core.utils as utils
 from synapseclient import Synapse
+from synapseclient.api.file_services import get_file_handle_for_download
 from synapseclient.core import exceptions
 from synapseclient.core.download import download_from_url, download_functions
 from synapseclient.core.exceptions import SynapseHTTPError, SynapseMd5MismatchError
 from synapseclient.models import File, Project
 from tests.test_utils import spy_for_async_function
+
+
+def _expire_url(url: str) -> str:
+    """Expire a string URL by setting the expiration date to 1900-01-01T00:00:00Z"""
+    parsed_url = urlparse(url)
+    params = parse_qs(parsed_url.query)
+    expired_date = datetime(1900, 1, 1, 0, 0, 0)
+    params["X-Amz-Date"] = [expired_date.strftime("%Y%m%dT%H%M%SZ")]
+    params["X-Amz-Expires"] = ["30"]  # Keep the original expiration duration
+    params["Expires"] = [str(int(expired_date.timestamp()))]
+    new_query = urlencode(params, doseq=True)
+    new_url = parsed_url._replace(query=new_query).geturl()
+    return new_url
 
 
 class TestDownloadCollisions:
@@ -278,34 +294,41 @@ class TestDownloadFromUrl:
 
     async def test_download_expired_url(
         self,
-        syn: Synapse,
+        mocker: MockerFixture,
         project_model: Project,
     ) -> None:
-        # simulate expired url for file
-        with patch.object(
-            exceptions,
-            "_raise_for_status",
-            side_effect=SynapseHTTPError(response=httpx.Response(403)),
-        ):
-            """Tests that a file download is retried when ."""
-            # GIVEN a file stored in synapse
-            original_file = utils.make_bogus_data_file(40000)
-            file = await File(
-                path=original_file, parent_id=project_model.id
-            ).store_async()
+        """Tests that a file download is retried when URL is expired."""
+        # GIVEN a file stored in synapse
+        original_file = utils.make_bogus_data_file(40000)
+        file = await File(path=original_file, parent_id=project_model.id).store_async()
 
-            # WHEN I download the file with a simulated expired url
-            path = download_from_url(
-                url=f"{syn.repoEndpoint}/entity/{file.id}/file",
-                destination=tempfile.gettempdir(),
-                object_id=file.id,
-                object_type="FileEntity",
-                file_handle_id=file.data_file_handle_id,
-                expected_md5=file.file_handle.content_md5,
-            )
+        # AND an expired preSignedURL for that file
+        file_handle_response = get_file_handle_for_download(
+            file_handle_id=file.data_file_handle_id,
+            synapse_id=file.id,
+            entity_type="FileEntity",
+        )
+        url = file_handle_response["preSignedURL"]
+        expired_url = _expire_url(url)
 
-            # THEN the file is downloaded anyway AND matches the original
-            assert filecmp.cmp(original_file, path), "File comparison failed"
+        # get_file_handle_for_download only runs if we are handling an expired URL
+        spy_file_handle = mocker.spy(download_functions, "get_file_handle_for_download")
+
+        # WHEN I download the file with a simulated expired url
+        path = download_from_url(
+            url=expired_url,
+            destination=tempfile.gettempdir(),
+            object_id=file.id,
+            object_type="FileEntity",
+            file_handle_id=file.data_file_handle_id,
+            expected_md5=file.file_handle.content_md5,
+        )
+
+        # THEN the expired URL is refreshed
+        spy_file_handle.assert_called_once()
+
+        # THEN the file is downloaded anyway AND matches the original
+        assert filecmp.cmp(original_file, path), "File comparison failed"
 
     async def test_download_via_get(
         self,

--- a/tests/integration/synapseclient/core/test_download.py
+++ b/tests/integration/synapseclient/core/test_download.py
@@ -1,6 +1,5 @@
 """Integration tests around downloading files from Synapse."""
 
-import datetime
 import filecmp
 import os
 import random
@@ -11,7 +10,6 @@ from unittest.mock import Mock, patch
 
 import httpx
 import pytest
-import requests
 from pytest_mock import MockerFixture
 
 import synapseclient

--- a/tests/integration/synapseclient/core/test_download.py
+++ b/tests/integration/synapseclient/core/test_download.py
@@ -442,17 +442,14 @@ class TestDownloadFromUrlMultiThreaded:
         os.remove(file_path)
         assert not os.path.exists(file_path)
 
-        with (
-            patch.object(
-                synapseclient.core.download.download_functions,
-                "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
-                new=500,
-            ),
-            patch.object(
-                synapseclient.core.download.download_async,
-                "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
-                new=500,
-            ),
+        with patch.object(
+            synapseclient.core.download.download_functions,
+            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+            new=500,
+        ), patch.object(
+            synapseclient.core.download.download_async,
+            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+            new=500,
         ):
             # WHEN I download the file with multiple parts
             file = await File(id=file.id, path=os.path.dirname(file.path)).get_async()
@@ -514,26 +511,21 @@ class TestDownloadFromUrlMultiThreaded:
                 # Call the real send function
                 return client.send(**kwargs)
 
-        with (
-            patch.object(
-                synapseclient.core.download.download_functions,
-                "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
-                new=500,
-            ),
-            patch.object(
-                synapseclient.core.download.download_async,
-                "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
-                new=500,
-            ),
-            patch.object(
-                syn._requests_session_storage,
-                "send",
-                mock_httpx_send,
-            ),
-            patch(
-                "synapseclient.core.download.download_async.DEFAULT_MAX_BACK_OFF_ASYNC",
-                0.2,
-            ),
+        with patch.object(
+            synapseclient.core.download.download_functions,
+            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+            new=500,
+        ), patch.object(
+            synapseclient.core.download.download_async,
+            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+            new=500,
+        ), patch.object(
+            syn._requests_session_storage,
+            "send",
+            mock_httpx_send,
+        ), patch(
+            "synapseclient.core.download.download_async.DEFAULT_MAX_BACK_OFF_ASYNC",
+            0.2,
         ):
             # WHEN I download the file with multiple parts
             file = await File(id=file.id, path=os.path.dirname(file.path)).get_async()
@@ -593,26 +585,21 @@ class TestDownloadFromUrlMultiThreaded:
                 # Call the real send function
                 return client.send(**kwargs)
 
-        with (
-            patch.object(
-                synapseclient.core.download.download_functions,
-                "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
-                new=500,
-            ),
-            patch.object(
-                synapseclient.core.download.download_async,
-                "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
-                new=500,
-            ),
-            patch.object(
-                syn._requests_session_storage,
-                "send",
-                mock_httpx_send,
-            ),
-            patch(
-                "synapseclient.core.download.download_async.DEFAULT_MAX_BACK_OFF_ASYNC",
-                0.2,
-            ),
+        with patch.object(
+            synapseclient.core.download.download_functions,
+            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+            new=500,
+        ), patch.object(
+            synapseclient.core.download.download_async,
+            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+            new=500,
+        ), patch.object(
+            syn._requests_session_storage,
+            "send",
+            mock_httpx_send,
+        ), patch(
+            "synapseclient.core.download.download_async.DEFAULT_MAX_BACK_OFF_ASYNC",
+            0.2,
         ):
             # WHEN I download the file with multiple parts
             file = await File(id=file.id, path=os.path.dirname(file.path)).get_async()

--- a/tests/integration/synapseclient/core/test_download.py
+++ b/tests/integration/synapseclient/core/test_download.py
@@ -231,9 +231,9 @@ class TestDownloadFromUrl:
             await download_from_url(
                 url=entity_bad_md5.external_url,
                 destination=tempfile.gettempdir(),
-                file_handle_id=entity_bad_md5.data_file_handle_id,
                 object_id=entity_bad_md5.id,
                 object_type="FileEntity",
+                file_handle_id=entity_bad_md5.data_file_handle_id,
                 expected_md5="2345a",
             )
 
@@ -266,9 +266,9 @@ class TestDownloadFromUrl:
         path = download_from_url(
             url=f"{syn.repoEndpoint}/entity/{file.id}/file",
             destination=tempfile.gettempdir(),
-            file_handle_id=file.data_file_handle_id,
             object_id=file.id,
             object_type="FileEntity",
+            file_handle_id=file.data_file_handle_id,
             expected_md5=file.file_handle.content_md5,
         )
 
@@ -391,14 +391,17 @@ class TestDownloadFromUrlMultiThreaded:
         os.remove(file_path)
         assert not os.path.exists(file_path)
 
-        with patch.object(
-            synapseclient.core.download.download_functions,
-            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
-            new=500,
-        ), patch.object(
-            synapseclient.core.download.download_async,
-            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
-            new=500,
+        with (
+            patch.object(
+                synapseclient.core.download.download_functions,
+                "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+                new=500,
+            ),
+            patch.object(
+                synapseclient.core.download.download_async,
+                "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+                new=500,
+            ),
         ):
             # WHEN I download the file with multiple parts
             file = await File(id=file.id, path=os.path.dirname(file.path)).get_async()
@@ -460,21 +463,26 @@ class TestDownloadFromUrlMultiThreaded:
                 # Call the real send function
                 return client.send(**kwargs)
 
-        with patch.object(
-            synapseclient.core.download.download_functions,
-            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
-            new=500,
-        ), patch.object(
-            synapseclient.core.download.download_async,
-            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
-            new=500,
-        ), patch.object(
-            syn._requests_session_storage,
-            "send",
-            mock_httpx_send,
-        ), patch(
-            "synapseclient.core.download.download_async.DEFAULT_MAX_BACK_OFF_ASYNC",
-            0.2,
+        with (
+            patch.object(
+                synapseclient.core.download.download_functions,
+                "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+                new=500,
+            ),
+            patch.object(
+                synapseclient.core.download.download_async,
+                "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+                new=500,
+            ),
+            patch.object(
+                syn._requests_session_storage,
+                "send",
+                mock_httpx_send,
+            ),
+            patch(
+                "synapseclient.core.download.download_async.DEFAULT_MAX_BACK_OFF_ASYNC",
+                0.2,
+            ),
         ):
             # WHEN I download the file with multiple parts
             file = await File(id=file.id, path=os.path.dirname(file.path)).get_async()
@@ -534,21 +542,26 @@ class TestDownloadFromUrlMultiThreaded:
                 # Call the real send function
                 return client.send(**kwargs)
 
-        with patch.object(
-            synapseclient.core.download.download_functions,
-            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
-            new=500,
-        ), patch.object(
-            synapseclient.core.download.download_async,
-            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
-            new=500,
-        ), patch.object(
-            syn._requests_session_storage,
-            "send",
-            mock_httpx_send,
-        ), patch(
-            "synapseclient.core.download.download_async.DEFAULT_MAX_BACK_OFF_ASYNC",
-            0.2,
+        with (
+            patch.object(
+                synapseclient.core.download.download_functions,
+                "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+                new=500,
+            ),
+            patch.object(
+                synapseclient.core.download.download_async,
+                "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+                new=500,
+            ),
+            patch.object(
+                syn._requests_session_storage,
+                "send",
+                mock_httpx_send,
+            ),
+            patch(
+                "synapseclient.core.download.download_async.DEFAULT_MAX_BACK_OFF_ASYNC",
+                0.2,
+            ),
         ):
             # WHEN I download the file with multiple parts
             file = await File(id=file.id, path=os.path.dirname(file.path)).get_async()

--- a/tests/integration/synapseclient/core/test_download.py
+++ b/tests/integration/synapseclient/core/test_download.py
@@ -244,8 +244,8 @@ class TestDownloadFromUrl:
             await download_from_url(
                 url=entity_bad_md5.external_url,
                 destination=tempfile.gettempdir(),
-                object_id=entity_bad_md5.id,
-                object_type="FileEntity",
+                entity_id=entity_bad_md5.id,
+                file_handle_associate_type="FileEntity",
                 file_handle_id=entity_bad_md5.data_file_handle_id,
                 expected_md5="2345a",
             )
@@ -279,8 +279,8 @@ class TestDownloadFromUrl:
         path = download_from_url(
             url=f"{syn.repoEndpoint}/entity/{file.id}/file",
             destination=tempfile.gettempdir(),
-            object_id=file.id,
-            object_type="FileEntity",
+            entity_id=file.id,
+            file_handle_associate_type="FileEntity",
             file_handle_id=file.data_file_handle_id,
             expected_md5=file.file_handle.content_md5,
         )
@@ -318,8 +318,8 @@ class TestDownloadFromUrl:
         path = download_from_url(
             url=expired_url,
             destination=tempfile.gettempdir(),
-            object_id=file.id,
-            object_type="FileEntity",
+            entity_id=file.id,
+            file_handle_associate_type="FileEntity",
             file_handle_id=file.data_file_handle_id,
             expected_md5=file.file_handle.content_md5,
         )
@@ -442,14 +442,17 @@ class TestDownloadFromUrlMultiThreaded:
         os.remove(file_path)
         assert not os.path.exists(file_path)
 
-        with patch.object(
-            synapseclient.core.download.download_functions,
-            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
-            new=500,
-        ), patch.object(
-            synapseclient.core.download.download_async,
-            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
-            new=500,
+        with (
+            patch.object(
+                synapseclient.core.download.download_functions,
+                "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+                new=500,
+            ),
+            patch.object(
+                synapseclient.core.download.download_async,
+                "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+                new=500,
+            ),
         ):
             # WHEN I download the file with multiple parts
             file = await File(id=file.id, path=os.path.dirname(file.path)).get_async()
@@ -511,21 +514,26 @@ class TestDownloadFromUrlMultiThreaded:
                 # Call the real send function
                 return client.send(**kwargs)
 
-        with patch.object(
-            synapseclient.core.download.download_functions,
-            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
-            new=500,
-        ), patch.object(
-            synapseclient.core.download.download_async,
-            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
-            new=500,
-        ), patch.object(
-            syn._requests_session_storage,
-            "send",
-            mock_httpx_send,
-        ), patch(
-            "synapseclient.core.download.download_async.DEFAULT_MAX_BACK_OFF_ASYNC",
-            0.2,
+        with (
+            patch.object(
+                synapseclient.core.download.download_functions,
+                "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+                new=500,
+            ),
+            patch.object(
+                synapseclient.core.download.download_async,
+                "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+                new=500,
+            ),
+            patch.object(
+                syn._requests_session_storage,
+                "send",
+                mock_httpx_send,
+            ),
+            patch(
+                "synapseclient.core.download.download_async.DEFAULT_MAX_BACK_OFF_ASYNC",
+                0.2,
+            ),
         ):
             # WHEN I download the file with multiple parts
             file = await File(id=file.id, path=os.path.dirname(file.path)).get_async()
@@ -585,21 +593,26 @@ class TestDownloadFromUrlMultiThreaded:
                 # Call the real send function
                 return client.send(**kwargs)
 
-        with patch.object(
-            synapseclient.core.download.download_functions,
-            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
-            new=500,
-        ), patch.object(
-            synapseclient.core.download.download_async,
-            "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
-            new=500,
-        ), patch.object(
-            syn._requests_session_storage,
-            "send",
-            mock_httpx_send,
-        ), patch(
-            "synapseclient.core.download.download_async.DEFAULT_MAX_BACK_OFF_ASYNC",
-            0.2,
+        with (
+            patch.object(
+                synapseclient.core.download.download_functions,
+                "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+                new=500,
+            ),
+            patch.object(
+                synapseclient.core.download.download_async,
+                "SYNAPSE_DEFAULT_DOWNLOAD_PART_SIZE",
+                new=500,
+            ),
+            patch.object(
+                syn._requests_session_storage,
+                "send",
+                mock_httpx_send,
+            ),
+            patch(
+                "synapseclient.core.download.download_async.DEFAULT_MAX_BACK_OFF_ASYNC",
+                0.2,
+            ),
         ):
             # WHEN I download the file with multiple parts
             file = await File(id=file.id, path=os.path.dirname(file.path)).get_async()

--- a/tests/integration/synapseclient/core/test_download.py
+++ b/tests/integration/synapseclient/core/test_download.py
@@ -1,10 +1,9 @@
 """Integration tests around downloading files from Synapse."""
 
+import datetime
 import filecmp
 import os
 import random
-import datetime
-import requests
 import shutil
 import tempfile
 from typing import Callable
@@ -12,17 +11,16 @@ from unittest.mock import Mock, patch
 
 import httpx
 import pytest
+import requests
 from pytest_mock import MockerFixture
 
 import synapseclient
 import synapseclient.core.utils as utils
 from synapseclient import Synapse
 from synapseclient.core.download import download_from_url, download_functions
-from synapseclient.core.exceptions import SynapseMd5MismatchError
+from synapseclient.core.exceptions import SynapseHTTPError, SynapseMd5MismatchError
 from synapseclient.models import File, Project
 from tests.test_utils import spy_for_async_function
-
-from synapseclient.core.exceptions import SynapseHTTPError
 
 
 class TestDownloadCollisions:

--- a/tests/integration/synapseclient/core/test_download.py
+++ b/tests/integration/synapseclient/core/test_download.py
@@ -29,10 +29,10 @@ def _expire_url(url: str) -> str:
     """Expire a string URL by setting the expiration date to 1900-01-01T00:00:00Z"""
     parsed_url = urlparse(url)
     params = parse_qs(parsed_url.query)
-    expired_date = datetime(1900, 1, 1, 0, 0, 0)
+    expired_date = datetime(1970, 1, 1, 0, 0, 0)
     params["X-Amz-Date"] = [expired_date.strftime("%Y%m%dT%H%M%SZ")]
-    params["X-Amz-Expires"] = ["30"]  # Keep the original expiration duration
-    params["Expires"] = [str(int(expired_date.timestamp()))]
+    params["X-Amz-Expires"] = ["30"]
+    params["Expires"] = ["0"]
     new_query = urlencode(params, doseq=True)
     new_url = parsed_url._replace(query=new_query).geturl()
     return new_url

--- a/tests/integration/synapseclient/core/test_external_storage.py
+++ b/tests/integration/synapseclient/core/test_external_storage.py
@@ -304,7 +304,7 @@ class TestExernalStorage:
                     Bucket=bucket_name,
                     Key=remote_key,
                 )
-            assert "Access Denied" in str(ex_cm.value)
+            assert "AccessDenied" in str(ex_cm.value)
 
             # WHEN I put an object directly using the STS read/write credentials
             s3_write_client.upload_file(

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -569,12 +569,13 @@ class TestDownloadFromUrlMultiThreaded:
         self.syn = syn
 
     async def test_md5_mismatch(self) -> None:
-        with (
-            patch("synapseclient.core.download.download_functions.download_file"),
-            patch.object(utils, "md5_for_file") as mock_md5_for_file,
-            patch.object(os, "remove") as mock_os_remove,
-            patch.object(shutil, "move") as mock_move,
-        ):
+        with patch(
+            "synapseclient.core.download.download_functions.download_file"
+        ), patch.object(utils, "md5_for_file") as mock_md5_for_file, patch.object(
+            os, "remove"
+        ) as mock_os_remove, patch.object(
+            shutil, "move"
+        ) as mock_move:
             path = os.path.abspath("/myfakepath")
 
             mock_md5_for_file.return_value.hexdigest.return_value = "unexpetedMd5"
@@ -597,16 +598,17 @@ class TestDownloadFromUrlMultiThreaded:
     async def test_md5_match(self) -> None:
         expected_md5 = "myExpectedMd5"
 
-        with (
-            patch("synapseclient.core.download.download_functions.download_file"),
-            patch.object(
-                utils,
-                "md5_for_file_hex",
-                return_value=expected_md5,
-            ),
-            patch.object(os, "remove") as mock_os_remove,
-            patch.object(shutil, "move") as mock_move,
-        ):
+        with patch(
+            "synapseclient.core.download.download_functions.download_file"
+        ), patch.object(
+            utils,
+            "md5_for_file_hex",
+            return_value=expected_md5,
+        ), patch.object(
+            os, "remove"
+        ) as mock_os_remove, patch.object(
+            shutil, "move"
+        ) as mock_move:
             path = os.path.abspath("/myfakepath")
 
             await download_from_url_multi_threaded(

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -834,31 +834,22 @@ class TestDownloadFromUrl:
             assert not mocked_remove.called
 
     async def test_download_expired_url(self, syn: Synapse) -> None:
-        url = "http://www.ayy.lmao/filerino.txt"
-        new_url = "http://www.ayy.lmao/new_url.txt"
+        url = "http://www.ayy.lmao/filerino.txt?Expires=0"
+        new_url = "http://www.ayy.lmao/new_url.txt?Expires=1715000000"
         contents = "\n".join(str(i) for i in range(1000))
         temp_destination = os.path.normpath(
             os.path.expanduser("~/fake/path/filerino.txt.temp")
         )
         destination = os.path.normpath(os.path.expanduser("~/fake/path/filerino.txt"))
 
-        partial_content_break = len(contents) // 7 * 3
         mock_requests_get = MockRequestGetFunction(
             [
                 create_mock_response(
                     url,
                     "stream",
-                    contents=contents[:partial_content_break],
-                    buffer_size=1024,
-                    partial_end=len(contents),
-                    status_code=403,
-                ),
-                create_mock_response(
-                    url,
-                    "stream",
                     contents=contents,
                     buffer_size=1024,
-                    partial_start=len(contents),
+                    partial_end=len(contents),
                     status_code=200,
                 ),
             ]
@@ -902,6 +893,70 @@ class TestDownloadFromUrl:
             # AND I expect the download to be retried with the new URL
             mocked_get.assert_called_with(
                 url=new_url,
+                headers=mock_generate_headers(self),
+                stream=True,
+                allow_redirects=False,
+                auth=None,
+            )
+
+    async def test_download_url_no_expiration(self, syn: Synapse) -> None:
+        url = "http://www.ayy.lmao/filerino.txt"
+        contents = "\n".join(str(i) for i in range(1000))
+        temp_destination = os.path.normpath(
+            os.path.expanduser("~/fake/path/filerino.txt.temp")
+        )
+        destination = os.path.normpath(os.path.expanduser("~/fake/path/filerino.txt"))
+
+        mock_requests_get = MockRequestGetFunction(
+            [
+                create_mock_response(
+                    url,
+                    "stream",
+                    contents=contents,
+                    buffer_size=1024,
+                    partial_end=len(contents),
+                    status_code=200,
+                ),
+            ]
+        )
+        with patch.object(
+            syn._requests_session, "get", side_effect=mock_requests_get
+        ) as mocked_get, patch(
+            "synapseclient.core.download.download_functions._pre_signed_url_expiration_time",
+            return_value=datetime.datetime(1900, 1, 1, tzinfo=datetime.timezone.utc),
+        ) as mocked_pre_signed_url_expiration_time, patch(
+            "synapseclient.core.download.download_functions.get_file_handle_for_download",
+        ) as mocked_get_file_handle_for_download, patch.object(
+            Synapse, "_generate_headers", side_effect=mock_generate_headers
+        ), patch.object(
+            utils, "temp_download_filename", return_value=temp_destination
+        ), patch(
+            "synapseclient.core.download.download_functions.open",
+            new_callable=mock_open(),
+            create=True,
+        ), patch.object(
+            hashlib, "new"
+        ) as mocked_hashlib_new, patch.object(
+            shutil, "move"
+        ), patch.object(
+            os, "remove"
+        ):
+            mocked_hashlib_new.return_value.hexdigest.return_value = "fake md5 is fake"
+            # WHEN I call download_from_url with an expired url
+            download_from_url(
+                url=url,
+                destination=destination,
+                entity_id=OBJECT_ID,
+                file_handle_associate_type=OBJECT_TYPE,
+                expected_md5="fake md5 is fake",
+            )
+            # I expect the expired url to be identified
+            mocked_pre_signed_url_expiration_time.assert_not_called()
+            # AND I expect the URL to be refreshed
+            mocked_get_file_handle_for_download.assert_not_called()
+            # AND I expect the download to be retried with the new URL
+            mocked_get.assert_called_with(
+                url=url,
                 headers=mock_generate_headers(self),
                 stream=True,
                 allow_redirects=False,

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -524,17 +524,14 @@ class TestDownloadFileHandle:
         await self._multithread_not_applicable(file_handle)
 
     async def test_multithread_false_s3_file_handle(self) -> None:
-        with (
-            patch.object(os, "makedirs"),
-            patch(
-                GET_FILE_HANDLE_FOR_DOWNLOAD,
-                new_callable=AsyncMock,
-            ) as mock_getFileHandleDownload,
-            patch(
-                DOWNLOAD_FROM_URL,
-                new_callable=AsyncMock,
-            ) as mock_download_from_URL,
-            patch.object(self.syn, "cache"),
+        with patch.object(os, "makedirs"), patch(
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
+            new_callable=AsyncMock,
+        ) as mock_getFileHandleDownload, patch(
+            DOWNLOAD_FROM_URL,
+            new_callable=AsyncMock,
+        ) as mock_download_from_URL, patch.object(
+            self.syn, "cache"
         ):
             mock_getFileHandleDownload.return_value = {
                 "fileHandle": {

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -751,23 +751,23 @@ class TestDownloadFromUrl:
             ]
         )
 
-        with (
-            patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
-            patch.object(
-                Synapse, "_generate_headers", side_effect=mock_generate_headers
-            ),
-            patch.object(
-                utils, "temp_download_filename", return_value=temp_destination
-            ) as mocked_temp_dest,
-            patch(
-                "synapseclient.core.download.download_functions.open",
-                new_callable=mock_open(),
-                create=True,
-            ) as mocked_open,
-            patch.object(os.path, "exists", side_effect=[False, True]) as mocked_exists,
-            patch.object(shutil, "move") as mocked_move,
-            patch.object(os, "remove") as mocked_remove,
-        ):
+        with patch.object(
+            syn._requests_session, "get", side_effect=mock_requests_get
+        ), patch.object(
+            Synapse, "_generate_headers", side_effect=mock_generate_headers
+        ), patch.object(
+            utils, "temp_download_filename", return_value=temp_destination
+        ) as mocked_temp_dest, patch(
+            "synapseclient.core.download.download_functions.open",
+            new_callable=mock_open(),
+            create=True,
+        ) as mocked_open, patch.object(
+            os.path, "exists", side_effect=[False, True]
+        ) as mocked_exists, patch.object(
+            shutil, "move"
+        ) as mocked_move, patch.object(
+            os, "remove"
+        ) as mocked_remove:
             # function under test
             with pytest.raises(SynapseMd5MismatchError):
                 await download_from_url(
@@ -806,17 +806,15 @@ class TestDownloadFromUrl:
         url = "file:///some/file/path.txt"
         destination = os.path.normpath(os.path.expanduser("~/fake/path/filerino.txt"))
 
-        with (
-            patch.object(
-                utils, "file_url_to_path", return_value=destination
-            ) as mocked_file_url_to_path,
-            patch.object(
-                utils,
-                "md5_for_file_hex",
-                return_value="Some other incorrect md5",
-            ) as mocked_md5_for_file,
-            patch("os.remove") as mocked_remove,
-        ):
+        with patch.object(
+            utils, "file_url_to_path", return_value=destination
+        ) as mocked_file_url_to_path, patch.object(
+            utils,
+            "md5_for_file_hex",
+            return_value="Some other incorrect md5",
+        ) as mocked_md5_for_file, patch(
+            "os.remove"
+        ) as mocked_remove:
             # function under test
             with pytest.raises(SynapseMd5MismatchError):
                 await download_from_url(

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -481,11 +481,7 @@ class TestDownloadFileHandle:
             new_callable=AsyncMock,
         ) as mock_download_from_URL, patch.object(
             self.syn, "cache"
-            mock_getFileHandleDownload.return_value = {
-                "fileHandle": file_handle,
-                "preSignedURL": "asdf.com",
-            }
-
+        ):
             # multi_threaded/max_threads will have effect
             self.syn.multi_threaded = True
             await download_by_file_handle(

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -155,10 +155,9 @@ async def test_mock_download(syn: Synapse) -> None:
         [create_mock_response(url, "stream", contents=contents, buffer_size=1024)]
     )
 
-    with (
-        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
-        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
-    ):
+    with patch.object(
+        syn._requests_session, "get", side_effect=mock_requests_get
+    ), patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers):
         download_from_url(
             url=url,
             destination=temp_dir,
@@ -178,10 +177,9 @@ async def test_mock_download(syn: Synapse) -> None:
         ]
     )
 
-    with (
-        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
-        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
-    ):
+    with patch.object(
+        syn._requests_session, "get", side_effect=mock_requests_get
+    ), patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers):
         download_from_url(
             url=url,
             destination=temp_dir,
@@ -233,14 +231,12 @@ async def test_mock_download(syn: Synapse) -> None:
         },
     }
 
-    with (
-        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
-        patch.object(syn, "_generate_headers", side_effect=mock_generate_headers),
-        patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-            return_value=_getFileHandleDownload_return_value,
-        ),
+    with patch.object(
+        syn._requests_session, "get", side_effect=mock_requests_get
+    ), patch.object(syn, "_generate_headers", side_effect=mock_generate_headers), patch(
+        GET_FILE_HANDLE_FOR_DOWNLOAD,
+        new_callable=AsyncMock,
+        return_value=_getFileHandleDownload_return_value,
     ):
         await download_by_file_handle(
             file_handle_id=FILE_HANDLE_ID,
@@ -283,14 +279,14 @@ async def test_mock_download(syn: Synapse) -> None:
     # with patch.object(
     #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
     # )
-    with (
-        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
-        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
-        patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-            return_value=_getFileHandleDownload_return_value,
-        ),
+    with patch.object(
+        syn._requests_session, "get", side_effect=mock_requests_get
+    ), patch.object(
+        Synapse, "_generate_headers", side_effect=mock_generate_headers
+    ), patch(
+        GET_FILE_HANDLE_FOR_DOWNLOAD,
+        new_callable=AsyncMock,
+        return_value=_getFileHandleDownload_return_value,
     ):
         await download_by_file_handle(
             file_handle_id=FILE_HANDLE_ID,
@@ -334,14 +330,14 @@ async def test_mock_download(syn: Synapse) -> None:
     # with patch.object(
     #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
     # )
-    with (
-        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
-        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
-        patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-            return_value=_getFileHandleDownload_return_value,
-        ),
+    with patch.object(
+        syn._requests_session, "get", side_effect=mock_requests_get
+    ), patch.object(
+        Synapse, "_generate_headers", side_effect=mock_generate_headers
+    ), patch(
+        GET_FILE_HANDLE_FOR_DOWNLOAD,
+        new_callable=AsyncMock,
+        return_value=_getFileHandleDownload_return_value,
     ):
         with pytest.raises(Exception):
             await download_by_file_handle(
@@ -376,14 +372,14 @@ async def test_mock_download(syn: Synapse) -> None:
     # with patch.object(
     #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
     # )
-    with (
-        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
-        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
-        patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-            return_value=_getFileHandleDownload_return_value,
-        ),
+    with patch.object(
+        syn._requests_session, "get", side_effect=mock_requests_get
+    ), patch.object(
+        Synapse, "_generate_headers", side_effect=mock_generate_headers
+    ), patch(
+        GET_FILE_HANDLE_FOR_DOWNLOAD,
+        new_callable=AsyncMock,
+        return_value=_getFileHandleDownload_return_value,
     ):
         await download_by_file_handle(
             file_handle_id=FILE_HANDLE_ID,
@@ -407,14 +403,14 @@ async def test_mock_download(syn: Synapse) -> None:
     # with patch.object(
     #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
     # )
-    with (
-        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
-        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
-        patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-            return_value=_getFileHandleDownload_return_value,
-        ),
+    with patch.object(
+        syn._requests_session, "get", side_effect=mock_requests_get
+    ), patch.object(
+        Synapse, "_generate_headers", side_effect=mock_generate_headers
+    ), patch(
+        GET_FILE_HANDLE_FOR_DOWNLOAD,
+        new_callable=AsyncMock,
+        return_value=_getFileHandleDownload_return_value,
     ):
         with pytest.raises(SynapseHTTPError):
             await download_by_file_handle(
@@ -435,17 +431,14 @@ class TestDownloadFileHandle:
         self.syn.multi_threaded = False
 
     async def test_multithread_true_s3_file_handle(self) -> None:
-        with (
-            patch.object(os, "makedirs"),
-            patch(
-                GET_FILE_HANDLE_FOR_DOWNLOAD,
-                new_callable=AsyncMock,
-            ) as mock_getFileHandleDownload,
-            patch(
-                "synapseclient.core.download.download_functions.download_from_url_multi_threaded",
-                new_callable=AsyncMock,
-            ) as mock_multi_thread_download,
-            patch.object(self.syn, "cache"),
+        with patch.object(os, "makedirs"), patch(
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
+            new_callable=AsyncMock,
+        ) as mock_getFileHandleDownload, patch(
+            "synapseclient.core.download.download_functions.download_from_url_multi_threaded",
+            new_callable=AsyncMock,
+        ) as mock_multi_thread_download, patch.object(
+            self.syn, "cache"
         ):
             mock_getFileHandleDownload.return_value = {
                 "fileHandle": {
@@ -481,18 +474,15 @@ class TestDownloadFileHandle:
             "preSignedURL": "asdf.com",
         }
 
-        with (
-            patch.object(os, "makedirs"),
-            patch(
-                GET_FILE_HANDLE_FOR_DOWNLOAD,
-                new_callable=AsyncMock,
-                return_value=get_file_handle_for_download_return_value,
-            ),
-            patch(
-                DOWNLOAD_FROM_URL,
-                new_callable=AsyncMock,
-            ) as mock_download_from_URL,
-            patch.object(self.syn, "cache"),
+        with patch.object(os, "makedirs"), patch(
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
+            new_callable=AsyncMock,
+            return_value=get_file_handle_for_download_return_value,
+        ), patch(
+            DOWNLOAD_FROM_URL,
+            new_callable=AsyncMock,
+        ) as mock_download_from_URL, patch.object(
+            self.syn, "cache"
         ):
             # multi_threaded/max_threads will have effect
             self.syn.multi_threaded = True
@@ -536,17 +526,14 @@ class TestDownloadFileHandle:
         await self._multithread_not_applicable(file_handle)
 
     async def test_multithread_false_s3_file_handle(self) -> None:
-        with (
-            patch.object(os, "makedirs"),
-            patch(
-                GET_FILE_HANDLE_FOR_DOWNLOAD,
-                new_callable=AsyncMock,
-            ) as mock_getFileHandleDownload,
-            patch(
-                DOWNLOAD_FROM_URL,
-                new_callable=AsyncMock,
-            ) as mock_download_from_URL,
-            patch.object(self.syn, "cache"),
+        with patch.object(os, "makedirs"), patch(
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
+            new_callable=AsyncMock,
+        ) as mock_getFileHandleDownload, patch(
+            DOWNLOAD_FROM_URL,
+            new_callable=AsyncMock,
+        ) as mock_download_from_URL, patch.object(
+            self.syn, "cache"
         ):
             mock_getFileHandleDownload.return_value = {
                 "fileHandle": {
@@ -584,12 +571,13 @@ class TestDownloadFromUrlMultiThreaded:
         self.syn = syn
 
     async def test_md5_mismatch(self) -> None:
-        with (
-            patch("synapseclient.core.download.download_functions.download_file"),
-            patch.object(utils, "md5_for_file") as mock_md5_for_file,
-            patch.object(os, "remove") as mock_os_remove,
-            patch.object(shutil, "move") as mock_move,
-        ):
+        with patch(
+            "synapseclient.core.download.download_functions.download_file"
+        ), patch.object(utils, "md5_for_file") as mock_md5_for_file, patch.object(
+            os, "remove"
+        ) as mock_os_remove, patch.object(
+            shutil, "move"
+        ) as mock_move:
             path = os.path.abspath("/myfakepath")
 
             mock_md5_for_file.return_value.hexdigest.return_value = "unexpetedMd5"
@@ -612,16 +600,17 @@ class TestDownloadFromUrlMultiThreaded:
     async def test_md5_match(self) -> None:
         expected_md5 = "myExpectedMd5"
 
-        with (
-            patch("synapseclient.core.download.download_functions.download_file"),
-            patch.object(
-                utils,
-                "md5_for_file_hex",
-                return_value=expected_md5,
-            ),
-            patch.object(os, "remove") as mock_os_remove,
-            patch.object(shutil, "move") as mock_move,
-        ):
+        with patch(
+            "synapseclient.core.download.download_functions.download_file"
+        ), patch.object(
+            utils,
+            "md5_for_file_hex",
+            return_value=expected_md5,
+        ), patch.object(
+            os, "remove"
+        ) as mock_os_remove, patch.object(
+            shutil, "move"
+        ) as mock_move:
             path = os.path.abspath("/myfakepath")
 
             await download_from_url_multi_threaded(
@@ -690,26 +679,25 @@ class TestDownloadFromUrl:
         # with patch.object(
         #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
         # )
-        with (
-            patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
-            patch.object(
-                Synapse, "_generate_headers", side_effect=mock_generate_headers
-            ),
-            patch.object(
-                utils, "temp_download_filename", return_value=temp_destination
-            ) as mocked_temp_dest,
-            patch(
-                "synapseclient.core.download.download_functions.open",
-                new_callable=mock_open(),
-                create=True,
-            ) as mocked_open,
-            patch.object(os.path, "exists", side_effect=[False, True]) as mocked_exists,
-            patch.object(
-                os.path, "getsize", return_value=partial_content_break
-            ) as mocked_getsize,
-            patch.object(utils, "md5_for_file"),
-            patch.object(shutil, "move") as mocked_move,
-        ):
+        with patch.object(
+            syn._requests_session, "get", side_effect=mock_requests_get
+        ), patch.object(
+            Synapse, "_generate_headers", side_effect=mock_generate_headers
+        ), patch.object(
+            utils, "temp_download_filename", return_value=temp_destination
+        ) as mocked_temp_dest, patch(
+            "synapseclient.core.download.download_functions.open",
+            new_callable=mock_open(),
+            create=True,
+        ) as mocked_open, patch.object(
+            os.path, "exists", side_effect=[False, True]
+        ) as mocked_exists, patch.object(
+            os.path, "getsize", return_value=partial_content_break
+        ) as mocked_getsize, patch.object(
+            utils, "md5_for_file"
+        ), patch.object(
+            shutil, "move"
+        ) as mocked_move:
             # function under test
             download_from_url(
                 url=url,
@@ -766,23 +754,23 @@ class TestDownloadFromUrl:
             ]
         )
 
-        with (
-            patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
-            patch.object(
-                Synapse, "_generate_headers", side_effect=mock_generate_headers
-            ),
-            patch.object(
-                utils, "temp_download_filename", return_value=temp_destination
-            ) as mocked_temp_dest,
-            patch(
-                "synapseclient.core.download.download_functions.open",
-                new_callable=mock_open(),
-                create=True,
-            ) as mocked_open,
-            patch.object(os.path, "exists", side_effect=[False, True]) as mocked_exists,
-            patch.object(shutil, "move") as mocked_move,
-            patch.object(os, "remove") as mocked_remove,
-        ):
+        with patch.object(
+            syn._requests_session, "get", side_effect=mock_requests_get
+        ), patch.object(
+            Synapse, "_generate_headers", side_effect=mock_generate_headers
+        ), patch.object(
+            utils, "temp_download_filename", return_value=temp_destination
+        ) as mocked_temp_dest, patch(
+            "synapseclient.core.download.download_functions.open",
+            new_callable=mock_open(),
+            create=True,
+        ) as mocked_open, patch.object(
+            os.path, "exists", side_effect=[False, True]
+        ) as mocked_exists, patch.object(
+            shutil, "move"
+        ) as mocked_move, patch.object(
+            os, "remove"
+        ) as mocked_remove:
             # function under test
             with pytest.raises(SynapseMd5MismatchError):
                 await download_from_url(
@@ -821,17 +809,15 @@ class TestDownloadFromUrl:
         url = "file:///some/file/path.txt"
         destination = os.path.normpath(os.path.expanduser("~/fake/path/filerino.txt"))
 
-        with (
-            patch.object(
-                utils, "file_url_to_path", return_value=destination
-            ) as mocked_file_url_to_path,
-            patch.object(
-                utils,
-                "md5_for_file_hex",
-                return_value="Some other incorrect md5",
-            ) as mocked_md5_for_file,
-            patch("os.remove") as mocked_remove,
-        ):
+        with patch.object(
+            utils, "file_url_to_path", return_value=destination
+        ) as mocked_file_url_to_path, patch.object(
+            utils,
+            "md5_for_file_hex",
+            return_value="Some other incorrect md5",
+        ) as mocked_md5_for_file, patch(
+            "os.remove"
+        ) as mocked_remove:
             # function under test
             with pytest.raises(SynapseMd5MismatchError):
                 await download_from_url(
@@ -877,34 +863,28 @@ class TestDownloadFromUrl:
                 ),
             ]
         )
-        with (
-            patch.object(
-                syn._requests_session, "get", side_effect=mock_requests_get
-            ) as mocked_get,
-            patch(
-                "synapseclient.core.download.download_functions._pre_signed_url_expiration_time",
-                return_value=datetime.datetime(
-                    1900, 1, 1, tzinfo=datetime.timezone.utc
-                ),
-            ) as mocked_pre_signed_url_expiration_time,
-            patch(
-                "synapseclient.core.download.download_functions.get_file_handle_for_download",
-                return_value={"preSignedURL": new_url},
-            ) as mocked_get_file_handle_for_download,
-            patch.object(
-                Synapse, "_generate_headers", side_effect=mock_generate_headers
-            ),
-            patch.object(
-                utils, "temp_download_filename", return_value=temp_destination
-            ),
-            patch(
-                "synapseclient.core.download.download_functions.open",
-                new_callable=mock_open(),
-                create=True,
-            ),
-            patch.object(hashlib, "new") as mocked_hashlib_new,
-            patch.object(shutil, "move"),
-            patch.object(os, "remove"),
+        with patch.object(
+            syn._requests_session, "get", side_effect=mock_requests_get
+        ) as mocked_get, patch(
+            "synapseclient.core.download.download_functions._pre_signed_url_expiration_time",
+            return_value=datetime.datetime(1900, 1, 1, tzinfo=datetime.timezone.utc),
+        ) as mocked_pre_signed_url_expiration_time, patch(
+            "synapseclient.core.download.download_functions.get_file_handle_for_download",
+            return_value={"preSignedURL": new_url},
+        ) as mocked_get_file_handle_for_download, patch.object(
+            Synapse, "_generate_headers", side_effect=mock_generate_headers
+        ), patch.object(
+            utils, "temp_download_filename", return_value=temp_destination
+        ), patch(
+            "synapseclient.core.download.download_functions.open",
+            new_callable=mock_open(),
+            create=True,
+        ), patch.object(
+            hashlib, "new"
+        ) as mocked_hashlib_new, patch.object(
+            shutil, "move"
+        ), patch.object(
+            os, "remove"
         ):
             mocked_hashlib_new.return_value.hexdigest.return_value = "fake md5 is fake"
             # WHEN I call download_from_url with an expired url

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -155,14 +155,15 @@ async def test_mock_download(syn: Synapse) -> None:
         [create_mock_response(url, "stream", contents=contents, buffer_size=1024)]
     )
 
-    with patch.object(
-        syn._requests_session, "get", side_effect=mock_requests_get
-    ), patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers):
+    with (
+        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
+        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
+    ):
         download_from_url(
             url=url,
             destination=temp_dir,
-            object_id=OBJECT_ID,
-            object_type=OBJECT_TYPE,
+            entity_id=OBJECT_ID,
+            file_handle_associate_type=OBJECT_TYPE,
             file_handle_id=12345,
             expected_md5=contents_md5,
             synapse_client=syn,
@@ -177,14 +178,15 @@ async def test_mock_download(syn: Synapse) -> None:
         ]
     )
 
-    with patch.object(
-        syn._requests_session, "get", side_effect=mock_requests_get
-    ), patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers):
+    with (
+        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
+        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
+    ):
         download_from_url(
             url=url,
             destination=temp_dir,
-            object_id=OBJECT_ID,
-            object_type=OBJECT_TYPE,
+            entity_id=OBJECT_ID,
+            file_handle_associate_type=OBJECT_TYPE,
             file_handle_id=12345,
             expected_md5=contents_md5,
             synapse_client=syn,
@@ -231,12 +233,14 @@ async def test_mock_download(syn: Synapse) -> None:
         },
     }
 
-    with patch.object(
-        syn._requests_session, "get", side_effect=mock_requests_get
-    ), patch.object(syn, "_generate_headers", side_effect=mock_generate_headers), patch(
-        GET_FILE_HANDLE_FOR_DOWNLOAD,
-        new_callable=AsyncMock,
-        return_value=_getFileHandleDownload_return_value,
+    with (
+        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
+        patch.object(syn, "_generate_headers", side_effect=mock_generate_headers),
+        patch(
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
+            new_callable=AsyncMock,
+            return_value=_getFileHandleDownload_return_value,
+        ),
     ):
         await download_by_file_handle(
             file_handle_id=FILE_HANDLE_ID,
@@ -279,14 +283,14 @@ async def test_mock_download(syn: Synapse) -> None:
     # with patch.object(
     #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
     # )
-    with patch.object(
-        syn._requests_session, "get", side_effect=mock_requests_get
-    ), patch.object(
-        Synapse, "_generate_headers", side_effect=mock_generate_headers
-    ), patch(
-        GET_FILE_HANDLE_FOR_DOWNLOAD,
-        new_callable=AsyncMock,
-        return_value=_getFileHandleDownload_return_value,
+    with (
+        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
+        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
+        patch(
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
+            new_callable=AsyncMock,
+            return_value=_getFileHandleDownload_return_value,
+        ),
     ):
         await download_by_file_handle(
             file_handle_id=FILE_HANDLE_ID,
@@ -330,14 +334,14 @@ async def test_mock_download(syn: Synapse) -> None:
     # with patch.object(
     #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
     # )
-    with patch.object(
-        syn._requests_session, "get", side_effect=mock_requests_get
-    ), patch.object(
-        Synapse, "_generate_headers", side_effect=mock_generate_headers
-    ), patch(
-        GET_FILE_HANDLE_FOR_DOWNLOAD,
-        new_callable=AsyncMock,
-        return_value=_getFileHandleDownload_return_value,
+    with (
+        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
+        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
+        patch(
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
+            new_callable=AsyncMock,
+            return_value=_getFileHandleDownload_return_value,
+        ),
     ):
         with pytest.raises(Exception):
             await download_by_file_handle(
@@ -372,14 +376,14 @@ async def test_mock_download(syn: Synapse) -> None:
     # with patch.object(
     #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
     # )
-    with patch.object(
-        syn._requests_session, "get", side_effect=mock_requests_get
-    ), patch.object(
-        Synapse, "_generate_headers", side_effect=mock_generate_headers
-    ), patch(
-        GET_FILE_HANDLE_FOR_DOWNLOAD,
-        new_callable=AsyncMock,
-        return_value=_getFileHandleDownload_return_value,
+    with (
+        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
+        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
+        patch(
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
+            new_callable=AsyncMock,
+            return_value=_getFileHandleDownload_return_value,
+        ),
     ):
         await download_by_file_handle(
             file_handle_id=FILE_HANDLE_ID,
@@ -403,14 +407,14 @@ async def test_mock_download(syn: Synapse) -> None:
     # with patch.object(
     #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
     # )
-    with patch.object(
-        syn._requests_session, "get", side_effect=mock_requests_get
-    ), patch.object(
-        Synapse, "_generate_headers", side_effect=mock_generate_headers
-    ), patch(
-        GET_FILE_HANDLE_FOR_DOWNLOAD,
-        new_callable=AsyncMock,
-        return_value=_getFileHandleDownload_return_value,
+    with (
+        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
+        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
+        patch(
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
+            new_callable=AsyncMock,
+            return_value=_getFileHandleDownload_return_value,
+        ),
     ):
         with pytest.raises(SynapseHTTPError):
             await download_by_file_handle(
@@ -431,14 +435,17 @@ class TestDownloadFileHandle:
         self.syn.multi_threaded = False
 
     async def test_multithread_true_s3_file_handle(self) -> None:
-        with patch.object(os, "makedirs"), patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-        ) as mock_getFileHandleDownload, patch(
-            "synapseclient.core.download.download_functions.download_from_url_multi_threaded",
-            new_callable=AsyncMock,
-        ) as mock_multi_thread_download, patch.object(
-            self.syn, "cache"
+        with (
+            patch.object(os, "makedirs"),
+            patch(
+                GET_FILE_HANDLE_FOR_DOWNLOAD,
+                new_callable=AsyncMock,
+            ) as mock_getFileHandleDownload,
+            patch(
+                "synapseclient.core.download.download_functions.download_from_url_multi_threaded",
+                new_callable=AsyncMock,
+            ) as mock_multi_thread_download,
+            patch.object(self.syn, "cache"),
         ):
             mock_getFileHandleDownload.return_value = {
                 "fileHandle": {
@@ -474,15 +481,18 @@ class TestDownloadFileHandle:
             "preSignedURL": "asdf.com",
         }
 
-        with patch.object(os, "makedirs"), patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-            return_value=get_file_handle_for_download_return_value,
-        ), patch(
-            DOWNLOAD_FROM_URL,
-            new_callable=AsyncMock,
-        ) as mock_download_from_URL, patch.object(
-            self.syn, "cache"
+        with (
+            patch.object(os, "makedirs"),
+            patch(
+                GET_FILE_HANDLE_FOR_DOWNLOAD,
+                new_callable=AsyncMock,
+                return_value=get_file_handle_for_download_return_value,
+            ),
+            patch(
+                DOWNLOAD_FROM_URL,
+                new_callable=AsyncMock,
+            ) as mock_download_from_URL,
+            patch.object(self.syn, "cache"),
         ):
             # multi_threaded/max_threads will have effect
             self.syn.multi_threaded = True
@@ -497,8 +507,8 @@ class TestDownloadFileHandle:
             mock_download_from_URL.assert_called_once_with(
                 url="asdf.com",
                 destination="/myfakepath",
-                object_id=456,
-                object_type="FileEntity",
+                entity_id=456,
+                file_handle_associate_type="FileEntity",
                 file_handle_id="123",
                 expected_md5="someMD5",
                 progress_bar=ANY,
@@ -526,14 +536,17 @@ class TestDownloadFileHandle:
         await self._multithread_not_applicable(file_handle)
 
     async def test_multithread_false_s3_file_handle(self) -> None:
-        with patch.object(os, "makedirs"), patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-        ) as mock_getFileHandleDownload, patch(
-            DOWNLOAD_FROM_URL,
-            new_callable=AsyncMock,
-        ) as mock_download_from_URL, patch.object(
-            self.syn, "cache"
+        with (
+            patch.object(os, "makedirs"),
+            patch(
+                GET_FILE_HANDLE_FOR_DOWNLOAD,
+                new_callable=AsyncMock,
+            ) as mock_getFileHandleDownload,
+            patch(
+                DOWNLOAD_FROM_URL,
+                new_callable=AsyncMock,
+            ) as mock_download_from_URL,
+            patch.object(self.syn, "cache"),
         ):
             mock_getFileHandleDownload.return_value = {
                 "fileHandle": {
@@ -556,8 +569,8 @@ class TestDownloadFileHandle:
             mock_download_from_URL.assert_called_once_with(
                 url="asdf.com",
                 destination="/myfakepath",
-                object_id=456,
-                object_type="FileEntity",
+                entity_id=456,
+                file_handle_associate_type="FileEntity",
                 file_handle_id="123",
                 expected_md5="someMD5",
                 progress_bar=ANY,
@@ -571,13 +584,12 @@ class TestDownloadFromUrlMultiThreaded:
         self.syn = syn
 
     async def test_md5_mismatch(self) -> None:
-        with patch(
-            "synapseclient.core.download.download_functions.download_file"
-        ), patch.object(utils, "md5_for_file") as mock_md5_for_file, patch.object(
-            os, "remove"
-        ) as mock_os_remove, patch.object(
-            shutil, "move"
-        ) as mock_move:
+        with (
+            patch("synapseclient.core.download.download_functions.download_file"),
+            patch.object(utils, "md5_for_file") as mock_md5_for_file,
+            patch.object(os, "remove") as mock_os_remove,
+            patch.object(shutil, "move") as mock_move,
+        ):
             path = os.path.abspath("/myfakepath")
 
             mock_md5_for_file.return_value.hexdigest.return_value = "unexpetedMd5"
@@ -600,17 +612,16 @@ class TestDownloadFromUrlMultiThreaded:
     async def test_md5_match(self) -> None:
         expected_md5 = "myExpectedMd5"
 
-        with patch(
-            "synapseclient.core.download.download_functions.download_file"
-        ), patch.object(
-            utils,
-            "md5_for_file_hex",
-            return_value=expected_md5,
-        ), patch.object(
-            os, "remove"
-        ) as mock_os_remove, patch.object(
-            shutil, "move"
-        ) as mock_move:
+        with (
+            patch("synapseclient.core.download.download_functions.download_file"),
+            patch.object(
+                utils,
+                "md5_for_file_hex",
+                return_value=expected_md5,
+            ),
+            patch.object(os, "remove") as mock_os_remove,
+            patch.object(shutil, "move") as mock_move,
+        ):
             path = os.path.abspath("/myfakepath")
 
             await download_from_url_multi_threaded(
@@ -679,31 +690,32 @@ class TestDownloadFromUrl:
         # with patch.object(
         #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
         # )
-        with patch.object(
-            syn._requests_session, "get", side_effect=mock_requests_get
-        ), patch.object(
-            Synapse, "_generate_headers", side_effect=mock_generate_headers
-        ), patch.object(
-            utils, "temp_download_filename", return_value=temp_destination
-        ) as mocked_temp_dest, patch(
-            "synapseclient.core.download.download_functions.open",
-            new_callable=mock_open(),
-            create=True,
-        ) as mocked_open, patch.object(
-            os.path, "exists", side_effect=[False, True]
-        ) as mocked_exists, patch.object(
-            os.path, "getsize", return_value=partial_content_break
-        ) as mocked_getsize, patch.object(
-            utils, "md5_for_file"
-        ), patch.object(
-            shutil, "move"
-        ) as mocked_move:
+        with (
+            patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
+            patch.object(
+                Synapse, "_generate_headers", side_effect=mock_generate_headers
+            ),
+            patch.object(
+                utils, "temp_download_filename", return_value=temp_destination
+            ) as mocked_temp_dest,
+            patch(
+                "synapseclient.core.download.download_functions.open",
+                new_callable=mock_open(),
+                create=True,
+            ) as mocked_open,
+            patch.object(os.path, "exists", side_effect=[False, True]) as mocked_exists,
+            patch.object(
+                os.path, "getsize", return_value=partial_content_break
+            ) as mocked_getsize,
+            patch.object(utils, "md5_for_file"),
+            patch.object(shutil, "move") as mocked_move,
+        ):
             # function under test
             download_from_url(
                 url=url,
                 destination=destination,
-                object_id=OBJECT_ID,
-                object_type=OBJECT_TYPE,
+                entity_id=OBJECT_ID,
+                file_handle_associate_type=OBJECT_TYPE,
                 synapse_client=syn,
             )
 
@@ -754,30 +766,30 @@ class TestDownloadFromUrl:
             ]
         )
 
-        with patch.object(
-            syn._requests_session, "get", side_effect=mock_requests_get
-        ), patch.object(
-            Synapse, "_generate_headers", side_effect=mock_generate_headers
-        ), patch.object(
-            utils, "temp_download_filename", return_value=temp_destination
-        ) as mocked_temp_dest, patch(
-            "synapseclient.core.download.download_functions.open",
-            new_callable=mock_open(),
-            create=True,
-        ) as mocked_open, patch.object(
-            os.path, "exists", side_effect=[False, True]
-        ) as mocked_exists, patch.object(
-            shutil, "move"
-        ) as mocked_move, patch.object(
-            os, "remove"
-        ) as mocked_remove:
+        with (
+            patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
+            patch.object(
+                Synapse, "_generate_headers", side_effect=mock_generate_headers
+            ),
+            patch.object(
+                utils, "temp_download_filename", return_value=temp_destination
+            ) as mocked_temp_dest,
+            patch(
+                "synapseclient.core.download.download_functions.open",
+                new_callable=mock_open(),
+                create=True,
+            ) as mocked_open,
+            patch.object(os.path, "exists", side_effect=[False, True]) as mocked_exists,
+            patch.object(shutil, "move") as mocked_move,
+            patch.object(os, "remove") as mocked_remove,
+        ):
             # function under test
             with pytest.raises(SynapseMd5MismatchError):
                 await download_from_url(
                     url=url,
                     destination=destination,
-                    object_id=OBJECT_ID,
-                    object_type=OBJECT_TYPE,
+                    entity_id=OBJECT_ID,
+                    file_handle_associate_type=OBJECT_TYPE,
                     expected_md5="fake md5 is fake",
                     synapse_client=syn,
                 )
@@ -809,22 +821,24 @@ class TestDownloadFromUrl:
         url = "file:///some/file/path.txt"
         destination = os.path.normpath(os.path.expanduser("~/fake/path/filerino.txt"))
 
-        with patch.object(
-            utils, "file_url_to_path", return_value=destination
-        ) as mocked_file_url_to_path, patch.object(
-            utils,
-            "md5_for_file_hex",
-            return_value="Some other incorrect md5",
-        ) as mocked_md5_for_file, patch(
-            "os.remove"
-        ) as mocked_remove:
+        with (
+            patch.object(
+                utils, "file_url_to_path", return_value=destination
+            ) as mocked_file_url_to_path,
+            patch.object(
+                utils,
+                "md5_for_file_hex",
+                return_value="Some other incorrect md5",
+            ) as mocked_md5_for_file,
+            patch("os.remove") as mocked_remove,
+        ):
             # function under test
             with pytest.raises(SynapseMd5MismatchError):
                 await download_from_url(
                     url=url,
                     destination=destination,
-                    object_id=OBJECT_ID,
-                    object_type=OBJECT_TYPE,
+                    entity_id=OBJECT_ID,
+                    file_handle_associate_type=OBJECT_TYPE,
                     expected_md5="fake md5 is fake",
                 )
 
@@ -863,36 +877,42 @@ class TestDownloadFromUrl:
                 ),
             ]
         )
-        with patch.object(
-            syn._requests_session, "get", side_effect=mock_requests_get
-        ) as mocked_get, patch(
-            "synapseclient.core.download.download_functions._pre_signed_url_expiration_time",
-            return_value=datetime.datetime(1900, 1, 1, tzinfo=datetime.timezone.utc),
-        ) as mocked_pre_signed_url_expiration_time, patch(
-            "synapseclient.core.download.download_functions.get_file_handle_for_download",
-            return_value={"preSignedURL": new_url},
-        ) as mocked_get_file_handle_for_download, patch.object(
-            Synapse, "_generate_headers", side_effect=mock_generate_headers
-        ), patch.object(
-            utils, "temp_download_filename", return_value=temp_destination
-        ), patch(
-            "synapseclient.core.download.download_functions.open",
-            new_callable=mock_open(),
-            create=True,
-        ), patch.object(
-            hashlib, "new"
-        ) as mocked_hashlib_new, patch.object(
-            shutil, "move"
-        ), patch.object(
-            os, "remove"
+        with (
+            patch.object(
+                syn._requests_session, "get", side_effect=mock_requests_get
+            ) as mocked_get,
+            patch(
+                "synapseclient.core.download.download_functions._pre_signed_url_expiration_time",
+                return_value=datetime.datetime(
+                    1900, 1, 1, tzinfo=datetime.timezone.utc
+                ),
+            ) as mocked_pre_signed_url_expiration_time,
+            patch(
+                "synapseclient.core.download.download_functions.get_file_handle_for_download",
+                return_value={"preSignedURL": new_url},
+            ) as mocked_get_file_handle_for_download,
+            patch.object(
+                Synapse, "_generate_headers", side_effect=mock_generate_headers
+            ),
+            patch.object(
+                utils, "temp_download_filename", return_value=temp_destination
+            ),
+            patch(
+                "synapseclient.core.download.download_functions.open",
+                new_callable=mock_open(),
+                create=True,
+            ),
+            patch.object(hashlib, "new") as mocked_hashlib_new,
+            patch.object(shutil, "move"),
+            patch.object(os, "remove"),
         ):
             mocked_hashlib_new.return_value.hexdigest.return_value = "fake md5 is fake"
             # WHEN I call download_from_url with an expired url
             download_from_url(
                 url=url,
                 destination=destination,
-                object_id=OBJECT_ID,
-                object_type=OBJECT_TYPE,
+                entity_id=OBJECT_ID,
+                file_handle_associate_type=OBJECT_TYPE,
                 expected_md5="fake md5 is fake",
             )
             # I expect the expired url to be identified

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -860,34 +860,28 @@ class TestDownloadFromUrl:
                 ),
             ]
         )
-        with (
-            patch.object(
-                syn._requests_session, "get", side_effect=mock_requests_get
-            ) as mocked_get,
-            patch(
-                "synapseclient.core.download.download_functions._pre_signed_url_expiration_time",
-                return_value=datetime.datetime(
-                    1900, 1, 1, tzinfo=datetime.timezone.utc
-                ),
-            ) as mocked_pre_signed_url_expiration_time,
-            patch(
-                "synapseclient.core.download.download_functions.get_file_handle_for_download",
-                return_value={"preSignedURL": new_url},
-            ) as mocked_get_file_handle_for_download,
-            patch.object(
-                Synapse, "_generate_headers", side_effect=mock_generate_headers
-            ),
-            patch.object(
-                utils, "temp_download_filename", return_value=temp_destination
-            ),
-            patch(
-                "synapseclient.core.download.download_functions.open",
-                new_callable=mock_open(),
-                create=True,
-            ),
-            patch.object(hashlib, "new") as mocked_hashlib_new,
-            patch.object(shutil, "move"),
-            patch.object(os, "remove"),
+        with patch.object(
+            syn._requests_session, "get", side_effect=mock_requests_get
+        ) as mocked_get, patch(
+            "synapseclient.core.download.download_functions._pre_signed_url_expiration_time",
+            return_value=datetime.datetime(1900, 1, 1, tzinfo=datetime.timezone.utc),
+        ) as mocked_pre_signed_url_expiration_time, patch(
+            "synapseclient.core.download.download_functions.get_file_handle_for_download",
+            return_value={"preSignedURL": new_url},
+        ) as mocked_get_file_handle_for_download, patch.object(
+            Synapse, "_generate_headers", side_effect=mock_generate_headers
+        ), patch.object(
+            utils, "temp_download_filename", return_value=temp_destination
+        ), patch(
+            "synapseclient.core.download.download_functions.open",
+            new_callable=mock_open(),
+            create=True,
+        ), patch.object(
+            hashlib, "new"
+        ) as mocked_hashlib_new, patch.object(
+            shutil, "move"
+        ), patch.object(
+            os, "remove"
         ):
             mocked_hashlib_new.return_value.hexdigest.return_value = "fake md5 is fake"
             # WHEN I call download_from_url with an expired url

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -676,26 +676,25 @@ class TestDownloadFromUrl:
         # with patch.object(
         #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
         # )
-        with (
-            patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
-            patch.object(
-                Synapse, "_generate_headers", side_effect=mock_generate_headers
-            ),
-            patch.object(
-                utils, "temp_download_filename", return_value=temp_destination
-            ) as mocked_temp_dest,
-            patch(
-                "synapseclient.core.download.download_functions.open",
-                new_callable=mock_open(),
-                create=True,
-            ) as mocked_open,
-            patch.object(os.path, "exists", side_effect=[False, True]) as mocked_exists,
-            patch.object(
-                os.path, "getsize", return_value=partial_content_break
-            ) as mocked_getsize,
-            patch.object(utils, "md5_for_file"),
-            patch.object(shutil, "move") as mocked_move,
-        ):
+        with patch.object(
+            syn._requests_session, "get", side_effect=mock_requests_get
+        ), patch.object(
+            Synapse, "_generate_headers", side_effect=mock_generate_headers
+        ), patch.object(
+            utils, "temp_download_filename", return_value=temp_destination
+        ) as mocked_temp_dest, patch(
+            "synapseclient.core.download.download_functions.open",
+            new_callable=mock_open(),
+            create=True,
+        ) as mocked_open, patch.object(
+            os.path, "exists", side_effect=[False, True]
+        ) as mocked_exists, patch.object(
+            os.path, "getsize", return_value=partial_content_break
+        ) as mocked_getsize, patch.object(
+            utils, "md5_for_file"
+        ), patch.object(
+            shutil, "move"
+        ) as mocked_move:
             # function under test
             download_from_url(
                 url=url,

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -435,17 +435,14 @@ class TestDownloadFileHandle:
         self.syn.multi_threaded = False
 
     async def test_multithread_true_s3_file_handle(self) -> None:
-        with (
-            patch.object(os, "makedirs"),
-            patch(
-                GET_FILE_HANDLE_FOR_DOWNLOAD,
-                new_callable=AsyncMock,
-            ) as mock_getFileHandleDownload,
-            patch(
-                "synapseclient.core.download.download_functions.download_from_url_multi_threaded",
-                new_callable=AsyncMock,
-            ) as mock_multi_thread_download,
-            patch.object(self.syn, "cache"),
+        with patch.object(os, "makedirs"), patch(
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
+            new_callable=AsyncMock,
+        ) as mock_getFileHandleDownload, patch(
+            "synapseclient.core.download.download_functions.download_from_url_multi_threaded",
+            new_callable=AsyncMock,
+        ) as mock_multi_thread_download, patch.object(
+            self.syn, "cache"
         ):
             mock_getFileHandleDownload.return_value = {
                 "fileHandle": {

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -155,9 +155,9 @@ async def test_mock_download(syn: Synapse) -> None:
         [create_mock_response(url, "stream", contents=contents, buffer_size=1024)]
     )
 
-    with patch.object(syn._requests_session, "get", side_effect=mock_requests_get), patch.object(
-        Synapse, "_generate_headers", side_effect=mock_generate_headers
-        ):
+    with patch.object(
+        syn._requests_session, "get", side_effect=mock_requests_get
+    ), patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers):
         download_from_url(
             url=url,
             destination=temp_dir,
@@ -177,8 +177,9 @@ async def test_mock_download(syn: Synapse) -> None:
         ]
     )
 
-    with patch.object(syn._requests_session, "get", side_effect=mock_requests_get), patch.object(
-        Synapse, "_generate_headers", side_effect=mock_generate_headers):
+    with patch.object(
+        syn._requests_session, "get", side_effect=mock_requests_get
+    ), patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers):
         download_from_url(
             url=url,
             destination=temp_dir,

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+import datetime
 import os
 import shutil
 import tempfile
@@ -10,7 +11,6 @@ from unittest.mock import ANY, AsyncMock, MagicMock, call, mock_open, patch
 
 import pytest
 import requests
-
 import synapseclient.core.constants.concrete_types as concrete_types
 import synapseclient.core.download.download_async as download_async
 from synapseclient import Synapse
@@ -843,6 +843,87 @@ class TestDownloadFromUrl:
             mocked_md5_for_file.assert_called_once()
             # assert file was NOT removed
             assert not mocked_remove.called
+
+    def test_download_expired_url(self, syn: Synapse) -> None:
+        url = "http://www.ayy.lmao/filerino.txt"
+        new_url = "http://www.ayy.lmao/new_url.txt"
+        contents = "\n".join(str(i) for i in range(1000))
+        temp_destination = os.path.normpath(
+            os.path.expanduser("~/fake/path/filerino.txt.temp")
+        )
+        destination = os.path.normpath(os.path.expanduser("~/fake/path/filerino.txt"))
+
+        partial_content_break = len(contents) // 7 * 3
+        mock_requests_get = MockRequestGetFunction(
+            [
+                create_mock_response(
+                    url,
+                    "stream",
+                    contents=contents[:partial_content_break],
+                    buffer_size=1024,
+                    partial_end=len(contents),
+                    status_code=403,
+                ),
+                create_mock_response(
+                    url,
+                    "stream",
+                    contents=contents,
+                    buffer_size=1024,
+                    partial_start=len(contents),
+                    status_code=200,
+                ),
+            ]
+        )
+        with (
+            patch.object(
+                syn._requests_session, "get", side_effect=mock_requests_get
+            ) as mocked_get,
+            patch(
+                "synapseclient.core.download.download_functions._pre_signed_url_expiration_time",
+                return_value=datetime.datetime(
+                    1900, 1, 1, tzinfo=datetime.timezone.utc
+                ),
+            ) as mocked_pre_signed_url_expiration_time,
+            patch(
+                "synapseclient.core.download.download_functions.get_file_handle_for_download",
+                return_value={"preSignedURL": new_url},
+            ) as mocked_get_file_handle_for_download,
+            patch.object(
+                Synapse, "_generate_headers", side_effect=mock_generate_headers
+            ),
+            patch.object(
+                utils, "temp_download_filename", return_value=temp_destination
+            ),
+            patch(
+                "synapseclient.core.download.download_functions.open",
+                new_callable=mock_open(),
+                create=True,
+            ),
+            patch.object(hashlib, "new") as mocked_hashlib_new,
+            patch.object(shutil, "move"),
+            patch.object(os, "remove"),
+        ):
+            mocked_hashlib_new.return_value.hexdigest.return_value = "fake md5 is fake"
+            # WHEN I call download_from_url with an expired url
+            download_from_url(
+                url=url,
+                destination=destination,
+                object_id=OBJECT_ID,
+                object_type=OBJECT_TYPE,
+                expected_md5="fake md5 is fake",
+            )
+            # I expect the expired url to be identified
+            mocked_pre_signed_url_expiration_time.assert_called_once_with(url)
+            # AND I expect the URL to be refreshed
+            mocked_get_file_handle_for_download.assert_called_once()
+            # AND I expect the download to be retried with the new URL
+            mocked_get.assert_called_with(
+                url=new_url,
+                headers=mock_generate_headers(self),
+                stream=True,
+                allow_redirects=False,
+                auth=None,
+            )
 
 
 async def test_get_file_handle_download__error_unauthorized(syn: Synapse) -> None:

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -33,6 +33,10 @@ GET_FILE_HANDLE_FOR_DOWNLOAD = (
 )
 DOWNLOAD_FROM_URL = "synapseclient.core.download.download_functions.download_from_url"
 
+FILE_HANDLE_ID = "42"
+OBJECT_ID = "syn789"
+OBJECT_TYPE = "FileEntity"
+
 
 # a callable that mocks the requests.get function
 class MockRequestGetFunction(object):
@@ -135,10 +139,6 @@ def mock_generate_headers(self, headers=None):
 async def test_mock_download(syn: Synapse) -> None:
     temp_dir = tempfile.gettempdir()
 
-    fileHandleId = "42"
-    objectId = "syn789"
-    objectType = "FileEntity"
-
     # make bogus content
     contents = "\n".join(str(i) for i in range(1000))
 
@@ -154,12 +154,15 @@ async def test_mock_download(syn: Synapse) -> None:
         [create_mock_response(url, "stream", contents=contents, buffer_size=1024)]
     )
 
-    with patch.object(
-        syn._requests_session, "get", side_effect=mock_requests_get
-    ), patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers):
+    with (
+        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
+        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
+    ):
         download_from_url(
             url=url,
             destination=temp_dir,
+            object_id=OBJECT_ID,
+            object_type=OBJECT_TYPE,
             file_handle_id=12345,
             expected_md5=contents_md5,
             synapse_client=syn,
@@ -174,12 +177,15 @@ async def test_mock_download(syn: Synapse) -> None:
         ]
     )
 
-    with patch.object(
-        syn._requests_session, "get", side_effect=mock_requests_get
-    ), patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers):
+    with (
+        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
+        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
+    ):
         download_from_url(
             url=url,
             destination=temp_dir,
+            object_id=OBJECT_ID,
+            object_type=OBJECT_TYPE,
             file_handle_id=12345,
             expected_md5=contents_md5,
             synapse_client=syn,
@@ -226,17 +232,19 @@ async def test_mock_download(syn: Synapse) -> None:
         },
     }
 
-    with patch.object(
-        syn._requests_session, "get", side_effect=mock_requests_get
-    ), patch.object(syn, "_generate_headers", side_effect=mock_generate_headers), patch(
-        GET_FILE_HANDLE_FOR_DOWNLOAD,
-        new_callable=AsyncMock,
-        return_value=_getFileHandleDownload_return_value,
+    with (
+        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
+        patch.object(syn, "_generate_headers", side_effect=mock_generate_headers),
+        patch(
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
+            new_callable=AsyncMock,
+            return_value=_getFileHandleDownload_return_value,
+        ),
     ):
         await download_by_file_handle(
-            file_handle_id=fileHandleId,
-            synapse_id=objectId,
-            entity_type=objectType,
+            file_handle_id=FILE_HANDLE_ID,
+            synapse_id=OBJECT_ID,
+            entity_type=OBJECT_TYPE,
             destination=temp_dir,
             synapse_client=syn,
         )
@@ -274,19 +282,19 @@ async def test_mock_download(syn: Synapse) -> None:
     # with patch.object(
     #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
     # )
-    with patch.object(
-        syn._requests_session, "get", side_effect=mock_requests_get
-    ), patch.object(
-        Synapse, "_generate_headers", side_effect=mock_generate_headers
-    ), patch(
-        GET_FILE_HANDLE_FOR_DOWNLOAD,
-        new_callable=AsyncMock,
-        return_value=_getFileHandleDownload_return_value,
+    with (
+        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
+        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
+        patch(
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
+            new_callable=AsyncMock,
+            return_value=_getFileHandleDownload_return_value,
+        ),
     ):
         await download_by_file_handle(
-            file_handle_id=fileHandleId,
-            synapse_id=objectId,
-            entity_type=objectType,
+            file_handle_id=FILE_HANDLE_ID,
+            synapse_id=OBJECT_ID,
+            entity_type=OBJECT_TYPE,
             destination=temp_dir,
             synapse_client=syn,
         )
@@ -325,20 +333,20 @@ async def test_mock_download(syn: Synapse) -> None:
     # with patch.object(
     #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
     # )
-    with patch.object(
-        syn._requests_session, "get", side_effect=mock_requests_get
-    ), patch.object(
-        Synapse, "_generate_headers", side_effect=mock_generate_headers
-    ), patch(
-        GET_FILE_HANDLE_FOR_DOWNLOAD,
-        new_callable=AsyncMock,
-        return_value=_getFileHandleDownload_return_value,
+    with (
+        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
+        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
+        patch(
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
+            new_callable=AsyncMock,
+            return_value=_getFileHandleDownload_return_value,
+        ),
     ):
         with pytest.raises(Exception):
             await download_by_file_handle(
-                file_handle_id=fileHandleId,
-                synapse_id=objectId,
-                entity_type=objectType,
+                file_handle_id=FILE_HANDLE_ID,
+                synapse_id=OBJECT_ID,
+                entity_type=OBJECT_TYPE,
                 destination=temp_dir,
                 synapse_client=syn,
             )
@@ -367,19 +375,19 @@ async def test_mock_download(syn: Synapse) -> None:
     # with patch.object(
     #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
     # )
-    with patch.object(
-        syn._requests_session, "get", side_effect=mock_requests_get
-    ), patch.object(
-        Synapse, "_generate_headers", side_effect=mock_generate_headers
-    ), patch(
-        GET_FILE_HANDLE_FOR_DOWNLOAD,
-        new_callable=AsyncMock,
-        return_value=_getFileHandleDownload_return_value,
+    with (
+        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
+        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
+        patch(
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
+            new_callable=AsyncMock,
+            return_value=_getFileHandleDownload_return_value,
+        ),
     ):
         await download_by_file_handle(
-            file_handle_id=fileHandleId,
-            synapse_id=objectId,
-            entity_type=objectType,
+            file_handle_id=FILE_HANDLE_ID,
+            synapse_id=OBJECT_ID,
+            entity_type=OBJECT_TYPE,
             destination=temp_dir,
             synapse_client=syn,
         )
@@ -398,20 +406,20 @@ async def test_mock_download(syn: Synapse) -> None:
     # with patch.object(
     #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
     # )
-    with patch.object(
-        syn._requests_session, "get", side_effect=mock_requests_get
-    ), patch.object(
-        Synapse, "_generate_headers", side_effect=mock_generate_headers
-    ), patch(
-        GET_FILE_HANDLE_FOR_DOWNLOAD,
-        new_callable=AsyncMock,
-        return_value=_getFileHandleDownload_return_value,
+    with (
+        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
+        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
+        patch(
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
+            new_callable=AsyncMock,
+            return_value=_getFileHandleDownload_return_value,
+        ),
     ):
         with pytest.raises(SynapseHTTPError):
             await download_by_file_handle(
-                file_handle_id=fileHandleId,
-                synapse_id=objectId,
-                entity_type=objectType,
+                file_handle_id=FILE_HANDLE_ID,
+                synapse_id=OBJECT_ID,
+                entity_type=OBJECT_TYPE,
                 destination=temp_dir,
                 synapse_client=syn,
             )
@@ -426,14 +434,17 @@ class TestDownloadFileHandle:
         self.syn.multi_threaded = False
 
     async def test_multithread_true_s3_file_handle(self) -> None:
-        with patch.object(os, "makedirs"), patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-        ) as mock_getFileHandleDownload, patch(
-            "synapseclient.core.download.download_functions.download_from_url_multi_threaded",
-            new_callable=AsyncMock,
-        ) as mock_multi_thread_download, patch.object(
-            self.syn, "cache"
+        with (
+            patch.object(os, "makedirs"),
+            patch(
+                GET_FILE_HANDLE_FOR_DOWNLOAD,
+                new_callable=AsyncMock,
+            ) as mock_getFileHandleDownload,
+            patch(
+                "synapseclient.core.download.download_functions.download_from_url_multi_threaded",
+                new_callable=AsyncMock,
+            ) as mock_multi_thread_download,
+            patch.object(self.syn, "cache"),
         ):
             mock_getFileHandleDownload.return_value = {
                 "fileHandle": {
@@ -464,14 +475,17 @@ class TestDownloadFileHandle:
             )
 
     async def _multithread_not_applicable(self, file_handle: Dict[str, str]) -> None:
-        with patch.object(os, "makedirs"), patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-        ) as mock_getFileHandleDownload, patch(
-            DOWNLOAD_FROM_URL,
-            new_callable=AsyncMock,
-        ) as mock_download_from_URL, patch.object(
-            self.syn, "cache"
+        with (
+            patch.object(os, "makedirs"),
+            patch(
+                GET_FILE_HANDLE_FOR_DOWNLOAD,
+                new_callable=AsyncMock,
+            ) as mock_getFileHandleDownload,
+            patch(
+                DOWNLOAD_FROM_URL,
+                new_callable=AsyncMock,
+            ) as mock_download_from_URL,
+            patch.object(self.syn, "cache"),
         ):
             mock_getFileHandleDownload.return_value = {
                 "fileHandle": file_handle,
@@ -491,6 +505,8 @@ class TestDownloadFileHandle:
             mock_download_from_URL.assert_called_once_with(
                 url="asdf.com",
                 destination="/myfakepath",
+                object_id=456,
+                object_type="FileEntity",
                 file_handle_id="123",
                 expected_md5="someMD5",
                 progress_bar=ANY,
@@ -518,14 +534,17 @@ class TestDownloadFileHandle:
         await self._multithread_not_applicable(file_handle)
 
     async def test_multithread_false_s3_file_handle(self) -> None:
-        with patch.object(os, "makedirs"), patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-        ) as mock_getFileHandleDownload, patch(
-            DOWNLOAD_FROM_URL,
-            new_callable=AsyncMock,
-        ) as mock_download_from_URL, patch.object(
-            self.syn, "cache"
+        with (
+            patch.object(os, "makedirs"),
+            patch(
+                GET_FILE_HANDLE_FOR_DOWNLOAD,
+                new_callable=AsyncMock,
+            ) as mock_getFileHandleDownload,
+            patch(
+                DOWNLOAD_FROM_URL,
+                new_callable=AsyncMock,
+            ) as mock_download_from_URL,
+            patch.object(self.syn, "cache"),
         ):
             mock_getFileHandleDownload.return_value = {
                 "fileHandle": {
@@ -548,6 +567,8 @@ class TestDownloadFileHandle:
             mock_download_from_URL.assert_called_once_with(
                 url="asdf.com",
                 destination="/myfakepath",
+                object_id=456,
+                object_type="FileEntity",
                 file_handle_id="123",
                 expected_md5="someMD5",
                 progress_bar=ANY,
@@ -561,13 +582,12 @@ class TestDownloadFromUrlMultiThreaded:
         self.syn = syn
 
     async def test_md5_mismatch(self) -> None:
-        with patch(
-            "synapseclient.core.download.download_functions.download_file"
-        ), patch.object(utils, "md5_for_file") as mock_md5_for_file, patch.object(
-            os, "remove"
-        ) as mock_os_remove, patch.object(
-            shutil, "move"
-        ) as mock_move:
+        with (
+            patch("synapseclient.core.download.download_functions.download_file"),
+            patch.object(utils, "md5_for_file") as mock_md5_for_file,
+            patch.object(os, "remove") as mock_os_remove,
+            patch.object(shutil, "move") as mock_move,
+        ):
             path = os.path.abspath("/myfakepath")
 
             mock_md5_for_file.return_value.hexdigest.return_value = "unexpetedMd5"
@@ -590,17 +610,16 @@ class TestDownloadFromUrlMultiThreaded:
     async def test_md5_match(self) -> None:
         expected_md5 = "myExpectedMd5"
 
-        with patch(
-            "synapseclient.core.download.download_functions.download_file"
-        ), patch.object(
-            utils,
-            "md5_for_file_hex",
-            return_value=expected_md5,
-        ), patch.object(
-            os, "remove"
-        ) as mock_os_remove, patch.object(
-            shutil, "move"
-        ) as mock_move:
+        with (
+            patch("synapseclient.core.download.download_functions.download_file"),
+            patch.object(
+                utils,
+                "md5_for_file_hex",
+                return_value=expected_md5,
+            ),
+            patch.object(os, "remove") as mock_os_remove,
+            patch.object(shutil, "move") as mock_move,
+        ):
             path = os.path.abspath("/myfakepath")
 
             await download_from_url_multi_threaded(
@@ -663,27 +682,32 @@ async def test_download_end_early_retry(syn: Synapse) -> None:
     # with patch.object(
     #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
     # )
-    with patch.object(
-        syn._requests_session, "get", side_effect=mock_requests_get
-    ), patch.object(
-        Synapse, "_generate_headers", side_effect=mock_generate_headers
-    ), patch.object(
-        utils, "temp_download_filename", return_value=temp_destination
-    ) as mocked_temp_dest, patch(
-        "synapseclient.core.download.download_functions.open",
-        new_callable=mock_open(),
-        create=True,
-    ) as mocked_open, patch.object(
-        os.path, "exists", side_effect=[False, True]
-    ) as mocked_exists, patch.object(
-        os.path, "getsize", return_value=partial_content_break
-    ) as mocked_getsize, patch.object(
-        utils, "md5_for_file"
-    ), patch.object(
-        shutil, "move"
-    ) as mocked_move:
+    with (
+        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
+        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
+        patch.object(
+            utils, "temp_download_filename", return_value=temp_destination
+        ) as mocked_temp_dest,
+        patch(
+            "synapseclient.core.download.download_functions.open",
+            new_callable=mock_open(),
+            create=True,
+        ) as mocked_open,
+        patch.object(os.path, "exists", side_effect=[False, True]) as mocked_exists,
+        patch.object(
+            os.path, "getsize", return_value=partial_content_break
+        ) as mocked_getsize,
+        patch.object(utils, "md5_for_file"),
+        patch.object(shutil, "move") as mocked_move,
+    ):
         # function under test
-        download_from_url(url=url, destination=destination, synapse_client=syn)
+        download_from_url(
+            url=url,
+            destination=destination,
+            object_id=OBJECT_ID,
+            object_type=OBJECT_TYPE,
+            synapse_client=syn,
+        )
 
         # assert temp_download_filename() called 2 times with same parameters
         assert [
@@ -731,28 +755,28 @@ async def test_download_md5_mismatch__not_local_file(syn: Synapse) -> None:
         ]
     )
 
-    with patch.object(
-        syn._requests_session, "get", side_effect=mock_requests_get
-    ), patch.object(
-        Synapse, "_generate_headers", side_effect=mock_generate_headers
-    ), patch.object(
-        utils, "temp_download_filename", return_value=temp_destination
-    ) as mocked_temp_dest, patch(
-        "synapseclient.core.download.download_functions.open",
-        new_callable=mock_open(),
-        create=True,
-    ) as mocked_open, patch.object(
-        os.path, "exists", side_effect=[False, True]
-    ) as mocked_exists, patch.object(
-        shutil, "move"
-    ) as mocked_move, patch.object(
-        os, "remove"
-    ) as mocked_remove:
+    with (
+        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
+        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
+        patch.object(
+            utils, "temp_download_filename", return_value=temp_destination
+        ) as mocked_temp_dest,
+        patch(
+            "synapseclient.core.download.download_functions.open",
+            new_callable=mock_open(),
+            create=True,
+        ) as mocked_open,
+        patch.object(os.path, "exists", side_effect=[False, True]) as mocked_exists,
+        patch.object(shutil, "move") as mocked_move,
+        patch.object(os, "remove") as mocked_remove,
+    ):
         # function under test
         with pytest.raises(SynapseMd5MismatchError):
             await download_from_url(
                 url=url,
                 destination=destination,
+                object_id=OBJECT_ID,
+                object_type=OBJECT_TYPE,
                 expected_md5="fake md5 is fake",
                 synapse_client=syn,
             )
@@ -785,19 +809,25 @@ async def test_download_md5_mismatch_local_file() -> None:
     url = "file:///some/file/path.txt"
     destination = os.path.normpath(os.path.expanduser("~/fake/path/filerino.txt"))
 
-    with patch.object(
-        utils, "file_url_to_path", return_value=destination
-    ) as mocked_file_url_to_path, patch.object(
-        utils,
-        "md5_for_file_hex",
-        return_value="Some other incorrect md5",
-    ) as mocked_md5_for_file, patch(
-        "os.remove"
-    ) as mocked_remove:
+    with (
+        patch.object(
+            utils, "file_url_to_path", return_value=destination
+        ) as mocked_file_url_to_path,
+        patch.object(
+            utils,
+            "md5_for_file_hex",
+            return_value="Some other incorrect md5",
+        ) as mocked_md5_for_file,
+        patch("os.remove") as mocked_remove,
+    ):
         # function under test
         with pytest.raises(SynapseMd5MismatchError):
             await download_from_url(
-                url=url, destination=destination, expected_md5="fake md5 is fake"
+                url=url,
+                destination=destination,
+                object_id=OBJECT_ID,
+                object_type=OBJECT_TYPE,
+                expected_md5="fake md5 is fake",
             )
 
         mocked_file_url_to_path.assert_called_once_with(url, verify_exists=True)

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -1,8 +1,8 @@
 """Unit tests for downloads."""
 
+import datetime
 import hashlib
 import json
-import datetime
 import os
 import shutil
 import tempfile
@@ -11,6 +11,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, call, mock_open, patch
 
 import pytest
 import requests
+
 import synapseclient.core.constants.concrete_types as concrete_types
 import synapseclient.core.download.download_async as download_async
 from synapseclient import Synapse
@@ -844,7 +845,7 @@ class TestDownloadFromUrl:
             # assert file was NOT removed
             assert not mocked_remove.called
 
-    def test_download_expired_url(self, syn: Synapse) -> None:
+    async def test_download_expired_url(self, syn: Synapse) -> None:
         url = "http://www.ayy.lmao/filerino.txt"
         new_url = "http://www.ayy.lmao/new_url.txt"
         contents = "\n".join(str(i) for i in range(1000))

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -473,10 +473,16 @@ class TestDownloadFileHandle:
             )
 
     async def _multithread_not_applicable(self, file_handle: Dict[str, str]) -> None:
+        get_file_handle_for_download_return_value = {
+            "fileHandle": file_handle,
+            "preSignedURL": "asdf.com",
+        }
+
         with patch.object(os, "makedirs"), patch(
             GET_FILE_HANDLE_FOR_DOWNLOAD,
             new_callable=AsyncMock,
-        ) as mock_getFileHandleDownload, patch(
+            return_value=get_file_handle_for_download_return_value,
+        ), patch(
             DOWNLOAD_FROM_URL,
             new_callable=AsyncMock,
         ) as mock_download_from_URL, patch.object(

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -473,18 +473,14 @@ class TestDownloadFileHandle:
             )
 
     async def _multithread_not_applicable(self, file_handle: Dict[str, str]) -> None:
-        with (
-            patch.object(os, "makedirs"),
-            patch(
-                GET_FILE_HANDLE_FOR_DOWNLOAD,
-                new_callable=AsyncMock,
-            ) as mock_getFileHandleDownload,
-            patch(
-                DOWNLOAD_FROM_URL,
-                new_callable=AsyncMock,
-            ) as mock_download_from_URL,
-            patch.object(self.syn, "cache"),
-        ):
+        with patch.object(os, "makedirs"), patch(
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
+            new_callable=AsyncMock,
+        ) as mock_getFileHandleDownload, patch(
+            DOWNLOAD_FROM_URL,
+            new_callable=AsyncMock,
+        ) as mock_download_from_URL, patch.object(
+            self.syn, "cache"
             mock_getFileHandleDownload.return_value = {
                 "fileHandle": file_handle,
                 "preSignedURL": "asdf.com",

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -667,7 +667,8 @@ class TestDownloadFromUrl:
             ]
         )
 
-        # make the first response's 'content-type' header say it will transfer the full content even though it
+        # make the first response's 'content-type' header say
+        # it will transfer the full content even though it
         # is only partially doing so
         mock_requests_get.responses[0].headers["content-length"] = len(contents)
         mock_requests_get.responses[1].headers["content-length"] = len(

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -231,14 +231,12 @@ async def test_mock_download(syn: Synapse) -> None:
         },
     }
 
-    with (
-        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
-        patch.object(syn, "_generate_headers", side_effect=mock_generate_headers),
-        patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-            return_value=_getFileHandleDownload_return_value,
-        ),
+    with patch.object(
+        syn._requests_session, "get", side_effect=mock_requests_get
+    ), patch.object(syn, "_generate_headers", side_effect=mock_generate_headers), patch(
+        GET_FILE_HANDLE_FOR_DOWNLOAD,
+        new_callable=AsyncMock,
+        return_value=_getFileHandleDownload_return_value,
     ):
         await download_by_file_handle(
             file_handle_id=FILE_HANDLE_ID,
@@ -281,14 +279,14 @@ async def test_mock_download(syn: Synapse) -> None:
     # with patch.object(
     #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
     # )
-    with (
-        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
-        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
-        patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-            return_value=_getFileHandleDownload_return_value,
-        ),
+    with patch.object(
+        syn._requests_session, "get", side_effect=mock_requests_get
+    ), patch.object(
+        Synapse, "_generate_headers", side_effect=mock_generate_headers
+    ), patch(
+        GET_FILE_HANDLE_FOR_DOWNLOAD,
+        new_callable=AsyncMock,
+        return_value=_getFileHandleDownload_return_value,
     ):
         await download_by_file_handle(
             file_handle_id=FILE_HANDLE_ID,
@@ -332,14 +330,14 @@ async def test_mock_download(syn: Synapse) -> None:
     # with patch.object(
     #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
     # )
-    with (
-        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
-        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
-        patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-            return_value=_getFileHandleDownload_return_value,
-        ),
+    with patch.object(
+        syn._requests_session, "get", side_effect=mock_requests_get
+    ), patch.object(
+        Synapse, "_generate_headers", side_effect=mock_generate_headers
+    ), patch(
+        GET_FILE_HANDLE_FOR_DOWNLOAD,
+        new_callable=AsyncMock,
+        return_value=_getFileHandleDownload_return_value,
     ):
         with pytest.raises(Exception):
             await download_by_file_handle(
@@ -374,14 +372,14 @@ async def test_mock_download(syn: Synapse) -> None:
     # with patch.object(
     #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
     # )
-    with (
-        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
-        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
-        patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-            return_value=_getFileHandleDownload_return_value,
-        ),
+    with patch.object(
+        syn._requests_session, "get", side_effect=mock_requests_get
+    ), patch.object(
+        Synapse, "_generate_headers", side_effect=mock_generate_headers
+    ), patch(
+        GET_FILE_HANDLE_FOR_DOWNLOAD,
+        new_callable=AsyncMock,
+        return_value=_getFileHandleDownload_return_value,
     ):
         await download_by_file_handle(
             file_handle_id=FILE_HANDLE_ID,
@@ -405,14 +403,14 @@ async def test_mock_download(syn: Synapse) -> None:
     # with patch.object(
     #     syn, "rest_get_async", new_callable=AsyncMock, side_effect=mock_requests_get
     # )
-    with (
-        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
-        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
-        patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-            return_value=_getFileHandleDownload_return_value,
-        ),
+    with patch.object(
+        syn._requests_session, "get", side_effect=mock_requests_get
+    ), patch.object(
+        Synapse, "_generate_headers", side_effect=mock_generate_headers
+    ), patch(
+        GET_FILE_HANDLE_FOR_DOWNLOAD,
+        new_callable=AsyncMock,
+        return_value=_getFileHandleDownload_return_value,
     ):
         with pytest.raises(SynapseHTTPError):
             await download_by_file_handle(

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -155,10 +155,9 @@ async def test_mock_download(syn: Synapse) -> None:
         [create_mock_response(url, "stream", contents=contents, buffer_size=1024)]
     )
 
-    with (
-        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
-        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
-    ):
+    with patch.object(syn._requests_session, "get", side_effect=mock_requests_get), patch.object(
+        Synapse, "_generate_headers", side_effect=mock_generate_headers
+        ):
         download_from_url(
             url=url,
             destination=temp_dir,
@@ -178,10 +177,8 @@ async def test_mock_download(syn: Synapse) -> None:
         ]
     )
 
-    with (
-        patch.object(syn._requests_session, "get", side_effect=mock_requests_get),
-        patch.object(Synapse, "_generate_headers", side_effect=mock_generate_headers),
-    ):
+    with patch.object(syn._requests_session, "get", side_effect=mock_requests_get), patch.object(
+        Synapse, "_generate_headers", side_effect=mock_generate_headers):
         download_from_url(
             url=url,
             destination=temp_dir,

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -338,15 +338,12 @@ class TestDownloadFileHandle:
             (disk_space_error, 1),
             (ValueError("foo"), retries),
         ]:
-            with (
-                patch(
-                    GET_FILE_HANDLE_FOR_DOWNLOAD,
-                    new_callable=AsyncMock,
-                ) as mock_get_file_handle_download,
-                patch(
-                    DOWNLOAD_FROM_URL,
-                ) as mock_download_from_URL,
-            ):
+            with patch(
+                GET_FILE_HANDLE_FOR_DOWNLOAD,
+                new_callable=AsyncMock,
+            ) as mock_get_file_handle_download, patch(
+                DOWNLOAD_FROM_URL,
+            ) as mock_download_from_URL:
                 mock_get_file_handle_download.return_value = {
                     "fileHandle": {
                         "id": file_handle_id,
@@ -410,13 +407,10 @@ class TestDownloadFileHandle:
         expected_download_path = FOO_KEY
         mock_s3_client_wrapper.download_file.return_value = expected_download_path
 
-        with (
-            patch(
-                GET_FILE_HANDLE_FOR_DOWNLOAD,
-                new_callable=AsyncMock,
-            ) as mock_get_file_handle_download,
-            patch.object(self.syn, "cache") as cache,
-        ):
+        with patch(
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
+            new_callable=AsyncMock,
+        ) as mock_get_file_handle_download, patch.object(self.syn, "cache") as cache:
             mock_get_file_handle_download.return_value = {
                 "fileHandle": {
                     "id": file_handle_id,
@@ -468,20 +462,19 @@ class TestDownloadFileHandle:
         destination = "/tmp"
         expected_destination = os.path.abspath(destination)
 
-        with (
-            patch(
-                GET_FILE_HANDLE_FOR_DOWNLOAD,
-                new_callable=AsyncMock,
-            ) as mock_get_file_handle_download,
-            patch.object(self.syn, "cache"),
-            patch.object(urllib_request, "urlretrieve") as mock_url_retrieve,
-            patch.object(utils, "md5_for_file") as mock_md5_for_file,
-            patch.object(os, "makedirs"),
-            patch.object(
-                sts_transfer,
-                "is_storage_location_sts_enabled_async",
-                return_value=False,
-            ),
+        with patch(
+            GET_FILE_HANDLE_FOR_DOWNLOAD,
+            new_callable=AsyncMock,
+        ) as mock_get_file_handle_download, patch.object(
+            self.syn, "cache"
+        ), patch.object(
+            urllib_request, "urlretrieve"
+        ) as mock_url_retrieve, patch.object(
+            utils, "md5_for_file"
+        ) as mock_md5_for_file, patch.object(
+            os, "makedirs"
+        ), patch.object(
+            sts_transfer, "is_storage_location_sts_enabled_async", return_value=False
         ):
             mock_get_file_handle_download.return_value = {
                 "fileHandle": {
@@ -831,12 +824,12 @@ class TestSubmit:
             "contributors": self.contributors,
             "submitterAlias": self.team["name"],
         }
-        with (
-            patch.object(self.syn, "get", return_value=docker_entity) as patch_syn_get,
-            patch.object(
-                self.syn, "_get_docker_digest", return_value=docker_digest
-            ) as patch_get_digest,
-            patch.object(self.syn, "_submit", return_value=expected_submission),
+        with patch.object(
+            self.syn, "get", return_value=docker_entity
+        ) as patch_syn_get, patch.object(
+            self.syn, "_get_docker_digest", return_value=docker_digest
+        ) as patch_get_digest, patch.object(
+            self.syn, "_submit", return_value=expected_submission
         ):
             submission = self.syn.submit("9090", patch_syn_get, name="George")
             patch_get_digest.assert_called_once_with(docker_entity, "latest")
@@ -967,14 +960,13 @@ def test_send_message(syn: Synapse) -> None:
         "Through caverns measureless to man\n"
         "Down to a sunless sea.\n"
     )
-    with (
-        patch(
-            "synapseclient.client.multipart_upload_string_async",
-            new_callable=AsyncMock,
-            return_value="7365905",
-        ) as mock_upload_string,
-        patch("synapseclient.client.Synapse.restPOST") as post_mock,
-    ):
+    with patch(
+        "synapseclient.client.multipart_upload_string_async",
+        new_callable=AsyncMock,
+        return_value="7365905",
+    ) as mock_upload_string, patch(
+        "synapseclient.client.Synapse.restPOST"
+    ) as post_mock:
         syn.sendMessage(
             userIds=[1421212], messageSubject="Xanadu", messageBody=messageBody
         )
@@ -1018,17 +1010,15 @@ class TestPrivateUploadExternallyStoringProjects:
         max_threads = 8
 
         # method under test
-        with (
-            patch.object(
-                upload_functions,
-                "multipart_upload_file",
-                return_value=expected_file_handle_id,
-            ) as mocked_multipart_upload,
-            patch.object(self.syn.cache, "add") as mocked_cache_add,
-            patch.object(
-                self.syn, "_get_file_handle_as_creator"
-            ) as mocked_get_file_handle,
-        ):
+        with patch.object(
+            upload_functions,
+            "multipart_upload_file",
+            return_value=expected_file_handle_id,
+        ) as mocked_multipart_upload, patch.object(
+            self.syn.cache, "add"
+        ) as mocked_cache_add, patch.object(
+            self.syn, "_get_file_handle_as_creator"
+        ) as mocked_get_file_handle:
             upload_functions.upload_file_handle(
                 syn=self.syn,
                 parent_entity=test_file["parentId"],
@@ -1377,10 +1367,9 @@ def test_move(syn: Synapse) -> None:
     entity = Folder(name="folder", parent="syn456")
     moved_entity = entity
     moved_entity.parentId = "syn789"
-    with (
-        patch.object(syn, "get", return_value=entity) as syn_get_patch,
-        patch.object(syn, "store", return_value=moved_entity) as syn_store_patch,
-    ):
+    with patch.object(syn, "get", return_value=entity) as syn_get_patch, patch.object(
+        syn, "store", return_value=moved_entity
+    ) as syn_store_patch:
         assert moved_entity == syn.move("syn123", "syn789")
         syn_get_patch.assert_called_once_with("syn123", downloadFile=False)
         syn_store_patch.assert_called_once_with(moved_entity, forceVersion=False)
@@ -1431,11 +1420,9 @@ def test_set_permissions_default_permissions(syn: Synapse) -> None:
             {"accessType": ["READ", "DOWNLOAD"], "principalId": principalId}
         ]
     }
-    with (
-        patch.object(syn, "_getBenefactor", return_value=entity),
-        patch.object(syn, "_getACL", return_value=acl),
-        patch.object(syn, "_storeACL", return_value=update_acl) as patch_store_acl,
-    ):
+    with patch.object(syn, "_getBenefactor", return_value=entity), patch.object(
+        syn, "_getACL", return_value=acl
+    ), patch.object(syn, "_storeACL", return_value=update_acl) as patch_store_acl:
         assert update_acl == syn.setPermissions(entity, principalId)
         patch_store_acl.assert_called_once_with(entity, update_acl)
 
@@ -1629,11 +1616,9 @@ class TestCreateS3StorageLocation:
     def _create_storage_location_test(
         self, expected_post_body, *args, **kwargs
     ) -> None:
-        with (
-            patch.object(self.syn, "restPOST") as mock_post,
-            patch.object(self.syn, "setStorageLocation") as mock_set_storage_location,
-            patch.object(self.syn, "store") as syn_store,
-        ):
+        with patch.object(self.syn, "restPOST") as mock_post, patch.object(
+            self.syn, "setStorageLocation"
+        ) as mock_set_storage_location, patch.object(self.syn, "store") as syn_store:
             mock_post.return_value = {"storageLocationId": 456}
             mock_set_storage_location.return_value = {"id": "foo"}
 
@@ -1705,16 +1690,19 @@ class TestCreateExternalS3FileHandle:
         self.syn = syn
 
     def _s3_file_handle_test(self, **kwargs) -> None:
-        with (
-            patch.object(
-                self.syn, "_getDefaultUploadDestination"
-            ) as mock_get_upload_dest,
-            patch.object(os, "path") as mock_os_path,
-            patch.object(os, "stat") as mock_os_stat,
-            patch.object(utils, "md5_for_file") as mock_md5,
-            patch("mimetypes.guess_type") as mock_guess_mimetype,
-            patch.object(self.syn, "restPOST") as mock_post,
-        ):
+        with patch.object(
+            self.syn, "_getDefaultUploadDestination"
+        ) as mock_get_upload_dest, patch.object(
+            os, "path"
+        ) as mock_os_path, patch.object(
+            os, "stat"
+        ) as mock_os_stat, patch.object(
+            utils, "md5_for_file"
+        ) as mock_md5, patch(
+            "mimetypes.guess_type"
+        ) as mock_guess_mimetype, patch.object(
+            self.syn, "restPOST"
+        ) as mock_post:
             bucket_name = "foo_bucket"
             s3_file_key = "/foo/bar/baz"
             file_path = "/tmp/foo"
@@ -1873,17 +1861,13 @@ class TestMembershipInvitation:
             "inviteeEmail": self.email,
             "inviteeId": None,
         }
-        with (
-            patch.object(
-                self.syn, "get_team_open_invitations", return_value=[]
-            ) as patch_get_invites,
-            patch.object(
-                self.syn, "getUserProfile", return_value=self.profile
-            ) as patch_get_profile,
-            patch.object(
-                self.syn, "send_membership_invitation", return_value=self.response
-            ) as patch_invitation,
-        ):
+        with patch.object(
+            self.syn, "get_team_open_invitations", return_value=[]
+        ) as patch_get_invites, patch.object(
+            self.syn, "getUserProfile", return_value=self.profile
+        ) as patch_get_profile, patch.object(
+            self.syn, "send_membership_invitation", return_value=self.response
+        ) as patch_invitation:
             invite = self.syn.invite_to_team(
                 self.team, inviteeEmail=self.email, message=self.message
             )
@@ -1896,20 +1880,15 @@ class TestMembershipInvitation:
         """Invite user to team via their Synapse userid"""
         self.member_status["isMember"] = False
         invite_body = {"inviteeId": self.userid, "inviteeEmail": None, "message": None}
-        with (
-            patch.object(
-                self.syn, "get_membership_status", return_value=self.member_status
-            ) as patch_getmem,
-            patch.object(
-                self.syn, "get_team_open_invitations", return_value=[]
-            ) as patch_get_invites,
-            patch.object(
-                self.syn, "getUserProfile", return_value=self.profile
-            ) as patch_get_profile,
-            patch.object(
-                self.syn, "send_membership_invitation", return_value=self.response
-            ) as patch_invitation,
-        ):
+        with patch.object(
+            self.syn, "get_membership_status", return_value=self.member_status
+        ) as patch_getmem, patch.object(
+            self.syn, "get_team_open_invitations", return_value=[]
+        ) as patch_get_invites, patch.object(
+            self.syn, "getUserProfile", return_value=self.profile
+        ) as patch_get_profile, patch.object(
+            self.syn, "send_membership_invitation", return_value=self.response
+        ) as patch_invitation:
             invite = self.syn.invite_to_team(self.team, user=self.userid)
             patch_getmem.assert_called_once_with(self.userid, self.team.id)
             patch_get_profile.assert_called_once_with(self.userid)
@@ -1921,20 +1900,15 @@ class TestMembershipInvitation:
         """Invite user to team via their Synapse username"""
         self.member_status["isMember"] = False
         invite_body = {"inviteeId": self.userid, "inviteeEmail": None, "message": None}
-        with (
-            patch.object(
-                self.syn, "get_membership_status", return_value=self.member_status
-            ) as patch_getmem,
-            patch.object(
-                self.syn, "get_team_open_invitations", return_value=[]
-            ) as patch_get_invites,
-            patch.object(
-                self.syn, "getUserProfile", return_value=self.profile
-            ) as patch_get_profile,
-            patch.object(
-                self.syn, "send_membership_invitation", return_value=self.response
-            ) as patch_invitation,
-        ):
+        with patch.object(
+            self.syn, "get_membership_status", return_value=self.member_status
+        ) as patch_getmem, patch.object(
+            self.syn, "get_team_open_invitations", return_value=[]
+        ) as patch_get_invites, patch.object(
+            self.syn, "getUserProfile", return_value=self.profile
+        ) as patch_get_profile, patch.object(
+            self.syn, "send_membership_invitation", return_value=self.response
+        ) as patch_invitation:
             invite = self.syn.invite_to_team(self.team, user=self.username)
             patch_getmem.assert_called_once_with(self.userid, self.team.id)
             patch_get_profile.assert_called_once_with(self.username)
@@ -1944,20 +1918,15 @@ class TestMembershipInvitation:
 
     def test_invite_to_team__ismember(self) -> None:
         """None returned when user is already a member"""
-        with (
-            patch.object(
-                self.syn, "get_membership_status", return_value=self.member_status
-            ) as patch_getmem,
-            patch.object(
-                self.syn, "get_team_open_invitations", return_value=[]
-            ) as patch_get_invites,
-            patch.object(
-                self.syn, "getUserProfile", return_value=self.profile
-            ) as patch_get_profile,
-            patch.object(
-                self.syn, "send_membership_invitation", return_value=self.response
-            ) as patch_invitation,
-        ):
+        with patch.object(
+            self.syn, "get_membership_status", return_value=self.member_status
+        ) as patch_getmem, patch.object(
+            self.syn, "get_team_open_invitations", return_value=[]
+        ) as patch_get_invites, patch.object(
+            self.syn, "getUserProfile", return_value=self.profile
+        ) as patch_get_profile, patch.object(
+            self.syn, "send_membership_invitation", return_value=self.response
+        ) as patch_invitation:
             invite = self.syn.invite_to_team(self.team, user=self.userid)
             patch_getmem.assert_called_once_with(self.userid, self.team.id)
             patch_get_profile.assert_called_once_with(self.userid)
@@ -1969,21 +1938,17 @@ class TestMembershipInvitation:
         """None returned when user already has an invitation"""
         self.member_status["isMember"] = False
         invite_body = {"inviteeId": self.userid}
-        with (
-            patch.object(
-                self.syn, "get_membership_status", return_value=self.member_status
-            ) as patch_getmem,
-            patch.object(
-                self.syn, "get_team_open_invitations", return_value=[invite_body]
-            ) as patch_get_invites,
-            patch.object(
-                self.syn, "getUserProfile", return_value=self.profile
-            ) as patch_get_profile,
-            patch.object(self.syn, "_delete_membership_invitation") as patch_delete,
-            patch.object(
-                self.syn, "send_membership_invitation", return_value=self.response
-            ) as patch_invitation,
-        ):
+        with patch.object(
+            self.syn, "get_membership_status", return_value=self.member_status
+        ) as patch_getmem, patch.object(
+            self.syn, "get_team_open_invitations", return_value=[invite_body]
+        ) as patch_get_invites, patch.object(
+            self.syn, "getUserProfile", return_value=self.profile
+        ) as patch_get_profile, patch.object(
+            self.syn, "_delete_membership_invitation"
+        ) as patch_delete, patch.object(
+            self.syn, "send_membership_invitation", return_value=self.response
+        ) as patch_invitation:
             invite = self.syn.invite_to_team(self.team, user=self.userid)
             patch_getmem.assert_called_once_with(self.userid, self.team.id)
             patch_get_profile.assert_called_once_with(self.userid)
@@ -1995,15 +1960,13 @@ class TestMembershipInvitation:
     def test_invite_to_team__email_openinvite(self) -> None:
         """None returned when email already has an invitation"""
         invite_body = {"inviteeEmail": self.email}
-        with (
-            patch.object(
-                self.syn, "get_team_open_invitations", return_value=[invite_body]
-            ) as patch_get_invites,
-            patch.object(self.syn, "_delete_membership_invitation") as patch_delete,
-            patch.object(
-                self.syn, "send_membership_invitation", return_value=self.response
-            ) as patch_invitation,
-        ):
+        with patch.object(
+            self.syn, "get_team_open_invitations", return_value=[invite_body]
+        ) as patch_get_invites, patch.object(
+            self.syn, "_delete_membership_invitation"
+        ) as patch_delete, patch.object(
+            self.syn, "send_membership_invitation", return_value=self.response
+        ) as patch_invitation:
             invite = self.syn.invite_to_team(self.team, inviteeEmail=self.email)
             patch_get_invites.assert_called_once_with(self.team.id)
             patch_invitation.assert_not_called()
@@ -2014,15 +1977,13 @@ class TestMembershipInvitation:
     def test_invite_to_team__none_matching_invitation(self) -> None:
         """Invitation sent when no matching open invitations"""
         invite_body = {"inviteeEmail": self.email + "foo"}
-        with (
-            patch.object(
-                self.syn, "get_team_open_invitations", return_value=[invite_body]
-            ) as patch_get_invites,
-            patch.object(self.syn, "_delete_membership_invitation") as patch_delete,
-            patch.object(
-                self.syn, "send_membership_invitation", return_value=self.response
-            ) as patch_invitation,
-        ):
+        with patch.object(
+            self.syn, "get_team_open_invitations", return_value=[invite_body]
+        ) as patch_get_invites, patch.object(
+            self.syn, "_delete_membership_invitation"
+        ) as patch_delete, patch.object(
+            self.syn, "send_membership_invitation", return_value=self.response
+        ) as patch_invitation:
             invite = self.syn.invite_to_team(self.team, inviteeEmail=self.email)
             patch_get_invites.assert_called_once_with(self.team.id)
             patch_delete.assert_not_called()
@@ -2033,15 +1994,13 @@ class TestMembershipInvitation:
         """Invitation sent when force the invite, make sure open invitation
         is deleted"""
         open_invitations = {"inviteeEmail": self.email, "id": "9938"}
-        with (
-            patch.object(
-                self.syn, "get_team_open_invitations", return_value=[open_invitations]
-            ) as patch_get_invites,
-            patch.object(self.syn, "_delete_membership_invitation") as patch_delete,
-            patch.object(
-                self.syn, "send_membership_invitation", return_value=self.response
-            ) as patch_invitation,
-        ):
+        with patch.object(
+            self.syn, "get_team_open_invitations", return_value=[open_invitations]
+        ) as patch_get_invites, patch.object(
+            self.syn, "_delete_membership_invitation"
+        ) as patch_delete, patch.object(
+            self.syn, "send_membership_invitation", return_value=self.response
+        ) as patch_invitation:
             invite = self.syn.invite_to_team(
                 self.team, inviteeEmail=self.email, force=True
             )
@@ -2270,16 +2229,15 @@ class TestRestCalls:
         kwargs = {"stream": True}
 
         requests_session = requests_session or self.syn._requests_session
-        with (
-            patch.object(
-                self.syn, "_build_uri_and_headers"
-            ) as mock_build_uri_and_headers,
-            patch.object(self.syn, "_build_retry_policy") as mock_build_retry_policy,
-            patch.object(
-                self.syn, "_handle_synapse_http_error"
-            ) as mock_handle_synapse_http_error,
-            patch.object(requests_session, method) as mock_requests_call,
-        ):
+        with patch.object(
+            self.syn, "_build_uri_and_headers"
+        ) as mock_build_uri_and_headers, patch.object(
+            self.syn, "_build_retry_policy"
+        ) as mock_build_retry_policy, patch.object(
+            self.syn, "_handle_synapse_http_error"
+        ) as mock_handle_synapse_http_error, patch.object(
+            requests_session, method
+        ) as mock_requests_call:
             mock_build_uri_and_headers.return_value = (uri, headers)
             mock_build_retry_policy.return_value = retryPolicy
 
@@ -2520,18 +2478,22 @@ def test_store_needs_upload_false_file_handle_id_not_in_local_state(
         ],
         "annotations": {"id": synapse_id, "etag": etag, "annotations": {}},
     }
-    with (
-        patch.object(syn, "_getEntityBundle", return_value=returned_bundle),
-        patch.object(
-            synapseclient.client,
-            "upload_file_handle_async",
-            return_value=returned_file_handle,
-        ),
-        patch.object(syn.cache, "contains", return_value=True),
-        patch.object(syn, "_updateEntity"),
-        patch.object(syn, "set_annotations"),
-        patch.object(Entity, "create"),
-        patch.object(syn, "get"),
+    with patch.object(
+        syn, "_getEntityBundle", return_value=returned_bundle
+    ), patch.object(
+        synapseclient.client,
+        "upload_file_handle_async",
+        return_value=returned_file_handle,
+    ), patch.object(
+        syn.cache, "contains", return_value=True
+    ), patch.object(
+        syn, "_updateEntity"
+    ), patch.object(
+        syn, "set_annotations"
+    ), patch.object(
+        Entity, "create"
+    ), patch.object(
+        syn, "get"
     ):
         f = File("/fake_file.txt", parent=parent_id)
         syn.store(f)
@@ -2596,20 +2558,22 @@ def test_store_existing_processed_as_update(syn: Synapse) -> None:
         "baz": [4],
     }
 
-    with (
-        patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle,
-        patch.object(
-            synapseclient.client,
-            "upload_file_handle_async",
-            return_value=returned_file_handle,
-        ),
-        patch.object(syn.cache, "contains", return_value=True),
-        patch.object(syn, "_createEntity") as mock_createEntity,
-        patch.object(syn, "_updateEntity") as mock_updateEntity,
-        patch.object(syn, "findEntityId") as mock_findEntityId,
-        patch.object(syn, "set_annotations") as mock_set_annotations,
-        patch.object(Entity, "create"),
-        patch.object(syn, "get"),
+    with patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle, patch.object(
+        synapseclient.client,
+        "upload_file_handle_async",
+        return_value=returned_file_handle,
+    ), patch.object(syn.cache, "contains", return_value=True), patch.object(
+        syn, "_createEntity"
+    ) as mock_createEntity, patch.object(
+        syn, "_updateEntity"
+    ) as mock_updateEntity, patch.object(
+        syn, "findEntityId"
+    ) as mock_findEntityId, patch.object(
+        syn, "set_annotations"
+    ) as mock_set_annotations, patch.object(
+        Entity, "create"
+    ), patch.object(
+        syn, "get"
     ):
         mock_get_entity_bundle.return_value = returned_bundle
 
@@ -2690,21 +2654,23 @@ def test_store__409_processed_as_update(syn: Synapse) -> None:
         "baz": [4],
     }
 
-    with (
-        patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle,
-        patch.object(
-            synapseclient.client,
-            "upload_file_handle_async",
-            new_callable=AsyncMock,
-            return_value=returned_file_handle,
-        ),
-        patch.object(syn.cache, "contains", return_value=True),
-        patch.object(syn, "_createEntity") as mock_createEntity,
-        patch.object(syn, "_updateEntity") as mock_updateEntity,
-        patch.object(syn, "findEntityId") as mock_findEntityId,
-        patch.object(syn, "set_annotations") as mock_set_annotations,
-        patch.object(Entity, "create"),
-        patch.object(syn, "get"),
+    with patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle, patch.object(
+        synapseclient.client,
+        "upload_file_handle_async",
+        new_callable=AsyncMock,
+        return_value=returned_file_handle,
+    ), patch.object(syn.cache, "contains", return_value=True), patch.object(
+        syn, "_createEntity"
+    ) as mock_createEntity, patch.object(
+        syn, "_updateEntity"
+    ) as mock_updateEntity, patch.object(
+        syn, "findEntityId"
+    ) as mock_findEntityId, patch.object(
+        syn, "set_annotations"
+    ) as mock_set_annotations, patch.object(
+        Entity, "create"
+    ), patch.object(
+        syn, "get"
     ):
         mock_get_entity_bundle.side_effect = [None, returned_bundle]
         mock_createEntity.side_effect = SynapseHTTPError(
@@ -2769,20 +2735,22 @@ def test_store__no_need_to_update_annotation(syn: Synapse) -> None:
         },
     }
 
-    with (
-        patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle,
-        patch.object(
-            synapseclient.client,
-            "upload_file_handle_async",
-            return_value=returned_file_handle,
-        ),
-        patch.object(syn.cache, "contains", return_value=True),
-        patch.object(syn, "_createEntity"),
-        patch.object(syn, "_updateEntity"),
-        patch.object(syn, "findEntityId"),
-        patch.object(syn, "set_annotations") as mock_set_annotations,
-        patch.object(Entity, "create"),
-        patch.object(syn, "get"),
+    with patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle, patch.object(
+        synapseclient.client,
+        "upload_file_handle_async",
+        return_value=returned_file_handle,
+    ), patch.object(syn.cache, "contains", return_value=True), patch.object(
+        syn, "_createEntity"
+    ), patch.object(
+        syn, "_updateEntity"
+    ), patch.object(
+        syn, "findEntityId"
+    ), patch.object(
+        syn, "set_annotations"
+    ) as mock_set_annotations, patch.object(
+        Entity, "create"
+    ), patch.object(
+        syn, "get"
     ):
         mock_get_entity_bundle.return_value = returned_bundle
 
@@ -2838,20 +2806,22 @@ def test_store__update_version_comment(syn: Synapse) -> None:
         "versionComment": "12345",
     }
 
-    with (
-        patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle,
-        patch.object(
-            synapseclient.client,
-            "upload_file_handle_async",
-            return_value=returned_file_handle,
-        ),
-        patch.object(syn.cache, "contains", return_value=True),
-        patch.object(syn, "_createEntity") as mock_createEntity,
-        patch.object(syn, "_updateEntity") as mock_updateEntity,
-        patch.object(syn, "findEntityId") as mock_findEntityId,
-        patch.object(syn, "set_annotations") as mock_set_annotations,
-        patch.object(Entity, "create"),
-        patch.object(syn, "get"),
+    with patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle, patch.object(
+        synapseclient.client,
+        "upload_file_handle_async",
+        return_value=returned_file_handle,
+    ), patch.object(syn.cache, "contains", return_value=True), patch.object(
+        syn, "_createEntity"
+    ) as mock_createEntity, patch.object(
+        syn, "_updateEntity"
+    ) as mock_updateEntity, patch.object(
+        syn, "findEntityId"
+    ) as mock_findEntityId, patch.object(
+        syn, "set_annotations"
+    ) as mock_set_annotations, patch.object(
+        Entity, "create"
+    ), patch.object(
+        syn, "get"
     ):
         mock_get_entity_bundle.return_value = returned_bundle
 
@@ -2945,17 +2915,16 @@ def test_store__existing_no_update(syn: Synapse) -> None:
         "annotations": {},
     }
 
-    with (
-        patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle,
-        patch.object(
-            synapseclient.client,
-            "upload_file_handle_async",
-            return_value=returned_file_handle,
-        ),
-        patch.object(syn.cache, "contains", return_value=True),
-        patch.object(syn, "_createEntity") as mock_createEntity,
-        patch.object(syn, "_updateEntity") as mock_updatentity,
-        patch.object(syn, "get"),
+    with patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle, patch.object(
+        synapseclient.client,
+        "upload_file_handle_async",
+        return_value=returned_file_handle,
+    ), patch.object(syn.cache, "contains", return_value=True), patch.object(
+        syn, "_createEntity"
+    ) as mock_createEntity, patch.object(
+        syn, "_updateEntity"
+    ) as mock_updatentity, patch.object(
+        syn, "get"
     ):
         mock_get_entity_bundle.return_value = returned_bundle
         mock_createEntity.side_effect = SynapseHTTPError(
@@ -3011,10 +2980,9 @@ def test_get_submission_with_annotations(syn: Synapse) -> None:
         "entityBundleJSON": json.dumps(entity_bundle_json),
     }
 
-    with (
-        patch.object(syn, "restGET") as restGET,
-        patch.object(syn, "_getWithEntityBundle") as get_entity,
-    ):
+    with patch.object(syn, "restGET") as restGET, patch.object(
+        syn, "_getWithEntityBundle"
+    ) as get_entity:
         restGET.return_value = submission
         response = syn.getSubmission(submission_id)
 
@@ -3061,10 +3029,9 @@ class TestTableSnapshot:
             "description": activity["description"],
             "id": 123,
         }
-        with (
-            patch.object(syn, "restPOST", return_value=snapshot) as restpost,
-            patch.object(syn, "_saveActivity") as mock__saveActivity,
-        ):
+        with patch.object(
+            syn, "restPOST", return_value=snapshot
+        ) as restpost, patch.object(syn, "_saveActivity") as mock__saveActivity:
             mock__saveActivity.return_value = mock_dict
             syn._create_table_snapshot(
                 "syn1234", comment="foo", label="new_label", activity=activity
@@ -3125,14 +3092,11 @@ class TestTableSnapshot:
         """Create Table snapshot"""
         table = Mock(Schema)
         snapshot_version = 3
-        with (
-            patch.object(syn, "get", return_value=table) as get,
-            patch.object(
-                syn,
-                "_create_table_snapshot",
-                return_value={"snapshotVersionNumber": snapshot_version},
-            ) as create,
-        ):
+        with patch.object(syn, "get", return_value=table) as get, patch.object(
+            syn,
+            "_create_table_snapshot",
+            return_value={"snapshotVersionNumber": snapshot_version},
+        ) as create:
             result = syn.create_snapshot_version(
                 "syn1234", comment="foo", label="new_label", activity=2, wait=True
             )
@@ -3152,14 +3116,11 @@ class TestTableSnapshot:
         views = [Mock(EntityViewSchema), Mock(SubmissionViewSchema)]
         for view in views:
             snapshot_version = 3
-            with (
-                patch.object(syn, "get", return_value=view) as get,
-                patch.object(
-                    syn,
-                    "_async_table_update",
-                    return_value={"snapshotVersionNumber": snapshot_version},
-                ) as update,
-            ):
+            with patch.object(syn, "get", return_value=view) as get, patch.object(
+                syn,
+                "_async_table_update",
+                return_value={"snapshotVersionNumber": snapshot_version},
+            ) as update:
                 result = syn.create_snapshot_version(
                     "syn1234",
                     comment="foo",
@@ -3178,12 +3139,9 @@ class TestTableSnapshot:
                 )
                 assert snapshot_version == result
 
-            with (
-                patch.object(syn, "get", return_value=view) as get,
-                patch.object(
-                    syn, "_async_table_update", return_value={"token": 5}
-                ) as update,
-            ):
+            with patch.object(syn, "get", return_value=view) as get, patch.object(
+                syn, "_async_table_update", return_value={"token": 5}
+            ) as update:
                 result = syn.create_snapshot_version(
                     "syn1234", comment="foo", label="new_label", activity=2, wait=False
                 )
@@ -3201,12 +3159,9 @@ class TestTableSnapshot:
     def test_create_snapshot_version_raiseerror(self, syn: Synapse) -> None:
         """Raise error if entity view or table not passed in"""
         wrong_type = Mock()
-        with (
-            patch.object(syn, "get", return_value=wrong_type),
-            pytest.raises(
-                ValueError,
-                match="This function only accepts Synapse ids of Tables or Views",
-            ),
+        with patch.object(syn, "get", return_value=wrong_type), pytest.raises(
+            ValueError,
+            match="This function only accepts Synapse ids of Tables or Views",
         ):
             syn.create_snapshot_version("syn1234")
 
@@ -3351,15 +3306,14 @@ class TestTableQuery:
         expanduser = os.path.expanduser
         expandvars = os.path.expandvars
         os_join = os.path.join
-        with (
-            patch.object(syn, "_waitForAsync") as mock_wait_for_async,
-            patch.object(syn, "cache") as mock_cache,
-            patch(
-                "synapseclient.client.download_by_file_handle",
-                new_callable=AsyncMock,
-            ) as mock_download_file_handle,
-            patch.object(client, "os") as mock_os,
-        ):
+        with patch.object(syn, "_waitForAsync") as mock_wait_for_async, patch.object(
+            syn, "cache"
+        ) as mock_cache, patch(
+            "synapseclient.client.download_by_file_handle",
+            new_callable=AsyncMock,
+        ) as mock_download_file_handle, patch.object(
+            client, "os"
+        ) as mock_os:
             mock_download_result = {"resultsFileHandleId": file_handle_id}
             mock_wait_for_async.return_value = mock_download_result
             mock_cache.get.return_value = None
@@ -3465,14 +3419,11 @@ def test__get_certified_passing_record(userid, syn: Synapse) -> None:
 
 @pytest.mark.parametrize("response", [True, False])
 def test_is_certified(response, syn: Synapse) -> None:
-    with (
-        patch.object(
-            syn, "getUserProfile", return_value={"ownerId": "foobar"}
-        ) as patch_get_user,
-        patch.object(
-            syn, "_get_certified_passing_record", return_value={"passed": response}
-        ) as patch_get_cert,
-    ):
+    with patch.object(
+        syn, "getUserProfile", return_value={"ownerId": "foobar"}
+    ) as patch_get_user, patch.object(
+        syn, "_get_certified_passing_record", return_value={"passed": response}
+    ) as patch_get_cert:
         is_certified = syn.is_certified("test")
         patch_get_user.assert_called_once_with("test")
         patch_get_cert.assert_called_once_with("foobar")
@@ -3484,16 +3435,13 @@ def test_is_certified__no_quiz_results(syn: Synapse) -> None:
     In this case the back end returns a 404 rather than a result."""
     response = MagicMock(requests.Response)
     response.status_code = 404
-    with (
-        patch.object(
-            syn, "getUserProfile", return_value={"ownerId": "foobar"}
-        ) as patch_get_user,
-        patch.object(
-            syn,
-            "_get_certified_passing_record",
-            side_effect=SynapseHTTPError(response=response),
-        ) as patch_get_cert,
-    ):
+    with patch.object(
+        syn, "getUserProfile", return_value={"ownerId": "foobar"}
+    ) as patch_get_user, patch.object(
+        syn,
+        "_get_certified_passing_record",
+        side_effect=SynapseHTTPError(response=response),
+    ) as patch_get_cert:
         is_certified = syn.is_certified("test")
     patch_get_user.assert_called_once_with("test")
     patch_get_cert.assert_called_once_with("foobar")
@@ -3605,46 +3553,41 @@ class TestPermissionsOnProject:
 
     def test_get_permissions_with_defined_set_for_access(self) -> None:
         # GIVEN the API calls are mocked
-        with (
-            patch.object(
-                self.syn,
-                "_getUserbyPrincipalIdOrName",
-                # AND a user with id of 456
-                return_value=456,
-            ),
-            patch.object(
-                self.syn,
-                "_getACL",
-                return_value={
-                    "resourceAccess": [
-                        {
-                            "principalId": 456,
-                            # AND the permissions are given to the user
-                            "accessType": [
-                                "READ",
-                                "DELETE",
-                                "CHANGE_SETTINGS",
-                                "UPDATE",
-                                "CHANGE_PERMISSIONS",
-                                "CREATE",
-                                "MODERATE",
-                                "DOWNLOAD",
-                            ],
-                        }
-                    ]
-                },
-            ),
-            patch.object(
-                self.syn,
-                "_find_teams_for_principal",
-                # AND the user is a part of no teams
-                return_value=[],
-            ),
-            patch.object(
-                self.syn,
-                "_get_user_bundle",
-                return_value=None,
-            ),
+        with patch.object(
+            self.syn,
+            "_getUserbyPrincipalIdOrName",
+            # AND a user with id of 456
+            return_value=456,
+        ), patch.object(
+            self.syn,
+            "_getACL",
+            return_value={
+                "resourceAccess": [
+                    {
+                        "principalId": 456,
+                        # AND the permissions are given to the user
+                        "accessType": [
+                            "READ",
+                            "DELETE",
+                            "CHANGE_SETTINGS",
+                            "UPDATE",
+                            "CHANGE_PERMISSIONS",
+                            "CREATE",
+                            "MODERATE",
+                            "DOWNLOAD",
+                        ],
+                    }
+                ]
+            },
+        ), patch.object(
+            self.syn,
+            "_find_teams_for_principal",
+            # AND the user is a part of no teams
+            return_value=[],
+        ), patch.object(
+            self.syn,
+            "_get_user_bundle",
+            return_value=None,
         ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")
@@ -3664,46 +3607,41 @@ class TestPermissionsOnProject:
 
     def test_get_permissions_with_no_permissions_for_user(self) -> None:
         # GIVEN the API calls are mocked
-        with (
-            patch.object(
-                self.syn,
-                "_getUserbyPrincipalIdOrName",
-                # AND a user with id of 456
-                return_value=456,
-            ),
-            patch.object(
-                self.syn,
-                "_getACL",
-                return_value={
-                    "resourceAccess": [
-                        {
-                            # AND the permissions are given to an unknown user
-                            "principalId": 99999,
-                            "accessType": [
-                                "READ",
-                                "DELETE",
-                                "CHANGE_SETTINGS",
-                                "UPDATE",
-                                "CHANGE_PERMISSIONS",
-                                "CREATE",
-                                "MODERATE",
-                                "DOWNLOAD",
-                            ],
-                        }
-                    ]
-                },
-            ),
-            patch.object(
-                self.syn,
-                "_find_teams_for_principal",
-                # AND the user is a part of no teams
-                return_value=[],
-            ),
-            patch.object(
-                self.syn,
-                "_get_user_bundle",
-                return_value=None,
-            ),
+        with patch.object(
+            self.syn,
+            "_getUserbyPrincipalIdOrName",
+            # AND a user with id of 456
+            return_value=456,
+        ), patch.object(
+            self.syn,
+            "_getACL",
+            return_value={
+                "resourceAccess": [
+                    {
+                        # AND the permissions are given to an unknown user
+                        "principalId": 99999,
+                        "accessType": [
+                            "READ",
+                            "DELETE",
+                            "CHANGE_SETTINGS",
+                            "UPDATE",
+                            "CHANGE_PERMISSIONS",
+                            "CREATE",
+                            "MODERATE",
+                            "DOWNLOAD",
+                        ],
+                    }
+                ]
+            },
+        ), patch.object(
+            self.syn,
+            "_find_teams_for_principal",
+            # AND the user is a part of no teams
+            return_value=[],
+        ), patch.object(
+            self.syn,
+            "_get_user_bundle",
+            return_value=None,
         ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")
@@ -3714,46 +3652,41 @@ class TestPermissionsOnProject:
 
     def test_get_permissions_with_permissions_given_through_single_team(self) -> None:
         # GIVEN the API calls are mocked
-        with (
-            patch.object(
-                self.syn,
-                "_getUserbyPrincipalIdOrName",
-                # AND a user with id of 456
-                return_value=456,
-            ),
-            patch.object(
-                self.syn,
-                "_getACL",
-                return_value={
-                    "resourceAccess": [
-                        {
-                            # AND the permissions are given to a team
-                            "principalId": 999,
-                            "accessType": [
-                                "READ",
-                                "DELETE",
-                                "CHANGE_SETTINGS",
-                                "UPDATE",
-                                "CHANGE_PERMISSIONS",
-                                "CREATE",
-                                "MODERATE",
-                                "DOWNLOAD",
-                            ],
-                        }
-                    ]
-                },
-            ),
-            patch.object(
-                self.syn,
-                "_find_teams_for_principal",
-                # AND the user is assigned to a team
-                return_value=[Team(id=999)],
-            ),
-            patch.object(
-                self.syn,
-                "_get_user_bundle",
-                return_value=None,
-            ),
+        with patch.object(
+            self.syn,
+            "_getUserbyPrincipalIdOrName",
+            # AND a user with id of 456
+            return_value=456,
+        ), patch.object(
+            self.syn,
+            "_getACL",
+            return_value={
+                "resourceAccess": [
+                    {
+                        # AND the permissions are given to a team
+                        "principalId": 999,
+                        "accessType": [
+                            "READ",
+                            "DELETE",
+                            "CHANGE_SETTINGS",
+                            "UPDATE",
+                            "CHANGE_PERMISSIONS",
+                            "CREATE",
+                            "MODERATE",
+                            "DOWNLOAD",
+                        ],
+                    }
+                ]
+            },
+        ), patch.object(
+            self.syn,
+            "_find_teams_for_principal",
+            # AND the user is assigned to a team
+            return_value=[Team(id=999)],
+        ), patch.object(
+            self.syn,
+            "_get_user_bundle",
+            return_value=None,
         ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")
@@ -3775,54 +3708,49 @@ class TestPermissionsOnProject:
         self,
     ) -> None:
         # GIVEN the API calls are mocked
-        with (
-            patch.object(
-                self.syn,
-                "_getUserbyPrincipalIdOrName",
-                # AND a user with id of 456
-                return_value=456,
-            ),
-            patch.object(
-                self.syn,
-                "_getACL",
-                return_value={
-                    "resourceAccess": [
-                        # AND the permissions are spread across a set of 2 teams
-                        {
-                            "principalId": 888,
-                            "accessType": [
-                                "READ",
-                                "DELETE",
-                                "CHANGE_SETTINGS",
-                                "UPDATE",
-                                "CHANGE_PERMISSIONS",
-                            ],
-                        },
-                        {
-                            "principalId": 999,
-                            "accessType": [
-                                "READ",
-                                "UPDATE",
-                                "CHANGE_PERMISSIONS",
-                                "CREATE",
-                                "MODERATE",
-                                "DOWNLOAD",
-                            ],
-                        },
-                    ]
-                },
-            ),
-            patch.object(
-                self.syn,
-                "_find_teams_for_principal",
-                # AND the user is assigned to both of the teams
-                return_value=[Team(id=888), Team(id=999)],
-            ),
-            patch.object(
-                self.syn,
-                "_get_user_bundle",
-                return_value=None,
-            ),
+        with patch.object(
+            self.syn,
+            "_getUserbyPrincipalIdOrName",
+            # AND a user with id of 456
+            return_value=456,
+        ), patch.object(
+            self.syn,
+            "_getACL",
+            return_value={
+                "resourceAccess": [
+                    # AND the permissions are spread across a set of 2 teams
+                    {
+                        "principalId": 888,
+                        "accessType": [
+                            "READ",
+                            "DELETE",
+                            "CHANGE_SETTINGS",
+                            "UPDATE",
+                            "CHANGE_PERMISSIONS",
+                        ],
+                    },
+                    {
+                        "principalId": 999,
+                        "accessType": [
+                            "READ",
+                            "UPDATE",
+                            "CHANGE_PERMISSIONS",
+                            "CREATE",
+                            "MODERATE",
+                            "DOWNLOAD",
+                        ],
+                    },
+                ]
+            },
+        ), patch.object(
+            self.syn,
+            "_find_teams_for_principal",
+            # AND the user is assigned to both of the teams
+            return_value=[Team(id=888), Team(id=999)],
+        ), patch.object(
+            self.syn,
+            "_get_user_bundle",
+            return_value=None,
         ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -338,12 +338,15 @@ class TestDownloadFileHandle:
             (disk_space_error, 1),
             (ValueError("foo"), retries),
         ]:
-            with patch(
-                GET_FILE_HANDLE_FOR_DOWNLOAD,
-                new_callable=AsyncMock,
-            ) as mock_get_file_handle_download, patch(
-                DOWNLOAD_FROM_URL,
-            ) as mock_download_from_URL:
+            with (
+                patch(
+                    GET_FILE_HANDLE_FOR_DOWNLOAD,
+                    new_callable=AsyncMock,
+                ) as mock_get_file_handle_download,
+                patch(
+                    DOWNLOAD_FROM_URL,
+                ) as mock_download_from_URL,
+            ):
                 mock_get_file_handle_download.return_value = {
                     "fileHandle": {
                         "id": file_handle_id,
@@ -407,10 +410,13 @@ class TestDownloadFileHandle:
         expected_download_path = FOO_KEY
         mock_s3_client_wrapper.download_file.return_value = expected_download_path
 
-        with patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-        ) as mock_get_file_handle_download, patch.object(self.syn, "cache") as cache:
+        with (
+            patch(
+                GET_FILE_HANDLE_FOR_DOWNLOAD,
+                new_callable=AsyncMock,
+            ) as mock_get_file_handle_download,
+            patch.object(self.syn, "cache") as cache,
+        ):
             mock_get_file_handle_download.return_value = {
                 "fileHandle": {
                     "id": file_handle_id,
@@ -462,19 +468,20 @@ class TestDownloadFileHandle:
         destination = "/tmp"
         expected_destination = os.path.abspath(destination)
 
-        with patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-        ) as mock_get_file_handle_download, patch.object(
-            self.syn, "cache"
-        ), patch.object(
-            urllib_request, "urlretrieve"
-        ) as mock_url_retrieve, patch.object(
-            utils, "md5_for_file"
-        ) as mock_md5_for_file, patch.object(
-            os, "makedirs"
-        ), patch.object(
-            sts_transfer, "is_storage_location_sts_enabled_async", return_value=False
+        with (
+            patch(
+                GET_FILE_HANDLE_FOR_DOWNLOAD,
+                new_callable=AsyncMock,
+            ) as mock_get_file_handle_download,
+            patch.object(self.syn, "cache"),
+            patch.object(urllib_request, "urlretrieve") as mock_url_retrieve,
+            patch.object(utils, "md5_for_file") as mock_md5_for_file,
+            patch.object(os, "makedirs"),
+            patch.object(
+                sts_transfer,
+                "is_storage_location_sts_enabled_async",
+                return_value=False,
+            ),
         ):
             mock_get_file_handle_download.return_value = {
                 "fileHandle": {
@@ -519,8 +526,8 @@ class TestDownloadFileHandle:
 
         out_destination = download_from_url(
             url=uri,
-            object_id="syn123",
-            object_type="FileEntity",
+            entity_id="syn123",
+            file_handle_associate_type="FileEntity",
             destination=in_destination.name,
             synapse_client=self.syn,
         )
@@ -550,8 +557,8 @@ class TestDownloadFileHandle:
         out_destination = download_from_url(
             url=uri,
             destination=in_destination.name,
-            object_id="syn123",
-            object_type="FileEntity",
+            entity_id="syn123",
+            file_handle_associate_type="FileEntity",
             synapse_client=self.syn,
         )
         assert mock_get.call_args[1]["auth"] is None
@@ -824,12 +831,12 @@ class TestSubmit:
             "contributors": self.contributors,
             "submitterAlias": self.team["name"],
         }
-        with patch.object(
-            self.syn, "get", return_value=docker_entity
-        ) as patch_syn_get, patch.object(
-            self.syn, "_get_docker_digest", return_value=docker_digest
-        ) as patch_get_digest, patch.object(
-            self.syn, "_submit", return_value=expected_submission
+        with (
+            patch.object(self.syn, "get", return_value=docker_entity) as patch_syn_get,
+            patch.object(
+                self.syn, "_get_docker_digest", return_value=docker_digest
+            ) as patch_get_digest,
+            patch.object(self.syn, "_submit", return_value=expected_submission),
         ):
             submission = self.syn.submit("9090", patch_syn_get, name="George")
             patch_get_digest.assert_called_once_with(docker_entity, "latest")
@@ -960,13 +967,14 @@ def test_send_message(syn: Synapse) -> None:
         "Through caverns measureless to man\n"
         "Down to a sunless sea.\n"
     )
-    with patch(
-        "synapseclient.client.multipart_upload_string_async",
-        new_callable=AsyncMock,
-        return_value="7365905",
-    ) as mock_upload_string, patch(
-        "synapseclient.client.Synapse.restPOST"
-    ) as post_mock:
+    with (
+        patch(
+            "synapseclient.client.multipart_upload_string_async",
+            new_callable=AsyncMock,
+            return_value="7365905",
+        ) as mock_upload_string,
+        patch("synapseclient.client.Synapse.restPOST") as post_mock,
+    ):
         syn.sendMessage(
             userIds=[1421212], messageSubject="Xanadu", messageBody=messageBody
         )
@@ -1010,15 +1018,17 @@ class TestPrivateUploadExternallyStoringProjects:
         max_threads = 8
 
         # method under test
-        with patch.object(
-            upload_functions,
-            "multipart_upload_file",
-            return_value=expected_file_handle_id,
-        ) as mocked_multipart_upload, patch.object(
-            self.syn.cache, "add"
-        ) as mocked_cache_add, patch.object(
-            self.syn, "_get_file_handle_as_creator"
-        ) as mocked_get_file_handle:
+        with (
+            patch.object(
+                upload_functions,
+                "multipart_upload_file",
+                return_value=expected_file_handle_id,
+            ) as mocked_multipart_upload,
+            patch.object(self.syn.cache, "add") as mocked_cache_add,
+            patch.object(
+                self.syn, "_get_file_handle_as_creator"
+            ) as mocked_get_file_handle,
+        ):
             upload_functions.upload_file_handle(
                 syn=self.syn,
                 parent_entity=test_file["parentId"],
@@ -1367,9 +1377,10 @@ def test_move(syn: Synapse) -> None:
     entity = Folder(name="folder", parent="syn456")
     moved_entity = entity
     moved_entity.parentId = "syn789"
-    with patch.object(syn, "get", return_value=entity) as syn_get_patch, patch.object(
-        syn, "store", return_value=moved_entity
-    ) as syn_store_patch:
+    with (
+        patch.object(syn, "get", return_value=entity) as syn_get_patch,
+        patch.object(syn, "store", return_value=moved_entity) as syn_store_patch,
+    ):
         assert moved_entity == syn.move("syn123", "syn789")
         syn_get_patch.assert_called_once_with("syn123", downloadFile=False)
         syn_store_patch.assert_called_once_with(moved_entity, forceVersion=False)
@@ -1420,9 +1431,11 @@ def test_set_permissions_default_permissions(syn: Synapse) -> None:
             {"accessType": ["READ", "DOWNLOAD"], "principalId": principalId}
         ]
     }
-    with patch.object(syn, "_getBenefactor", return_value=entity), patch.object(
-        syn, "_getACL", return_value=acl
-    ), patch.object(syn, "_storeACL", return_value=update_acl) as patch_store_acl:
+    with (
+        patch.object(syn, "_getBenefactor", return_value=entity),
+        patch.object(syn, "_getACL", return_value=acl),
+        patch.object(syn, "_storeACL", return_value=update_acl) as patch_store_acl,
+    ):
         assert update_acl == syn.setPermissions(entity, principalId)
         patch_store_acl.assert_called_once_with(entity, update_acl)
 
@@ -1616,9 +1629,11 @@ class TestCreateS3StorageLocation:
     def _create_storage_location_test(
         self, expected_post_body, *args, **kwargs
     ) -> None:
-        with patch.object(self.syn, "restPOST") as mock_post, patch.object(
-            self.syn, "setStorageLocation"
-        ) as mock_set_storage_location, patch.object(self.syn, "store") as syn_store:
+        with (
+            patch.object(self.syn, "restPOST") as mock_post,
+            patch.object(self.syn, "setStorageLocation") as mock_set_storage_location,
+            patch.object(self.syn, "store") as syn_store,
+        ):
             mock_post.return_value = {"storageLocationId": 456}
             mock_set_storage_location.return_value = {"id": "foo"}
 
@@ -1690,19 +1705,16 @@ class TestCreateExternalS3FileHandle:
         self.syn = syn
 
     def _s3_file_handle_test(self, **kwargs) -> None:
-        with patch.object(
-            self.syn, "_getDefaultUploadDestination"
-        ) as mock_get_upload_dest, patch.object(
-            os, "path"
-        ) as mock_os_path, patch.object(
-            os, "stat"
-        ) as mock_os_stat, patch.object(
-            utils, "md5_for_file"
-        ) as mock_md5, patch(
-            "mimetypes.guess_type"
-        ) as mock_guess_mimetype, patch.object(
-            self.syn, "restPOST"
-        ) as mock_post:
+        with (
+            patch.object(
+                self.syn, "_getDefaultUploadDestination"
+            ) as mock_get_upload_dest,
+            patch.object(os, "path") as mock_os_path,
+            patch.object(os, "stat") as mock_os_stat,
+            patch.object(utils, "md5_for_file") as mock_md5,
+            patch("mimetypes.guess_type") as mock_guess_mimetype,
+            patch.object(self.syn, "restPOST") as mock_post,
+        ):
             bucket_name = "foo_bucket"
             s3_file_key = "/foo/bar/baz"
             file_path = "/tmp/foo"
@@ -1861,13 +1873,17 @@ class TestMembershipInvitation:
             "inviteeEmail": self.email,
             "inviteeId": None,
         }
-        with patch.object(
-            self.syn, "get_team_open_invitations", return_value=[]
-        ) as patch_get_invites, patch.object(
-            self.syn, "getUserProfile", return_value=self.profile
-        ) as patch_get_profile, patch.object(
-            self.syn, "send_membership_invitation", return_value=self.response
-        ) as patch_invitation:
+        with (
+            patch.object(
+                self.syn, "get_team_open_invitations", return_value=[]
+            ) as patch_get_invites,
+            patch.object(
+                self.syn, "getUserProfile", return_value=self.profile
+            ) as patch_get_profile,
+            patch.object(
+                self.syn, "send_membership_invitation", return_value=self.response
+            ) as patch_invitation,
+        ):
             invite = self.syn.invite_to_team(
                 self.team, inviteeEmail=self.email, message=self.message
             )
@@ -1880,15 +1896,20 @@ class TestMembershipInvitation:
         """Invite user to team via their Synapse userid"""
         self.member_status["isMember"] = False
         invite_body = {"inviteeId": self.userid, "inviteeEmail": None, "message": None}
-        with patch.object(
-            self.syn, "get_membership_status", return_value=self.member_status
-        ) as patch_getmem, patch.object(
-            self.syn, "get_team_open_invitations", return_value=[]
-        ) as patch_get_invites, patch.object(
-            self.syn, "getUserProfile", return_value=self.profile
-        ) as patch_get_profile, patch.object(
-            self.syn, "send_membership_invitation", return_value=self.response
-        ) as patch_invitation:
+        with (
+            patch.object(
+                self.syn, "get_membership_status", return_value=self.member_status
+            ) as patch_getmem,
+            patch.object(
+                self.syn, "get_team_open_invitations", return_value=[]
+            ) as patch_get_invites,
+            patch.object(
+                self.syn, "getUserProfile", return_value=self.profile
+            ) as patch_get_profile,
+            patch.object(
+                self.syn, "send_membership_invitation", return_value=self.response
+            ) as patch_invitation,
+        ):
             invite = self.syn.invite_to_team(self.team, user=self.userid)
             patch_getmem.assert_called_once_with(self.userid, self.team.id)
             patch_get_profile.assert_called_once_with(self.userid)
@@ -1900,15 +1921,20 @@ class TestMembershipInvitation:
         """Invite user to team via their Synapse username"""
         self.member_status["isMember"] = False
         invite_body = {"inviteeId": self.userid, "inviteeEmail": None, "message": None}
-        with patch.object(
-            self.syn, "get_membership_status", return_value=self.member_status
-        ) as patch_getmem, patch.object(
-            self.syn, "get_team_open_invitations", return_value=[]
-        ) as patch_get_invites, patch.object(
-            self.syn, "getUserProfile", return_value=self.profile
-        ) as patch_get_profile, patch.object(
-            self.syn, "send_membership_invitation", return_value=self.response
-        ) as patch_invitation:
+        with (
+            patch.object(
+                self.syn, "get_membership_status", return_value=self.member_status
+            ) as patch_getmem,
+            patch.object(
+                self.syn, "get_team_open_invitations", return_value=[]
+            ) as patch_get_invites,
+            patch.object(
+                self.syn, "getUserProfile", return_value=self.profile
+            ) as patch_get_profile,
+            patch.object(
+                self.syn, "send_membership_invitation", return_value=self.response
+            ) as patch_invitation,
+        ):
             invite = self.syn.invite_to_team(self.team, user=self.username)
             patch_getmem.assert_called_once_with(self.userid, self.team.id)
             patch_get_profile.assert_called_once_with(self.username)
@@ -1918,15 +1944,20 @@ class TestMembershipInvitation:
 
     def test_invite_to_team__ismember(self) -> None:
         """None returned when user is already a member"""
-        with patch.object(
-            self.syn, "get_membership_status", return_value=self.member_status
-        ) as patch_getmem, patch.object(
-            self.syn, "get_team_open_invitations", return_value=[]
-        ) as patch_get_invites, patch.object(
-            self.syn, "getUserProfile", return_value=self.profile
-        ) as patch_get_profile, patch.object(
-            self.syn, "send_membership_invitation", return_value=self.response
-        ) as patch_invitation:
+        with (
+            patch.object(
+                self.syn, "get_membership_status", return_value=self.member_status
+            ) as patch_getmem,
+            patch.object(
+                self.syn, "get_team_open_invitations", return_value=[]
+            ) as patch_get_invites,
+            patch.object(
+                self.syn, "getUserProfile", return_value=self.profile
+            ) as patch_get_profile,
+            patch.object(
+                self.syn, "send_membership_invitation", return_value=self.response
+            ) as patch_invitation,
+        ):
             invite = self.syn.invite_to_team(self.team, user=self.userid)
             patch_getmem.assert_called_once_with(self.userid, self.team.id)
             patch_get_profile.assert_called_once_with(self.userid)
@@ -1938,17 +1969,21 @@ class TestMembershipInvitation:
         """None returned when user already has an invitation"""
         self.member_status["isMember"] = False
         invite_body = {"inviteeId": self.userid}
-        with patch.object(
-            self.syn, "get_membership_status", return_value=self.member_status
-        ) as patch_getmem, patch.object(
-            self.syn, "get_team_open_invitations", return_value=[invite_body]
-        ) as patch_get_invites, patch.object(
-            self.syn, "getUserProfile", return_value=self.profile
-        ) as patch_get_profile, patch.object(
-            self.syn, "_delete_membership_invitation"
-        ) as patch_delete, patch.object(
-            self.syn, "send_membership_invitation", return_value=self.response
-        ) as patch_invitation:
+        with (
+            patch.object(
+                self.syn, "get_membership_status", return_value=self.member_status
+            ) as patch_getmem,
+            patch.object(
+                self.syn, "get_team_open_invitations", return_value=[invite_body]
+            ) as patch_get_invites,
+            patch.object(
+                self.syn, "getUserProfile", return_value=self.profile
+            ) as patch_get_profile,
+            patch.object(self.syn, "_delete_membership_invitation") as patch_delete,
+            patch.object(
+                self.syn, "send_membership_invitation", return_value=self.response
+            ) as patch_invitation,
+        ):
             invite = self.syn.invite_to_team(self.team, user=self.userid)
             patch_getmem.assert_called_once_with(self.userid, self.team.id)
             patch_get_profile.assert_called_once_with(self.userid)
@@ -1960,13 +1995,15 @@ class TestMembershipInvitation:
     def test_invite_to_team__email_openinvite(self) -> None:
         """None returned when email already has an invitation"""
         invite_body = {"inviteeEmail": self.email}
-        with patch.object(
-            self.syn, "get_team_open_invitations", return_value=[invite_body]
-        ) as patch_get_invites, patch.object(
-            self.syn, "_delete_membership_invitation"
-        ) as patch_delete, patch.object(
-            self.syn, "send_membership_invitation", return_value=self.response
-        ) as patch_invitation:
+        with (
+            patch.object(
+                self.syn, "get_team_open_invitations", return_value=[invite_body]
+            ) as patch_get_invites,
+            patch.object(self.syn, "_delete_membership_invitation") as patch_delete,
+            patch.object(
+                self.syn, "send_membership_invitation", return_value=self.response
+            ) as patch_invitation,
+        ):
             invite = self.syn.invite_to_team(self.team, inviteeEmail=self.email)
             patch_get_invites.assert_called_once_with(self.team.id)
             patch_invitation.assert_not_called()
@@ -1977,13 +2014,15 @@ class TestMembershipInvitation:
     def test_invite_to_team__none_matching_invitation(self) -> None:
         """Invitation sent when no matching open invitations"""
         invite_body = {"inviteeEmail": self.email + "foo"}
-        with patch.object(
-            self.syn, "get_team_open_invitations", return_value=[invite_body]
-        ) as patch_get_invites, patch.object(
-            self.syn, "_delete_membership_invitation"
-        ) as patch_delete, patch.object(
-            self.syn, "send_membership_invitation", return_value=self.response
-        ) as patch_invitation:
+        with (
+            patch.object(
+                self.syn, "get_team_open_invitations", return_value=[invite_body]
+            ) as patch_get_invites,
+            patch.object(self.syn, "_delete_membership_invitation") as patch_delete,
+            patch.object(
+                self.syn, "send_membership_invitation", return_value=self.response
+            ) as patch_invitation,
+        ):
             invite = self.syn.invite_to_team(self.team, inviteeEmail=self.email)
             patch_get_invites.assert_called_once_with(self.team.id)
             patch_delete.assert_not_called()
@@ -1994,13 +2033,15 @@ class TestMembershipInvitation:
         """Invitation sent when force the invite, make sure open invitation
         is deleted"""
         open_invitations = {"inviteeEmail": self.email, "id": "9938"}
-        with patch.object(
-            self.syn, "get_team_open_invitations", return_value=[open_invitations]
-        ) as patch_get_invites, patch.object(
-            self.syn, "_delete_membership_invitation"
-        ) as patch_delete, patch.object(
-            self.syn, "send_membership_invitation", return_value=self.response
-        ) as patch_invitation:
+        with (
+            patch.object(
+                self.syn, "get_team_open_invitations", return_value=[open_invitations]
+            ) as patch_get_invites,
+            patch.object(self.syn, "_delete_membership_invitation") as patch_delete,
+            patch.object(
+                self.syn, "send_membership_invitation", return_value=self.response
+            ) as patch_invitation,
+        ):
             invite = self.syn.invite_to_team(
                 self.team, inviteeEmail=self.email, force=True
             )
@@ -2229,15 +2270,16 @@ class TestRestCalls:
         kwargs = {"stream": True}
 
         requests_session = requests_session or self.syn._requests_session
-        with patch.object(
-            self.syn, "_build_uri_and_headers"
-        ) as mock_build_uri_and_headers, patch.object(
-            self.syn, "_build_retry_policy"
-        ) as mock_build_retry_policy, patch.object(
-            self.syn, "_handle_synapse_http_error"
-        ) as mock_handle_synapse_http_error, patch.object(
-            requests_session, method
-        ) as mock_requests_call:
+        with (
+            patch.object(
+                self.syn, "_build_uri_and_headers"
+            ) as mock_build_uri_and_headers,
+            patch.object(self.syn, "_build_retry_policy") as mock_build_retry_policy,
+            patch.object(
+                self.syn, "_handle_synapse_http_error"
+            ) as mock_handle_synapse_http_error,
+            patch.object(requests_session, method) as mock_requests_call,
+        ):
             mock_build_uri_and_headers.return_value = (uri, headers)
             mock_build_retry_policy.return_value = retryPolicy
 
@@ -2478,22 +2520,18 @@ def test_store_needs_upload_false_file_handle_id_not_in_local_state(
         ],
         "annotations": {"id": synapse_id, "etag": etag, "annotations": {}},
     }
-    with patch.object(
-        syn, "_getEntityBundle", return_value=returned_bundle
-    ), patch.object(
-        synapseclient.client,
-        "upload_file_handle_async",
-        return_value=returned_file_handle,
-    ), patch.object(
-        syn.cache, "contains", return_value=True
-    ), patch.object(
-        syn, "_updateEntity"
-    ), patch.object(
-        syn, "set_annotations"
-    ), patch.object(
-        Entity, "create"
-    ), patch.object(
-        syn, "get"
+    with (
+        patch.object(syn, "_getEntityBundle", return_value=returned_bundle),
+        patch.object(
+            synapseclient.client,
+            "upload_file_handle_async",
+            return_value=returned_file_handle,
+        ),
+        patch.object(syn.cache, "contains", return_value=True),
+        patch.object(syn, "_updateEntity"),
+        patch.object(syn, "set_annotations"),
+        patch.object(Entity, "create"),
+        patch.object(syn, "get"),
     ):
         f = File("/fake_file.txt", parent=parent_id)
         syn.store(f)
@@ -2558,22 +2596,20 @@ def test_store_existing_processed_as_update(syn: Synapse) -> None:
         "baz": [4],
     }
 
-    with patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle, patch.object(
-        synapseclient.client,
-        "upload_file_handle_async",
-        return_value=returned_file_handle,
-    ), patch.object(syn.cache, "contains", return_value=True), patch.object(
-        syn, "_createEntity"
-    ) as mock_createEntity, patch.object(
-        syn, "_updateEntity"
-    ) as mock_updateEntity, patch.object(
-        syn, "findEntityId"
-    ) as mock_findEntityId, patch.object(
-        syn, "set_annotations"
-    ) as mock_set_annotations, patch.object(
-        Entity, "create"
-    ), patch.object(
-        syn, "get"
+    with (
+        patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle,
+        patch.object(
+            synapseclient.client,
+            "upload_file_handle_async",
+            return_value=returned_file_handle,
+        ),
+        patch.object(syn.cache, "contains", return_value=True),
+        patch.object(syn, "_createEntity") as mock_createEntity,
+        patch.object(syn, "_updateEntity") as mock_updateEntity,
+        patch.object(syn, "findEntityId") as mock_findEntityId,
+        patch.object(syn, "set_annotations") as mock_set_annotations,
+        patch.object(Entity, "create"),
+        patch.object(syn, "get"),
     ):
         mock_get_entity_bundle.return_value = returned_bundle
 
@@ -2654,23 +2690,21 @@ def test_store__409_processed_as_update(syn: Synapse) -> None:
         "baz": [4],
     }
 
-    with patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle, patch.object(
-        synapseclient.client,
-        "upload_file_handle_async",
-        new_callable=AsyncMock,
-        return_value=returned_file_handle,
-    ), patch.object(syn.cache, "contains", return_value=True), patch.object(
-        syn, "_createEntity"
-    ) as mock_createEntity, patch.object(
-        syn, "_updateEntity"
-    ) as mock_updateEntity, patch.object(
-        syn, "findEntityId"
-    ) as mock_findEntityId, patch.object(
-        syn, "set_annotations"
-    ) as mock_set_annotations, patch.object(
-        Entity, "create"
-    ), patch.object(
-        syn, "get"
+    with (
+        patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle,
+        patch.object(
+            synapseclient.client,
+            "upload_file_handle_async",
+            new_callable=AsyncMock,
+            return_value=returned_file_handle,
+        ),
+        patch.object(syn.cache, "contains", return_value=True),
+        patch.object(syn, "_createEntity") as mock_createEntity,
+        patch.object(syn, "_updateEntity") as mock_updateEntity,
+        patch.object(syn, "findEntityId") as mock_findEntityId,
+        patch.object(syn, "set_annotations") as mock_set_annotations,
+        patch.object(Entity, "create"),
+        patch.object(syn, "get"),
     ):
         mock_get_entity_bundle.side_effect = [None, returned_bundle]
         mock_createEntity.side_effect = SynapseHTTPError(
@@ -2735,22 +2769,20 @@ def test_store__no_need_to_update_annotation(syn: Synapse) -> None:
         },
     }
 
-    with patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle, patch.object(
-        synapseclient.client,
-        "upload_file_handle_async",
-        return_value=returned_file_handle,
-    ), patch.object(syn.cache, "contains", return_value=True), patch.object(
-        syn, "_createEntity"
-    ), patch.object(
-        syn, "_updateEntity"
-    ), patch.object(
-        syn, "findEntityId"
-    ), patch.object(
-        syn, "set_annotations"
-    ) as mock_set_annotations, patch.object(
-        Entity, "create"
-    ), patch.object(
-        syn, "get"
+    with (
+        patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle,
+        patch.object(
+            synapseclient.client,
+            "upload_file_handle_async",
+            return_value=returned_file_handle,
+        ),
+        patch.object(syn.cache, "contains", return_value=True),
+        patch.object(syn, "_createEntity"),
+        patch.object(syn, "_updateEntity"),
+        patch.object(syn, "findEntityId"),
+        patch.object(syn, "set_annotations") as mock_set_annotations,
+        patch.object(Entity, "create"),
+        patch.object(syn, "get"),
     ):
         mock_get_entity_bundle.return_value = returned_bundle
 
@@ -2806,22 +2838,20 @@ def test_store__update_version_comment(syn: Synapse) -> None:
         "versionComment": "12345",
     }
 
-    with patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle, patch.object(
-        synapseclient.client,
-        "upload_file_handle_async",
-        return_value=returned_file_handle,
-    ), patch.object(syn.cache, "contains", return_value=True), patch.object(
-        syn, "_createEntity"
-    ) as mock_createEntity, patch.object(
-        syn, "_updateEntity"
-    ) as mock_updateEntity, patch.object(
-        syn, "findEntityId"
-    ) as mock_findEntityId, patch.object(
-        syn, "set_annotations"
-    ) as mock_set_annotations, patch.object(
-        Entity, "create"
-    ), patch.object(
-        syn, "get"
+    with (
+        patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle,
+        patch.object(
+            synapseclient.client,
+            "upload_file_handle_async",
+            return_value=returned_file_handle,
+        ),
+        patch.object(syn.cache, "contains", return_value=True),
+        patch.object(syn, "_createEntity") as mock_createEntity,
+        patch.object(syn, "_updateEntity") as mock_updateEntity,
+        patch.object(syn, "findEntityId") as mock_findEntityId,
+        patch.object(syn, "set_annotations") as mock_set_annotations,
+        patch.object(Entity, "create"),
+        patch.object(syn, "get"),
     ):
         mock_get_entity_bundle.return_value = returned_bundle
 
@@ -2915,16 +2945,17 @@ def test_store__existing_no_update(syn: Synapse) -> None:
         "annotations": {},
     }
 
-    with patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle, patch.object(
-        synapseclient.client,
-        "upload_file_handle_async",
-        return_value=returned_file_handle,
-    ), patch.object(syn.cache, "contains", return_value=True), patch.object(
-        syn, "_createEntity"
-    ) as mock_createEntity, patch.object(
-        syn, "_updateEntity"
-    ) as mock_updatentity, patch.object(
-        syn, "get"
+    with (
+        patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle,
+        patch.object(
+            synapseclient.client,
+            "upload_file_handle_async",
+            return_value=returned_file_handle,
+        ),
+        patch.object(syn.cache, "contains", return_value=True),
+        patch.object(syn, "_createEntity") as mock_createEntity,
+        patch.object(syn, "_updateEntity") as mock_updatentity,
+        patch.object(syn, "get"),
     ):
         mock_get_entity_bundle.return_value = returned_bundle
         mock_createEntity.side_effect = SynapseHTTPError(
@@ -2980,9 +3011,10 @@ def test_get_submission_with_annotations(syn: Synapse) -> None:
         "entityBundleJSON": json.dumps(entity_bundle_json),
     }
 
-    with patch.object(syn, "restGET") as restGET, patch.object(
-        syn, "_getWithEntityBundle"
-    ) as get_entity:
+    with (
+        patch.object(syn, "restGET") as restGET,
+        patch.object(syn, "_getWithEntityBundle") as get_entity,
+    ):
         restGET.return_value = submission
         response = syn.getSubmission(submission_id)
 
@@ -3029,9 +3061,10 @@ class TestTableSnapshot:
             "description": activity["description"],
             "id": 123,
         }
-        with patch.object(
-            syn, "restPOST", return_value=snapshot
-        ) as restpost, patch.object(syn, "_saveActivity") as mock__saveActivity:
+        with (
+            patch.object(syn, "restPOST", return_value=snapshot) as restpost,
+            patch.object(syn, "_saveActivity") as mock__saveActivity,
+        ):
             mock__saveActivity.return_value = mock_dict
             syn._create_table_snapshot(
                 "syn1234", comment="foo", label="new_label", activity=activity
@@ -3092,11 +3125,14 @@ class TestTableSnapshot:
         """Create Table snapshot"""
         table = Mock(Schema)
         snapshot_version = 3
-        with patch.object(syn, "get", return_value=table) as get, patch.object(
-            syn,
-            "_create_table_snapshot",
-            return_value={"snapshotVersionNumber": snapshot_version},
-        ) as create:
+        with (
+            patch.object(syn, "get", return_value=table) as get,
+            patch.object(
+                syn,
+                "_create_table_snapshot",
+                return_value={"snapshotVersionNumber": snapshot_version},
+            ) as create,
+        ):
             result = syn.create_snapshot_version(
                 "syn1234", comment="foo", label="new_label", activity=2, wait=True
             )
@@ -3116,11 +3152,14 @@ class TestTableSnapshot:
         views = [Mock(EntityViewSchema), Mock(SubmissionViewSchema)]
         for view in views:
             snapshot_version = 3
-            with patch.object(syn, "get", return_value=view) as get, patch.object(
-                syn,
-                "_async_table_update",
-                return_value={"snapshotVersionNumber": snapshot_version},
-            ) as update:
+            with (
+                patch.object(syn, "get", return_value=view) as get,
+                patch.object(
+                    syn,
+                    "_async_table_update",
+                    return_value={"snapshotVersionNumber": snapshot_version},
+                ) as update,
+            ):
                 result = syn.create_snapshot_version(
                     "syn1234",
                     comment="foo",
@@ -3139,9 +3178,12 @@ class TestTableSnapshot:
                 )
                 assert snapshot_version == result
 
-            with patch.object(syn, "get", return_value=view) as get, patch.object(
-                syn, "_async_table_update", return_value={"token": 5}
-            ) as update:
+            with (
+                patch.object(syn, "get", return_value=view) as get,
+                patch.object(
+                    syn, "_async_table_update", return_value={"token": 5}
+                ) as update,
+            ):
                 result = syn.create_snapshot_version(
                     "syn1234", comment="foo", label="new_label", activity=2, wait=False
                 )
@@ -3159,9 +3201,12 @@ class TestTableSnapshot:
     def test_create_snapshot_version_raiseerror(self, syn: Synapse) -> None:
         """Raise error if entity view or table not passed in"""
         wrong_type = Mock()
-        with patch.object(syn, "get", return_value=wrong_type), pytest.raises(
-            ValueError,
-            match="This function only accepts Synapse ids of Tables or Views",
+        with (
+            patch.object(syn, "get", return_value=wrong_type),
+            pytest.raises(
+                ValueError,
+                match="This function only accepts Synapse ids of Tables or Views",
+            ),
         ):
             syn.create_snapshot_version("syn1234")
 
@@ -3306,14 +3351,15 @@ class TestTableQuery:
         expanduser = os.path.expanduser
         expandvars = os.path.expandvars
         os_join = os.path.join
-        with patch.object(syn, "_waitForAsync") as mock_wait_for_async, patch.object(
-            syn, "cache"
-        ) as mock_cache, patch(
-            "synapseclient.client.download_by_file_handle",
-            new_callable=AsyncMock,
-        ) as mock_download_file_handle, patch.object(
-            client, "os"
-        ) as mock_os:
+        with (
+            patch.object(syn, "_waitForAsync") as mock_wait_for_async,
+            patch.object(syn, "cache") as mock_cache,
+            patch(
+                "synapseclient.client.download_by_file_handle",
+                new_callable=AsyncMock,
+            ) as mock_download_file_handle,
+            patch.object(client, "os") as mock_os,
+        ):
             mock_download_result = {"resultsFileHandleId": file_handle_id}
             mock_wait_for_async.return_value = mock_download_result
             mock_cache.get.return_value = None
@@ -3419,11 +3465,14 @@ def test__get_certified_passing_record(userid, syn: Synapse) -> None:
 
 @pytest.mark.parametrize("response", [True, False])
 def test_is_certified(response, syn: Synapse) -> None:
-    with patch.object(
-        syn, "getUserProfile", return_value={"ownerId": "foobar"}
-    ) as patch_get_user, patch.object(
-        syn, "_get_certified_passing_record", return_value={"passed": response}
-    ) as patch_get_cert:
+    with (
+        patch.object(
+            syn, "getUserProfile", return_value={"ownerId": "foobar"}
+        ) as patch_get_user,
+        patch.object(
+            syn, "_get_certified_passing_record", return_value={"passed": response}
+        ) as patch_get_cert,
+    ):
         is_certified = syn.is_certified("test")
         patch_get_user.assert_called_once_with("test")
         patch_get_cert.assert_called_once_with("foobar")
@@ -3435,13 +3484,16 @@ def test_is_certified__no_quiz_results(syn: Synapse) -> None:
     In this case the back end returns a 404 rather than a result."""
     response = MagicMock(requests.Response)
     response.status_code = 404
-    with patch.object(
-        syn, "getUserProfile", return_value={"ownerId": "foobar"}
-    ) as patch_get_user, patch.object(
-        syn,
-        "_get_certified_passing_record",
-        side_effect=SynapseHTTPError(response=response),
-    ) as patch_get_cert:
+    with (
+        patch.object(
+            syn, "getUserProfile", return_value={"ownerId": "foobar"}
+        ) as patch_get_user,
+        patch.object(
+            syn,
+            "_get_certified_passing_record",
+            side_effect=SynapseHTTPError(response=response),
+        ) as patch_get_cert,
+    ):
         is_certified = syn.is_certified("test")
     patch_get_user.assert_called_once_with("test")
     patch_get_cert.assert_called_once_with("foobar")
@@ -3553,41 +3605,46 @@ class TestPermissionsOnProject:
 
     def test_get_permissions_with_defined_set_for_access(self) -> None:
         # GIVEN the API calls are mocked
-        with patch.object(
-            self.syn,
-            "_getUserbyPrincipalIdOrName",
-            # AND a user with id of 456
-            return_value=456,
-        ), patch.object(
-            self.syn,
-            "_getACL",
-            return_value={
-                "resourceAccess": [
-                    {
-                        "principalId": 456,
-                        # AND the permissions are given to the user
-                        "accessType": [
-                            "READ",
-                            "DELETE",
-                            "CHANGE_SETTINGS",
-                            "UPDATE",
-                            "CHANGE_PERMISSIONS",
-                            "CREATE",
-                            "MODERATE",
-                            "DOWNLOAD",
-                        ],
-                    }
-                ]
-            },
-        ), patch.object(
-            self.syn,
-            "_find_teams_for_principal",
-            # AND the user is a part of no teams
-            return_value=[],
-        ), patch.object(
-            self.syn,
-            "_get_user_bundle",
-            return_value=None,
+        with (
+            patch.object(
+                self.syn,
+                "_getUserbyPrincipalIdOrName",
+                # AND a user with id of 456
+                return_value=456,
+            ),
+            patch.object(
+                self.syn,
+                "_getACL",
+                return_value={
+                    "resourceAccess": [
+                        {
+                            "principalId": 456,
+                            # AND the permissions are given to the user
+                            "accessType": [
+                                "READ",
+                                "DELETE",
+                                "CHANGE_SETTINGS",
+                                "UPDATE",
+                                "CHANGE_PERMISSIONS",
+                                "CREATE",
+                                "MODERATE",
+                                "DOWNLOAD",
+                            ],
+                        }
+                    ]
+                },
+            ),
+            patch.object(
+                self.syn,
+                "_find_teams_for_principal",
+                # AND the user is a part of no teams
+                return_value=[],
+            ),
+            patch.object(
+                self.syn,
+                "_get_user_bundle",
+                return_value=None,
+            ),
         ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")
@@ -3607,41 +3664,46 @@ class TestPermissionsOnProject:
 
     def test_get_permissions_with_no_permissions_for_user(self) -> None:
         # GIVEN the API calls are mocked
-        with patch.object(
-            self.syn,
-            "_getUserbyPrincipalIdOrName",
-            # AND a user with id of 456
-            return_value=456,
-        ), patch.object(
-            self.syn,
-            "_getACL",
-            return_value={
-                "resourceAccess": [
-                    {
-                        # AND the permissions are given to an unknown user
-                        "principalId": 99999,
-                        "accessType": [
-                            "READ",
-                            "DELETE",
-                            "CHANGE_SETTINGS",
-                            "UPDATE",
-                            "CHANGE_PERMISSIONS",
-                            "CREATE",
-                            "MODERATE",
-                            "DOWNLOAD",
-                        ],
-                    }
-                ]
-            },
-        ), patch.object(
-            self.syn,
-            "_find_teams_for_principal",
-            # AND the user is a part of no teams
-            return_value=[],
-        ), patch.object(
-            self.syn,
-            "_get_user_bundle",
-            return_value=None,
+        with (
+            patch.object(
+                self.syn,
+                "_getUserbyPrincipalIdOrName",
+                # AND a user with id of 456
+                return_value=456,
+            ),
+            patch.object(
+                self.syn,
+                "_getACL",
+                return_value={
+                    "resourceAccess": [
+                        {
+                            # AND the permissions are given to an unknown user
+                            "principalId": 99999,
+                            "accessType": [
+                                "READ",
+                                "DELETE",
+                                "CHANGE_SETTINGS",
+                                "UPDATE",
+                                "CHANGE_PERMISSIONS",
+                                "CREATE",
+                                "MODERATE",
+                                "DOWNLOAD",
+                            ],
+                        }
+                    ]
+                },
+            ),
+            patch.object(
+                self.syn,
+                "_find_teams_for_principal",
+                # AND the user is a part of no teams
+                return_value=[],
+            ),
+            patch.object(
+                self.syn,
+                "_get_user_bundle",
+                return_value=None,
+            ),
         ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")
@@ -3652,41 +3714,46 @@ class TestPermissionsOnProject:
 
     def test_get_permissions_with_permissions_given_through_single_team(self) -> None:
         # GIVEN the API calls are mocked
-        with patch.object(
-            self.syn,
-            "_getUserbyPrincipalIdOrName",
-            # AND a user with id of 456
-            return_value=456,
-        ), patch.object(
-            self.syn,
-            "_getACL",
-            return_value={
-                "resourceAccess": [
-                    {
-                        # AND the permissions are given to a team
-                        "principalId": 999,
-                        "accessType": [
-                            "READ",
-                            "DELETE",
-                            "CHANGE_SETTINGS",
-                            "UPDATE",
-                            "CHANGE_PERMISSIONS",
-                            "CREATE",
-                            "MODERATE",
-                            "DOWNLOAD",
-                        ],
-                    }
-                ]
-            },
-        ), patch.object(
-            self.syn,
-            "_find_teams_for_principal",
-            # AND the user is assigned to a team
-            return_value=[Team(id=999)],
-        ), patch.object(
-            self.syn,
-            "_get_user_bundle",
-            return_value=None,
+        with (
+            patch.object(
+                self.syn,
+                "_getUserbyPrincipalIdOrName",
+                # AND a user with id of 456
+                return_value=456,
+            ),
+            patch.object(
+                self.syn,
+                "_getACL",
+                return_value={
+                    "resourceAccess": [
+                        {
+                            # AND the permissions are given to a team
+                            "principalId": 999,
+                            "accessType": [
+                                "READ",
+                                "DELETE",
+                                "CHANGE_SETTINGS",
+                                "UPDATE",
+                                "CHANGE_PERMISSIONS",
+                                "CREATE",
+                                "MODERATE",
+                                "DOWNLOAD",
+                            ],
+                        }
+                    ]
+                },
+            ),
+            patch.object(
+                self.syn,
+                "_find_teams_for_principal",
+                # AND the user is assigned to a team
+                return_value=[Team(id=999)],
+            ),
+            patch.object(
+                self.syn,
+                "_get_user_bundle",
+                return_value=None,
+            ),
         ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")
@@ -3708,49 +3775,54 @@ class TestPermissionsOnProject:
         self,
     ) -> None:
         # GIVEN the API calls are mocked
-        with patch.object(
-            self.syn,
-            "_getUserbyPrincipalIdOrName",
-            # AND a user with id of 456
-            return_value=456,
-        ), patch.object(
-            self.syn,
-            "_getACL",
-            return_value={
-                "resourceAccess": [
-                    # AND the permissions are spread across a set of 2 teams
-                    {
-                        "principalId": 888,
-                        "accessType": [
-                            "READ",
-                            "DELETE",
-                            "CHANGE_SETTINGS",
-                            "UPDATE",
-                            "CHANGE_PERMISSIONS",
-                        ],
-                    },
-                    {
-                        "principalId": 999,
-                        "accessType": [
-                            "READ",
-                            "UPDATE",
-                            "CHANGE_PERMISSIONS",
-                            "CREATE",
-                            "MODERATE",
-                            "DOWNLOAD",
-                        ],
-                    },
-                ]
-            },
-        ), patch.object(
-            self.syn,
-            "_find_teams_for_principal",
-            # AND the user is assigned to both of the teams
-            return_value=[Team(id=888), Team(id=999)],
-        ), patch.object(
-            self.syn,
-            "_get_user_bundle",
-            return_value=None,
+        with (
+            patch.object(
+                self.syn,
+                "_getUserbyPrincipalIdOrName",
+                # AND a user with id of 456
+                return_value=456,
+            ),
+            patch.object(
+                self.syn,
+                "_getACL",
+                return_value={
+                    "resourceAccess": [
+                        # AND the permissions are spread across a set of 2 teams
+                        {
+                            "principalId": 888,
+                            "accessType": [
+                                "READ",
+                                "DELETE",
+                                "CHANGE_SETTINGS",
+                                "UPDATE",
+                                "CHANGE_PERMISSIONS",
+                            ],
+                        },
+                        {
+                            "principalId": 999,
+                            "accessType": [
+                                "READ",
+                                "UPDATE",
+                                "CHANGE_PERMISSIONS",
+                                "CREATE",
+                                "MODERATE",
+                                "DOWNLOAD",
+                            ],
+                        },
+                    ]
+                },
+            ),
+            patch.object(
+                self.syn,
+                "_find_teams_for_principal",
+                # AND the user is assigned to both of the teams
+                return_value=[Team(id=888), Team(id=999)],
+            ),
+            patch.object(
+                self.syn,
+                "_get_user_bundle",
+                return_value=None,
+            ),
         ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -1,4 +1,5 @@
 """Unit tests for the Synapse client"""
+
 import configparser
 import datetime
 import errno
@@ -518,6 +519,8 @@ class TestDownloadFileHandle:
 
         out_destination = download_from_url(
             url=uri,
+            object_id="syn123",
+            object_type="FileEntity",
             destination=in_destination.name,
             synapse_client=self.syn,
         )
@@ -547,6 +550,8 @@ class TestDownloadFileHandle:
         out_destination = download_from_url(
             url=uri,
             destination=in_destination.name,
+            object_id="syn123",
+            object_type="FileEntity",
             synapse_client=self.syn,
         )
         assert mock_get.call_args[1]["auth"] is None


### PR DESCRIPTION
**Problem:**

Due to the unordered nature of AsyncIO executing tasks async, when there is a large queue of files to download, the file may not be downloaded for a while after a pre-signed URL is retrieved. This shows up as a `403 Forbidden` error which needs to be handled for these cases to prevent downloads from failing.

**Solution:**

Update `download_from_url` to handle these `403` responses and try again by checking if the URL is expired when we receive a 403 response code, retrieving a new URL and retrying the download.

**Testing:**

- This was tested by:
  1. Reproducing the error faced by a [user](https://sagebionetworks.jira.com/browse/SYNSD-1188) by using the `random` package to have this failure occur.
  2. Hard-coding an expired URL into the code and running a `synapse get` CLI command
- new unit and integration tests were added