### PR TITLE
[SYNPY-1521] Fixes `asDataFrame` `kwarg` Collision Issue

### DIFF
--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -418,7 +418,7 @@ def _csv_to_pandas_df(
                     Passed as `sep` to pandas. If `sep` is supplied as a `kwarg`
                     it will be used instead of this `separator` argument.
         quote_char: The quote character for the file,
-                    Defaults to `DEFAULT_QUOTE_CHARACTER`. 
+                    Defaults to `DEFAULT_QUOTE_CHARACTER`.
                     Passed as `quotechar` to pandas. If `quotechar` is supplied as a `kwarg`
                     it will be used instead of this `quote_char` argument.
         escape_char: The escape character for the file,
@@ -426,7 +426,7 @@ def _csv_to_pandas_df(
         contain_headers: Whether the file contains headers,
                     Defaults to `True`.
         lines_to_skip: The number of lines to skip at the beginning of the file,
-                        Defaults to `0`. Passed as `skiprows` to pandas. 
+                        Defaults to `0`. Passed as `skiprows` to pandas.
                         If `skiprows` is supplied as a `kwarg`
                         it will be used instead of this `lines_to_skip` argument.
         date_columns: The names of the date columns in the file

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -34,7 +34,7 @@ import os
 import re
 import tempfile
 from builtins import zip
-from typing import Dict, List, Tuple, TypeVar, Union, Optional, Any
+from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
 
 from synapseclient.core.constants import concrete_types
 from synapseclient.core.exceptions import SynapseError
@@ -408,7 +408,7 @@ def _csv_to_pandas_df(
     rowIdAndVersionInIndex: bool = True,
     dtype: Optional[Dict[str, Any]] = None,
     **kwargs,
-) -> "pd.DataFrame":
+):
     """
     Convert a csv file to a pandas dataframe
 

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -447,7 +447,6 @@ def _csv_to_pandas_df(
         "escapechar": escape_char,
         "header": 0 if contain_headers else None,
         "skiprows": lines_to_skip,
-        **kwargs,
     }
     pandas_args.update(kwargs)
 

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -450,7 +450,7 @@ def _csv_to_pandas_df(
         **kwargs,
     }
     pandas_args.update(kwargs)
-    
+
     # assign line terminator only if for single character
     # line terminators (e.g. not '\r\n') 'cause pandas doesn't
     # longer line terminators. See: <https://github.com/pydata/pandas/issues/3501>
@@ -458,9 +458,9 @@ def _csv_to_pandas_df(
     df = pd.read_csv(
         filepath,
         lineterminator=line_terminator if len(line_terminator) == 1 else None,
-        **pandas_args
-        )
-    
+        **pandas_args,
+    )
+
     # parse date columns if exists
     if date_columns:
         df = _convert_df_date_cols_to_datetime(df, date_columns)

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -440,21 +440,27 @@ def _csv_to_pandas_df(
 
     line_terminator = str(os.linesep)
 
+    pandas_args = {
+        "dtype": dtype,
+        "sep": separator,
+        "quotechar": quote_char,
+        "escapechar": escape_char,
+        "header": 0 if contain_headers else None,
+        "skiprows": lines_to_skip,
+        **kwargs,
+    }
+    pandas_args.update(kwargs)
+    
     # assign line terminator only if for single character
     # line terminators (e.g. not '\r\n') 'cause pandas doesn't
     # longer line terminators. See: <https://github.com/pydata/pandas/issues/3501>
     # "ValueError: Only length-1 line terminators supported"
     df = pd.read_csv(
         filepath,
-        dtype=dtype,
-        sep=separator,
         lineterminator=line_terminator if len(line_terminator) == 1 else None,
-        quotechar=quote_char,
-        escapechar=escape_char,
-        header=0 if contain_headers else None,
-        skiprows=lines_to_skip,
-        **kwargs,
-    )
+        **pandas_args
+        )
+    
     # parse date columns if exists
     if date_columns:
         df = _convert_df_date_cols_to_datetime(df, date_columns)

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -415,14 +415,20 @@ def _csv_to_pandas_df(
     Arguments:
         filepath: The path to the file.
         separator: The separator for the file, Defaults to `DEFAULT_SEPARATOR`.
+                    Passed as `sep` to pandas. If `sep` is supplied as a `kwarg`
+                    it will be used instead of this `separator` argument.
         quote_char: The quote character for the file,
-          Defaults to `DEFAULT_QUOTE_CHARACTER`.
+                    Defaults to `DEFAULT_QUOTE_CHARACTER`. 
+                    Passed as `quotechar` to pandas. If `quotechar` is supplied as a `kwarg`
+                    it will be used instead of this `quote_char` argument.
         escape_char: The escape character for the file,
                     Defaults to `DEFAULT_ESCAPSE_CHAR`.
-                    contain_headers: Whether the file contains headers,
+        contain_headers: Whether the file contains headers,
                     Defaults to `True`.
         lines_to_skip: The number of lines to skip at the beginning of the file,
-                        Defaults to `0`.
+                        Defaults to `0`. Passed as `skiprows` to pandas. 
+                        If `skiprows` is supplied as a `kwarg`
+                        it will be used instead of this `lines_to_skip` argument.
         date_columns: The names of the date columns in the file
         list_columns: The names of the list columns in the file
         rowIdAndVersionInIndex: Whether the file contains rowId and
@@ -2430,6 +2436,12 @@ class CsvFileTable(TableAbstractBaseClass):
         includeRowIdAndRowVersion=None,
         headers=None,
     ):
+        """Initialize a CsvFileTable object.
+
+        Note: Some arguments provided to this constructor are passed to pandas.read_csv()
+        including `quoteCharacter`, `escapeCharacter`, `lineEnd`, and `separator`.
+        These arguments can be overwritten by passing `pandas.read_csv` kwargs to `asDataFrame`.
+        """
         self.filepath = filepath
 
         self.includeRowIdAndRowVersion = includeRowIdAndRowVersion
@@ -2485,6 +2497,11 @@ class CsvFileTable(TableAbstractBaseClass):
         **kwargs,
     ):
         """Convert query result to a Pandas DataFrame.
+
+        Note: Class attributes  `quoteCharacter`, `escapeCharacter`, `lineEnd`, and `separator`
+        are used as `quotechar`, `escapechar`, `lineterminator`, and `sep` in `pandas.read_csv`
+        within this method. If you want to override these values, you can do so by passing the
+        appropriate keyword arguments to this method.
 
         Arguments:
             rowIdAndVersionInIndex: Make the dataframe index consist of the

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -34,7 +34,7 @@ import os
 import re
 import tempfile
 from builtins import zip
-from typing import Dict, List, Tuple, TypeVar, Union
+from typing import Dict, List, Tuple, TypeVar, Union, Optional, Any
 
 from synapseclient.core.constants import concrete_types
 from synapseclient.core.exceptions import SynapseError
@@ -397,18 +397,18 @@ def _convert_df_date_cols_to_datetime(
 
 
 def _csv_to_pandas_df(
-    filepath,
-    separator=DEFAULT_SEPARATOR,
-    quote_char=DEFAULT_QUOTE_CHARACTER,
-    escape_char=DEFAULT_ESCAPSE_CHAR,
-    contain_headers=True,
-    lines_to_skip=0,
-    date_columns=None,
-    list_columns=None,
-    rowIdAndVersionInIndex=True,
-    dtype=None,
+    filepath: str,
+    separator: str = DEFAULT_SEPARATOR,
+    quote_char: str = DEFAULT_QUOTE_CHARACTER,
+    escape_char: str = DEFAULT_ESCAPSE_CHAR,
+    contain_headers: bool = True,
+    lines_to_skip: int = 0,
+    date_columns: Optional[List[str]] = None,
+    list_columns: Optional[List[str]] = None,
+    rowIdAndVersionInIndex: bool = True,
+    dtype: Optional[Dict[str, Any]] = None,
     **kwargs,
-):
+) -> "pd.DataFrame":
     """
     Convert a csv file to a pandas dataframe
 

--- a/tests/unit/synapseclient/unit_test_tables.py
+++ b/tests/unit/synapseclient/unit_test_tables.py
@@ -288,7 +288,8 @@ def test_csv_to_pandas_df_no_kwargs():
             lineterminator=None,
         )
 
-        # AND I expect the returned DataFrame to be the same as the original DataFrame (file)
+        # AND I expect the returned DataFrame to be 
+        # the same as the original DataFrame (file)
         pd.testing.assert_frame_equal(df, expected_df)
 
 
@@ -355,7 +356,8 @@ def test_csv_to_pandas_df_calls_convert_date_cols():
             dtype=None,
         )
 
-        # THEN I expect _convert_df_date_cols_to_datetime to be called with the expected DataFrame and date columns
+        # THEN I expect _convert_df_date_cols_to_datetime to be 
+        # called with the expected DataFrame and date columns
         mock_convert_dates.assert_called_once_with(expected_df, ["date_col"])
 
 
@@ -407,7 +409,8 @@ def test_csv_to_pandas_df_handles_row_id_and_version():
         }
     )
 
-    # AND a pandas DataFrame (expected result) with the ROW_ID and ROW_VERSION columns removed
+    # AND a pandas DataFrame (expected result) 
+    # with the ROW_ID and ROW_VERSION columns removed
     expected_final_df = pd.DataFrame(
         {"col1": ["a", "b", "c"], "col2": [10, 20, 30]}, index=["1_1", "2_1", "3_2"]
     )  # Index format: ROW_ID_ROW_VERSION
@@ -434,7 +437,8 @@ def test_csv_to_pandas_df_handles_row_id_and_version():
         # THEN I expect row_labels_from_id_and_version to be called once
         mock_row_labels.assert_called_once()
 
-        # AND I expect the returned DataFrame to match the expected DataFrame with the ROW_ID and ROW_VERSION columns removed
+        # AND I expect the returned DataFrame to match the expected 
+        # DataFrame with the ROW_ID and ROW_VERSION columns removed
         pd.testing.assert_frame_equal(result_df, expected_final_df)
 
         # AND I expect the index of the result_df to be as expected

--- a/tests/unit/synapseclient/unit_test_tables.py
+++ b/tests/unit/synapseclient/unit_test_tables.py
@@ -288,7 +288,7 @@ def test_csv_to_pandas_df_no_kwargs():
             lineterminator=None,
         )
 
-        # AND I expect the returned DataFrame to be 
+        # AND I expect the returned DataFrame to be
         # the same as the original DataFrame (file)
         pd.testing.assert_frame_equal(df, expected_df)
 
@@ -356,7 +356,7 @@ def test_csv_to_pandas_df_calls_convert_date_cols():
             dtype=None,
         )
 
-        # THEN I expect _convert_df_date_cols_to_datetime to be 
+        # THEN I expect _convert_df_date_cols_to_datetime to be
         # called with the expected DataFrame and date columns
         mock_convert_dates.assert_called_once_with(expected_df, ["date_col"])
 
@@ -409,7 +409,7 @@ def test_csv_to_pandas_df_handles_row_id_and_version():
         }
     )
 
-    # AND a pandas DataFrame (expected result) 
+    # AND a pandas DataFrame (expected result)
     # with the ROW_ID and ROW_VERSION columns removed
     expected_final_df = pd.DataFrame(
         {"col1": ["a", "b", "c"], "col2": [10, 20, 30]}, index=["1_1", "2_1", "3_2"]
@@ -437,7 +437,7 @@ def test_csv_to_pandas_df_handles_row_id_and_version():
         # THEN I expect row_labels_from_id_and_version to be called once
         mock_row_labels.assert_called_once()
 
-        # AND I expect the returned DataFrame to match the expected 
+        # AND I expect the returned DataFrame to match the expected
         # DataFrame with the ROW_ID and ROW_VERSION columns removed
         pd.testing.assert_frame_equal(result_df, expected_final_df)
 

--- a/tests/unit/synapseclient/unit_test_tables.py
+++ b/tests/unit/synapseclient/unit_test_tables.py
@@ -259,7 +259,9 @@ def test_csv_to_pandas_df_no_kwargs():
         {"col1": [1, 2, 3], "col2": ["a", "b", "c"], "col3": [True, False, True]}
     )
 
-    with patch.object(pd, "read_csv", return_value=expected_df) as mock_read_csv:
+    with patch.object(
+        pd, "read_csv", return_value=expected_df
+    ) as mock_read_csv, patch.object(os, "linesep", "\r\n"):
         # WHEN I call _csv_to_pandas_df with default parameters
         df = _csv_to_pandas_df(
             filepath="dummy_path.csv",
@@ -283,7 +285,7 @@ def test_csv_to_pandas_df_no_kwargs():
             escapechar=synapseclient.table.DEFAULT_ESCAPSE_CHAR,
             header=0,
             skiprows=0,
-            lineterminator="\n",
+            lineterminator=None,
         )
 
         # AND I expect the returned DataFrame to be the same as the original DataFrame (file)
@@ -294,7 +296,9 @@ def test_csv_to_pandas_df_with_kwargs() -> None:
     # GIVEN a pandas DataFrame (CSV file stand-in)
     expected_df = pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
 
-    with patch.object(pd, "read_csv", return_value=expected_df) as mock_read_csv:
+    with patch.object(
+        pd, "read_csv", return_value=expected_df
+    ) as mock_read_csv, patch.object(os, "linesep", "\r\n"):
         # WHEN I call _csv_to_pandas_df with custom keyword arguments
         kwargs = {"escapechar": "\\", "keep_default_na": False}
         df = _csv_to_pandas_df(
@@ -321,7 +325,7 @@ def test_csv_to_pandas_df_with_kwargs() -> None:
             header=0,
             skiprows=0,
             keep_default_na=False,
-            lineterminator="\n",
+            lineterminator=None,
         )
 
         # AND I expect the returned DataFrame to match the expected DataFrame


### PR DESCRIPTION
**Problem:**

In #1127, I added the ability to pass `pandas.read_csv` keyword arguments to `CsvFileTable.asDataFrame` to give users the ability to have more control over the dataframe that was produced (such as determining which values should be treated as NA). An unintended side-effect of this was that users could unintentionally pass a keyword argument that is already set in the code that calls `read_csv` in `_csv_to_pandas_df`, causing an error like this one:
```
    446 # "ValueError: Only length-1 line terminators supported"
--> 447 df = pd.read_csv(
    448     filepath,
    449     dtype=dtype,
    450     sep=separator,
    451     lineterminator=line_terminator if len(line_terminator) == 1 else None,
    452     quotechar=quote_char,
    453     escapechar=escape_char,
    454     header=0 if contain_headers else None,
    455     skiprows=lines_to_skip,
    456     **kwargs,
    457 )
    458 # parse date columns if exists
    459 if date_columns:

TypeError: pandas.io.parsers.readers.read_csv() got multiple values for keyword argument 'sep'
```

**Solution:**

Add logic to `_csv_to_pandas_df` which creates a keyword arguments dictionary which is then updated to resolve any conflicts while giving precedence to the arguments passed intentionally by the user.

**Testing:**

- Tested that the change behaves as expected (works with duplicate keyword arguments) using this script:
```
import synapseclient
from synapseclient.table import CsvFileTable

syn = synapseclient.Synapse()
syn.login()

import pandas as pd

data = {
    'id': ['1', '2', '3', '4', '5'],
    'test_num': ['1', '2', '3', '4', '5'],
}

test_df = pd.DataFrame(data)
schema = synapseclient.table.Schema(
    name="test_table",
    parent="syn59478569",
    column_names=["id", "version"],
    column_types=["STRING", "STRING"],
)

test_table = CsvFileTable.from_data_frame(df=test_df, schema=schema)

# Data should be read in as expected without errors

test_table_df_sep = test_table.asDataFrame(sep=",")
test_table_df_sep.to_csv("test_table_with_sep.csv", index=False)

test_table_df_quote_char = test_table.asDataFrame(quotechar='"')
test_table_df_quote_char.to_csv("test_table_with_quote_char.csv", index=False)
```
- Added unit tests for `_csv_to_pandas_df`. Previously there were none.
