### PR TITLE
[SYNPY-1575] Support waiting for evetually consistent view after changes are made

### DIFF
--- a/synapseclient/models/mixins/table_operator.py
+++ b/synapseclient/models/mixins/table_operator.py
@@ -1900,7 +1900,7 @@ class TableRowOperator(TableRowOperatorSynchronousProtocol):
         Returns:
             A tuple containing a list of PartialRow objects that will be used to update
             rows in Synapse, a list of the indexs of the rows in the original
-            DataFrame that have changes, a list of the indexs of the rows in the
+            DataFrame that have changes, a list of the indexes of the rows in the
             original DataFrame that do not have changes, and a list of the etags for
             the rows that have changes.
         """
@@ -2162,7 +2162,7 @@ class TableRowOperator(TableRowOperatorSynchronousProtocol):
                 The default is 600 seconds
 
             wait_for_eventually_consistent_view: Only used if the table is a view. If
-                set to True this will wait for the view to be reflect any changes that
+                set to True this will wait for the view to reflect any changes that
                 you've made to the view. This is useful if you need to query the view
                 after making changes to the data.
 

--- a/synapseclient/models/mixins/table_operator.py
+++ b/synapseclient/models/mixins/table_operator.py
@@ -2161,6 +2161,14 @@ class TableRowOperator(TableRowOperatorSynchronousProtocol):
                 is reached a `SynapseTimeoutError` will be raised.
                 The default is 600 seconds
 
+            wait_for_eventually_consistent_view: Only used if the table is a view. If
+                set to True this will wait for the view to be reflect any changes that
+                you've made to the view. This is useful if you need to query the view
+                after making changes to the data.
+
+            wait_for_eventually_consistent_view_timeout: The maximum amount of time to
+                wait for a view to be eventually consistent. The default is 600 seconds.
+
             synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor

--- a/synapseclient/models/mixins/table_operator.py
+++ b/synapseclient/models/mixins/table_operator.py
@@ -2423,11 +2423,13 @@ class TableRowOperator(TableRowOperatorSynchronousProtocol):
                 quoted_etags = [f"'{etag}'" for etag in original_etags_to_track]
                 wait_select_statement = f"select etag from {self.id} where etag IN ({','.join(quoted_etags)})"
                 results = await self.query_async(
-                    query=wait_select_statement, synapse_client=synapse_client
+                    query=wait_select_statement,
+                    synapse_client=synapse_client,
+                    include_row_id_and_row_version=False,
                 )
                 for row in results.itertuples(index=False):
-                    if row.ROW_ETAG in original_etags_to_track:
-                        original_etags_to_track.remove(row.ROW_ETAG)
+                    if row.etag in original_etags_to_track:
+                        original_etags_to_track.remove(row.etag)
                         progress_bar.update(1)
                 progress_bar.refresh()
                 if not original_etags_to_track:


### PR DESCRIPTION
**Problem:**

1. When changes are made to a view in Synapse an eventually consistent process is kicked off in order to bring that view up to date. If you query the view directly after the changes are made you will not see your changes reflected in that view.

**Solution:**

1. During the upsert method call allow users to specify if they would like to wait for their changes to show up in the view before returning control.

**Testing:**

1. I wrote an integration test (For FileViews that are not yet committed) to verify the functionality before and after