### PR TITLE
Prevent concurrent builds per branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,6 @@ jobs:
         python-version: '3.13'
     - uses: pre-commit/action@v3.0.1
 
-
   # run unit (and integration tests if account secrets available) on our build matrix
   test:
     needs: [pre-commit]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,10 @@ jobs:
 
   # run unit (and integration tests if account secrets available) on our build matrix
   test:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
     needs: [pre-commit]
 
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,6 @@ jobs:
 
   # run unit (and integration tests if account secrets available) on our build matrix
   test:
-
     # Cancel any previous runs of this workflow that are still in progress.
     # This is to avoid running the same tests multiple times concurrently.
     concurrency:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,12 @@ on:
     types:
       - 'published'
 
+# Cancel any previous runs of this workflow that are still in progress.
+# This is to avoid running the same tests multiple times concurrently.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   pre-commit:
@@ -41,12 +47,6 @@ jobs:
 
   # run unit (and integration tests if account secrets available) on our build matrix
   test:
-    # Cancel any previous runs of this workflow that are still in progress.
-    # This is to avoid running the same tests multiple times concurrently.
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-py-${{ matrix.python }}
-      cancel-in-progress: true
-
     needs: [pre-commit]
 
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,11 @@ jobs:
 
   # run unit (and integration tests if account secrets available) on our build matrix
   test:
+
+    # Cancel any previous runs of this workflow that are still in progress.
+    # This is to avoid running the same tests multiple times concurrently.
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-py-${{ matrix.python }}
       cancel-in-progress: true
 
     needs: [pre-commit]


### PR DESCRIPTION
**Problem:**

1. The integration tests for the SYNPY client take a very long time to run, and even longer so when a single feature branch is running multiple sets of tests. Currently, every commit would cause the tests to run and no previous runs are getting cancelled.

**Solution:**

1. Using a [concurrency group](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency) I am causing previous build jobs to be cancelled if there is a new commit pushed to the branch.


**Testing:**

1. I verified after pushing a new commit to this feature branch that the existing action was cancelled:
2. https://github.com/Sage-Bionetworks/synapsePythonClient/actions/runs/13707998334
![image](https://github.com/user-attachments/assets/e1e6c12c-2152-4bb5-ba7f-bd6e11ae9769)
