### PR TITLE
[SYNPY-1544] Return the AgentPrompt when calling the prompt function

### DIFF
--- a/synapseclient/models/agent.py
+++ b/synapseclient/models/agent.py
@@ -384,7 +384,7 @@ class AgentSession(AgentSessionSynchronousProtocol):
         newer_than: Optional[int] = None,
         *,
         synapse_client: Optional[Synapse] = None,
-    ) -> None:
+    ) -> AgentPrompt:
         """Sends a prompt to the agent and adds the response to the AgentSession's
         chat history. A session must be started before sending a prompt.
 
@@ -431,6 +431,7 @@ class AgentSession(AgentSessionSynchronousProtocol):
             client.logger.info(f"RESPONSE:\n{agent_prompt.response}\n")
             if enable_trace:
                 client.logger.info(f"TRACE:\n{agent_prompt.trace}")
+        return agent_prompt
 
 
 @dataclass
@@ -811,7 +812,7 @@ class Agent(AgentSynchronousProtocol):
         newer_than: Optional[int] = None,
         *,
         synapse_client: Optional[Synapse] = None,
-    ) -> None:
+    ) -> AgentPrompt:
         """Sends a prompt to the agent for the current session.
             If no session is currently active, a new session will be started.
 
@@ -908,7 +909,7 @@ class Agent(AgentSynchronousProtocol):
             if not self.current_session:
                 await self.start_session_async(synapse_client=synapse_client)
 
-        await self.current_session.prompt_async(
+        return await self.current_session.prompt_async(
             prompt=prompt,
             enable_trace=enable_trace,
             newer_than=newer_than,

--- a/synapseclient/models/protocols/agent_protocol.py
+++ b/synapseclient/models/protocols/agent_protocol.py
@@ -6,7 +6,12 @@ from typing import TYPE_CHECKING, Optional, Protocol
 from synapseclient import Synapse
 
 if TYPE_CHECKING:
-    from synapseclient.models import Agent, AgentSession, AgentSessionAccessLevel
+    from synapseclient.models import (
+        Agent,
+        AgentPrompt,
+        AgentSession,
+        AgentSessionAccessLevel,
+    )
 
 
 class AgentSessionSynchronousProtocol(Protocol):
@@ -109,7 +114,7 @@ class AgentSessionSynchronousProtocol(Protocol):
         newer_than: Optional[int] = None,
         *,
         synapse_client: Optional[Synapse] = None,
-    ) -> None:
+    ) -> "AgentPrompt":
         """Sends a prompt to the agent and adds the response to the AgentSession's
         chat history. A session must be started before sending a prompt.
 
@@ -140,7 +145,7 @@ class AgentSessionSynchronousProtocol(Protocol):
                     print_response=True,
                 )
         """
-        return None
+        return AgentPrompt()
 
 
 class AgentSynchronousProtocol(Protocol):
@@ -313,7 +318,7 @@ class AgentSynchronousProtocol(Protocol):
         newer_than: Optional[int] = None,
         *,
         synapse_client: Optional[Synapse] = None,
-    ) -> None:
+    ) -> "AgentPrompt":
         """Sends a prompt to the agent for the current session.
             If no session is currently active, a new session will be started.
 
@@ -388,4 +393,4 @@ class AgentSynchronousProtocol(Protocol):
                     session=my_second_session,
                 )
         """
-        return None
+        return AgentPrompt()


### PR DESCRIPTION
**Problem:**

1. When calling the `prompt` function it was a bit awkward to get the response out of the chat history in order to programmatically use the result.

**Solution:**

1. Return back the AgentPrompt when calling the `prompt` function

**Testing:**

1. I manually verified that I was getting back the expected object from the prompt call