### PR TITLE
[FDS-2386] Add owner id to the credentials to be used later on

### DIFF
--- a/synapseclient/core/credentials/cred_data.py
+++ b/synapseclient/core/credentials/cred_data.py
@@ -20,6 +20,11 @@ class SynapseCredentials(requests.auth.AuthBase, abc.ABC):
     def secret(self) -> None:
         """The secret associated with these credentials."""
 
+    @property
+    @abc.abstractmethod
+    def owner_id(self) -> None:
+        """The owner id, or profile id, associated with these credentials."""
+
 
 class SynapseAuthTokenCredentials(SynapseCredentials):
     @classmethod
@@ -69,6 +74,7 @@ class SynapseAuthTokenCredentials(SynapseCredentials):
         self._token = token
         self.username = username
         self.displayname = displayname
+        self.owner_id = None
 
     @property
     def username(self) -> str:
@@ -89,6 +95,15 @@ class SynapseAuthTokenCredentials(SynapseCredentials):
         self._displayname = displayname
 
     @property
+    def owner_id(self) -> str:
+        """The owner id associated with this token."""
+        return self._owner_id
+
+    @owner_id.setter
+    def owner_id(self, owner_id: str) -> None:
+        self._owner_id = owner_id
+
+    @property
     def secret(self) -> str:
         """The bearer token."""
         return self._token
@@ -102,7 +117,8 @@ class SynapseAuthTokenCredentials(SynapseCredentials):
             f"SynapseAuthTokenCredentials("
             f"username='{self.username}', "
             f"displayname='{self.displayname}', "
-            f"token='{self.secret}')"
+            f"token='{self.secret}', "
+            f"owner_id='{self.owner_id}')"
         )
 
 

--- a/synapseclient/core/credentials/credential_provider.py
+++ b/synapseclient/core/credentials/credential_provider.py
@@ -91,6 +91,7 @@ class SynapseCredentialsProvider(metaclass=abc.ABCMeta):
                 )
             credentials.username = profile_username
             credentials.displayname = profile_displayname
+            credentials.owner_id = profile.get("ownerId", None)
 
             return credentials
 

--- a/tests/unit/synapseclient/core/credentials/unit_test_cred_data.py
+++ b/tests/unit/synapseclient/core/credentials/unit_test_cred_data.py
@@ -13,6 +13,7 @@ class TestSynapseAuthTokenCredentials:
         self.username = "ahhhhhhhhhhhhhh"
         self.auth_token = "opensesame"
         self.displayname = "hhhhhaaaa"
+        self.owner_id = 123
         self.credentials = SynapseAuthTokenCredentials(
             self.auth_token, username=self.username, displayname=self.displayname
         )
@@ -57,7 +58,8 @@ class TestSynapseAuthTokenCredentials:
             f"SynapseAuthTokenCredentials("
             f"username='{self.username}', "
             f"displayname='{self.displayname}', "
-            f"token='{self.auth_token}')" == repr(self.credentials)
+            f"token='{self.auth_token}')" == repr(self.credentials),
+            f"owner_id={self.owner_id}",
         )
 
     def test_tokens_validated(self, mocker):


### PR DESCRIPTION
**Problem:**

1. Within schematic there is a need to know the ID of the user that is logged in as it is passed to the Synapse servers to lookup data the user has access to. What needed to be done was another HTTP call to get the user profile and then extract the ownerId from that call.

**Solution:**

1. When logging into Synapse and getting the user profile stash the ownerId onto the credentials object so that schematic can use this and skip an HTTP call.

**Testing:**

1. Unit test
2. I have been using this code locally within schematic.