### PR TITLE
Update misaligned script

### DIFF
--- a/docs/tutorials/python/download_data_in_bulk.md
+++ b/docs/tutorials/python/download_data_in_bulk.md
@@ -43,17 +43,17 @@ another desired directory exists.
 
 #### First let's set up some constants we'll use in this script
 ```python
-{!docs/tutorials/python/tutorial_scripts/download_data_in_bulk.py!lines=5-20}
+{!docs/tutorials/python/tutorial_scripts/download_data_in_bulk.py!lines=5-19}
 ```
 
 #### Next we'll create an instance of the Project we are going to sync
 ```python
-{!docs/tutorials/python/tutorial_scripts/download_data_in_bulk.py!lines=23}
+{!docs/tutorials/python/tutorial_scripts/download_data_in_bulk.py!lines=20-22}
 ```
 
 #### Finally we'll sync the project from synapse to your local machine
 ```python
-{!docs/tutorials/python/tutorial_scripts/download_data_in_bulk.py!lines=25-30}
+{!docs/tutorials/python/tutorial_scripts/download_data_in_bulk.py!lines=23-28}
 ```
 
 <details class="example">
@@ -84,7 +84,7 @@ Downloading  [####################]100.00%   4.0bytes/4.0bytes (1.6kB/s) fileD.t
 Following the same set of steps let's sync a specific folder
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/download_data_in_bulk.py!lines=33-37}
+{!docs/tutorials/python/tutorial_scripts/download_data_in_bulk.py!lines=30-36}
 ```
 
 <details class="example">
@@ -109,7 +109,7 @@ Using `sync_from_synapse` will load into memory the state of all Folders and Fil
 retrieved from Synapse. This will allow you to loop over the contents of your container.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/download_data_in_bulk.py!lines=40-47}
+{!docs/tutorials/python/tutorial_scripts/download_data_in_bulk.py!lines=37-47}
 ```
 
 <details class="example">


### PR DESCRIPTION
## Problem

The live documentation site was pointing to incorrect sections of the tutorial script

## Solution

Fix that
<img width="654" alt="image" src="https://github.com/user-attachments/assets/131b6ab8-580d-40d2-aeb3-b1bd34f09dd6">
<img width="663" alt="image" src="https://github.com/user-attachments/assets/6d42ced4-3900-48da-bf8e-67565996cc23">
<img width="647" alt="image" src="https://github.com/user-attachments/assets/613dc147-8e26-4720-872b-538ed05657a2">
