### PR TITLE
Add procps to Dockerfile to enable use of container in Nextflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     gcc \
+    procps \
     python3-dev \
     python3-setuptools \
     python3-pip \


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile`. The change adds the `procps` package to the list of installed packages. `ps` from `procps` is required by Nextflow. There are many use cases where having auto-built, latest version of synapsePythonClient in a Docker container will be valuable for users.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R7): Added `procps` to the list of installed packages.