### PR TITLE
[SYNPY-1524] Fixes `ghcr-build-and-push-on-develop` and `ghcr-build-and-push-on-release` Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,7 +253,7 @@ jobs:
 
     runs-on: ubuntu-20.04
 
-    if: github.event_name == 'release'
+    # if: github.event_name == 'release'
 
     outputs:
       sdist-package-name: ${{ steps.build-package.outputs.sdist-package-name }}
@@ -462,6 +462,9 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
       - name: Extract Release Version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,7 +253,7 @@ jobs:
 
     runs-on: ubuntu-20.04
 
-    # if: github.event_name == 'release'
+    if: github.event_name == 'release'
 
     outputs:
       sdist-package-name: ${{ steps.build-package.outputs.sdist-package-name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -518,6 +518,9 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Log in to GitHub Container Registry


### PR DESCRIPTION
**Problem:**
When I merged #1134, the `ghcr-build-and-push-on-develop` step of the CI workflow [failed](https://github.com/Sage-Bionetworks/synapsePythonClient/actions/runs/11043502633/job/30677883684). This appears to be because there was no Python version specified for this workflow step and the Actions runner defaulted to 3.8 which prevented `synapseclient` from being able to be installed.

**Solution:**
I added steps to specify the Python version for both `ghcr-build-and-push-on-develop` and `ghcr-build-and-push-on-release` which shoule hopefully allow the workflow to work for both types of GHCR publishing.

**Testing:**
It is difficult to test these changes because these CI workflow steps are only triggered on release (or push to `develop`) and I don't really want to force a fake release for this fix.
