### PR TITLE
[SYNPY-1551] Tables refactor

### DIFF
--- a/docs/reference/oop/table_refactor.md
+++ b/docs/reference/oop/table_refactor.md
@@ -1,0 +1,30 @@
+Contained within this file are proposed changes for interacting with Tables via this
+client.
+
+
+
+::: synapseclient.models.Table
+    options:
+        inherited_members: true
+        members:
+        - get
+        - store
+        - delete
+        - query
+        - store_rows
+        - delete_rows
+        - delete_column
+        - add_column
+        - reorder_column
+        - set_columns
+        - get_permissions
+        - get_acl
+        - set_permissions
+
+::: synapseclient.models.FacetType
+::: synapseclient.models.ColumnType
+::: synapseclient.models.table.JsonSubColumn
+
+::: synapseclient.models.Column
+    options:
+        members:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,8 +75,9 @@ nav:
       - Core: reference/core.md
       - REST Apis: reference/rest_apis.md
       - Experimental:
-          - Object-Orientated Models: reference/oop/models.md
-          - Async Object-Orientated Models: reference/oop/models_async.md
+        - Object-Orientated Models: reference/oop/models.md
+        - Async Object-Orientated Models: reference/oop/models_async.md
+        - Table refactor: reference/oop/table_refactor.md
   - Further Reading:
       - Home: explanations/home.md
       - Domain Models of Synapse: explanations/domain_models_of_synapse.md
@@ -120,6 +121,8 @@ theme:
     - toc.follow
     - navigation.tabs
     - navigation.tabs.sticky
+    - navigation.instant
+    - navigation.instant.progress
 
 extra_css:
   - css/custom.css

--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -38,6 +38,7 @@ from .file_services import (
     put_file_multipart_add,
     put_file_multipart_complete,
 )
+from .table_services import get_columns
 
 __all__ = [
     # annotations
@@ -78,4 +79,6 @@ __all__ = [
     "get_transfer_config",
     # entity_factory
     "get_from_entity_factory",
+    # columns
+    "get_columns",
 ]

--- a/synapseclient/api/table_services.py
+++ b/synapseclient/api/table_services.py
@@ -1,0 +1,93 @@
+"""
+The purpose of this module is to provide any functions that are needed to interact with
+columns in the Synapse REST API.
+"""
+
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from synapseclient import Synapse
+    from synapseclient.models import Column
+
+
+async def get_columns(
+    table_id: str,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> List["Column"]:
+    """Call to synapse and set the annotations for the given input.
+
+    Arguments:
+        table_id: The ID of the Table to get the columns for.
+        synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+    Returns: The annotations set in Synapse.
+    """
+    from synapseclient import Synapse
+    from synapseclient.models import Column
+
+    result = await Synapse.get_client(synapse_client=synapse_client).rest_get_async(
+        f"/entity/{table_id}/column",
+    )
+
+    columns = []
+
+    for column in result.get("results", []):
+        columns.append(Column().fill_from_dict(synapse_column=column))
+
+    return columns
+
+
+# TODO: Finish this function, this was copied out of the Synapse class and will be used to implement this API: https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/TableSchemaChangeRequest.html
+# async def table_updates(
+#     self,
+#     table_id: str,
+#     changes: List[dict] = [],
+#     create_snapshot: bool = False,
+#     comment: str = None,
+#     label: str = None,
+#     activity: str = None,
+#     wait: bool = True,
+# ) -> dict:
+#     """
+#     Creates view updates and snapshots
+
+#     Arguments:
+#         table:           The schema of the EntityView or its ID.
+#         changes:         Array of Table changes
+#         create_snapshot: Create snapshot
+#         comment:         Optional snapshot comment.
+#         label:           Optional snapshot label.
+#         activity:        Optional activity ID applied to snapshot version.
+#         wait:            True to wait for async table update to complete
+
+#     Returns:
+#         A Snapshot Response
+#     """
+#     snapshot_options = {
+#         "snapshotComment": comment,
+#         "snapshotLabel": label,
+#         "snapshotActivityId": activity,
+#     }
+#     new_snapshot = {
+#         key: value for key, value in snapshot_options.items() if value is not None
+#     }
+#     table_update_body = {
+#         "changes": changes,
+#         "createSnapshot": create_snapshot,
+#         "snapshotOptions": new_snapshot,
+#     }
+
+#     uri = "/entity/{}/table/transaction/async".format(id_of(table))
+
+#     if wait:
+#         result = self._waitForAsync(uri, table_update_body)
+
+#     else:
+#         result = self.restPOST(
+#             "{}/start".format(uri), body=json.dumps(table_update_body)
+#         )
+
+#     return result

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -34,7 +34,7 @@ from opentelemetry import trace
 from synapseclient.core.logging_setup import DEFAULT_LOGGER_NAME
 
 if TYPE_CHECKING:
-    from synapseclient.models import File, Folder, Project
+    from synapseclient.models import File, Folder, Project, Table
 
 R = TypeVar("R")
 
@@ -1376,10 +1376,10 @@ def delete_none_keys(incoming_object: typing.Dict) -> None:
 
 
 def merge_dataclass_entities(
-    source: typing.Union["Project", "Folder", "File"],
-    destination: typing.Union["Project", "Folder", "File"],
+    source: typing.Union["Project", "Folder", "File", "Table"],
+    destination: typing.Union["Project", "Folder", "File", "Table"],
     fields_to_ignore: typing.List[str] = None,
-) -> typing.Union["Project", "Folder", "File"]:
+) -> typing.Union["Project", "Folder", "File", "Table"]:
     """
     Utility function to merge two dataclass entities together. This is used when we are
     upserting an entity from the Synapse service with the requested changes.

--- a/synapseclient/models/protocols/table_protocol.py
+++ b/synapseclient/models/protocols/table_protocol.py
@@ -1,21 +1,15 @@
 """Protocol for the specific methods of this class that have synchronous counterparts
 generated at runtime."""
 
-from typing import TYPE_CHECKING, List, Optional, Protocol, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Protocol, Union
 
+import pandas as pd
 from typing_extensions import Self
 
 from synapseclient import Synapse
-from synapseclient.table import CsvFileTable as Synapse_CsvFileTable
-from synapseclient.table import TableQueryResult as Synaspe_TableQueryResult
 
 if TYPE_CHECKING:
-    from synapseclient.models.table import (
-        CsvResultFormat,
-        Row,
-        RowsetResultFormat,
-        Table,
-    )
+    from synapseclient.models.table import Table
 
 
 class ColumnSynchronousProtocol(Protocol):
@@ -40,29 +34,40 @@ class TableSynchronousProtocol(Protocol):
     have a synchronous counterpart that may also be called.
     """
 
-    def store_rows_from_csv(
-        self, csv_path: str, *, synapse_client: Optional[Synapse] = None
-    ) -> str:
-        """Takes in a path to a CSV and stores the rows to Synapse.
+    def store(
+        self, dry_run: bool = False, *, synapse_client: Optional[Synapse] = None
+    ) -> Self:
+        """Store non-row information about a table including the columns and annotations.
 
         Arguments:
-            csv_path: The path to the CSV to store.
+            dry_run: If True, will not actually store the table but will return log to
+                the console what would have been stored.
             synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.
 
         Returns:
-            The path to the CSV that was stored.
+            The Table instance stored in synapse.
         """
-        return ""
+        return self
 
-    def delete_rows(
-        self, rows: List["Row"], *, synapse_client: Optional[Synapse] = None
+    def store_rows(
+        self,
+        values: Union[str, List[Dict[str, Any]], Dict[str, Any], pd.DataFrame],
+        *,
+        synapse_client: Optional[Synapse] = None,
     ) -> None:
-        """Delete rows from a table.
+        """
+        Takes in values from the sources defined below and stores the rows to Synapse.
 
         Arguments:
-            rows: The rows to delete.
+            values: Supports storing data from the following sources:
+
+                - A string holding the path to a CSV file
+                - A list of lists (or tuples) where each element is a row
+                - A dictionary where the key is the column name and the value is one or more values. The values will be wrapped into a [Pandas DataFrame](http://pandas.pydata.org/pandas-docs/stable/api.html#dataframe).
+                - A [Pandas DataFrame](http://pandas.pydata.org/pandas-docs/stable/api.html#dataframe)
+
             synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.
@@ -72,23 +77,21 @@ class TableSynchronousProtocol(Protocol):
         """
         return None
 
-    def store_schema(self, *, synapse_client: Optional[Synapse] = None) -> "Table":
-        """Store non-row information about a table including the columns and annotations.
-
-        Arguments:
-            synapse_client: If not passed in and caching was not disabled by
-                `Synapse.allow_client_caching(False)` this will use the last created
-                instance from the Synapse class constructor.
-
-        Returns:
-            The Table instance stored in synapse.
-        """
-        return self
-
-    def get(self, *, synapse_client: Optional[Synapse] = None) -> "Table":
+    def get(
+        self,
+        include_columns: bool = False,
+        include_activity: bool = False,
+        *,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "Table":
         """Get the metadata about the table from synapse.
 
         Arguments:
+            include_columns: If True, will include fully filled column objects in the
+                `.columns` attribute. When False, the columns will not be filled in.
+            include_activity: If True the activity will be included in the file
+                if it exists.
+
             synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.
@@ -98,7 +101,7 @@ class TableSynchronousProtocol(Protocol):
         """
         return self
 
-    def delete(self, *, synapse_client: Optional[Synapse] = None) -> None:
+    def delete_async(self, *, synapse_client: Optional[Synapse] = None) -> None:
         """Delete the table from synapse.
 
         Arguments:
@@ -111,15 +114,14 @@ class TableSynchronousProtocol(Protocol):
         """
         return None
 
-    @classmethod
+    @staticmethod
     def query(
-        cls,
         query: str,
-        result_format: Union["CsvResultFormat", "RowsetResultFormat"] = None,
         *,
         synapse_client: Optional[Synapse] = None,
-    ) -> Union[Synapse_CsvFileTable, Synaspe_TableQueryResult, None]:
-        """Query for data on a table stored in Synapse.
+    ) -> pd.DataFrame:
+        """Query for data on a table stored in Synapse. The results will always be
+        returned as a Pandas DataFrame.
 
         Arguments:
             query: The query to run.
@@ -129,6 +131,6 @@ class TableSynchronousProtocol(Protocol):
                 instance from the Synapse class constructor.
 
         Returns:
-            The results of the query.
+            The results of the query as a Pandas DataFrame.
         """
-        return None
+        return pd.DataFrame()

--- a/synapseclient/models/protocols/table_protocol.py
+++ b/synapseclient/models/protocols/table_protocol.py
@@ -101,7 +101,7 @@ class TableSynchronousProtocol(Protocol):
         """
         return self
 
-    def delete_async(self, *, synapse_client: Optional[Synapse] = None) -> None:
+    def delete(self, *, synapse_client: Optional[Synapse] = None) -> None:
         """Delete the table from synapse.
 
         Arguments:

--- a/synapseclient/models/protocols/table_protocol.py
+++ b/synapseclient/models/protocols/table_protocol.py
@@ -9,7 +9,7 @@ from typing_extensions import Self
 from synapseclient import Synapse
 
 if TYPE_CHECKING:
-    from synapseclient.models.table import Table
+    from synapseclient.models.table import Row, Table
 
 
 class ColumnSynchronousProtocol(Protocol):
@@ -74,6 +74,24 @@ class TableSynchronousProtocol(Protocol):
 
         Returns:
             None
+        """
+        return None
+
+    def delete_rows(
+        self, rows: List["Row"], *, synapse_client: Optional[Synapse] = None
+    ) -> None:
+        """Delete rows from a table.
+
+        Arguments:
+            rows: The rows to delete.
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            None
+
+        # TODO: Add example of how to delete rows
         """
         return None
 

--- a/synapseclient/models/table.py
+++ b/synapseclient/models/table.py
@@ -1098,6 +1098,9 @@ class Table(TableSynchronousProtocol, AccessControllable):
             index: The index to insert the column at. If not passed in the column will
                 be added to the end of the list.
         """
+        if index is not None:
+            raise NotImplementedError("Index is not yet implemented")
+
         if isinstance(column, list):
             for col in column:
                 self.columns[col.name] = col

--- a/synapseclient/models/table.py
+++ b/synapseclient/models/table.py
@@ -1,32 +1,33 @@
 import asyncio
-import os
+import dataclasses
+from collections import OrderedDict
+from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
+import pandas as pd
 from opentelemetry import trace
 
 from synapseclient import Column as Synapse_Column
 from synapseclient import Schema as Synapse_Schema
 from synapseclient import Synapse
 from synapseclient import Table as Synapse_Table
+from synapseclient.api import get_columns
 from synapseclient.core.async_utils import async_to_sync, otel_trace_method
+from synapseclient.core.utils import merge_dataclass_entities
 from synapseclient.models import Activity, Annotations
 from synapseclient.models.mixins.access_control import AccessControllable
 from synapseclient.models.protocols.table_protocol import (
     ColumnSynchronousProtocol,
     TableSynchronousProtocol,
 )
+from synapseclient.models.services.search import get_id
 from synapseclient.models.services.storable_entity_components import (
     store_entity_components,
 )
-from synapseclient.table import CsvFileTable as Synapse_CsvFileTable
-from synapseclient.table import TableQueryResult as Synaspe_TableQueryResult
 from synapseclient.table import delete_rows
-
-# TODO: Have a plug-and-play interface to plugin different dataframes,
-# or perhaps stream a CSV back when querying for data and uploading data
 
 
 class FacetType(str, Enum):
@@ -151,45 +152,6 @@ class ColumnType(str, Enum):
 
 
 @dataclass
-class CsvResultFormat:
-    """CSV result format options."""
-
-    quote_character: Optional[str] = '"'
-    """default double quote"""
-
-    escape_character: Optional[str] = "\\"
-    """default backslash"""
-
-    line_end: Optional[str] = str(os.linesep)
-    """defaults to os.linesep"""
-
-    separator: Optional[str] = ","
-    """defaults to comma"""
-
-    header: Optional[bool] = True
-    """True by default"""
-
-    include_row_id_and_row_version: Optional[bool] = True
-    """True by default"""
-
-    download_location: Optional[str] = None
-    """directory path to download the CSV file to"""
-
-    def to_dict(self):
-        """Converts the CsvResultFormat into a dictionary that can be passed into the synapseclient."""
-        return {
-            "resultsAs": "csv",
-            "quoteCharacter": self.quote_character,
-            "escapeCharacter": self.escape_character,
-            "lineEnd": self.line_end,
-            "separator": self.separator,
-            "header": self.header,
-            "includeRowIdAndRowVersion": self.include_row_id_and_row_version,
-            "downloadLocation": self.download_location,
-        }
-
-
-@dataclass
 class RowsetResultFormat:
     """Rowset result format options."""
 
@@ -253,13 +215,13 @@ class Row:
 class Column(ColumnSynchronousProtocol):
     """A column model contains the metadata of a single column of a table or view."""
 
-    id: str
+    id: Optional[str] = None
     """The immutable ID issued to new columns"""
 
-    name: str
+    name: Optional[str] = None
     """The display name of the column"""
 
-    column_type: ColumnType
+    column_type: Optional[ColumnType] = None
     """The column type determines the type of data that can be stored in a column.
     Switching between types (using a transaction with TableUpdateTransactionRequest
     in the "changes" list) is generally allowed except for switching to "_LIST"
@@ -294,9 +256,9 @@ class Column(ColumnSynchronousProtocol):
 
     def fill_from_dict(self, synapse_column: Synapse_Column) -> "Column":
         """Converts a response from the synapseclient into this dataclass."""
-        self.id = synapse_column.id
-        self.name = synapse_column.name
-        self.column_type = synapse_column.columnType
+        self.id = synapse_column.get("id", None)
+        self.name = synapse_column.get("name", None)
+        self.column_type = synapse_column.get("columnType", None)
         self.facet_type = synapse_column.get("facetType", None)
         self.default_value = synapse_column.get("defaultValue", None)
         self.maximum_size = synapse_column.get("maximumSize", None)
@@ -321,8 +283,8 @@ class Column(ColumnSynchronousProtocol):
         Returns:
             The Column instance stored in synapse.
         """
-        # TODO - We need to add in some validation before the store to verify we have enough
-        # information to store the data
+        # TODO - Update the storage of columns to go through this API: https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/TableSchemaChangeRequest.html
+        # TODO: As of right now since we are not using this API the columns do not maintain the data that is stored in them. This is a limitation of the current implementation.
 
         # Call synapse
         loop = asyncio.get_event_loop()
@@ -353,8 +315,47 @@ class Table(TableSynchronousProtocol, AccessControllable):
             contain: letters, numbers, spaces, underscores, hyphens, periods, plus
             signs, apostrophes, and parentheses
         parent_id: The ID of the Entity that is the parent of this table.
-        columns: The columns of this table.
-        description: The description of this entity. Must be 1000 characters or less.
+        columns: The columns of this table. This is an ordered dictionary where the key is the
+            name of the column and the value is the Column object. When creating a new instance
+            of a Table object you may pass any of the following types as the `columns` argument:
+
+            - A list of Column objects
+            - A dictionary where the key is the name of the column and the value is the Column object
+            - An OrderedDict where the key is the name of the column and the value is the Column object
+
+            After the Table object is created the columns attribute will be an OrderedDict. If
+            you wish to replace the columns after the Table is constructed you may do so by
+            calling the `.set_columns()` method. For example:
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Column, ColumnType, Table
+
+            syn = Synapse()
+            syn.login()
+
+            # Initialize the table with a list of columns
+            table = Table(name="my_table", columns=[Column(name="my_column", column_type=ColumnType.STRING)])
+
+            # Replace the columns with a different list of columns
+            table.set_columns(columns=[Column(name="my_new_column", column_type=ColumnType.STRING)])
+            table.store()
+            ```
+
+
+            The order of the columns will be the order they are stored in Synapse. If you need
+            to reorder the columns the recommended approach is to use the `.reorder_column()`
+            method. Additionally, you may add, and delete columns using the `.add_column()`,
+            and `.delete_column()` methods on your table class instance.
+
+
+            Note that the keys in this dictionary should match the column names as they are in
+            Synapse. However, know that the name attribute of the Column object is used for
+            all interactions with the Synapse API. The OrderedDict key is purely for the usage
+            of this interface. For example, if you wish to rename a column you may do so by
+            changing the name attribute of the Column object. The key in the OrderedDict does
+            not need to be changed. The next time you store the table the column will be updated
+            in Synapse with the new name and the key in the OrderedDict will be updated.
         etag: Synapse employs an Optimistic Concurrency Control (OCC) scheme to handle
             concurrent updates. Since the E-Tag changes every time an entity is updated
             it is used to detect when a client's current representation of an entity is
@@ -367,7 +368,7 @@ class Table(TableSynchronousProtocol, AccessControllable):
         version_number: The version number issued to this version on the object.
         version_label: The version label for this table
         version_comment: The version comment for this table
-        is_latest_version: If this is the latest version of the object.
+        is_latest_version: (Read Only) If this is the latest version of the object.
         is_search_enabled: When creating or updating a table or view specifies if full
             text search should be enabled. Note that enabling full text search might
             slow down the indexing of the table or view.
@@ -383,6 +384,182 @@ class Table(TableSynchronousProtocol, AccessControllable):
             associated with all values in the list. To remove all annotations set this
             to an empty dict `{}` or None and store the entity.
 
+    Example: Create a table with data without specifying columns
+        This API is setup to allow the data to define which columns are created on the
+        Synapse table automatically. The limitation with this behavior is that the
+        columns created will only be of the following types:
+
+        - STRING
+        - LARGETEXT
+        - INTEGER
+        - DOUBLE
+        - BOOLEAN
+        - DATE
+
+        The determination of the column type is based on the data that is passed in
+        using the pandas function `infer_dtype`. If you need a more specific column
+        type, or need to add options to the colums follow the examples below.
+
+            import pandas as pd
+
+            from synapseclient import Synapse
+            from synapseclient.models import Table
+
+            syn = Synapse()
+            syn.login()
+
+            my_data = pd.DataFrame(
+                {
+                    "my_string_column": ["a", "b", "c", "d"],
+                    "my_integer_column": [1, 2, 3, 4],
+                    "my_double_column": [1.0, 2.0, 3.0, 4.0],
+                    "my_boolean_column": [True, False, True, False],
+                }
+            )
+
+            table = Table(
+                name="my_table",
+                parent_id="syn1234",
+            )
+
+            # The call to `store_rows` will also call `.store()` on the table too,
+            # meaning if the table does not exist it will be created.
+            table.store_rows(values=my_data)
+
+            # Prints out the stored data about this specific column
+            print(table.columns["my_string_column"])
+
+    Example: Create a table with a new columns
+        This example shows how you may create a new table with a list of columns.
+
+            from synapseclient import Synapse
+            from synapseclient.models import Column, ColumnType, Table
+
+            syn = Synapse()
+            syn.login()
+
+            columns = [
+                Column(name="my_string_column", column_type=ColumnType.STRING),
+                Column(name="my_integer_column", column_type=ColumnType.INTEGER),
+                Column(name="my_double_column", column_type=ColumnType.DOUBLE),
+                Column(name="my_boolean_column", column_type=ColumnType.BOOLEAN),
+            ]
+
+            table = Table(
+                name="my_table",
+                parent_id="syn1234",
+                columns=columns
+            )
+
+            table.store()
+
+    Example: Rename an existing column
+        This examples shows how you may retrieve a table from synapse, rename a column,
+        and then store the table back in synapse.
+
+            from synapseclient import Synapse
+            from synapseclient.models import Table
+
+            syn = Synapse()
+            syn.login()
+
+            table = Table(
+                name="my_table",
+                parent_id="syn1234",
+            ).get()
+
+            # You may also get the table by id:
+            table = Table(
+                id="syn4567"
+            ).get()
+
+            table.columns["my_old_column"].name = "my_new_column"
+
+            # Before the data is stored in synapse you'll still be able to use the old key to access the column entry
+            print(table.columns["my_old_column"])
+
+            table.store()
+
+            # After the data is stored in synapse you'll be able to use the new key to access the column entry
+            print(table.columns["my_new_column"])
+
+    Example: Replacing all columns with a list of columns
+        Using the `set_columns()` method you may replace all columns in a table with a
+        new list of columns.
+
+            from synapseclient import Synapse
+            from synapseclient.models import Column, ColumnType, Table
+
+            syn = Synapse()
+            syn.login()
+
+            table = Table(
+                id="syn1234"
+            ).get()
+
+            columns = [
+                Column(name="my_string_column", column_type=ColumnType.STRING),
+                Column(name="my_integer_column", column_type=ColumnType.INTEGER),
+                Column(name="my_double_column", column_type=ColumnType.DOUBLE),
+                Column(name="my_boolean_column", column_type=ColumnType.BOOLEAN),
+            ]
+
+            table.set_columns(columns=columns)
+            table.store()
+
+
+    Example: Replacing all columns with a dictionary of columns
+        When specifying a number of columns via a dict setting the `name` attribute
+        on the `Column` object is optional. When it is not specified it will be
+        pulled from the key of the dict.
+
+            from synapseclient import Synapse
+            from synapseclient.models import Column, ColumnType, Table
+
+            syn = Synapse()
+            syn.login()
+
+            columns = {
+                "my_string_column": Column(column_type=ColumnType.STRING),
+                "my_integer_column": Column(column_type=ColumnType.INTEGER),
+                "my_double_column": Column(column_type=ColumnType.DOUBLE),
+                "my_boolean_column": Column(column_type=ColumnType.BOOLEAN),
+            }
+
+            table = Table(
+                name="my_table",
+                parent_id="syn1234",
+                columns=columns
+            )
+
+            table.store()
+
+    Example: Replacing all columns with an OrderedDict of columns
+        When specifying a number of columns via a dict setting the `name` attribute
+        on the `Column` object is optional. When it is not specified it will be
+        pulled from the key of the dict.
+
+            from synapseclient import Synapse
+            from synapseclient.models import Column, ColumnType, Table
+
+            syn = Synapse()
+            syn.login()
+
+            columns = OrderedDict({
+                "my_string_column": Column(column_type=ColumnType.STRING),
+                "my_integer_column": Column(column_type=ColumnType.INTEGER),
+                "my_double_column": Column(column_type=ColumnType.DOUBLE),
+                "my_boolean_column": Column(column_type=ColumnType.BOOLEAN),
+            })
+
+            table = Table(
+                name="my_table",
+                parent_id="syn1234",
+                columns=columns
+            )
+
+            table.store()
+
     """
 
     id: Optional[str] = None
@@ -397,32 +574,76 @@ class Table(TableSynchronousProtocol, AccessControllable):
     parent_id: Optional[str] = None
     """The ID of the Entity that is the parent of this table."""
 
-    columns: Optional[List[Column]] = None
+    columns: Optional[
+        Union[List[Column], OrderedDict[str, Column], Dict[str, Column]]
+    ] = field(default_factory=OrderedDict)
+    """
+    The columns of this table. This is an ordered dictionary where the key is the
+    name of the column and the value is the Column object. When creating a new instance
+    of a Table object you may pass any of the following types as the `columns` argument:
 
-    # TODO: Description doesn't seem to be returned from the API. Look into why.
-    # description: Optional[str] = None
-    # """The description of this entity. Must be 1000 characters or less."""
+    - A list of Column objects
+    - A dictionary where the key is the name of the column and the value is the Column object
+    - An OrderedDict where the key is the name of the column and the value is the Column object
 
-    etag: Optional[str] = None
+    After the Table object is created the columns attribute will be an OrderedDict. If
+    you wish to replace the columns after the Table is constructed you may do so by
+    calling the `.set_columns()` method. For example:
+
+    ```python
+    from synapseclient import Synapse
+    from synapseclient.models import Column, ColumnType, Table
+
+    syn = Synapse()
+    syn.login()
+
+    # Initialize the table with a list of columns
+    table = Table(name="my_table", columns=[Column(name="my_column", column_type=ColumnType.STRING)])
+
+    # Replace the columns with a different list of columns
+    table.set_columns(columns=[Column(name="my_new_column", column_type=ColumnType.STRING)])
+    table.store()
+    ```
+
+
+    The order of the columns will be the order they are stored in Synapse. If you need
+    to reorder the columns the recommended approach is to use the `.reorder_column()`
+    method. Additionally, you may add, and delete columns using the `.add_column()`,
+    and `.delete_column()` methods on your table class instance.
+
+
+    Note that the keys in this dictionary should match the column names as they are in
+    Synapse. However, know that the name attribute of the Column object is used for
+    all interactions with the Synapse API. The OrderedDict key is purely for the usage
+    of this interface. For example, if you wish to rename a column you may do so by
+    changing the name attribute of the Column object. The key in the OrderedDict does
+    not need to be changed. The next time you store the table the column will be updated
+    in Synapse with the new name and the key in the OrderedDict will be updated.
+    """
+
+    # TODO: This is not used at the moment, but will be when swapping to use this api: <https://rest-docs.synapse.org/rest/POST/entity/id/table/transaction/async/start.html>
+    _columns_to_delete: Optional[Dict[str, Column]] = field(default_factory=dict)
+
+    etag: Optional[str] = field(default=None, compare=False)
     """
     Synapse employs an Optimistic Concurrency Control (OCC) scheme to handle
     concurrent updates. Since the E-Tag changes every time an entity is updated it is
     used to detect when a client's current representation of an entity is out-of-date.
     """
 
-    created_on: Optional[str] = None
+    created_on: Optional[str] = field(default=None, compare=False)
     """The date this table was created."""
 
-    created_by: Optional[str] = None
+    created_by: Optional[str] = field(default=None, compare=False)
     """The ID of the user that created this table."""
 
-    modified_on: Optional[str] = None
+    modified_on: Optional[str] = field(default=None, compare=False)
     """The date this table was last modified. In YYYY-MM-DD-Thh:mm:ss.sssZ format"""
 
-    modified_by: Optional[str] = None
+    modified_by: Optional[str] = field(default=None, compare=False)
     """The ID of the user that last modified this table."""
 
-    version_number: Optional[int] = None
+    version_number: Optional[int] = field(default=None, compare=False)
     """The version number issued to this version on the object."""
 
     version_label: Optional[str] = None
@@ -431,15 +652,15 @@ class Table(TableSynchronousProtocol, AccessControllable):
     version_comment: Optional[str] = None
     """The version comment for this table"""
 
-    is_latest_version: Optional[bool] = None
-    """If this is the latest version of the object."""
+    is_latest_version: Optional[bool] = field(default=None, compare=False)
+    """(Read Only) If this is the latest version of the object."""
 
     is_search_enabled: Optional[bool] = None
     """When creating or updating a table or view specifies if full text search
     should be enabled. Note that enabling full text search might slow down the
     indexing of the table or view."""
 
-    activity: Optional[Activity] = None
+    activity: Optional[Activity] = field(default=None, compare=False)
     """The Activity model represents the main record of Provenance in Synapse.  It is
     analygous to the Activity defined in the
     [W3C Specification](https://www.w3.org/TR/prov-n/) on Provenance. Activity cannot
@@ -460,25 +681,98 @@ class Table(TableSynchronousProtocol, AccessControllable):
                 List[datetime],
             ],
         ]
-    ] = field(default_factory=dict)
+    ] = field(default_factory=dict, compare=False)
     """Additional metadata associated with the table. The key is the name of your
     desired annotations. The value is an object containing a list of values
     (use empty list to represent no values for key) and the value type associated with
     all values in the list. To remove all annotations set this to an empty dict `{}`
     or None and store the entity."""
 
+    _last_persistent_instance: Optional["Table"] = field(
+        default=None, repr=False, compare=False
+    )
+    """The last persistent instance of this object. This is used to determine if the
+    object has been changed and needs to be updated in Synapse."""
+
+    @staticmethod
+    def _convert_columns_to_ordered_dict(
+        columns: Union[List[Column], OrderedDict[str, Column], Dict[str, Column], None]
+    ) -> OrderedDict[str, Column]:
+        """Converts the columns attribute to an OrderedDict if it is a list or dict."""
+        if not columns:
+            return OrderedDict()
+
+        if isinstance(columns, list):
+            return OrderedDict((column.name, column) for column in columns)
+        elif isinstance(columns, dict):
+            results = OrderedDict()
+            for key, column in columns.items():
+                if column.name:
+                    results[column.name] = column
+                else:
+                    column.name = key
+                    results[key] = column
+            return results
+        elif isinstance(columns, OrderedDict):
+            results = OrderedDict()
+            for key, column in columns.items():
+                if column.name:
+                    results[column.name] = column
+                else:
+                    column.name = key
+                    results[key] = column
+            return results
+
+        else:
+            raise ValueError("columns must be a list, dict, or OrderedDict")
+
+    def __post_init__(self):
+        """Post initialization of the Table object. This is used to set the columns
+        attribute to an OrderedDict if it is a list or dict."""
+        self.columns = Table._convert_columns_to_ordered_dict(columns=self.columns)
+
+    @property
+    def has_changed(self) -> bool:
+        """Determines if the object has been changed and needs to be updated in Synapse."""
+        return (
+            not self._last_persistent_instance or self._last_persistent_instance != self
+        )
+
+    def _set_last_persistent_instance(self) -> None:
+        """Stash the last time this object interacted with Synapse. This is used to
+        determine if the object has been changed and needs to be updated in Synapse."""
+        del self._last_persistent_instance
+        self._last_persistent_instance = dataclasses.replace(self)
+        self._last_persistent_instance.activity = (
+            dataclasses.replace(self.activity) if self.activity else None
+        )
+        self._last_persistent_instance.columns = (
+            OrderedDict(
+                (key, dataclasses.replace(column))
+                for key, column in self.columns.items()
+            )
+            if self.columns
+            else OrderedDict()
+        )
+        self._last_persistent_instance.annotations = (
+            deepcopy(self.annotations) if self.annotations else {}
+        )
+
     def fill_from_dict(
         self, synapse_table: Synapse_Table, set_annotations: bool = True
     ) -> "Table":
-        """Converts the data coming from the Synapse API into this datamodel.
+        """
+        Converts the data coming from the Synapse API into this datamodel.
 
-        :param synapse_table: The data coming from the Synapse API
+        Arguments:
+            synapse_table: The data coming from the Synapse API
+
+        Returns:
+            The Table object instance.
         """
         self.id = synapse_table.get("id", None)
         self.name = synapse_table.get("name", None)
         self.parent_id = synapse_table.get("parentId", None)
-        # TODO: Description doesn't seem to be returned from the API. Look into why.
-        # self.description = synapse_table.description
         self.etag = synapse_table.get("etag", None)
         self.created_on = synapse_table.get("createdOn", None)
         self.created_by = synapse_table.get("createdBy", None)
@@ -489,45 +783,75 @@ class Table(TableSynchronousProtocol, AccessControllable):
         self.version_comment = synapse_table.get("versionComment", None)
         self.is_latest_version = synapse_table.get("isLatestVersion", None)
         self.is_search_enabled = synapse_table.get("isSearchEnabled", False)
-        self.columns = [
-            Column(id=columnId, name=None, column_type=None)
-            for columnId in synapse_table.get("columnIds", [])
-        ]
+
         if set_annotations:
             self.annotations = Annotations.from_dict(
                 synapse_table.get("annotations", {})
             )
         return self
 
-    @otel_trace_method(
-        method_to_trace_name=lambda _, **kwargs: f"Store_rows_by_csv: {kwargs.get('csv_path', None)}"
-    )
-    async def store_rows_from_csv_async(
-        self, csv_path: str, *, synapse_client: Optional[Synapse] = None
-    ) -> str:
-        """Takes in a path to a CSV and stores the rows to Synapse.
+    # TODO: Finish implementation
+    async def store_rows_async(
+        self,
+        values: Union[str, List[Dict[str, Any]], Dict[str, Any], pd.DataFrame],
+        *,
+        synapse_client: Optional[Synapse] = None,
+    ) -> None:
+        """
+        Takes in values from the sources defined below and stores the rows to Synapse.
 
         Arguments:
-            csv_path: The path to the CSV to store.
+            values: Supports storing data from the following sources:
+
+                - A string holding the path to a CSV file
+                - A list of lists (or tuples) where each element is a row
+                - A dictionary where the key is the column name and the value is one or more values. The values will be wrapped into a [Pandas DataFrame](http://pandas.pydata.org/pandas-docs/stable/api.html#dataframe).
+                - A [Pandas DataFrame](http://pandas.pydata.org/pandas-docs/stable/api.html#dataframe)
+
             synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.
 
         Returns:
-            The path to the CSV that was stored.
+            None
         """
-        synapse_table = Synapse_Table(schema=self.id, values=csv_path)
-        loop = asyncio.get_event_loop()
-        entity = await loop.run_in_executor(
-            None,
-            lambda: Synapse.get_client(synapse_client=synapse_client).store(
-                obj=synapse_table
-            ),
+        client = Synapse.get_client(synapse_client=synapse_client)
+        client.logger.info(
+            f"Checking for changes to the schema of table: {self.name or self.id}"
         )
-        print(entity)
-        # TODO: What should this return?
-        return csv_path
+        await self.store_async(synapse_client=synapse_client)
 
+        client.logger.info(f"Storing rows for table {self.name or self.id}")
+
+        if isinstance(values, (list, tuple)):
+            # Current functionality uses this to convert the values over
+            # return CsvFileTable.from_list_of_rows(schema, values, **kwargs)
+            client.logger.info(f"Storing rows for table {self.name or self.id} as list")
+        elif isinstance(values, str):
+            client.logger.info(
+                f"Storing rows for table {self.name or self.id} as path to CSV"
+            )
+        elif isinstance(values, pd.DataFrame):
+            # Current functionality uses this to convert the values over
+            # return CsvFileTable.from_data_frame(schema, values, **kwargs)
+            client.logger.info(
+                f"Storing rows for table {self.name or self.id} as DataFrame"
+            )
+
+        # dict
+        elif isinstance(values, dict):
+            # Current functionality uses this to convert the values over
+            # return CsvFileTable.from_data_frame(schema, pd.DataFrame(values), **kwargs)
+            client.logger.info(f"Storing rows for table {self.name or self.id} as dict")
+
+        else:
+            raise ValueError(
+                "Don't know how to make tables from values of type %s." % type(values)
+            )
+
+        raise NotImplementedError("This method is not yet implemented")
+
+    # TODO: Refactor this function as it's really rough to work with in it's current implementation
     @otel_trace_method(
         method_to_trace_name=lambda self, **kwargs: f"Delete_rows: {self.name}"
     )
@@ -544,6 +868,8 @@ class Table(TableSynchronousProtocol, AccessControllable):
 
         Returns:
             None
+
+        # TODO: Add example of how to delete rows
         """
         rows_to_delete = []
         for row in rows:
@@ -559,14 +885,16 @@ class Table(TableSynchronousProtocol, AccessControllable):
         )
 
     @otel_trace_method(
-        method_to_trace_name=lambda self, **kwargs: f"Table_Schema_Store: {self.name}"
+        method_to_trace_name=lambda self, **kwargs: f"Table_Store: {self.name}"
     )
-    async def store_schema_async(
-        self, *, synapse_client: Optional[Synapse] = None
+    async def store_async(
+        self, dry_run: bool = False, *, synapse_client: Optional[Synapse] = None
     ) -> "Table":
         """Store non-row information about a table including the columns and annotations.
 
         Arguments:
+            dry_run: If True, will not actually store the table but will return log to
+                the console what would have been stored.
             synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.
@@ -574,70 +902,109 @@ class Table(TableSynchronousProtocol, AccessControllable):
         Returns:
             The Table instance stored in synapse.
         """
-        tasks = []
-        if self.columns:
-            # TODO: When a table is retrieved via `.get()` we create Column objects but
-            # TODO: We only have the ID attribute. THis is causing this if check to eval
-            # TODO: To True, however, we aren't actually modifying the column.
-            # TODO: Perhaps we should have a `has_changed` boolean on all dataclasses
-            # TODO: That we can check to see if we need to store the data.
-            tasks.extend(
-                column.store_async(synapse_client=synapse_client)
-                for column in self.columns
+        client = Synapse.get_client(synapse_client=synapse_client)
+
+        if (
+            (not self._last_persistent_instance)
+            and (
+                existing_id := await get_id(
+                    entity=self, synapse_client=synapse_client, failure_strategy=None
+                )
             )
-            try:
-                results = await asyncio.gather(*tasks, return_exceptions=True)
+            and (
+                existing_entity := await Table(id=existing_id).get_async(
+                    include_columns=True, synapse_client=synapse_client
+                )
+            )
+        ):
+            merge_dataclass_entities(
+                source=existing_entity,
+                destination=self,
+            )
 
-                # TODO: Proper exception handling
-                for result in results:
-                    if isinstance(result, Column):
-                        print(f"Stored {result.name}")
-                    else:
-                        if isinstance(result, BaseException):
-                            raise result
-                        raise ValueError(f"Unknown type: {type(result)}", result)
-            except Exception as ex:
-                Synapse.get_client(synapse_client=synapse_client).logger.exception(ex)
-                print("I hit an exception")
+        if dry_run:
+            client.logger.info(f"Dry run for table {self.name or self.id}")
+            # TODO: Implement and check what columns/attributes are present and differ from what is in Synapse
 
-        synapse_schema = Synapse_Schema(
-            name=self.name,
-            columns=self.columns,
-            parent=self.parent_id,
-        )
-        trace.get_current_span().set_attributes(
-            {
-                "synapse.name": self.name or "",
-                "synapse.id": self.id or "",
-            }
-        )
-        loop = asyncio.get_event_loop()
-        entity = await loop.run_in_executor(
-            None,
-            lambda: Synapse.get_client(synapse_client=synapse_client).store(
-                obj=synapse_schema
-            ),
-        )
+            raise NotImplementedError("This argument is not yet implemented")
 
-        self.fill_from_dict(synapse_table=entity, set_annotations=False)
+        if not self.has_changed:
+            client.logger.info(f"No changes detected for table {self.name or self.id}")
+
+        if self.has_changed:
+            # TODO: Swap the storage of the table to be done in a single transaction via: https://rest-docs.synapse.org/rest/POST/entity/id/table/transaction/async/start.html
+            tasks = []
+            if self.columns:
+                tasks.extend(
+                    column.store_async(synapse_client=synapse_client)
+                    for column in self.columns.values()
+                )
+                try:
+                    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+                    # TODO: Proper exception handling. Similar behavior to the current implementation in File, Folder, Project should be followed
+                    for result in results:
+                        if isinstance(result, Column):
+                            print(f"Stored {result.name}")
+                        else:
+                            if isinstance(result, BaseException):
+                                raise result
+                            raise ValueError(f"Unknown type: {type(result)}", result)
+                except Exception as ex:
+                    Synapse.get_client(synapse_client=synapse_client).logger.exception(
+                        ex
+                    )
+                    print("I hit an exception")
+
+            synapse_schema = Synapse_Schema(
+                name=self.name,
+                columns=self.columns.values(),
+                parent=self.parent_id,
+            )
+            trace.get_current_span().set_attributes(
+                {
+                    "synapse.name": self.name or "",
+                    "synapse.id": self.id or "",
+                }
+            )
+            loop = asyncio.get_event_loop()
+            entity = await loop.run_in_executor(
+                None,
+                lambda: client.store(obj=synapse_schema),
+            )
+
+            self.fill_from_dict(synapse_table=entity, set_annotations=False)
 
         re_read_required = await store_entity_components(
             root_resource=self, synapse_client=synapse_client
         )
         if re_read_required:
             await self.get_async(
+                include_columns=False,
                 synapse_client=synapse_client,
             )
+        self._set_last_persistent_instance()
 
         return self
 
     @otel_trace_method(
         method_to_trace_name=lambda self, **kwargs: f"Table_Get: {self.name}"
     )
-    async def get_async(self, *, synapse_client: Optional[Synapse] = None) -> "Table":
+    async def get_async(
+        self,
+        include_columns: bool = False,
+        include_activity: bool = False,
+        *,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "Table":
         """Get the metadata about the table from synapse.
 
         Arguments:
+            include_columns: If True, will include fully filled column objects in the
+                `.columns` attribute. When False, the columns will not be filled in.
+            include_activity: If True the activity will be included in the file
+                if it exists.
+
             synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.
@@ -645,7 +1012,11 @@ class Table(TableSynchronousProtocol, AccessControllable):
         Returns:
             The Table instance stored in synapse.
         """
-        # TODO: How do we want to support retriving the table? Do we want to support by name, and parent?
+        if not self.id and self.name and self.parent_id:
+            raise NotImplementedError(
+                "This method does not yet support getting by name and parent_id"
+            )
+
         loop = asyncio.get_event_loop()
         entity = await loop.run_in_executor(
             None,
@@ -654,13 +1025,26 @@ class Table(TableSynchronousProtocol, AccessControllable):
             ),
         )
         self.fill_from_dict(synapse_table=entity, set_annotations=True)
+
+        if include_columns:
+            column_instances = await get_columns(
+                table_id=self.id, synapse_client=synapse_client
+            )
+            for column in column_instances:
+                if column.name not in self.columns:
+                    self.columns[column.name] = column
+
+        if include_activity:
+            self.activity = await Activity.from_parent_async(
+                parent=self, synapse_client=synapse_client
+            )
+
+        self._set_last_persistent_instance()
         return self
 
     @otel_trace_method(
         method_to_trace_name=lambda self, **kwargs: f"Table_Delete: {self.name}"
     )
-    # TODO: Synapse allows immediate deletion of entities, but the Synapse Client does not
-    # TODO: Should we support immediate deletion?
     async def delete_async(self, *, synapse_client: Optional[Synapse] = None) -> None:
         """Delete the table from synapse.
 
@@ -680,35 +1064,202 @@ class Table(TableSynchronousProtocol, AccessControllable):
             ),
         )
 
-    @classmethod
+    def delete_column(self, name: str) -> None:
+        """
+        Mark a column for deletion. Note that this does not delete the column from
+        Synapse. You must call the `.store()` function on this table class instance to
+        delete the column from Synapse. This is a convenience function to eliminate
+        the need to manually delete the column from the dictionary and add it to the
+        `._columns_to_delete` attribute.
+
+        Arguments:
+            name: The name of the column to delete.
+        """
+        # TODO: _columns_to_delete is not used at the moment, it will be used when swapping to use this synapse API: <https://rest-docs.synapse.org/rest/POST/entity/id/table/transaction/async/start.html>
+        self._columns_to_delete[name.name] = name
+        self.columns.pop(name.name, None)
+
+    def add_column(
+        self, column: Union[Column, List[Column]], index: int = None
+    ) -> None:
+        """Add column(s) to the table. Note that this does not store the column(s) in
+        Synapse. You must call the `.store()` function on this table class instance to
+        store the column(s) in Synapse. This is a convenience function to eliminate
+        the need to manually add the column(s) to the dictionary.
+
+
+        This function will add an item to the `.columns` attribute of this class
+        instance. `.columns` is a dictionary where the key is the name of the column
+        and the value is the Column object.
+
+        Arguments:
+            column: The column(s) to add, may be a single Column object or a list of
+                Column objects.
+            index: The index to insert the column at. If not passed in the column will
+                be added to the end of the list.
+        """
+        if isinstance(column, list):
+            for col in column:
+                self.columns[col.name] = col
+        else:
+            self.columns[column.name] = column
+
+    def reorder_column(self, name: str, index: int) -> None:
+        """Reorder a column in the table. Note that this does not store the column in
+        Synapse. You must call the `.store()` function on this table class instance to
+        store the column in Synapse. This is a convenience function to eliminate
+        the need to manually reorder the `.columns` attribute dictionary.
+
+        You must ensure that the index is within the bounds of the number of columns in
+        the table. If you pass in an index that is out of bounds the column will be
+        added to the end of the list.
+
+        Arguments:
+            name: The name of the column to reorder.
+            index: The index to move the column to starting with 0.
+        """
+
+        column_to_reorder = self.columns.pop(name, None)
+        if index >= len(self.columns):
+            self.columns[name] = column_to_reorder
+            return self
+
+        self.columns = OrderedDict(
+            list(self.columns.items())[:index]
+            + [(name, column_to_reorder)]
+            + list(self.columns.items())[index:]
+        )
+
+    def set_columns(
+        self, columns: Union[List[Column], OrderedDict[str, Column], Dict[str, Column]]
+    ) -> None:
+        """
+        Helper function to set the columns attribute with a number of columns. This
+        will convert the columns attribute to an OrderedDict if it is a list or dict. It
+        is meant as a convenience function to eliminate the need to manually convert the
+        columns attribute to an OrderedDict ahead of time.
+
+        **Warning**: This will act as a destructive operation if your Table class
+        instance has interacted with Synapse via a `.get()` or `.store()` operation.
+        The columns you pass in will replace all columns in the table with the columns
+        in the list. If you
+
+
+        In order to rename a column you should change the name attribute of the Column
+        object rather than call this function. The next time you store the table the
+        column will be updated in Synapse with the new name and the key in the
+        `.columns` OrderedDict will be updated. See examples on the Table class for
+        more information.
+
+        Arguments:
+            columns: The new columns to replace the existing columns with. This may be:
+
+                - A list of Column objects
+                - A dictionary where the key is the column name and the value is the Column object
+                - An OrderedDict where the key is the column name and the value is the Column object.
+
+        Returns:
+            None
+
+        Example: Replacing all columns with a list of columns
+            .
+
+                from synapseclient import Synapse
+                from synapseclient.models import Column, ColumnType, Table
+
+                syn = Synapse()
+                syn.login()
+
+                table = Table(
+                    id="syn1234"
+                ).get()
+
+                columns = [
+                    Column(name="my_string_column", column_type=ColumnType.STRING),
+                    Column(name="my_integer_column", column_type=ColumnType.INTEGER),
+                    Column(name="my_double_column", column_type=ColumnType.DOUBLE),
+                    Column(name="my_boolean_column", column_type=ColumnType.BOOLEAN),
+                ]
+
+                table.set_columns(columns=columns)
+                table.store()
+
+        Example: Replacing all columns with a dictionary of columns
+            When specifying a number of columns via a dict setting the `name` attribute
+            on the `Column` object is optional. When it is not specified it will be
+            pulled from the key of the dict.
+
+                from synapseclient import Synapse
+                from synapseclient.models import Column, ColumnType, Table
+
+                syn = Synapse()
+                syn.login()
+
+                table = Table(
+                    id="syn1234"
+                ).get()
+
+                columns = {
+                    "my_string_column": Column(column_type=ColumnType.STRING),
+                    "my_integer_column": Column(column_type=ColumnType.INTEGER),
+                    "my_double_column": Column(column_type=ColumnType.DOUBLE),
+                    "my_boolean_column": Column(column_type=ColumnType.BOOLEAN),
+                }
+
+                table.set_columns(columns=columns)
+                table.store()
+
+        Example: Replacing all columns with an OrderedDict of columns
+            .
+
+                from synapseclient import Synapse
+                from synapseclient.models import Column, ColumnType, Table
+
+                syn = Synapse()
+                syn.login()
+
+                table = Table(
+                    id="syn1234"
+                ).get()
+
+                columns = OrderedDict({
+                    "my_string_column": Column(column_type=ColumnType.STRING),
+                    "my_integer_column": Column(column_type=ColumnType.INTEGER),
+                    "my_double_column": Column(column_type=ColumnType.DOUBLE),
+                    "my_boolean_column": Column(column_type=ColumnType.BOOLEAN),
+                })
+
+                table.set_columns(columns=columns)
+                table.store()
+        """
+        if not self._last_persistent_instance:
+            raise ValueError(
+                "This method is only supported after interacting with Synapse via a `.get()` or `.store()` operation"
+            )
+
+        self.columns = Table._convert_columns_to_ordered_dict(columns=columns)
+
+    @staticmethod
     async def query_async(
-        cls,
         query: str,
-        result_format: Union[CsvResultFormat, RowsetResultFormat] = CsvResultFormat(),
         *,
         synapse_client: Optional[Synapse] = None,
-    ) -> Union[Synapse_CsvFileTable, Synaspe_TableQueryResult]:
-        """Query for data on a table stored in Synapse.
+    ) -> pd.DataFrame:
+        """Query for data on a table stored in Synapse. The results will always be
+        returned as a Pandas DataFrame.
 
         Arguments:
             query: The query to run.
-            result_format: The format of the results. Defaults to CsvResultFormat().
             synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.
 
         Returns:
-            The results of the query.
+            The results of the query as a Pandas DataFrame.
         """
-        loop = asyncio.get_event_loop()
-
-        # TODO: Future Idea - We stream back a CSV, and let those reading this to handle the CSV however they want
-        results = await loop.run_in_executor(
-            None,
-            lambda: Synapse.get_client(synapse_client=synapse_client).tableQuery(
-                query=query,
-                **result_format.to_dict(),
-            ),
-        )
-        print(results)
-        return results
+        # TODO: Implement similar logic to synapseclient/table.py::CsvFileTable::from_table_query and what it can handle
+        # It should handle for any of the arguments available there in order to support correctly reading in the CSV
+        # TODO: Additionally - the logic present in synapseclient/table.py::CsvFileTable::asDataFrame should be considered and implemented as well
+        # TODO: Lastly - When a query is executed both single-threaded and multi-threaded downloads of the CSV result should not write a file to disk, instead write the bytes to a BytesIO object and then use that object instead of a filepath
+        # TODO: Also support writing the CSV to disk if the user wants to do that
+        raise NotImplementedError("This method is not yet implemented")


### PR DESCRIPTION
Problem:

1. Working with tables in the current implementation is a difficult task. Many different functions must be strung together to accomplish some tasks, features like renaming columns is missing, and all data must go through a CSV written to disk when interacting with Synapse.

Solution:

1. Start the process of updating the initial Tables OOP model to bring forward a number of changes:

The main functions that exist on the Table to interact with required functionality include:

- store
- store_rows
- get
- delete
- delete_rows
- query

Convenience functions (Functions that smooth out setting attributes, but require a call to `.store()` to persist to Synapse)

- delete_column
- add_column
- reorder_column
- set_columns

1. Once the logic for these functions is nailed down the same ideas may be applied to both `EntityView` and `Dataset` concepts in Synapse. They're similar in concept to a Table, but serve different purposes for users. When we start to implement those 2 models we will be able to extract out common logic and re-use it across all 3 models.

TODO:

- [ ] Get feedback on proposed changes and smooth out rough edges
- [ ] Add additional examples and doc strings to all functions
- [ ] Implement logic to support loading results from Synapse directly into a pandas dataframe (Without requiring the usage of an intermediate CSV file written to disk)
- [ ] Implement querying and returning results via a DataFrame
- [ ] Add verbose integration tests for all logic
- [ ] Add verbose unit tests for all logic
- [ ] Swap the submission of data to Synapse to use a single transaction via this api: https://rest-docs.synapse.org/rest/POST/entity/id/table/transaction/async/start.html
- [ ] Implement a dry-run feature to both `store` and `store_rows` that prints out the changes to the schema that will be applied (Determine if we could do a diff of the data, if it's feasible to implement - If not, do not implement)
- [ ] Factor the `delete_rows` logic, or document the process well. Current behavior requires both a row_id and version_number to delete sourced from query results. As querying for data changed, so will the delete logic.
- [ ] Implement storing of rows for each of the formats we are going to let users submit data: Csv, list of lists, dictionary, pandas dataframe
- [ ] Implement a `_columns_to_delete` concept within the models to prevent unintentional deletion of columns and require that deleting a column go through the `delete_column` function.