### PR TITLE
Update Dockerfile - Fixes `pandas` installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update \
     python3-dev \
     python3-setuptools \
     python3-pip \
-    python3-pandas \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --upgrade pip
@@ -16,7 +15,7 @@ RUN pip3 install --upgrade pip
 WORKDIR /synapsePythonClient
 COPY . .
 
-RUN pip install --no-cache-dir .
+RUN pip install --no-cache-dir .[pandas]
 
 
 LABEL org.opencontainers.image.source='https://github.com/Sage-Bionetworks/synapsePythonClient'


### PR DESCRIPTION
# Problem

I realized because of an error encountered by an `nf-synapse` user that the newer versions of the `synapseclient` docker container do not have `pandas` installed properly.

# Solution

This issue was caused by mixing `apt-get` installing `python3-pandas` with a base Python image. The problem being that Python packages installed via `apt-get` don't automatically integrate with the Python environment from the Docker base image. Fortunately we have a `pandas` extra built into `setup.cfg`, so I switched to installing it that way.

# Testing

Built the container locally, started up a Python terminal inside of it, and ran `import pandas`. If you do this with `sagebionetworks/synapsepythonclient:v4.7.0` you get an import error.