### PR TITLE
[SYNPY-1575] Support default columns

### DIFF
--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -47,7 +47,7 @@ from .file_services import (
     put_file_multipart_add,
     put_file_multipart_complete,
 )
-from .table_services import get_columns, post_columns
+from .table_services import ViewTypeMask, get_columns, get_default_columns, post_columns
 
 __all__ = [
     # annotations
@@ -99,4 +99,6 @@ __all__ = [
     # columns
     "get_columns",
     "post_columns",
+    "get_default_columns",
+    "ViewTypeMask",
 ]

--- a/synapseclient/models/mixins/table_operator.py
+++ b/synapseclient/models/mixins/table_operator.py
@@ -208,6 +208,8 @@ class TableOperator(TableOperatorSynchronousProtocol):
         # part of the `TableSchemaChangeRequest`
         columns_to_persist = []
         for column in self.columns.values():
+            # TODO: Something like this is needed in order to add columns that already exist in Synapse to the Table (ie: The default columns for the type of view this is)
+            column_changes.append(ColumnChange(new_column_id=column.id))
             if column.has_changed:
                 if (
                     column._last_persistent_instance


### PR DESCRIPTION
**Problem:**

1. Views among other types of tables in Synapse have a number of default columns that may be added to the Table.

**Solution:**

1. Query for the default columns of the view according to the https://rest-docs.synapse.org/rest/GET/column/tableview/defaults.html API
2. Allow the schema change logic to handle these default columns as an "add" to the table schema

**Testing:**

1. More testing via integration is needed, but this was verified with a FileView