### PR TITLE
[SYNPY-1547] `parentWikiId=""` Bug

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -4996,7 +4996,7 @@ class Synapse(object):
                 if createOrUpdate and (
                     (
                         err.response.status_code == 400
-                        and "DuplicateKeyException" in err.message
+                        and "DuplicateKeyException" in err.response.text
                     )
                     or err.response.status_code == 409
                 ):

--- a/synapseclient/wiki.py
+++ b/synapseclient/wiki.py
@@ -122,6 +122,12 @@ class Wiki(DictObject):
                 kwargs["attachmentFileHandleIds"].append(handle)
             del kwargs["fileHandles"]
 
+        # if parentWikiId is a falsey value (empty string, None, etc),
+        # standardize it to None
+        if "parentWikiId" in kwargs:
+            if not kwargs["parentWikiId"]:
+                kwargs["parentWikiId"] = None
+
         super(Wiki, self).__init__(kwargs)
         self.ownerId = id_of(self.owner)
         del self["owner"]

--- a/synapseclient/wiki.py
+++ b/synapseclient/wiki.py
@@ -124,9 +124,8 @@ class Wiki(DictObject):
 
         # if parentWikiId is a falsey value (empty string, None, etc),
         # standardize it to None
-        if "parentWikiId" in kwargs:
-            if not kwargs["parentWikiId"]:
-                kwargs["parentWikiId"] = None
+        if "parentWikiId" in kwargs and not kwargs["parentWikiId"]:
+            kwargs["parentWikiId"] = None
 
         super(Wiki, self).__init__(kwargs)
         self.ownerId = id_of(self.owner)

--- a/tests/integration/synapseclient/test_wikis.py
+++ b/tests/integration/synapseclient/test_wikis.py
@@ -126,3 +126,18 @@ async def test_wiki_version(syn, project):
     w2 = syn.getWiki(owner=wiki.ownerId, subpageId=wiki.id, version=1)
     assert "version 2" in w2.title
     assert "version 2" in w2.markdown
+
+
+async def test_wiki_with_empty_string_parent_wiki_id(syn, project):
+    # WHEN a wiki is created with an empty string parentWikiId
+    # THEN it is still able to be stored
+    syn.store(
+        Wiki(
+            title="This is the title",
+            owner=project,
+            markdown="#Wikis are OK\n\nBlabber jabber blah blah blither blather bonk!",
+            parentWikiId="",
+        )
+    )
+    # AND there is no parentWikiId to check in the wiki object
+    # because it is not returned by the API when it is not set

--- a/tests/integration/synapseclient/test_wikis.py
+++ b/tests/integration/synapseclient/test_wikis.py
@@ -10,7 +10,9 @@ from synapseclient.core.upload.upload_functions import upload_synapse_s3
 
 
 @pytest.mark.flaky(reruns=3)
-async def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup):
+async def test_wikiAttachment(
+    syn: Synapse, project: Project, schedule_for_cleanup
+) -> None:
     # Upload a file to be attached to a Wiki
     filename = utils.make_bogus_data_file()
     attachname = utils.make_bogus_data_file()
@@ -80,7 +82,7 @@ async def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_clean
     pytest.raises(SynapseHTTPError, syn.getWiki, project)
 
 
-async def test_create_or_update_wiki(syn, project):
+async def test_create_or_update_wiki(syn: Synapse, project: Project) -> None:
     # create wiki once
     syn.store(
         Wiki(
@@ -103,7 +105,7 @@ async def test_create_or_update_wiki(syn, project):
     assert new_title == syn.getWiki(wiki.ownerId)["title"]
 
 
-async def test_wiki_version(syn, project):
+async def test_wiki_version(syn: Synapse, project: Project) -> None:
     # create a new project to avoid artifacts from previous tests
     project = syn.store(Project(name=str(uuid.uuid4())))
     wiki = syn.store(
@@ -128,10 +130,12 @@ async def test_wiki_version(syn, project):
     assert "version 2" in w2.markdown
 
 
-async def test_wiki_with_empty_string_parent_wiki_id(syn, project):
-    # WHEN a wiki is created with an empty string parentWikiId
-    # THEN it is still able to be stored
-    syn.store(
+async def test_wiki_with_empty_string_parent_wiki_id(
+    syn: Synapse, project: Project
+) -> None:
+    # GIVEN a wiki is created with an empty string parentWikiId
+    # WHEN it is stored
+    wiki_stored = syn.store(
         Wiki(
             title="This is the title",
             owner=project,
@@ -139,5 +143,8 @@ async def test_wiki_with_empty_string_parent_wiki_id(syn, project):
             parentWikiId="",
         )
     )
-    # AND there is no parentWikiId to check in the wiki object
-    # because it is not returned by the API when it is not set
+    # THEN it exists in Synapse
+    wiki_retrieved = syn.getWiki(owner=wiki_stored.ownerId, subpageId=wiki_stored.id)
+    # AND when we retrieve it, all attributes are set as expected
+    for property_name in wiki_stored:
+        assert wiki_stored[property_name] == wiki_retrieved[property_name]

--- a/tests/unit/synapseclient/unit_test_Wiki.py
+++ b/tests/unit/synapseclient/unit_test_Wiki.py
@@ -76,3 +76,12 @@ def test_wiki_with_none_attachments(syn: Synapse):
     with patch.object(syn, "restPOST"):
         w = Wiki(owner="syn1", markdown="markdown", attachments=None)
         syn.store(w)
+
+
+def test_wiki_with_empty_string_parent_wiki_id(syn: Synapse):
+    # WHEN a wiki is created with an empty string parentWikiId
+    with patch.object(syn, "restPOST"):
+        w = Wiki(owner="syn1", markdown="markdown", parentWikiId="")
+        # THEN the parentWikiId is set to None
+        assert w.parentWikiId is None
+        syn.store(w)

--- a/tests/unit/synapseclient/unit_test_Wiki.py
+++ b/tests/unit/synapseclient/unit_test_Wiki.py
@@ -26,9 +26,12 @@ def test_Wiki__with_markdown_file():
                     adkflajsl;kfjasd;lfkjsal;kfajslkfjasdlkfj
                     """
     markdown_path = "/somewhere/over/the/rainbow.txt"
-    with patch(
-        "synapseclient.wiki.open", mock_open(read_data=markdown_data), create=True
-    ) as mocked_open, patch("os.path.isfile", return_value=True):
+    with (
+        patch(
+            "synapseclient.wiki.open", mock_open(read_data=markdown_data), create=True
+        ) as mocked_open,
+        patch("os.path.isfile", return_value=True),
+    ):
         # method under test
         wiki = Wiki(owner="doesn't matter", markdownFile=markdown_path)
 
@@ -44,9 +47,10 @@ def test_Wiki__markdown_and_markdownFile_both_defined():
 
 def test_Wiki__markdown_is_None_markdownFile_defined():
     markdown_path = "/somewhere/over/the/rainbow.txt"
-    with patch(
-        "synapseclient.wiki.open", mock_open(), create=True
-    ) as mocked_open, patch("os.path.isfile", return_value=True):
+    with (
+        patch("synapseclient.wiki.open", mock_open(), create=True) as mocked_open,
+        patch("os.path.isfile", return_value=True),
+    ):
         # method under test
         Wiki(owner="doesn't matter", markdownFile=markdown_path)
 
@@ -79,9 +83,15 @@ def test_wiki_with_none_attachments(syn: Synapse):
 
 
 def test_wiki_with_empty_string_parent_wiki_id(syn: Synapse):
-    # WHEN a wiki is created with an empty string parentWikiId
-    with patch.object(syn, "restPOST"):
+    with patch.object(syn, "restPOST") as mock_restPOST:
+        # WHEN a wiki is created with an empty string parentWikiId
         w = Wiki(owner="syn1", markdown="markdown", parentWikiId="")
         # THEN the parentWikiId is set to None
         assert w.parentWikiId is None
+        # WHEN the wiki is stored
         syn.store(w)
+        # THEN the parentWikiId is set to None in the request
+        mock_restPOST.assert_called_once_with(
+            "/entity/syn1/wiki",
+            '{"markdown": "markdown", "parentWikiId": null, "attachmentFileHandleIds": []}',
+        )


### PR DESCRIPTION
**Description:**

A user reported an unhandled error when trying to store a Wiki object in Synapse like so (where syn123 is instead a valid Synapse project ID that the user has access to):
```
from synapseclient import Wiki
import synapseclient

foo = Wiki(owner="syn123", title="test", parentWikiId="")
syn.store(foo)
```
This happened because the API does not treat that value of `parentWikiId` like a `None` value and instead throws an error. To prevent that error from happening, I added logic in `Wiki.__init__` that converts any falsey value that is provided for `parentWikiId` to `None`. 

Additionally, the user was receiving this error message:
```
AttributeError: 'SynapseHTTPError' object has no attribute 'message'
```
rather than a message passed on from the API which I addressed by updating logic [here](https://github.com/Sage-Bionetworks/synapsePythonClient/blob/20be364ab981e3c577d337beff9ffc45aa0d5fe8/synapseclient/client.py#L4999) to check the response text.

**Testing:**
After these changes were made, the script above was able to be run successfully. I also added a unit test to ensure that `parentWikiId=""` is treated like `parentWikiId=None` and an integration test to ensure that Wiki objects created with `parentWikiId=""` are stored successfully in Synapse.