### PR TITLE
[SYNPY-1553] Update to support python 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
     - uses: pre-commit/action@v3.0.1
 
 
@@ -49,7 +49,7 @@ jobs:
 
         # if changing the below change the run-integration-tests versions and the check-deploy versions
         # Make sure that we are running the integration tests on the first and last versions of the matrix
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     runs-on: ${{ matrix.os }}
 
@@ -101,7 +101,7 @@ jobs:
           pytest -sv --cov-append --cov=. --cov-report xml tests/unit
       - name: Check for Secret availability
         id: secret-check
-        if: ${{ contains(fromJSON('["3.9"]'), matrix.python) || contains(fromJSON('["3.12"]'), matrix.python) }}
+        if: ${{ contains(fromJSON('["3.9"]'), matrix.python) || contains(fromJSON('["3.13"]'), matrix.python) }}
         # perform secret check & put boolean result as an output
         shell: bash
         run: |
@@ -160,7 +160,7 @@ jobs:
         shell: bash
 
         # keep versions consistent with the first and last from the strategy matrix
-        if: ${{ (contains(fromJSON('["3.9"]'), matrix.python) || contains(fromJSON('["3.12"]'), matrix.python)) && steps.secret-check.outputs.secrets_available == 'true'}}
+        if: ${{ (contains(fromJSON('["3.9"]'), matrix.python) || contains(fromJSON('["3.13"]'), matrix.python)) && steps.secret-check.outputs.secrets_available == 'true'}}
         run: |
           # decrypt the encrypted test synapse configuration
           openssl aes-256-cbc -K ${{ secrets.encrypted_d17283647768_key }} -iv ${{ secrets.encrypted_d17283647768_iv }} -in test.synapseConfig.enc -out test.synapseConfig -d
@@ -207,7 +207,7 @@ jobs:
       - name: Upload coverage report
         id: upload_coverage_report
         uses: actions/upload-artifact@v4
-        if: ${{ contains(fromJSON('["3.12"]'), matrix.python) && contains(fromJSON('["ubuntu-20.04"]'), matrix.os)}}
+        if: ${{ contains(fromJSON('["3.13"]'), matrix.python) && contains(fromJSON('["ubuntu-20.04"]'), matrix.os)}}
         with:
           name: coverage-report
           path: coverage.xml
@@ -402,7 +402,7 @@ jobs:
         os: [ubuntu-20.04, macos-13, windows-2022]
 
         # python versions should be consistent with the strategy matrix and the runs-integration-tests versions
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     runs-on: ${{ matrix.os }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ copied to forks).
 #### Installing the Python Client in a virtual environment with pipenv
 Perform the following one-time steps to set up your local environment.
 
-1. This package uses Python, if you have not already, please install [pyenv](https://github.com/pyenv/pyenv#installation) to manage your Python versions. Versions supported by this package are all versions >=3.9 and <=3.12. If you do not install `pyenv` make sure that Python and `pip` are installed correctly and have been added to your PATH by running `python3 --version` and `pip3 --version`. If your installation was successful, your terminal will return the versions of Python and `pip` that you installed.  **Note**: If you have `pyenv` it will install a specific version of Python for you.
+1. This package uses Python, if you have not already, please install [pyenv](https://github.com/pyenv/pyenv#installation) to manage your Python versions. Versions supported by this package are all versions >=3.9 and <=3.13. If you do not install `pyenv` make sure that Python and `pip` are installed correctly and have been added to your PATH by running `python3 --version` and `pip3 --version`. If your installation was successful, your terminal will return the versions of Python and `pip` that you installed.  **Note**: If you have `pyenv` it will install a specific version of Python for you.
 
 2. Install `pipenv` by running `pip install pipenv`.
     - If you already have `pipenv` installed, ensure that the version is >=2023.9.8 to avoid compatibility issues.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Python Synapse Client
 =====================
 
 Branch  | Build Status
---------|-------------
+--------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 develop | [![Build Status develop branch](https://github.com/Sage-Bionetworks/synapsePythonClient/workflows/build/badge.svg?branch=develop)](https://github.com/Sage-Bionetworks/synapsePythonClient/actions?query=branch%3Adevelop)
 master  | [![Build Status master branch](https://github.com/Sage-Bionetworks/synapsePythonClient/workflows/build/badge.svg?branch=master)](https://github.com/Sage-Bionetworks/synapsePythonClient/actions?query=branch%3Amaster)
 
@@ -36,7 +36,7 @@ or by sending an email to [python-announce+subscribe@sagebase.org](mailto:python
 Installation
 ------------
 
-The Python Synapse client has been tested on versions 3.9, 3.10, 3.11 and 3.12 on Mac OS X, Ubuntu Linux and Windows.
+The Python Synapse client has been tested on versions 3.9, 3.10, 3.11, 3.12 and 3.13 on Mac OS X, Ubuntu Linux and Windows.
 
 **Starting from Synapse Python client version 3.0, Synapse Python client requires Python >= 3.9**
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Operating System :: MacOS
     Operating System :: Microsoft :: Windows
     Operating System :: Unix
@@ -42,7 +43,7 @@ classifiers =
 zip_safe = False
 include_package_data = True
 packages = find:
-python_requires = >=3.9, <3.13
+python_requires = >=3.9, <3.14
 install_requires =
     # "requests>=2.22.0,<2.30.0; python_version<'3.10'",
     requests>=2.22.0,<3.0

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -3,7 +3,6 @@ Utility functions useful in the implementation and testing of the Synapse client
 """
 
 import base64
-import cgi
 import collections.abc
 import datetime
 import errno
@@ -26,6 +25,7 @@ import uuid
 import warnings
 import zipfile
 from dataclasses import asdict, is_dataclass
+from email.message import Message
 from typing import TYPE_CHECKING, TypeVar
 
 import requests
@@ -173,8 +173,9 @@ def extract_filename(content_disposition_header, default_filename=None):
 
     if not content_disposition_header:
         return default_filename
-    value, params = cgi.parse_header(content_disposition_header)
-    return params.get("filename", default_filename)
+    message = Message()
+    message.add_header("content-disposition", content_disposition_header)
+    return message.get_filename(failobj=default_filename)
 
 
 def extract_user_name(profile):


### PR DESCRIPTION
**Problem:**

1. Python 3.13 is not supported

**Solution:**

1. Update the github pipeline to build 3.13 and run integration tests on that version.
2. Updating the docs and install files to reference 3.13 as a valid version.
3. Removing the usage of `cgi.parse_header` in favor of the `email.message` `Message` class as mentioned in (PEP 594) https://docs.python.org/3/whatsnew/3.13.html#removed-modules-and-apis


**Testing:**

- [x] Unit/Integration testing
- [x] Verified that before the changes I can run into the `cgi` error as reported by the original user, and after the change I was able to download a small (few byte) file as expected:

![image](https://github.com/user-attachments/assets/9b70b2b9-c0ea-492a-847f-d2d7d2678b27)
