### PR TITLE
Removes example setting annotations with Agent class

### DIFF
--- a/synapseclient/models/agent.py
+++ b/synapseclient/models/agent.py
@@ -199,9 +199,9 @@ class AgentSession(AgentSessionSynchronousProtocol):
     """The unique ID of the agent session.
     Can only be used by the user that created it."""
 
-    access_level: Optional[
-        AgentSessionAccessLevel
-    ] = AgentSessionAccessLevel.PUBLICLY_ACCESSIBLE
+    access_level: Optional[AgentSessionAccessLevel] = (
+        AgentSessionAccessLevel.PUBLICLY_ACCESSIBLE
+    )
     """The access level of the agent session.
         One of PUBLICLY_ACCESSIBLE, READ_YOUR_PRIVATE_DATA, or
         WRITE_YOUR_PRIVATE_DATA. Defaults to PUBLICLY_ACCESSIBLE.
@@ -826,8 +826,8 @@ class Agent(AgentSynchronousProtocol):
                     `Synapse.allow_client_caching(False)` this will use the last created
                     instance from the Synapse class constructor.
 
-        Example: Prompt the baseline Synapse Agent to add annotations to a file on Synapse
-            The baseline Synpase Agent can be used to add annotations to files.
+        Example: Prompt the baseline Synapse Agent.
+            The baseline Synapse Agent is equivilent to the Agent available in the Synapse UI.
 
                 import asyncio
                 from synapseclient import Synapse
@@ -838,11 +838,8 @@ class Agent(AgentSynchronousProtocol):
 
                 async def main():
                     my_agent = Agent()
-                    await my_agent.start_session_async(
-                        access_level=AgentSessionAccessLevel.WRITE_YOUR_PRIVATE_DATA
-                    )
                     await my_agent.prompt_async(
-                        prompt="Add the annotation 'test' to the file 'syn123456789'",
+                        prompt="Can you tell me about the AD Knowledge Portal dataset?",
                         enable_trace=True,
                         print_response=True,
                     )

--- a/synapseclient/models/agent.py
+++ b/synapseclient/models/agent.py
@@ -199,9 +199,9 @@ class AgentSession(AgentSessionSynchronousProtocol):
     """The unique ID of the agent session.
     Can only be used by the user that created it."""
 
-    access_level: Optional[AgentSessionAccessLevel] = (
-        AgentSessionAccessLevel.PUBLICLY_ACCESSIBLE
-    )
+    access_level: Optional[
+        AgentSessionAccessLevel
+    ] = AgentSessionAccessLevel.PUBLICLY_ACCESSIBLE
     """The access level of the agent session.
         One of PUBLICLY_ACCESSIBLE, READ_YOUR_PRIVATE_DATA, or
         WRITE_YOUR_PRIVATE_DATA. Defaults to PUBLICLY_ACCESSIBLE.

--- a/synapseclient/models/protocols/agent_protocol.py
+++ b/synapseclient/models/protocols/agent_protocol.py
@@ -328,21 +328,18 @@ class AgentSynchronousProtocol(Protocol):
                     `Synapse.allow_client_caching(False)` this will use the last created
                     instance from the Synapse class constructor.
 
-        Example: Prompt the baseline Synapse Agent to add annotations to a file on Synapse
-            The baseline Synpase Agent can be used to add annotations to files.
+        Example: Prompt the baseline Synapse Agent.
+            The baseline Synapse Agent is equivilent to the Agent available in the Synapse UI.
 
             from synapseclient import Synapse
-            from synapseclient.models import Agent, AgentSessionAccessLevel
+            from synapseclient.models import Agent
 
             syn = Synapse()
             syn.login()
 
             my_agent = Agent()
-            my_agent.start_session(
-                access_level=AgentSessionAccessLevel.WRITE_YOUR_PRIVATE_DATA
-            )
             my_agent.prompt(
-                prompt="Add the annotation 'test' to the file 'syn123456789'",
+                prompt="Can you tell me about the AD Knowledge Portal dataset?",
                 enable_trace=True,
                 print_response=True,
             )


### PR DESCRIPTION
The feature allowing the Synapse Agent to create annotations has been disabled indefinitely. We should therefore not include this example usage in the `Agent` model.