### PR TITLE
[SYNPY-1524] Updates `Dockerfile`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,7 +253,7 @@ jobs:
 
     runs-on: ubuntu-20.04
 
-    if: github.event_name == 'release'
+    # if: github.event_name == 'release'
 
     outputs:
       sdist-package-name: ${{ steps.build-package.outputs.sdist-package-name }}
@@ -462,6 +462,9 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
       - name: Extract Release Version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -462,9 +462,6 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
       - name: Extract Release Version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
         shell: bash
@@ -515,12 +512,10 @@ jobs:
       contents: read
       packages: write
 
+
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -512,7 +512,6 @@ jobs:
       contents: read
       packages: write
 
-
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -462,9 +462,6 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
       - name: Extract Release Version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
         shell: bash
@@ -518,9 +515,6 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,7 +253,7 @@ jobs:
 
     runs-on: ubuntu-20.04
 
-    # if: github.event_name == 'release'
+    if: github.event_name == 'release'
 
     outputs:
       sdist-package-name: ${{ steps.build-package.outputs.sdist-package-name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -518,6 +518,9 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Log in to GitHub Container Registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM python:3.9
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.9-slim
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 RUN apt-get update \


### PR DESCRIPTION
I realized after merging #1136  that it was the Python version in the Dockerfile that was causing this error, not the Action runner. I reproduced the [issue](https://github.com/Sage-Bionetworks/synapsePythonClient/actions/runs/11055829020/job/30715915471) by trying to build the container locally and got the same error:
```
Dockerfile:18
--------------------
  16 |     COPY . .
  17 |     
  18 | >>> RUN pip install --no-cache-dir .
  19 |     
  20 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c pip install --no-cache-dir ." did not complete successfully: exit code: 1
```

But, I was able to successfully build the container after switching the base image to `python:3.9-slim` so that the Python version is set before installing the other dependencies.