### PR TITLE
[SYNPY-1513] Validate input submission ID in `getSubmission(...)`

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -4812,10 +4812,11 @@ class Synapse(object):
         self, id: typing.Union[str, int, collections.abc.Mapping], **kwargs
     ) -> Submission:
         """
-        Gets a [synapseclient.evaluation.Submission][] object by its id.
+        Gets a [synapseclient.evaluation.Submission][] object based on a given ID
+        or previous [synapseclient.evaluation.Submission][] object.
 
         Arguments:
-            id: The id of the submission to retrieve
+            id: The ID of the submission to retrieve or a [synapseclient.evaluation.Submission][] object
 
         Returns:
             A [synapseclient.evaluation.Submission][] object
@@ -4856,13 +4857,13 @@ class Synapse(object):
         return submission
 
     def getSubmissionStatus(
-        self, submission: typing.Union[str, int]
+        self, submission: typing.Union[str, int, collections.abc.Mapping]
     ) -> SubmissionStatus:
         """
-        Downloads the status of a Submission.
+        Downloads the status of a Submission given its ID or previous [synapseclient.evaluation.Submission][] object.
 
         Arguments:
-            submission: The submission to lookup
+            submission: The submission to lookup (ID or [synapseclient.evaluation.Submission][] object)
 
         Returns:
             A [synapseclient.evaluation.SubmissionStatus][] object

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -4808,7 +4808,9 @@ class Synapse(object):
             if next_page_token is None:
                 break
 
-    def getSubmission(self, id: typing.Union[str, int], **kwargs) -> Submission:
+    def getSubmission(
+        self, id: typing.Union[str, int, collections.abc.Mapping], **kwargs
+    ) -> Submission:
         """
         Gets a [synapseclient.evaluation.Submission][] object by its id.
 

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -114,6 +114,7 @@ from synapseclient.core.utils import (
     is_integer,
     is_json,
     require_param,
+    validate_submission_id,
 )
 from synapseclient.core.version_check import version_check
 
@@ -4807,7 +4808,7 @@ class Synapse(object):
             if next_page_token is None:
                 break
 
-    def getSubmission(self, id, **kwargs):
+    def getSubmission(self, id: typing.Union[str, int], **kwargs) -> Submission:
         """
         Gets a [synapseclient.evaluation.Submission][] object by its id.
 
@@ -4823,7 +4824,7 @@ class Synapse(object):
              on the *downloadFile*, *downloadLocation*, and *ifcollision* parameters
         """
 
-        submission_id = id_of(id)
+        submission_id = validate_submission_id(id)
         uri = Submission.getURI(submission_id)
         submission = Submission(**self.restGET(uri))
 
@@ -4852,7 +4853,7 @@ class Synapse(object):
 
         return submission
 
-    def getSubmissionStatus(self, submission):
+    def getSubmissionStatus(self, submission: typing.Union[str, int]) -> SubmissionStatus:
         """
         Downloads the status of a Submission.
 
@@ -4863,7 +4864,7 @@ class Synapse(object):
             A [synapseclient.evaluation.SubmissionStatus][] object
         """
 
-        submission_id = id_of(submission)
+        submission_id = validate_submission_id(submission)
         uri = SubmissionStatus.getURI(submission_id)
         val = self.restGET(uri)
         return SubmissionStatus(**val)

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -4853,7 +4853,9 @@ class Synapse(object):
 
         return submission
 
-    def getSubmissionStatus(self, submission: typing.Union[str, int]) -> SubmissionStatus:
+    def getSubmissionStatus(
+        self, submission: typing.Union[str, int]
+    ) -> SubmissionStatus:
         """
         Downloads the status of a Submission.
 

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -242,6 +242,32 @@ def id_of(obj: typing.Union[str, collections.abc.Mapping, numbers.Number]) -> st
     raise ValueError("Invalid parameters: couldn't find id of " + str(obj))
 
 
+def validate_submission_id(submission_id: typing.Union[str, int]) -> str:
+    """
+    Ensures that a given submission ID is either an integer or a string that
+    can be converted to an integer. Version notation is not supported for submission
+    IDs, therefore decimals are not allowed.
+
+    Arguments:
+        submission_id: The submission ID to validate
+
+    Returns:
+        The submission ID as a string
+
+    Raises:
+        ValueError: if the submission ID is invalid
+
+    """
+    if isinstance(submission_id, int):
+        return str(submission_id)
+    elif isinstance(submission_id, str) and submission_id.isdigit():
+        return submission_id
+    else:
+        raise ValueError(
+            f"Invalid submission ID: {submission_id}. ID can either be an integer or a string with no decimals."
+        )
+
+
 def concrete_type_of(obj: collections.abc.Mapping):
     """
     Return the concrete type of an object representing a Synapse entity.

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -53,7 +53,6 @@ SLASH_PREFIX_REGEX = re.compile(r"\/[A-Za-z]:")
 # Set up logging
 LOGGER_NAME = DEFAULT_LOGGER_NAME
 LOGGER = logging.getLogger(LOGGER_NAME)
-logging.getLogger("py.warnings").handlers = LOGGER.handlers
 
 
 def md5_for_file(

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -272,7 +272,7 @@ def validate_submission_id(
     elif isinstance(submission_id, collections.abc.Mapping):
         syn_id = _get_from_members_items_or_properties(submission_id, "id")
         if syn_id is not None:
-            return str((float(syn_id)))
+            return validate_submission_id(syn_id)
     else:
         int_submission_id = int(float(submission_id))
         LOGGER.warning(

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -274,7 +274,12 @@ def validate_submission_id(
         if syn_id is not None:
             return validate_submission_id(syn_id)
     else:
-        int_submission_id = int(float(submission_id))
+        try:
+            int_submission_id = int(float(submission_id))
+        except ValueError:
+            raise ValueError(
+                f"Submission ID '{submission_id}' is not a valid submission ID. Please use digits only."
+            )
         LOGGER.warning(
             f"Submission ID '{submission_id}' contains decimals which are not supported. "
             f"Submission ID will be converted to '{int_submission_id}'."

--- a/tests/integration/synapseclient/test_evaluations.py
+++ b/tests/integration/synapseclient/test_evaluations.py
@@ -66,7 +66,7 @@ async def test_evaluations(syn: Synapse, project: Project):
             assert p in permissions
 
         # Test getSubmissions with no Submissions (SYNR-453)
-        submissions = syn.getSubmissions(ev)
+        submissions = syn.getSubmissions(ev.get("id"))
         assert len(list(submissions)) == 0
 
         # Increase this to fully test paging by getEvaluationSubmissions
@@ -107,10 +107,10 @@ async def test_evaluations(syn: Synapse, project: Project):
         ]
 
         # Score the submissions
-        submissions = syn.getSubmissions(ev, limit=num_of_submissions - 1)
+        submissions = syn.getSubmissions(ev.get("id"), limit=num_of_submissions - 1)
         for submission in submissions:
             assert re.match("Submission \\d+", submission["name"])
-            status = syn.getSubmissionStatus(submission)
+            status = syn.getSubmissionStatus(submission.get("id"))
             if submission["name"] == "Submission 01":
                 status.status = "INVALID"
             else:
@@ -119,7 +119,7 @@ async def test_evaluations(syn: Synapse, project: Project):
 
         # Annotate the submissions
         bogosity = {}
-        submissions = syn.getSubmissions(ev)
+        submissions = syn.getSubmissions(ev.get("id"))
         b = 123
         for submission, status in syn.getSubmissionBundles(ev):
             bogosity[submission.id] = b

--- a/tests/integration/synapseclient/test_evaluations.py
+++ b/tests/integration/synapseclient/test_evaluations.py
@@ -110,7 +110,7 @@ async def test_evaluations(syn: Synapse, project: Project):
         submissions = syn.getSubmissions(ev, limit=num_of_submissions - 1)
         for submission in submissions:
             assert re.match("Submission \\d+", submission["name"])
-            status = syn.getSubmissionStatus(submission.get("id"))
+            status = syn.getSubmissionStatus(submission)
             if submission["name"] == "Submission 01":
                 status.status = "INVALID"
             else:

--- a/tests/integration/synapseclient/test_evaluations.py
+++ b/tests/integration/synapseclient/test_evaluations.py
@@ -66,7 +66,7 @@ async def test_evaluations(syn: Synapse, project: Project):
             assert p in permissions
 
         # Test getSubmissions with no Submissions (SYNR-453)
-        submissions = syn.getSubmissions(ev.get("id"))
+        submissions = syn.getSubmissions(ev)
         assert len(list(submissions)) == 0
 
         # Increase this to fully test paging by getEvaluationSubmissions
@@ -107,7 +107,7 @@ async def test_evaluations(syn: Synapse, project: Project):
         ]
 
         # Score the submissions
-        submissions = syn.getSubmissions(ev.get("id"), limit=num_of_submissions - 1)
+        submissions = syn.getSubmissions(ev, limit=num_of_submissions - 1)
         for submission in submissions:
             assert re.match("Submission \\d+", submission["name"])
             status = syn.getSubmissionStatus(submission.get("id"))
@@ -119,7 +119,7 @@ async def test_evaluations(syn: Synapse, project: Project):
 
         # Annotate the submissions
         bogosity = {}
-        submissions = syn.getSubmissions(ev.get("id"))
+        submissions = syn.getSubmissions(ev)
         b = 123
         for submission, status in syn.getSubmissionBundles(ev):
             bogosity[submission.id] = b

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -105,14 +105,20 @@ def test_validate_submission_id(caplog) -> None:
     # Test 1: Test valid inputs
     assert utils.validate_submission_id("123") == "123"
     assert utils.validate_submission_id(123) == "123"
-    
+
     # Test 2: Test invalid inputs get corrected
     with caplog.at_level(logging.WARNING):
         assert utils.validate_submission_id("123.0") == "123"
-        assert "Submission ID '123.0' contains decimals which are not supported" in caplog.text
+        assert (
+            "Submission ID '123.0' contains decimals which are not supported"
+            in caplog.text
+        )
     with caplog.at_level(logging.WARNING):
         assert utils.validate_submission_id(123.0) == "123"
-        assert "Submission ID '123.0' contains decimals which are not supported" in caplog.text
+        assert (
+            "Submission ID '123.0' contains decimals which are not supported"
+            in caplog.text
+        )
 
 
 # TODO: Add a test for is_synapse_id_str(...)

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -135,6 +135,15 @@ def test_validate_submission_id(input_value, expected_output, expected_warning, 
             assert not caplog.text
 
 
+def test_validate_submission_id_letters_input() -> None:
+    letters_input = "syn123"
+    expected_error = f"Submission ID '{letters_input}' is not a valid submission ID. Please use digits only."
+    with pytest.raises(ValueError) as err:
+        utils.validate_submission_id(letters_input)
+
+    assert str(err.value) == expected_error
+
+
 # TODO: Add a test for is_synapse_id_str(...)
 # https://sagebionetworks.jira.com/browse/SYNPY-1425
 

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -108,12 +108,23 @@ def test_id_of() -> None:
         ("123", "123", None),
         (123, "123", None),
         ({"id": "222"}, "222", None),
-
         # Test 2: Invalid inputs that should be corrected
-        ("123.0", "123", "Submission ID '123.0' contains decimals which are not supported"),
-        (123.0, "123", "Submission ID '123.0' contains decimals which are not supported"),
-        ({"id": "999.222"}, "999", "Submission ID '999.222' contains decimals which are not supported"),
-    ]
+        (
+            "123.0",
+            "123",
+            "Submission ID '123.0' contains decimals which are not supported",
+        ),
+        (
+            123.0,
+            "123",
+            "Submission ID '123.0' contains decimals which are not supported",
+        ),
+        (
+            {"id": "999.222"},
+            "999",
+            "Submission ID '999.222' contains decimals which are not supported",
+        ),
+    ],
 )
 def test_validate_submission_id(input_value, expected_output, expected_warning, caplog):
     with caplog.at_level(logging.WARNING):
@@ -122,6 +133,7 @@ def test_validate_submission_id(input_value, expected_output, expected_warning, 
             assert expected_warning in caplog.text
         else:
             assert not caplog.text
+
 
 # TODO: Add a test for is_synapse_id_str(...)
 # https://sagebionetworks.jira.com/browse/SYNPY-1425

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -1,6 +1,7 @@
 # unit tests for utils.py
 
 import base64
+import logging
 import os
 import re
 import tempfile
@@ -100,11 +101,18 @@ def test_id_of() -> None:
         assert utils.id_of(foo) == "123"
 
 
-def test_validate_submission_id() -> None:
+def test_validate_submission_id(caplog) -> None:
+    # Test 1: Test valid inputs
     assert utils.validate_submission_id("123") == "123"
     assert utils.validate_submission_id(123) == "123"
-    pytest.raises(ValueError, utils.validate_submission_id, "123.0")
-    pytest.raises(ValueError, utils.validate_submission_id, 123.0)
+    
+    # Test 2: Test invalid inputs get corrected
+    with caplog.at_level(logging.WARNING):
+        assert utils.validate_submission_id("123.0") == "123"
+        assert "Submission ID '123.0' contains decimals which are not supported" in caplog.text
+    with caplog.at_level(logging.WARNING):
+        assert utils.validate_submission_id(123.0) == "123"
+        assert "Submission ID '123.0' contains decimals which are not supported" in caplog.text
 
 
 # TODO: Add a test for is_synapse_id_str(...)

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -101,25 +101,27 @@ def test_id_of() -> None:
         assert utils.id_of(foo) == "123"
 
 
-def test_validate_submission_id(caplog) -> None:
-    # Test 1: Test valid inputs
-    assert utils.validate_submission_id("123") == "123"
-    assert utils.validate_submission_id(123) == "123"
+@pytest.mark.parametrize(
+    "input_value, expected_output, expected_warning",
+    [
+        # Test 1: Valid inputs
+        ("123", "123", None),
+        (123, "123", None),
+        ({"id": "222"}, "222", None),
 
-    # Test 2: Test invalid inputs get corrected
+        # Test 2: Invalid inputs that should be corrected
+        ("123.0", "123", "Submission ID '123.0' contains decimals which are not supported"),
+        (123.0, "123", "Submission ID '123.0' contains decimals which are not supported"),
+        ({"id": "999.222"}, "999", "Submission ID '999.222' contains decimals which are not supported"),
+    ]
+)
+def test_validate_submission_id(input_value, expected_output, expected_warning, caplog):
     with caplog.at_level(logging.WARNING):
-        assert utils.validate_submission_id("123.0") == "123"
-        assert (
-            "Submission ID '123.0' contains decimals which are not supported"
-            in caplog.text
-        )
-    with caplog.at_level(logging.WARNING):
-        assert utils.validate_submission_id(123.0) == "123"
-        assert (
-            "Submission ID '123.0' contains decimals which are not supported"
-            in caplog.text
-        )
-
+        assert utils.validate_submission_id(input_value) == expected_output
+        if expected_warning:
+            assert expected_warning in caplog.text
+        else:
+            assert not caplog.text
 
 # TODO: Add a test for is_synapse_id_str(...)
 # https://sagebionetworks.jira.com/browse/SYNPY-1425

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -100,6 +100,13 @@ def test_id_of() -> None:
         assert utils.id_of(foo) == "123"
 
 
+def test_validate_submission_id() -> None:
+    assert utils.validate_submission_id("123") == "123"
+    assert utils.validate_submission_id(123) == "123"
+    pytest.raises(ValueError, utils.validate_submission_id, "123.0")
+    pytest.raises(ValueError, utils.validate_submission_id, 123.0)
+
+
 # TODO: Add a test for is_synapse_id_str(...)
 # https://sagebionetworks.jira.com/browse/SYNPY-1425
 

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -3036,10 +3036,7 @@ def run_submission_test(
         if should_warn:
             with caplog.at_level(logging.WARNING):
                 syn.getSubmission(submission_id)
-                assert (
-                    f"contains decimals which are not supported"
-                    in caplog.text
-                )
+                assert f"contains decimals which are not supported" in caplog.text
         else:
             syn.getSubmission(submission_id)
 
@@ -3051,14 +3048,23 @@ def run_submission_test(
         )
 
 
-@pytest.mark.parametrize("submission_id, expected_id", [("123", "123"), (123, "123"), ({"id": 123}, "123"), ({"id": "123"}, "123")])
+@pytest.mark.parametrize(
+    "submission_id, expected_id",
+    [("123", "123"), (123, "123"), ({"id": 123}, "123"), ({"id": "123"}, "123")],
+)
 def test_get_submission_valid_id(syn: Synapse, submission_id, expected_id) -> None:
     """Test getSubmission with valid submission ID"""
     run_submission_test(syn, submission_id, expected_id)
 
 
 @pytest.mark.parametrize(
-    "submission_id, expected_id", [("123.0", "123"), (123.0, "123"), ({"id": 123.0}, "123"), ({"id": "123.0"}, "123")]
+    "submission_id, expected_id",
+    [
+        ("123.0", "123"),
+        (123.0, "123"),
+        ({"id": 123.0}, "123"),
+        ({"id": "123.0"}, "123"),
+    ],
 )
 def test_get_submission_invalid_id(
     syn: Synapse, submission_id, expected_id, caplog

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -2996,7 +2996,7 @@ def test_get_submission_with_annotations(syn: Synapse) -> None:
         assert evaluation_id == response["evaluationId"]
 
 
-def run_submission_test(
+def run_get_submission_test(
     syn: Synapse,
     submission_id: typing.Union[str, int],
     expected_id: str,
@@ -3054,7 +3054,7 @@ def run_submission_test(
 )
 def test_get_submission_valid_id(syn: Synapse, submission_id, expected_id) -> None:
     """Test getSubmission with valid submission ID"""
-    run_submission_test(syn, submission_id, expected_id)
+    run_get_submission_test(syn, submission_id, expected_id)
 
 
 @pytest.mark.parametrize(
@@ -3070,7 +3070,7 @@ def test_get_submission_invalid_id(
     syn: Synapse, submission_id, expected_id, caplog
 ) -> None:
     """Test getSubmission with invalid submission ID"""
-    run_submission_test(
+    run_get_submission_test(
         syn, submission_id, expected_id, should_warn=True, caplog=caplog
     )
 

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -7,9 +7,9 @@ import json
 import logging
 import os
 import tempfile
+import typing
 import urllib.request as urllib_request
 import uuid
-import typing
 from pathlib import Path
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, call, create_autospec, patch
 
@@ -2996,7 +2996,13 @@ def test_get_submission_with_annotations(syn: Synapse) -> None:
         assert evaluation_id == response["evaluationId"]
 
 
-def run_submission_test(syn: Synapse, submission_id: typing.Union[str, int], expected_id: str, should_warn: bool = False, caplog=None) -> None:
+def run_submission_test(
+    syn: Synapse,
+    submission_id: typing.Union[str, int],
+    expected_id: str,
+    should_warn: bool = False,
+    caplog=None,
+) -> None:
     """
     Common code for test_get_submission_valid_id and test_get_submission_invalid_id.
     Generates a dummy submission dictionary for regression testing, mocks the API calls,
@@ -3022,13 +3028,18 @@ def run_submission_test(syn: Synapse, submission_id: typing.Union[str, int], exp
         "entityBundleJSON": json.dumps({}),
     }
 
-    with patch.object(syn, "restGET") as restGET, patch.object(syn, "_getWithEntityBundle") as get_entity:
+    with patch.object(syn, "restGET") as restGET, patch.object(
+        syn, "_getWithEntityBundle"
+    ) as get_entity:
         restGET.return_value = submission
 
         if should_warn:
             with caplog.at_level(logging.WARNING):
                 syn.getSubmission(submission_id)
-                assert f"Submission ID '{submission_id}' contains decimals which are not supported" in caplog.text
+                assert (
+                    f"Submission ID '{submission_id}' contains decimals which are not supported"
+                    in caplog.text
+                )
         else:
             syn.getSubmission(submission_id)
 
@@ -3042,14 +3053,20 @@ def run_submission_test(syn: Synapse, submission_id: typing.Union[str, int], exp
 
 @pytest.mark.parametrize("submission_id, expected_id", [("123", "123"), (123, "123")])
 def test_get_submission_valid_id(syn: Synapse, submission_id, expected_id) -> None:
-    """ Test getSubmission with valid submission ID """
+    """Test getSubmission with valid submission ID"""
     run_submission_test(syn, submission_id, expected_id)
 
 
-@pytest.mark.parametrize("submission_id, expected_id", [("123.0", "123"), (123.0, "123")])
-def test_get_submission_invalid_id(syn: Synapse, submission_id, expected_id, caplog) -> None:
-    """ Test getSubmission with invalid submission ID """
-    run_submission_test(syn, submission_id, expected_id, should_warn=True, caplog=caplog)
+@pytest.mark.parametrize(
+    "submission_id, expected_id", [("123.0", "123"), (123.0, "123")]
+)
+def test_get_submission_invalid_id(
+    syn: Synapse, submission_id, expected_id, caplog
+) -> None:
+    """Test getSubmission with invalid submission ID"""
+    run_submission_test(
+        syn, submission_id, expected_id, should_warn=True, caplog=caplog
+    )
 
 
 class TestTableSnapshot:

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -3037,7 +3037,7 @@ def run_submission_test(
             with caplog.at_level(logging.WARNING):
                 syn.getSubmission(submission_id)
                 assert (
-                    f"Submission ID '{submission_id}' contains decimals which are not supported"
+                    f"contains decimals which are not supported"
                     in caplog.text
                 )
         else:
@@ -3051,14 +3051,14 @@ def run_submission_test(
         )
 
 
-@pytest.mark.parametrize("submission_id, expected_id", [("123", "123"), (123, "123")])
+@pytest.mark.parametrize("submission_id, expected_id", [("123", "123"), (123, "123"), ({"id": 123}, "123"), ({"id": "123"}, "123")])
 def test_get_submission_valid_id(syn: Synapse, submission_id, expected_id) -> None:
     """Test getSubmission with valid submission ID"""
     run_submission_test(syn, submission_id, expected_id)
 
 
 @pytest.mark.parametrize(
-    "submission_id, expected_id", [("123.0", "123"), (123.0, "123")]
+    "submission_id, expected_id", [("123.0", "123"), (123.0, "123"), ({"id": 123.0}, "123"), ({"id": "123.0"}, "123")]
 )
 def test_get_submission_invalid_id(
     syn: Synapse, submission_id, expected_id, caplog


### PR DESCRIPTION
## problem

The endpoint `evaluation/submission/{id}` was receiving communications with submission IDs that had decimal points in them (e.g. `123.0`). This was obstructing an ingestion process in Snowflake, and should not exist in the first place. Submission IDs are not ID types that support decimal points.

## solution

In `getSubmission(...)` and other related methods in `client.py`, the `id_of(...)` method from `utils.py` is utilized to retrieve a valid entity ID. This method was being used for submission IDs, but was effectively useless, as it would just return the same string object or numbers object (as a string) without verifying its format.

The solution involves creating a separate method called `validate_submission_id` and replacing `id_of` with it, to enforce the no-decimal rule in the input.

- [x] Create `utils.validate_submission_id` to handle decimals in input IDs
- [x] Add/update relevant unit and integration tests

## testing

### Test `getSubmission`
```
In [1]: import synapseclient

In [2]: syn = synapseclient.login()
Welcome, Jenny Medina!

# Testing an expected input in `getSubmission`
In [3]: syn.getSubmission("9745366")
Out[3]: 
{'id': '9745366',
 [ ... ]
 'filePath': None}

# Testing an input with a decimal in `getSubmission`
In [4]: syn.getSubmission("9745366.0")
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[4], line 1
----> 1 syn.getSubmission("9745366.0")

[ ... ]

ValueError: Invalid submission ID: 9745366.0. ID can either be an integer or a string with no decimals.

In [5]: 
```

### Test `getSubmissionStatus`
```
In [5]: syn.getSubmissionStatus("9745366")
Out[5]: 
{'id': '9745366',
[ ... ]
 'statusVersion': 7}

In [6]: syn.getSubmissionStatus("9745366.0")
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[6], line 1
----> 1 syn.getSubmissionStatus("9745366.0")

[ ... ]

ValueError: Invalid submission ID: 9745366.0. ID can either be an integer or a string with no decimals.

In [7]: 
```