### PR TITLE
Add table and file versioning tutorial updates

### DIFF
--- a/docs/tutorials/file_versioning.md
+++ b/docs/tutorials/file_versioning.md
@@ -11,6 +11,8 @@ Explicit example:
 ```python
 import synapseclient
 
+syn = synapseclient.login()
+
 # fetch the file in Synapse
 file_to_update = syn.get('syn2222', downloadFile=False)
 
@@ -58,14 +60,17 @@ file = syn.store(file, forceVersion=False)
 To set Provenance without changing the file version:
 
 ```python
+from synapseclient import Activity
+
 # Get file from Synapse, set download=False since we are only updating provenance
 file = syn.get('syn56789', download=False)
 
-# Add provenance
-file = syn.setProvenance(file, activity = Activity(used = '/path/to/example_code'))
-
-# Store the file without creating a new version
-file = syn.store(file, forceVersion=False)
+# Add provenance (passing in activity) and store the file without creating a new version
+file = syn.store(
+    file,
+    activity = Activity(used = ['syn64943795']),
+    forceVersion=False
+)
 ```
 
 ## Downloading a Specific Version

--- a/docs/tutorials/file_versioning.md
+++ b/docs/tutorials/file_versioning.md
@@ -68,7 +68,7 @@ file = syn.get('syn56789', download=False)
 # Add provenance (passing in activity) and store the file without creating a new version
 file = syn.store(
     file,
-    activity = Activity(used = ['syn64943795']),
+    activity = Activity(used = 'some_valid_file_synapse_id'),
     forceVersion=False
 )
 ```

--- a/docs/tutorials/tables.md
+++ b/docs/tutorials/tables.md
@@ -71,8 +71,8 @@ The `Table` function takes two arguments, a schema object and data in some form,
 With a bit of luck, we now have a table populated with data. Let's try to query:
 
 ```python
-results = syn.tableQuery("select * from %s where Chromosome='1' and Start < 41000 and End > 20000"
-                         % table.schema.id)
+results = syn.tableQuery(
+    f"SELECT * FROM {table.schema.id} WHERE Chromosome = '1' AND Start < 41000 AND \"End\" > 20000")
 for row in results:
     print(row)
 ```


### PR DESCRIPTION
### **Problem:** 
There were some missing code lines, and lines that produced errors in the [Table](https://python-docs.synapse.org/tutorials/tables/#tables) and [File Versioning](https://python-docs.synapse.org/tutorials/file_versioning/) tutorials

See this [validation results report for another ticket](https://sagebionetworks.jira.com/browse/SYNPY-1552?focusedCommentId=239464) for more info

### **Solution:**
- Added missing setup lines
- Replaced lines throwing errors with corrected lines of code

### **Testing:** 
Tested with `mkdocs serve` locally. 

See example change with file versioning tutorial

Before
<img width="860" alt="image" src="https://github.com/user-attachments/assets/6bc9d1e2-1a59-4715-b3f0-68a9a8c843a9" />

After
<img width="1020" alt="image" src="https://github.com/user-attachments/assets/ede89a7a-da05-46e5-a2f5-aa1ca3b11360" />


See  example change with tables tutorial

Before
<img width="872" alt="image" src="https://github.com/user-attachments/assets/0a669e8e-a658-44ce-8e68-e34ee3b58c73" />

After
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/955dc04f-258a-40b8-8dfb-3516b1906ef8" />
