### PR TITLE
[SYNPY-1544] Fixes docstring

### DIFF
--- a/synapseclient/models/agent.py
+++ b/synapseclient/models/agent.py
@@ -838,6 +838,9 @@ class Agent(AgentSynchronousProtocol):
 
                 async def main():
                     my_agent = Agent()
+                    await my_agent.start_session_async(
+                        access_level=AgentSessionAccessLevel.WRITE_YOUR_PRIVATE_DATA
+                    )
                     await my_agent.prompt_async(
                         prompt="Add the annotation 'test' to the file 'syn123456789'",
                         enable_trace=True,


### PR DESCRIPTION
This small PR updates an example docstring for the required access level to add annotations to a Synapse entity with a Synapse Agent prompt.