### PR TITLE
[SYNPY-1533] Lower the HTTPX connection limit to 5

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -335,7 +335,7 @@ class Synapse(object):
 
         httpx_timeout = httpx.Timeout(70, pool=None)
         self._requests_session_storage = requests_session_storage or httpx.Client(
-            timeout=httpx_timeout
+            limits=httpx.Limits(max_connections=5), timeout=httpx_timeout
         )
 
         cache_root_dir = (
@@ -427,7 +427,7 @@ class Synapse(object):
         self._requests_session_async_synapse.update(
             {
                 asyncio_event_loop: httpx.AsyncClient(
-                    limits=httpx.Limits(max_connections=25),
+                    limits=httpx.Limits(max_connections=5),
                     timeout=httpx_timeout,
                 )
             }


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/SYNPY-1533

Problem:

1. Found in this service desk ticket: https://sagebionetworks.jira.com/browse/SYNSD-1233 a collaborator was having issues uploading files for connection/read failures during the upload process.
2. The default HTTPX library max_connections is 100, for non-storage operations I originally lowered this to 25 as I found this to not affect any performed. This has been further lowered to 5.

Solution:

1. Lower max_connections to 5 for both storage operations (Like connecting to S3) and Synapse operations (REST API servers)

Testing:

1. We will need to test on a flaky connection as well as re-run a portion of the download/upload benchmarking to assess performance of the change.