### PR TITLE
[FDS-2458] Attach the user.id of the logged in user to the trace span

### DIFF
--- a/synapseclient/core/credentials/credential_provider.py
+++ b/synapseclient/core/credentials/credential_provider.py
@@ -7,6 +7,8 @@ import abc
 import os
 from typing import TYPE_CHECKING, Dict, Tuple, Union
 
+from opentelemetry import trace
+
 from synapseclient.api import get_config_authentication
 from synapseclient.core.credentials.cred_data import (
     SynapseAuthTokenCredentials,
@@ -92,6 +94,9 @@ class SynapseCredentialsProvider(metaclass=abc.ABCMeta):
             credentials.username = profile_username
             credentials.displayname = profile_displayname
             credentials.owner_id = profile.get("ownerId", None)
+            current_span = trace.get_current_span()
+            if current_span.is_recording():
+                current_span.set_attribute("user.id", syn.credentials.owner_id)
 
             return credentials
 

--- a/synapseclient/core/credentials/credential_provider.py
+++ b/synapseclient/core/credentials/credential_provider.py
@@ -96,7 +96,7 @@ class SynapseCredentialsProvider(metaclass=abc.ABCMeta):
             credentials.owner_id = profile.get("ownerId", None)
             current_span = trace.get_current_span()
             if current_span.is_recording():
-                current_span.set_attribute("user.id", syn.credentials.owner_id)
+                current_span.set_attribute("user.id", credentials.owner_id)
 
             return credentials
 


### PR DESCRIPTION
**Problem:**

1. When the user ID is retrieved the data is not added to any trace, by providing this information we can use telemetry data to track a user action in the data.

**Solution:**

1. When the credentials are retrieved attach the user.id if the span is being recorded.

**Testing:**

1. I verified that the data is being passed along as expected:

![image](https://github.com/user-attachments/assets/9b49a810-45a7-4223-aaa6-f59c8ffb3deb)
