### PR TITLE
[SYNPY-1522] Add note on lost shared libraries to install instructions for `conda`

### DIFF
--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -2,7 +2,18 @@
 
 By following the instructions below, you are installing the `synapseclient`, `synapseutils` and the command line client.
 
-## PyPI
+## TL;DR For Experts
+1. Set up your Python development environment in your preferred manner (e.g. with `conda`, `pyenv`, etc).
+2. Run
+```
+pip install --upgrade synapseclient
+```
+3. Verify your installation
+```
+pip show synapseclient
+```
+
+## Installation Guide For: PyPI Users
 
 The [synapseclient](https://pypi.python.org/pypi/synapseclient/) package is available from PyPI. It can be installed or upgraded with pip. Due to the nature of Python, we highly recommend you set up your python environment with [conda](https://www.anaconda.com/products/distribution) or [pyenv](https://github.com/pyenv/pyenv) and create virtual environments to control your Python dependencies for your work.
 
@@ -19,6 +30,14 @@ pip install --upgrade synapseclient
 pip install --upgrade "synapseclient[pandas]"
 pip install --upgrade "synapseclient[pandas, pysftp, boto3]"
 ```
+
+> **NOTE** <br>
+> The `synapseclient` package may require loading shared libraries located in your system's `/usr/local/lib` directory. Some users working
+with `conda` have experienced issues with shared libraries not being found due to the system searching in the wrong locations. Although
+not recommended, one solution for this is manually configuring the `LD_LIBRARY_PATH` environment variable to point
+to the `/usr/local/lib` directory. [See here](https://github.com/conda/conda/issues/12800) for more context on this solution, and for alternatives.
+
+----
 
 - pyenv: Use [virtualenv](https://virtualenv.pypa.io/en/latest/) to manage your python environment:
 
@@ -42,7 +61,7 @@ python3 -m pip3 install --upgrade "synapseclient[pandas, pysftp, boto3]"
 
 The dependencies on pandas, pysftp, and boto3 are optional. The Synapse `synapseclient.table` feature integrates with Pandas. Support for sftp is required for users of SFTP file storage. Both require native libraries to be compiled or installed separately from prebuilt binaries.
 
-## Local
+## Installation Guide For: Git Users
 
 Source code and development versions are [available on Github](https://github.com/Sage-Bionetworks/synapsePythonClient). Installing from source:
 


### PR DESCRIPTION
## problem

A `conda` user reported issues with `synapseclient` not working until `LD_LIBRARY_PATH` was specified on their system.

## solution

- [x] Update the Installation Guide with a note on this issue and a resource for solving it
- [x] Added a TL;DR section to follow a similar structure to Streamlit's [Installation Guide ](https://docs.streamlit.io/get-started/installation)

## testing & preview

I re-compiled the docs to preview what this change will look like on the website

<img width="803" alt="image" src="https://github.com/user-attachments/assets/c8d0b50b-6bcc-4376-8b25-327d8acd050c">
