### PR TITLE
[SYNSD-1233] Adding in a try/catch for HTTP 409 conflicts on entity creation

### DIFF
--- a/synapseclient/api/entity_services.py
+++ b/synapseclient/api/entity_services.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from async_lru import alru_cache
 
 from synapseclient.core.exceptions import SynapseHTTPError
+from synapseclient.core.retry import RETRYABLE_CONNECTION_EXCEPTIONS_NO_READ_ISSUES
 
 if TYPE_CHECKING:
     from synapseclient import Synapse
@@ -42,7 +43,12 @@ async def post_entity(
 
     try:
         return await client.rest_post_async(
-            uri="/entity", body=json.dumps(request), params=params
+            uri="/entity",
+            body=json.dumps(request),
+            params=params,
+            retry_policy={
+                "retry_exceptions": RETRYABLE_CONNECTION_EXCEPTIONS_NO_READ_ISSUES
+            },
         )
     except SynapseHTTPError:
         if "name" in request and "parentId" in request:

--- a/synapseclient/api/entity_services.py
+++ b/synapseclient/api/entity_services.py
@@ -2,10 +2,13 @@
 <https://rest-docs.synapse.org/rest/#org.sagebionetworks.repo.web.controller.EntityController>
 """
 
+import asyncio
 import json
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from async_lru import alru_cache
+
+from synapseclient.core.exceptions import SynapseHTTPError
 
 if TYPE_CHECKING:
     from synapseclient import Synapse
@@ -36,9 +39,40 @@ async def post_entity(
     params = {}
     if generated_by:
         params["generatedBy"] = generated_by
-    return await client.rest_post_async(
-        uri="/entity", body=json.dumps(request), params=params
-    )
+
+    try:
+        return await client.rest_post_async(
+            uri="/entity", body=json.dumps(request), params=params
+        )
+    except SynapseHTTPError:
+        if "name" in request and "parentId" in request:
+            loop = asyncio.get_event_loop()
+            entity_id = await loop.run_in_executor(
+                None,
+                lambda: Synapse.get_client(synapse_client=synapse_client).findEntityId(
+                    name=request["name"],
+                    parent=request["parentId"],
+                ),
+            )
+            if not entity_id:
+                raise
+
+            client.logger.warning(
+                "This is a temporary exception to recieving an HTTP 409 conflict error - Retrieving the state of the object in Synapse. If an error is not printed after this, assume the operation was successful (SYNSD-1233)."
+            )
+            existing_instance = await get_entity(
+                entity_id, synapse_client=synapse_client
+            )
+            # Loop over the request params and if any of them do not match the existing instance, raise the error
+            for key, value in request.items():
+                if key not in existing_instance or existing_instance[key] != value:
+                    client.logger.error(
+                        f"Failed temporary HTTP 409 logic check because {key} not in instance in Synapse or value does not match: [Existing: {existing_instance[key]}, Expected: {value}]."
+                    )
+                    raise
+            return existing_instance
+        else:
+            raise
 
 
 async def put_entity(

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -6299,6 +6299,7 @@ class Synapse(object):
         Returns:
             JSON encoding of response
         """
+        self.logger.debug(f"Sending {method} request to {uri}")
         uri, headers = self._build_uri_and_headers(
             uri, endpoint=endpoint, headers=headers
         )

--- a/synapseclient/core/retry.py
+++ b/synapseclient/core/retry.py
@@ -73,6 +73,21 @@ RETRYABLE_CONNECTION_EXCEPTIONS = [
     "SSLZeroReturnError",
 ]
 
+RETRYABLE_CONNECTION_EXCEPTIONS_NO_READ_ISSUES = [
+    "ChunkedEncodingError",
+    "ConnectionError",
+    "ConnectionResetError",
+    "Timeout",
+    "timeout",
+    # HTTPX Specific connection exceptions:
+    "RemoteProtocolError",
+    "TimeoutException",
+    "ConnectError",
+    "ConnectTimeout",
+    # SSL Specific exceptions:
+    "SSLZeroReturnError",
+]
+
 DEBUG_EXCEPTION = "calling %s resulted in an Exception"
 
 


### PR DESCRIPTION
**Problem:**

1. If an HTTP Read error occurs when receiving back the response from creating a Synapse entity an HTTP 409 error will be thrown when the request is retried.

**Solution:**

1. Try out removing the `ReadError` and `ReadTimeout` as exceptions that are retried. Instead let the `SynapseHTTPError` be raised and wrap the POST call in a try/except that will get the entity from Synapse if it was a conflict, then compare the results to what the expected state was.

**Testing:**

1. I did very light manual testing for this by running the `syncToSynapse` command and I manually triggered the exception to be raised.