### PR TITLE
[SYNPY-1488] Patch nested tqdm progress bars and messages to logger

### DIFF
--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -359,12 +359,12 @@ def show(args, syn):
 
     ent = syn.get(args.id, downloadFile=False)
     syn.printEntity(ent)
-    sys.stdout.write("Provenance:\n")
+    syn.logger.info("Provenance:")
     try:
         prov = syn.getProvenance(ent)
         syn.logger.info(prov)
     except SynapseHTTPError:
-        syn.logger.error("  No Activity specified.\n")
+        syn.logger.exception("No Activity specified.")
 
 
 def delete(args, syn):
@@ -1785,11 +1785,13 @@ def perform_main(args, syn):
             )
         try:
             args.func(args, syn)
-        except Exception as ex:
+        except Exception:
             if args.debug:
                 raise
             else:
-                sys.stderr.write(utils._synapse_error_msg(ex))
+                # TODO: Verify behavior
+                # sys.stderr.write(utils._synapse_error_msg(ex))
+                syn.logger.exception(f"Failed to perform command: {args.func}")
                 sys.exit(1)
     else:
         # if no command provided print out help and quit

--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -1789,8 +1789,6 @@ def perform_main(args, syn):
             if args.debug:
                 raise
             else:
-                # TODO: Verify behavior
-                # sys.stderr.write(utils._synapse_error_msg(ex))
                 syn.logger.exception(f"Failed to perform command: {args.func}")
                 sys.exit(1)
     else:

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -5171,8 +5171,8 @@ class Synapse(object):
                 + result.get("errorDetails", None),
                 asynchronousJobStatus=result,
             )
-
-        progress_bar.update(progress_bar.total - progress_bar.n)
+        if progress_bar.total and progress_bar.n:
+            progress_bar.update(progress_bar.total - progress_bar.n)
         progress_bar.refresh()
         progress_bar.close()
         return result

--- a/synapseclient/core/remote_file_storage_wrappers.py
+++ b/synapseclient/core/remote_file_storage_wrappers.py
@@ -215,6 +215,7 @@ class S3ClientWrapper:
                 unit_scale=True,
                 postfix=filename,
                 smoothing=0,
+                leave=None,
             )
             progress_callback = S3ClientWrapper._create_progress_callback_func(
                 progress_bar
@@ -291,6 +292,7 @@ class SFTPWrapper:
             unit_scale=True,
             smoothing=0,
             postfix=filepath,
+            leave=None,
         )
 
         def progress_callback(*args, **kwargs) -> None:

--- a/synapseclient/core/transfer_bar.py
+++ b/synapseclient/core/transfer_bar.py
@@ -159,6 +159,7 @@ def get_or_create_download_progress_bar(
             unit_scale=True,
             smoothing=0,
             postfix=postfix,
+            leave=None,
         )
         _thread_local.progress_bar_download = progress_bar
     else:

--- a/synapseclient/core/upload/multipart_upload_async.py
+++ b/synapseclient/core/upload/multipart_upload_async.py
@@ -357,6 +357,7 @@ class UploadAttemptAsync:
                     unit_scale=True,
                     postfix=self._dest_file_name,
                     smoothing=0,
+                    leave=None,
                 )
                 self._progress_bar.update(completed_part_count)
             else:
@@ -374,6 +375,7 @@ class UploadAttemptAsync:
                     unit_scale=True,
                     postfix=self._dest_file_name,
                     smoothing=0,
+                    leave=None,
                 )
                 self._progress_bar.update(previously_transferred)
 

--- a/synapseclient/models/mixins/table_operator.py
+++ b/synapseclient/models/mixins/table_operator.py
@@ -2262,6 +2262,7 @@ class TableRowOperator(TableRowOperatorSynchronousProtocol):
                 desc="Querying & Updating rows",
                 unit_scale=True,
                 smoothing=0,
+                leave=None,
             )
             for individual_chunk in chunk_list:
                 select_statement = self._construct_select_statement_for_upsert(
@@ -3116,6 +3117,7 @@ class TableRowOperator(TableRowOperatorSynchronousProtocol):
                 unit_scale=True,
                 smoothing=0,
                 unit="B",
+                leave=None,
             )
             # The original file is read twice, the reason is that on the first pass we
             # are calculating the size of the chunks that we will be uploading and the
@@ -3316,6 +3318,7 @@ class TableRowOperator(TableRowOperatorSynchronousProtocol):
             unit_scale=True,
             smoothing=0,
             unit="B",
+            leave=None,
         )
 
         changes = []

--- a/synapseutils/monitor.py
+++ b/synapseutils/monitor.py
@@ -1,8 +1,9 @@
 import functools
-import sys
 import traceback
 from multiprocessing import Lock, Value
 from typing import TYPE_CHECKING
+
+from deprecated import deprecated
 
 from synapseclient.core.utils import printTransferProgress
 
@@ -61,7 +62,9 @@ def notifyMe(syn: "Synapse", messageSubject: str = "", retries: int = 0):
                     )
                     return output
                 except Exception as e:
-                    sys.stderr.write(traceback.format_exc())
+                    syn.logger.exception(
+                        f"Encountered a temporary Failure during execution.  Will retry {retries - attempt} more times."
+                    )
                     syn.sendMessage(
                         [destination],
                         messageSubject,
@@ -140,7 +143,9 @@ def notify_me_async(syn: "Synapse", messageSubject: str = "", retries: int = 0):
                     )
                     return output
                 except Exception as e:
-                    sys.stderr.write(traceback.format_exc())
+                    syn.logger.exception(
+                        f"Encountered a temporary Failure during execution.  Will retry {retries - attempt} more times."
+                    )
                     syn.sendMessage(
                         [destination],
                         messageSubject,
@@ -157,6 +162,11 @@ def notify_me_async(syn: "Synapse", messageSubject: str = "", retries: int = 0):
     return notify_decorator
 
 
+@deprecated(
+    version="4.8.0",
+    reason="To be removed in 5.0.0. "
+    "This is removed in favor of using the tqdm library for progress bars.",
+)
 def with_progress_bar(func, totalCalls, prefix="", postfix="", isBytes=False):
     """Wraps a function to add a progress bar based on the number of calls to that function.
 

--- a/tests/unit/synapseclient/core/unit_test_remote_storage_file_wrappers.py
+++ b/tests/unit/synapseclient/core/unit_test_remote_storage_file_wrappers.py
@@ -52,7 +52,7 @@ class TestS3ClientWrapper:
                 endpoint_url,
                 remote_file_key,
                 download_file_path,
-                progress_bar=tqdm() if show_progress else None,
+                progress_bar=tqdm(leave=None) if show_progress else None,
                 **kwargs,
             )
 

--- a/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
+++ b/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
@@ -674,9 +674,7 @@ class TestMultipartUpload:
         ) as md5_for_file, mock.patch.object(
             multipart_upload,
             "_multipart_upload",
-        ) as mock_multipart_upload, mock.patch.object(
-            multipart_upload, "Spinner"
-        ) as mock_spinner:
+        ) as mock_multipart_upload:
             os_path_getsize.return_value = file_size
             md5_for_file.return_value.hexdigest.return_value = md5_hex
 
@@ -735,7 +733,7 @@ class TestMultipartUpload:
                 file_path,
                 storage_location_id=storage_location_id,
             )
-            md5_for_file.assert_called_with(file_path, callback=None)
+            assert md5_for_file.called
 
             syn_with_no_silent_mode = Synapse(
                 debug=False, skip_checks=True, cache_client=False
@@ -745,9 +743,7 @@ class TestMultipartUpload:
                 file_path,
                 storage_location_id=storage_location_id,
             )
-            md5_for_file.assert_called_with(
-                file_path, callback=mock_spinner.return_value.print_tick
-            )
+            assert md5_for_file.called
 
             mock_multipart_upload.reset_mock()
 

--- a/tests/unit/synapseutils/unit_test_synapseutils_describe.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_describe.py
@@ -148,8 +148,8 @@ class TestDescribe:
             },
         }
 
-    def test_describe_with_mixed_series(self):
-        result = _describe_wrapper(df=self.df_mixed)
+    def test_describe_with_mixed_series(self, syn: synapseclient.Synapse):
+        result = _describe_wrapper(df=self.df_mixed, syn=syn)
         assert result == self.expected_results
 
     def test_describe(self):
@@ -161,7 +161,7 @@ class TestDescribe:
         ) as mock_describe:
             result = describe_functions.describe(syn=syn, entity="syn1234")
             mock_open_entity.assert_called_once_with(syn=syn, entity="syn1234")
-            mock_describe.assert_called_once_with(self.df_mixed)
+            mock_describe.assert_called_once_with(self.df_mixed, syn=syn)
             assert result == self.expected_results
 
     def test_describe_none(self):


### PR DESCRIPTION
**Problem:**

1. Nested TQDM progress bars by default overwrite other progress bars. This leads to loss of information and poor looking logs.
2. There are a significant number of print, and sysout messages getting printed to the console. When messages are printed in this way then it will break the formatting of the tqdm progress bar.

**Solution:**

1. Updating the TQDM progress bars to include `leave=None`. This makes it so the behavior for the progress bars it to be removed if it isn't the highest level parent progress bar. It cleans up the bars significantly.
2. Updating many print and sysout messages to use the synapse class logger to print out exceptions, warnings, and info messages.


**Testing:**

1. The following are 2 short clips that show the console log during the creation, querying, and update of a FileView within Synapse during an integration test run:

Before Changes: https://www.loom.com/share/b4594dc4f83142c784f43aa7561d9652?sid=99de514e-9177-4453-b161-54c928af2cec
After Changes: https://www.loom.com/share/0dead7ad188a4bd191a8dfd2cf31ee0c?sid=365c3fd9-1a14-4c65-9499-7e120834d646

1. I also verified that the syncFromSynapse and syncToSynapse looks correct:

```python
from synapseclient import Synapse
from synapseutils import syncFromSynapse, syncToSynapse

syn = Synapse(debug=False)
syn.login()

syncFromSynapse(syn=syn, entity="syn60584018", path=".")
syncToSynapse(syn=syn, manifestFile="/home/ec2-user/SYNAPSE_METADATA_MANIFEST.tsv", dryRun=True)
```

![image](https://github.com/user-attachments/assets/476a2036-fc58-40fd-b301-223f9b0fb798)

![image](https://github.com/user-attachments/assets/1da75845-e35a-4461-b781-64bd8e83217e)

1. Finally, I verified that exceptions and the messages related to those exceptions occur as a result of running CLI commands:
(Before, only the message without any stacktrace would print)
![image](https://github.com/user-attachments/assets/2ed573c0-b5cc-4b30-9fb5-20dad5b34d79)

(After, it will also print the stack trace along with the given exception)
![image](https://github.com/user-attachments/assets/4b3c32b3-c196-40bb-8b08-4fa52fd9122b)
