### PR TITLE
[SYNPY-1575] Prevent upsert from showing

### DIFF
--- a/synapseclient/models/mixins/table_components.py
+++ b/synapseclient/models/mixins/table_components.py
@@ -495,13 +495,18 @@ class ViewStoreMixin(TableStoreMixin):
         client = Synapse.get_client(synapse_client=synapse_client)
 
         if self.include_default_columns:
+            view_type_mask = None
+            if self.view_type_mask:
+                if isinstance(self.view_type_mask, ViewTypeMask):
+                    view_type_mask = self.view_type_mask.value
+                else:
+                    view_type_mask = self.view_type_mask
+
             default_columns = await get_default_columns(
                 view_entity_type=(
                     self.view_entity_type if self.view_entity_type else None
                 ),
-                view_type_mask=(
-                    self.view_type_mask.value if self.view_type_mask else None
-                ),
+                view_type_mask=view_type_mask,
                 synapse_client=synapse_client,
             )
             for default_column in default_columns:
@@ -1072,313 +1077,455 @@ class ColumnMixin:
             raise ValueError("columns must be a list, dict, or OrderedDict")
 
 
-@async_to_sync
-class TableUpsertMixin:
-    def _construct_select_statement_for_upsert(
-        self,
-        df: DATA_FRAME_TYPE,
-        all_columns_from_df: List[str],
-        primary_keys: List[str],
-    ) -> str:
-        """
-        Create the select statement for a given DataFrame. This is used to select data
-        from Synapse to determine if a row already exists in the table. This is used
-        in the upsert method to determine if a row should be updated or inserted.
+def _construct_select_statement_for_upsert(
+    entity: TableBase,
+    df: DATA_FRAME_TYPE,
+    all_columns_from_df: List[str],
+    primary_keys: List[str],
+) -> str:
+    """
+    Create the select statement for a given DataFrame. This is used to select data
+    from Synapse to determine if a row already exists in the table. This is used
+    in the upsert method to determine if a row should be updated or inserted.
 
-        Arguments:
-            df: The DataFrame that contains the data to be upserted.
-            all_columns_from_df: A list of all the columns in the DataFrame.
-            primary_keys: A list of the columns that are used to determine if a row
-                already exists in the table.
+    Arguments:
+        df: The DataFrame that contains the data to be upserted.
+        all_columns_from_df: A list of all the columns in the DataFrame.
+        primary_keys: A list of the columns that are used to determine if a row
+            already exists in the table.
 
-        Returns:
-            The select statement that can be used to query Synapse to determine if a row
-            already exists in the
-        """
+    Returns:
+        The select statement that can be used to query Synapse to determine if a row
+        already exists in the
+    """
 
-        select_statement = "SELECT ROW_ID, "
+    select_statement = "SELECT ROW_ID, "
 
-        if self.__class__.__name__ in CLASSES_THAT_CONTAIN_ROW_ETAG:
-            select_statement += "ROW_ETAG, "
+    if entity.__class__.__name__ in CLASSES_THAT_CONTAIN_ROW_ETAG:
+        select_statement += "ROW_ETAG, "
 
-        select_statement += f"{', '.join(all_columns_from_df)} FROM {self.id} WHERE "
-        where_statements = []
-        for upsert_column in primary_keys:
-            column_model = self.columns[upsert_column]
-            if (
-                column_model.column_type
-                in (
-                    ColumnType.STRING_LIST,
-                    ColumnType.INTEGER_LIST,
-                    ColumnType.BOOLEAN_LIST,
-                    ColumnType.ENTITYID_LIST,
-                    ColumnType.USERID_LIST,
-                )
-                or column_model.column_type == ColumnType.JSON
-            ):
-                raise ValueError(
-                    f"Column type {column_model.column_type} is not supported for primary_keys"
-                )
-            elif column_model.column_type in (
-                ColumnType.STRING,
-                ColumnType.MEDIUMTEXT,
-                ColumnType.LARGETEXT,
-                ColumnType.LINK,
-                ColumnType.ENTITYID,
-            ):
-                values_for_where_statement = set(
-                    [f"'{value}'" for value in df[upsert_column] if value is not None]
-                )
+    select_statement += f"{', '.join(all_columns_from_df)} FROM {entity.id} WHERE "
+    where_statements = []
+    for upsert_column in primary_keys:
+        column_model = entity.columns[upsert_column]
+        if (
+            column_model.column_type
+            in (
+                ColumnType.STRING_LIST,
+                ColumnType.INTEGER_LIST,
+                ColumnType.BOOLEAN_LIST,
+                ColumnType.ENTITYID_LIST,
+                ColumnType.USERID_LIST,
+            )
+            or column_model.column_type == ColumnType.JSON
+        ):
+            raise ValueError(
+                f"Column type {column_model.column_type} is not supported for primary_keys"
+            )
+        elif column_model.column_type in (
+            ColumnType.STRING,
+            ColumnType.MEDIUMTEXT,
+            ColumnType.LARGETEXT,
+            ColumnType.LINK,
+            ColumnType.ENTITYID,
+        ):
+            values_for_where_statement = set(
+                [f"'{value}'" for value in df[upsert_column] if value is not None]
+            )
 
-            elif column_model.column_type == ColumnType.BOOLEAN:
-                include_true = False
-                include_false = False
-                for value in df[upsert_column]:
-                    if value is None:
-                        continue
-                    if value:
-                        include_true = True
-                    else:
-                        include_false = True
-                    if include_true and include_false:
-                        break
+        elif column_model.column_type == ColumnType.BOOLEAN:
+            include_true = False
+            include_false = False
+            for value in df[upsert_column]:
+                if value is None:
+                    continue
+                if value:
+                    include_true = True
+                else:
+                    include_false = True
                 if include_true and include_false:
-                    values_for_where_statement = ["'true'", "'false'"]
-                elif include_true:
-                    values_for_where_statement = ["'true'"]
-                elif include_false:
-                    values_for_where_statement = ["'false'"]
-            else:
-                values_for_where_statement = set(
-                    [str(value) for value in df[upsert_column] if value is not None]
-                )
-            if not values_for_where_statement:
-                continue
-            where_statements.append(
-                f"\"{upsert_column}\" IN ({', '.join(values_for_where_statement)})"
+                    break
+            if include_true and include_false:
+                values_for_where_statement = ["'true'", "'false'"]
+            elif include_true:
+                values_for_where_statement = ["'true'"]
+            elif include_false:
+                values_for_where_statement = ["'false'"]
+        else:
+            values_for_where_statement = set(
+                [str(value) for value in df[upsert_column] if value is not None]
             )
-
-        where_statement = " AND ".join(where_statements)
-        select_statement += where_statement
-        return select_statement
-
-    def _construct_partial_rows_for_upsert(
-        self,
-        results: DATA_FRAME_TYPE,
-        chunk_to_check_for_upsert: DATA_FRAME_TYPE,
-        primary_keys: List[str],
-        contains_etag: bool,
-    ) -> Tuple[List[PartialRow], List[int], List[int], List[str]]:
-        """
-        Handles the construction of the PartialRow objects that will be used to update
-        rows in Synapse. This method is used in the upsert method to determine which
-        rows need to be updated.
-
-        Arguments:
-            results: The DataFrame that contains the data that was queried from Synapse.
-            chunk_to_check_for_upsert: The DataFrame that contains the data that is
-                being upserted.
-            primary_keys: A list of the columns that are used to determine if a row
-                already exists in the table.
-
-        Returns:
-            A tuple containing a list of PartialRow objects that will be used to update
-            rows in Synapse, a list of the indexs of the rows in the original
-            DataFrame that have changes, a list of the indexes of the rows in the
-            original DataFrame that do not have changes, and a list of the etags for
-            the rows that have changes.
-        """
-
-        from pandas import isna
-
-        rows_to_update: List[PartialRow] = []
-        indexs_of_original_df_with_changes = []
-        indexs_of_original_df_without_changes = []
-        etags = []
-        for row in results.itertuples(index=False):
-            row_etag = None
-
-            if contains_etag:
-                row_etag = row.ROW_ETAG
-
-            partial_change_values = {}
-
-            # Find the matching row in `values` that matches the row in `results` for the primary_keys
-            matching_conditions = chunk_to_check_for_upsert[primary_keys[0]] == getattr(
-                row, primary_keys[0]
-            )
-            for col in primary_keys[1:]:
-                matching_conditions &= chunk_to_check_for_upsert[col] == getattr(
-                    row, col
-                )
-            matching_row = chunk_to_check_for_upsert.loc[matching_conditions]
-
-            # Determines which cells need to be updated
-            for column in chunk_to_check_for_upsert.columns:
-                if len(matching_row[column].values) > 1:
-                    raise ValueError(
-                        f"The values for the keys being upserted must be unique in the table: [{matching_row}]"
-                    )
-                elif column not in self.columns:
-                    continue
-                if len(matching_row[column].values) == 0:
-                    continue
-                column_id = self.columns[column].id
-                column_type = self.columns[column].column_type
-                cell_value = matching_row[column].values[0]
-                if not hasattr(row, column) or cell_value != getattr(row, column):
-                    if (
-                        isinstance(cell_value, list) and len(cell_value) > 0
-                    ) or not isna(cell_value):
-                        partial_change_values[
-                            column_id
-                        ] = _convert_pandas_row_to_python_types(
-                            cell=cell_value, column_type=column_type
-                        )
-                    else:
-                        partial_change_values[column_id] = None
-
-            if partial_change_values:
-                partial_change = PartialRow(
-                    row_id=row.ROW_ID,
-                    etag=row_etag,
-                    values=[
-                        {
-                            "key": partial_change_key,
-                            "value": partial_change_value,
-                        }
-                        for partial_change_key, partial_change_value in partial_change_values.items()
-                    ],
-                )
-                rows_to_update.append(partial_change)
-                indexs_of_original_df_with_changes.append(matching_row.index[0])
-                if row_etag:
-                    etags.append(row_etag)
-            else:
-                indexs_of_original_df_without_changes.append(matching_row.index[0])
-        return (
-            rows_to_update,
-            indexs_of_original_df_with_changes,
-            indexs_of_original_df_without_changes,
-            etags,
+        if not values_for_where_statement:
+            continue
+        where_statements.append(
+            f"\"{upsert_column}\" IN ({', '.join(values_for_where_statement)})"
         )
 
-    async def _push_row_updates_to_synapse(
-        self,
-        rows_to_update: List[PartialRow],
-        update_size_bytes: int,
-        progress_bar: tqdm,
-        job_timeout: int,
-        client: Synapse,
-    ) -> None:
-        current_chunk_size = 0
-        chunk = []
-        for row in rows_to_update:
-            row_size = row.size()
-            if current_chunk_size + row_size > update_size_bytes:
-                change = AppendableRowSetRequest(
-                    entity_id=self.id,
-                    to_append=PartialRowSet(
-                        table_id=self.id,
-                        rows=chunk,
-                    ),
-                )
+    where_statement = " AND ".join(where_statements)
+    select_statement += where_statement
+    return select_statement
 
-                request = TableUpdateTransaction(
-                    entity_id=self.id,
-                    changes=[change],
-                )
 
-                await request.send_job_and_wait_async(
-                    synapse_client=client, timeout=job_timeout
-                )
-                progress_bar.update(len(chunk))
-                chunk = []
-                current_chunk_size = 0
-            chunk.append(row)
-            current_chunk_size += row_size
+def _construct_partial_rows_for_upsert(
+    entity: TableBase,
+    results: DATA_FRAME_TYPE,
+    chunk_to_check_for_upsert: DATA_FRAME_TYPE,
+    primary_keys: List[str],
+    contains_etag: bool,
+) -> Tuple[List[PartialRow], List[int], List[int], List[str]]:
+    """
+    Handles the construction of the PartialRow objects that will be used to update
+    rows in Synapse. This method is used in the upsert method to determine which
+    rows need to be updated.
 
-        if chunk:
+    Arguments:
+        results: The DataFrame that contains the data that was queried from Synapse.
+        chunk_to_check_for_upsert: The DataFrame that contains the data that is
+            being upserted.
+        primary_keys: A list of the columns that are used to determine if a row
+            already exists in the table.
+
+    Returns:
+        A tuple containing a list of PartialRow objects that will be used to update
+        rows in Synapse, a list of the indexs of the rows in the original
+        DataFrame that have changes, a list of the indexes of the rows in the
+        original DataFrame that do not have changes, and a list of the etags for
+        the rows that have changes.
+    """
+
+    from pandas import isna
+
+    rows_to_update: List[PartialRow] = []
+    indexs_of_original_df_with_changes = []
+    indexs_of_original_df_without_changes = []
+    etags = []
+    for row in results.itertuples(index=False):
+        row_etag = None
+
+        if contains_etag:
+            row_etag = row.ROW_ETAG
+
+        partial_change_values = {}
+
+        # Find the matching row in `values` that matches the row in `results` for the primary_keys
+        matching_conditions = chunk_to_check_for_upsert[primary_keys[0]] == getattr(
+            row, primary_keys[0]
+        )
+        for col in primary_keys[1:]:
+            matching_conditions &= chunk_to_check_for_upsert[col] == getattr(row, col)
+        matching_row = chunk_to_check_for_upsert.loc[matching_conditions]
+
+        # Determines which cells need to be updated
+        for column in chunk_to_check_for_upsert.columns:
+            if len(matching_row[column].values) > 1:
+                raise ValueError(
+                    f"The values for the keys being upserted must be unique in the table: [{matching_row}]"
+                )
+            elif column not in entity.columns:
+                continue
+            if len(matching_row[column].values) == 0:
+                continue
+            column_id = entity.columns[column].id
+            column_type = entity.columns[column].column_type
+            cell_value = matching_row[column].values[0]
+            if not hasattr(row, column) or cell_value != getattr(row, column):
+                if (isinstance(cell_value, list) and len(cell_value) > 0) or not isna(
+                    cell_value
+                ):
+                    partial_change_values[
+                        column_id
+                    ] = _convert_pandas_row_to_python_types(
+                        cell=cell_value, column_type=column_type
+                    )
+                else:
+                    partial_change_values[column_id] = None
+
+        if partial_change_values:
+            partial_change = PartialRow(
+                row_id=row.ROW_ID,
+                etag=row_etag,
+                values=[
+                    {
+                        "key": partial_change_key,
+                        "value": partial_change_value,
+                    }
+                    for partial_change_key, partial_change_value in partial_change_values.items()
+                ],
+            )
+            rows_to_update.append(partial_change)
+            indexs_of_original_df_with_changes.append(matching_row.index[0])
+            if row_etag:
+                etags.append(row_etag)
+        else:
+            indexs_of_original_df_without_changes.append(matching_row.index[0])
+    return (
+        rows_to_update,
+        indexs_of_original_df_with_changes,
+        indexs_of_original_df_without_changes,
+        etags,
+    )
+
+
+async def _push_row_updates_to_synapse(
+    entity: TableBase,
+    rows_to_update: List[PartialRow],
+    update_size_bytes: int,
+    progress_bar: tqdm,
+    job_timeout: int,
+    client: Synapse,
+) -> None:
+    current_chunk_size = 0
+    chunk = []
+    for row in rows_to_update:
+        row_size = row.size()
+        if current_chunk_size + row_size > update_size_bytes:
             change = AppendableRowSetRequest(
-                entity_id=self.id,
+                entity_id=entity.id,
                 to_append=PartialRowSet(
-                    table_id=self.id,
+                    table_id=entity.id,
                     rows=chunk,
                 ),
             )
 
-            await TableUpdateTransaction(
-                entity_id=self.id,
+            request = TableUpdateTransaction(
+                entity_id=entity.id,
                 changes=[change],
-            ).send_job_and_wait_async(synapse_client=client, timeout=job_timeout)
-            progress_bar.update(len(chunk))
-
-    async def _wait_for_eventually_consistent_changes(
-        self,
-        original_etags_to_track: List[str],
-        wait_for_eventually_consistent_view_timeout: int,
-        synapse_client: Synapse,
-    ) -> None:
-        """
-        Given that a change has been made to a view, this method will wait for the
-        changes to be reflected in the view. This is done by querying the view for the
-        etags that were changed. If the etags are found in the view then we know that
-        the view has not yet been updated with the changes that were made. This method
-        will wait for the changes to be reflected in the view.
-
-        Arguments:
-            original_etags_to_track: A list of the etags that were changed.
-            wait_for_eventually_consistent_view_timeout: The maximum amount of time to
-                wait for the changes to be reflected in the view.
-            synapse_client: The Synapse client to use to query the view.
-
-        Raises:
-            SynapseTimeoutError: If the changes are not reflected in the view within
-                the timeout period.
-
-        Returns:
-            None
-        """
-        with logging_redirect_tqdm(loggers=[synapse_client.logger]):
-            number_of_changes_to_wait_for = len(original_etags_to_track)
-            progress_bar = tqdm(
-                total=number_of_changes_to_wait_for,
-                desc="Waiting for eventually-consistent changes to show up in the view",
-                unit_scale=True,
-                smoothing=0,
             )
-            start_time = time.time()
 
-            while (
-                time.time() - start_time < wait_for_eventually_consistent_view_timeout
-            ):
-                quoted_etags = [f"'{etag}'" for etag in original_etags_to_track]
-                wait_select_statement = f"select etag from {self.id} where etag IN ({','.join(quoted_etags)})"
-                results = await self.query_async(
-                    query=wait_select_statement,
-                    synapse_client=synapse_client,
-                    include_row_id_and_row_version=False,
+            await request.send_job_and_wait_async(
+                synapse_client=client, timeout=job_timeout
+            )
+            progress_bar.update(len(chunk))
+            chunk = []
+            current_chunk_size = 0
+        chunk.append(row)
+        current_chunk_size += row_size
+
+    if chunk:
+        change = AppendableRowSetRequest(
+            entity_id=entity.id,
+            to_append=PartialRowSet(
+                table_id=entity.id,
+                rows=chunk,
+            ),
+        )
+
+        await TableUpdateTransaction(
+            entity_id=entity.id,
+            changes=[change],
+        ).send_job_and_wait_async(synapse_client=client, timeout=job_timeout)
+        progress_bar.update(len(chunk))
+
+
+async def _wait_for_eventually_consistent_changes(
+    entity: TableBase,
+    original_etags_to_track: List[str],
+    wait_for_eventually_consistent_view_timeout: int,
+    synapse_client: Synapse,
+) -> None:
+    """
+    Given that a change has been made to a view, this method will wait for the
+    changes to be reflected in the view. This is done by querying the view for the
+    etags that were changed. If the etags are found in the view then we know that
+    the view has not yet been updated with the changes that were made. This method
+    will wait for the changes to be reflected in the view.
+
+    Arguments:
+        original_etags_to_track: A list of the etags that were changed.
+        wait_for_eventually_consistent_view_timeout: The maximum amount of time to
+            wait for the changes to be reflected in the view.
+        synapse_client: The Synapse client to use to query the view.
+
+    Raises:
+        SynapseTimeoutError: If the changes are not reflected in the view within
+            the timeout period.
+
+    Returns:
+        None
+    """
+    with logging_redirect_tqdm(loggers=[synapse_client.logger]):
+        number_of_changes_to_wait_for = len(original_etags_to_track)
+        progress_bar = tqdm(
+            total=number_of_changes_to_wait_for,
+            desc="Waiting for eventually-consistent changes to show up in the view",
+            unit_scale=True,
+            smoothing=0,
+        )
+        start_time = time.time()
+
+        while time.time() - start_time < wait_for_eventually_consistent_view_timeout:
+            quoted_etags = [f"'{etag}'" for etag in original_etags_to_track]
+            wait_select_statement = (
+                f"select etag from {entity.id} where etag IN ({','.join(quoted_etags)})"
+            )
+            results = await entity.query_async(
+                query=wait_select_statement,
+                synapse_client=synapse_client,
+                include_row_id_and_row_version=False,
+            )
+
+            etags_in_results = results["etag"].values
+            etags_to_remove = []
+            for etag in original_etags_to_track:
+                if etag not in etags_in_results:
+                    etags_to_remove.append(etag)
+            for etag in etags_to_remove:
+                original_etags_to_track.remove(etag)
+                progress_bar.update(1)
+
+            progress_bar.refresh()
+            if not original_etags_to_track:
+                progress_bar.close()
+                break
+            await asyncio.sleep(1)
+        else:
+            raise SynapseTimeoutError(
+                f"Timeout waiting for eventually consistent view: {time.time() - start_time} seconds"
+            )
+
+
+async def _upsert_rows_async(
+    entity: Union[TableBase, ViewBase],
+    values: DATA_FRAME_TYPE,
+    primary_keys: List[str],
+    dry_run: bool = False,
+    *,
+    rows_per_query: int = 50000,
+    update_size_bytes: int = 1.9 * MB,
+    insert_size_bytes: int = 900 * MB,
+    job_timeout: int = 600,
+    wait_for_eventually_consistent_view: bool = False,
+    wait_for_eventually_consistent_view_timeout: int = 600,
+    synapse_client: Optional[Synapse] = None,
+    **kwargs,
+) -> None:
+    """
+    This is used to internally wrap the upsert_rows_async method. This is used to
+    allow for the method to be overridden in the ViewUpdateMixin class with another
+    method name.
+    """
+    test_import_pandas()
+    from pandas import DataFrame
+
+    if not entity._last_persistent_instance:
+        await entity.get_async(include_columns=True, synapse_client=synapse_client)
+    if not entity.columns:
+        raise ValueError(
+            "There are no columns on this table. Unable to proceed with an upsert operation."
+        )
+
+    if isinstance(values, dict):
+        values = DataFrame(values)
+    elif isinstance(values, str):
+        values = csv_to_pandas_df(filepath=values, **kwargs)
+    elif isinstance(values, DataFrame):
+        pass
+    else:
+        raise ValueError(
+            "Don't know how to make tables from values of type %s." % type(values)
+        )
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    rows_to_update: List[PartialRow] = []
+    chunk_list: List[DataFrame] = []
+    for i in range(0, len(values), rows_per_query):
+        chunk_list.append(values[i : i + rows_per_query])
+
+    all_columns_from_df = [f'"{column}"' for column in values.columns]
+    contains_etag = entity.__class__.__name__ in CLASSES_THAT_CONTAIN_ROW_ETAG
+    original_etags_to_track = []
+    indexes_of_original_df_with_changes = []
+    indexes_of_original_df_with_no_changes = []
+    total_row_count_updated = 0
+
+    with logging_redirect_tqdm(loggers=[client.logger]):
+        progress_bar = tqdm(
+            total=len(values),
+            desc="Querying & Updating rows",
+            unit_scale=True,
+            smoothing=0,
+        )
+        for individual_chunk in chunk_list:
+            select_statement = _construct_select_statement_for_upsert(
+                entity=entity,
+                df=individual_chunk,
+                all_columns_from_df=all_columns_from_df,
+                primary_keys=primary_keys,
+            )
+
+            results = await entity.query_async(
+                query=select_statement, synapse_client=synapse_client
+            )
+
+            (
+                rows_to_update,
+                indexes_with_updates,
+                indexes_without_updates,
+                etags_to_track,
+            ) = _construct_partial_rows_for_upsert(
+                entity=entity,
+                results=results,
+                chunk_to_check_for_upsert=individual_chunk,
+                primary_keys=primary_keys,
+                contains_etag=contains_etag,
+            )
+            total_row_count_updated += len(rows_to_update)
+            indexes_of_original_df_with_changes.extend(indexes_with_updates)
+            indexes_of_original_df_with_no_changes.extend(indexes_without_updates)
+            if etags_to_track and contains_etag and wait_for_eventually_consistent_view:
+                original_etags_to_track.extend(etags_to_track)
+
+            if not dry_run and rows_to_update:
+                await _push_row_updates_to_synapse(
+                    entity=entity,
+                    rows_to_update=rows_to_update,
+                    update_size_bytes=update_size_bytes,
+                    progress_bar=progress_bar,
+                    client=client,
+                    job_timeout=job_timeout,
                 )
+            elif dry_run:
+                progress_bar.update(len(rows_to_update))
+            progress_bar.update(len(individual_chunk.index) - len(rows_to_update))
 
-                etags_in_results = results["etag"].values
-                etags_to_remove = []
-                for etag in original_etags_to_track:
-                    if etag not in etags_in_results:
-                        etags_to_remove.append(etag)
-                for etag in etags_to_remove:
-                    original_etags_to_track.remove(etag)
-                    progress_bar.update(1)
+            rows_to_update: List[PartialRow] = []
+        progress_bar.update(progress_bar.total - progress_bar.n)
+        progress_bar.refresh()
+        progress_bar.close()
 
-                progress_bar.refresh()
-                if not original_etags_to_track:
-                    progress_bar.close()
-                    break
-                await asyncio.sleep(1)
-            else:
-                raise SynapseTimeoutError(
-                    f"Timeout waiting for eventually consistent view: {time.time() - start_time} seconds"
-                )
+    rows_to_insert_df = values.loc[
+        ~values.index.isin(
+            indexes_of_original_df_with_changes + indexes_of_original_df_with_no_changes
+        )
+    ]
 
+    client.logger.info(
+        f"[{entity.id}:{entity.name}]: Found {total_row_count_updated}"
+        f" rows to update and {len(rows_to_insert_df)} rows to insert"
+    )
+
+    if wait_for_eventually_consistent_view and original_etags_to_track:
+        await _wait_for_eventually_consistent_changes(
+            entity=entity,
+            original_etags_to_track=original_etags_to_track,
+            wait_for_eventually_consistent_view_timeout=wait_for_eventually_consistent_view_timeout,
+            synapse_client=client,
+        )
+
+    # Only Tables can insert rows directly. Views and other table-like objects cannot.
+    if not isinstance(entity, ViewBase):
+        if not dry_run and not rows_to_insert_df.empty:
+            await entity.store_rows_async(
+                values=rows_to_insert_df,
+                dry_run=dry_run,
+                insert_size_bytes=insert_size_bytes,
+                synapse_client=synapse_client,
+            )
+
+
+@async_to_sync
+class TableUpsertMixin:
     async def upsert_rows_async(
         self,
         values: DATA_FRAME_TYPE,
@@ -1612,129 +1759,24 @@ class TableUpsertMixin:
             | B    | 2    |      |
 
         """
-        test_import_pandas()
-        from pandas import DataFrame
-
-        if not self._last_persistent_instance:
-            await self.get_async(include_columns=True, synapse_client=synapse_client)
-        if not self.columns:
-            raise ValueError(
-                "There are no columns on this table. Unable to proceed with an upsert operation."
-            )
-
-        if isinstance(values, dict):
-            values = DataFrame(values)
-        elif isinstance(values, str):
-            values = csv_to_pandas_df(filepath=values, **kwargs)
-        elif isinstance(values, DataFrame):
-            pass
-        else:
-            raise ValueError(
-                "Don't know how to make tables from values of type %s." % type(values)
-            )
-
-        client = Synapse.get_client(synapse_client=synapse_client)
-
-        rows_to_update: List[PartialRow] = []
-        chunk_list: List[DataFrame] = []
-        for i in range(0, len(values), rows_per_query):
-            chunk_list.append(values[i : i + rows_per_query])
-
-        all_columns_from_df = [f'"{column}"' for column in values.columns]
-        contains_etag = self.__class__.__name__ in CLASSES_THAT_CONTAIN_ROW_ETAG
-        original_etags_to_track = []
-        indexes_of_original_df_with_changes = []
-        indexes_of_original_df_with_no_changes = []
-        total_row_count_updated = 0
-
-        with logging_redirect_tqdm(loggers=[client.logger]):
-            progress_bar = tqdm(
-                total=len(values),
-                desc="Querying & Updating rows",
-                unit_scale=True,
-                smoothing=0,
-            )
-            for individual_chunk in chunk_list:
-                select_statement = self._construct_select_statement_for_upsert(
-                    df=individual_chunk,
-                    all_columns_from_df=all_columns_from_df,
-                    primary_keys=primary_keys,
-                )
-
-                results = await self.query_async(
-                    query=select_statement, synapse_client=synapse_client
-                )
-
-                (
-                    rows_to_update,
-                    indexes_with_updates,
-                    indexes_without_updates,
-                    etags_to_track,
-                ) = self._construct_partial_rows_for_upsert(
-                    results=results,
-                    chunk_to_check_for_upsert=individual_chunk,
-                    primary_keys=primary_keys,
-                    contains_etag=contains_etag,
-                )
-                total_row_count_updated += len(rows_to_update)
-                indexes_of_original_df_with_changes.extend(indexes_with_updates)
-                indexes_of_original_df_with_no_changes.extend(indexes_without_updates)
-                if (
-                    etags_to_track
-                    and contains_etag
-                    and wait_for_eventually_consistent_view
-                ):
-                    original_etags_to_track.extend(etags_to_track)
-
-                if not dry_run and rows_to_update:
-                    await self._push_row_updates_to_synapse(
-                        rows_to_update=rows_to_update,
-                        update_size_bytes=update_size_bytes,
-                        progress_bar=progress_bar,
-                        client=client,
-                        job_timeout=job_timeout,
-                    )
-                elif dry_run:
-                    progress_bar.update(len(rows_to_update))
-                progress_bar.update(len(individual_chunk.index) - len(rows_to_update))
-
-                rows_to_update: List[PartialRow] = []
-            progress_bar.update(progress_bar.total - progress_bar.n)
-            progress_bar.refresh()
-            progress_bar.close()
-
-        rows_to_insert_df = values.loc[
-            ~values.index.isin(
-                indexes_of_original_df_with_changes
-                + indexes_of_original_df_with_no_changes
-            )
-        ]
-
-        client.logger.info(
-            f"[{self.id}:{self.name}]: Found {total_row_count_updated}"
-            f" rows to update and {len(rows_to_insert_df)} rows to insert"
+        return await _upsert_rows_async(
+            entity=self,
+            values=values,
+            primary_keys=primary_keys,
+            dry_run=dry_run,
+            rows_per_query=rows_per_query,
+            update_size_bytes=update_size_bytes,
+            insert_size_bytes=insert_size_bytes,
+            job_timeout=job_timeout,
+            wait_for_eventually_consistent_view=wait_for_eventually_consistent_view,
+            wait_for_eventually_consistent_view_timeout=wait_for_eventually_consistent_view_timeout,
+            synapse_client=synapse_client,
+            **kwargs,
         )
-
-        if wait_for_eventually_consistent_view and original_etags_to_track:
-            await self._wait_for_eventually_consistent_changes(
-                original_etags_to_track=original_etags_to_track,
-                wait_for_eventually_consistent_view_timeout=wait_for_eventually_consistent_view_timeout,
-                synapse_client=client,
-            )
-
-        # Only Tables can insert rows directly. Views and other table-like objects cannot.
-        if not isinstance(self, ViewBase):
-            if not dry_run and not rows_to_insert_df.empty:
-                await self.store_rows_async(
-                    values=rows_to_insert_df,
-                    dry_run=dry_run,
-                    insert_size_bytes=insert_size_bytes,
-                    synapse_client=synapse_client,
-                )
 
 
 @async_to_sync
-class ViewUpdateMixin(TableUpsertMixin):
+class ViewUpdateMixin:
     async def update_rows_async(
         self,
         values: DATA_FRAME_TYPE,
@@ -1751,7 +1793,8 @@ class ViewUpdateMixin(TableUpsertMixin):
         **kwargs,
     ) -> None:
         """You can't insert rows into a view using this method, you can only update rows."""
-        await super().upsert_rows_async(
+        await _upsert_rows_async(
+            entity=self,
             values=values,
             primary_keys=primary_keys,
             dry_run=dry_run,

--- a/synapseclient/models/table.py
+++ b/synapseclient/models/table.py
@@ -1,30 +1,1072 @@
 import asyncio
 import dataclasses
+import os
 from collections import OrderedDict
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import date, datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Protocol, TypeVar, Union
+
+from typing_extensions import Self
 
 from synapseclient import Synapse
 from synapseclient import Table as Synapse_Table
 from synapseclient.core.async_utils import async_to_sync
 from synapseclient.core.constants import concrete_types
-from synapseclient.core.utils import delete_none_keys
+from synapseclient.core.utils import MB, delete_none_keys
 from synapseclient.models import Activity, Annotations
 from synapseclient.models.mixins.access_control import AccessControllable
 from synapseclient.models.mixins.table_components import (
+    AppendableRowSetRequest,
+    ColumnExpansionStrategy,
     ColumnMixin,
+    CsvTableDescriptor,
     DeleteMixin,
     GetMixin,
     QueryMixin,
+    QueryResultBundle,
+    SchemaStorageStrategy,
     TableBase,
     TableDeleteRowMixin,
+    TableSchemaChangeRequest,
     TableStoreMixin,
     TableStoreRowMixin,
     TableUpsertMixin,
+    UploadToTableRequest,
 )
 from synapseclient.models.table_components import Column
+
+DATA_FRAME_TYPE = TypeVar("pd.DataFrame")
+
+
+class TableSynchronousProtocol(Protocol):
+    def store(
+        self, dry_run: bool = False, *, synapse_client: Optional[Synapse] = None
+    ) -> "Self":
+        """Store non-row information about a table including the columns and annotations.
+
+
+        Note the following behavior for the order of columns:
+
+        - If a column is added via the `add_column` method it will be added at the
+            index you specify, or at the end of the columns list.
+        - If column(s) are added during the contruction of your `Table` instance, ie.
+            `Table(columns=[Column(name="foo")])`, they will be added at the begining
+            of the columns list.
+        - If you use the `store_rows` method and the `schema_storage_strategy` is set to
+            `INFER_FROM_DATA` the columns will be added at the end of the columns list.
+
+
+        Arguments:
+            dry_run: If True, will not actually store the table but will log to
+                the console what would have been stored.
+
+            job_timeout: The maximum amount of time to wait for a job to complete.
+                This is used when updating the table schema. If the timeout
+                is reached a `SynapseTimeoutError` will be raised.
+                The default is 600 seconds
+
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            The Table instance stored in synapse.
+        """
+        return self
+
+    def get(
+        self,
+        include_columns: bool = False,
+        include_activity: bool = False,
+        *,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "Self":
+        """Get the metadata about the table from synapse.
+
+        Arguments:
+            include_columns: If True, will include fully filled column objects in the
+                `.columns` attribute. Defaults to True.
+            include_activity: If True the activity will be included in the file
+                if it exists. Defaults to False.
+
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            The Table instance stored in synapse.
+
+        Example: Getting metadata about a table using id
+            Get a table by ID and print out the columns and activity. `include_columns`
+            defaults to True and `include_activity` defaults to False. When you need to
+            update existing columns or activity these need to be set to True during the
+            `get` call, then you'll make the changes, and finally call the
+            `.store()` method.
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Table
+
+            syn = Synapse()
+            syn.login()
+
+            table = Table(id="syn4567").get(include_activity=True)
+            print(table)
+
+            # Columns are retrieved by default
+            print(table.columns)
+            print(table.activity)
+            ```
+
+        Example: Getting metadata about a table using name and parent_id
+            Get a table by name/parent_id and print out the columns and activity.
+            `include_columns` defaults to True and `include_activity` defaults to
+            False. When you need to update existing columns or activity these need to
+            be set to True during the `get` call, then you'll make the changes,
+            and finally call the `.store()` method.
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Table
+
+            syn = Synapse()
+            syn.login()
+
+            table = Table(name="my_table", parent_id="syn1234").get(include_columns=True, include_activity=True)
+            print(table)
+            print(table.columns)
+            print(table.activity)
+            ```
+        """
+        return self
+
+    def delete(self, *, synapse_client: Optional[Synapse] = None) -> None:
+        """Delete the entity from synapse. This is not version specific. If you'd like
+        to delete a specific version of the entity you must use the
+        [synapseclient.api.delete_entity][] function directly.
+
+        Arguments:
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            None
+
+        Example: Deleting a table
+            Deleting a table is only supported by the ID of the table.
+
+            ```python
+            from synapseclient import Synapse
+
+            syn = Synapse()
+            syn.login()
+
+            Table(id="syn4567").delete()
+            ```
+        """
+        return None
+
+    @staticmethod
+    def query(
+        query: str,
+        include_row_id_and_row_version: bool = True,
+        convert_to_datetime: bool = False,
+        download_location=None,
+        quote_character='"',
+        escape_character="\\",
+        line_end=str(os.linesep),
+        separator=",",
+        header=True,
+        *,
+        synapse_client: Optional[Synapse] = None,
+        **kwargs,
+    ) -> DATA_FRAME_TYPE:
+        """Query for data on a table stored in Synapse. The results will always be
+        returned as a Pandas DataFrame unless you specify a `download_location` in which
+        case the results will be downloaded to that location. There are a number of
+        arguments that you may pass to this function depending on if you are getting
+        the results back as a DataFrame or downloading the results to a file.
+
+        Arguments:
+            query: The query to run. The query must be valid syntax that Synapse can
+                understand. See this document that describes the expected syntax of the
+                query:
+                <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/web/controller/TableExamples.html>
+            include_row_id_and_row_version: If True the `ROW_ID` and `ROW_VERSION`
+                columns will be returned in the DataFrame. These columns are required
+                if using the query results to update rows in the table. These columns
+                are the primary keys used by Synapse to uniquely identify rows in the
+                table.
+            convert_to_datetime: (DataFrame only) If set to True, will convert all
+                Synapse DATE columns from UNIX timestamp integers into UTC datetime
+                objects
+
+            download_location: (CSV Only) If set to a path the results will be
+                downloaded to that directory. The results will be downloaded as a CSV
+                file. A path to the downloaded file will be returned instead of a
+                DataFrame.
+
+            quote_character: (CSV Only) The character to use to quote fields. The
+                default is a double quote.
+
+            escape_character: (CSV Only) The character to use to escape special
+                characters. The default is a backslash.
+
+            line_end: (CSV Only) The character to use to end a line. The default is
+                the system's line separator.
+
+            separator: (CSV Only) The character to use to separate fields. The default
+                is a comma.
+
+            header: (CSV Only) If set to True the first row will be used as the header
+                row. The default is True.
+
+            **kwargs: (DataFrame only) Additional keyword arguments to pass to
+                pandas.read_csv. See
+                <https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html>
+                for complete list of supported arguments. This is exposed as
+                internally the query downloads a CSV from Synapse and then loads
+                it into a dataframe.
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            The results of the query as a Pandas DataFrame.
+
+        Example: Querying for data
+            This example shows how you may query for data in a table and print out the
+            results.
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import query
+
+            syn = Synapse()
+            syn.login()
+
+            results = query(query="SELECT * FROM syn1234")
+            print(results)
+            ```
+        """
+        from pandas import DataFrame
+
+        return DataFrame()
+
+    @staticmethod
+    def query_part_mask(
+        query: str,
+        part_mask: int,
+        *,
+        synapse_client: Optional[Synapse] = None,
+    ) -> QueryResultBundle:
+        """Query for data on a table stored in Synapse. This is a more advanced use case
+        of the `query` function that allows you to determine what addiitional metadata
+        about the table or query should also be returned. If you do not need this
+        additional information then you are better off using the `query` function.
+
+        The query for this method uses this Rest API:
+        <https://rest-docs.synapse.org/rest/POST/entity/id/table/query/async/start.html>
+
+        Arguments:
+            query: The query to run. The query must be valid syntax that Synapse can
+                understand. See this document that describes the expected syntax of the
+                query:
+                <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/web/controller/TableExamples.html>
+            part_mask: The bitwise OR of the part mask values you want to return in the
+                results. The following list of part masks are implemented to be returned
+                in the results:
+
+                - Query Results (queryResults) = 0x1
+                - Query Count (queryCount) = 0x2
+                - The sum of the file sizes (sumFileSizesBytes) = 0x40
+                - The last updated on date of the table (lastUpdatedOn) = 0x80
+
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            The results of the query as a Pandas DataFrame.
+
+        Example: Querying for data with a part mask
+            This example shows how to use the bitwise `OR` of Python to combine the
+            part mask values and then use that to query for data in a table and print
+            out the results.
+
+            In this case we are getting the results of the query, the count of rows, and
+            the last updated on date of the table.
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import query_part_mask
+
+            syn = Synapse()
+            syn.login()
+
+            QUERY_RESULTS = 0x1
+            QUERY_COUNT = 0x2
+            LAST_UPDATED_ON = 0x80
+
+            # Combine the part mask values using bitwise OR
+            part_mask = QUERY_RESULTS | QUERY_COUNT | LAST_UPDATED_ON
+
+
+            result = query_part_mask(query="SELECT * FROM syn1234", part_mask=part_mask)
+            print(result)
+            ```
+        """
+        return None
+
+    def upsert_rows(
+        self,
+        values: DATA_FRAME_TYPE,
+        primary_keys: List[str],
+        dry_run: bool = False,
+        *,
+        rows_per_query: int = 50000,
+        update_size_bytes: int = 1.9 * MB,
+        insert_size_bytes: int = 900 * MB,
+        job_timeout: int = 600,
+        wait_for_eventually_consistent_view: bool = False,
+        wait_for_eventually_consistent_view_timeout: int = 600,
+        synapse_client: Optional[Synapse] = None,
+        **kwargs,
+    ) -> None:
+        """
+        This method allows you to perform an `upsert` (Update and Insert) for row(s).
+        This means that you may update a row with only the data that you want to change.
+        When supplied with a row that does not match the given `primary_keys` a new
+        row will be inserted.
+
+
+        Using the `primary_keys` argument you may specify which columns to use to
+        determine if a row already exists. If a row exists with the same values in the
+        columns specified in this list the row will be updated. If a row does not exist
+        it will be inserted.
+
+
+        Limitations:
+
+        - The request to update, and the request to insert data does not occur in a
+            single transaction. This means that the update of data may succeed, but the
+            insert of data may fail. Additionally, as noted in the limitation below, if
+            data is chunked up into multiple requests you may find that a portion of
+            your data is updated, but another portion is not.
+        - The number of rows that may be upserted in a single call should be
+            kept to a minimum (< 50,000). There is significant overhead in the request
+            to Synapse for each row that is upserted. If you are upserting a large
+            number of rows a better approach may be to query for the data you want
+            to update, update the data, then use the [store_rows][synapseclient.models.mixins.table_components.TableStoreRowMixin.store_row] method to
+            update the data in Synapse. Any rows you want to insert may be added
+            to the DataFrame that is passed to the [store_rows][synapseclient.models.mixins.table_components.TableStoreRowMixin.store_rows] method.
+        - When upserting mnay rows the requests to Synapse will be chunked into smaller
+            requests. The limit is 2MB per request. This chunking will happen
+            automatically and should not be a concern for most users. If you are
+            having issues with the request being too large you may lower the
+            number of rows you are trying to upsert, or note the above limitation.
+        - The `primary_keys` argument must contain at least one column.
+        - The `primary_keys` argument cannot contain columns that are a LIST type.
+        - The `primary_keys` argument cannot contain columns that are a JSON type.
+        - The values used as the `primary_keys` must be unique in the table. If there
+            are multiple rows with the same values in the `primary_keys` the behavior
+            is that an exception will be raised.
+        - The columns used in `primary_keys` cannot contain updated values. Since
+            the values in these columns are used to determine if a row exists, they
+            cannot be updated in the same transaction.
+
+        The following is a Sequence Diagram that describces the upsert process at a
+        high level:
+
+        ```mermaid
+        sequenceDiagram
+            participant User
+            participant Table
+            participant Synapse
+
+            User->>Table: upsert_rows()
+
+            loop Query and Process Updates in Chunks (rows_per_query)
+                Table->>Synapse: Query existing rows using primary keys
+                Synapse-->>Table: Return matching rows
+                Note Over Table: Create partial row updates
+
+                loop For results from query
+                    Note Over Table: Sum row/chunk size
+                    alt Chunk size exceeds update_size_bytes
+                        Table->>Synapse: Push update chunk
+                        Synapse-->>Table: Acknowledge update
+                    end
+                    Table->>Table: Add row to chunk
+                end
+
+                alt Remaining updates exist
+                    Table->>Synapse: Push final update chunk
+                    Synapse-->>Table: Acknowledge update
+                end
+            end
+
+            alt New rows exist
+                Table->>Table: Identify new rows for insertion
+                Table->>Table: Call `store_rows()` function
+            end
+
+            Table-->>User: Upsert complete
+        ```
+
+        Arguments:
+            values: Supports storing data from the following sources:
+
+                - A string holding the path to a CSV file. Tthe data will be read into a [Pandas DataFrame](http://pandas.pydata.org/pandas-docs/stable/api.html#dataframe). The code makes assumptions about the format of the columns in the CSV as detailed in the [csv_to_pandas_df][synapseclient.models.mixins.table_components.csv_to_pandas_df] function. You may pass in additional arguments to the `csv_to_pandas_df` function by passing them in as keyword arguments to this function.
+                - A dictionary where the key is the column name and the value is one or more values. The values will be wrapped into a [Pandas DataFrame](http://pandas.pydata.org/pandas-docs/stable/api.html#dataframe). You may pass in additional arguments to the `pd.DataFrame` function by passing them in as keyword arguments to this function. Read about the available arguments in the [Pandas DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) documentation.
+                - A [Pandas DataFrame](http://pandas.pydata.org/pandas-docs/stable/api.html#dataframe)
+
+            primary_keys: The columns to use to determine if a row already exists. If
+                a row exists with the same values in the columns specified in this list
+                the row will be updated. If a row does not exist it will be inserted.
+
+            dry_run: If set to True the data will not be updated in Synapse. A message
+                will be printed to the console with the number of rows that would have
+                been updated and inserted. If you would like to see the data that would
+                be updated and inserted you may set the `dry_run` argument to True and
+                set the log level to DEBUG by setting the debug flag when creating
+                your Synapse class instance like: `syn = Synapse(debug=True)`.
+
+            rows_per_query: The number of rows that will be queries from Synapse per
+                request. Since we need to query for the data that is being updated
+                this will determine the number of rows that are queried at a time.
+                The default is 50,000 rows.
+
+            update_size_bytes: The maximum size of the request that will be sent to Synapse
+                when updating rows of data. The default is 1.9MB.
+
+            insert_size_bytes: The maximum size of the request that will be sent to Synapse
+                when inserting rows of data. The default is 900MB.
+
+            job_timeout: The maximum amount of time to wait for a job to complete.
+                This is used when inserting, and updating rows of data. Each individual
+                request to Synapse will be sent as an independent job. If the timeout
+                is reached a `SynapseTimeoutError` will be raised.
+                The default is 600 seconds
+
+            wait_for_eventually_consistent_view: Only used if the table is a view. If
+                set to True this will wait for the view to reflect any changes that
+                you've made to the view. This is useful if you need to query the view
+                after making changes to the data.
+
+            wait_for_eventually_consistent_view_timeout: The maximum amount of time to
+                wait for a view to be eventually consistent. The default is 600 seconds.
+
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor
+
+            **kwargs: Additional arguments that are passed to the `pd.DataFrame`
+                function when the `values` argument is a path to a csv file.
+
+
+        Example: Updating 2 rows and inserting 1 row
+            In this given example we have a table with the following data:
+
+            | col1 | col2 | col3 |
+            |------|------| -----|
+            | A    | 1    | 1    |
+            | B    | 2    | 2    |
+
+            The following code will update the first row's `col2` to `22`, update the
+            second row's `col3` to `33`, and insert a new row:
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Table
+            import pandas as pd
+
+            syn = Synapse()
+            syn.login()
+
+
+            table = Table(id="syn123").get(include_columns=True)
+
+            df = {
+                'col1': ['A', 'B', 'C'],
+                'col2': [22, 2, 3],
+                'col3': [1, 33, 3],
+            }
+
+            table.upsert_rows(values=df, primary_keys=["col1"])
+            ```
+
+            The resulting table will look like this:
+
+            | col1 | col2 | col3 |
+            |------|------| -----|
+            | A    | 22   | 1    |
+            | B    | 2    | 33   |
+            | C    | 3    | 3    |
+
+        Example: Deleting data from a specific cell
+            In this given example we have a table with the following data:
+
+            | col1 | col2 | col3 |
+            |------|------| -----|
+            | A    | 1    | 1    |
+            | B    | 2    | 2    |
+
+            The following code will update the first row's `col2` to `22`, update the
+            second row's `col3` to `33`, and insert a new row:
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Table
+
+            syn = Synapse()
+            syn.login()
+
+
+            table = Table(id="syn123").get(include_columns=True)
+
+            df = {
+                'col1': ['A', 'B'],
+                'col2': [None, 2],
+                'col3': [1, None],
+            }
+
+            table.upsert_rows(values=df, primary_keys=["col1"])
+            ```
+
+
+            The resulting table will look like this:
+
+            | col1 | col2 | col3 |
+            |------|------| -----|
+            | A    |      | 1    |
+            | B    | 2    |      |
+
+        """
+        return None
+
+    def store_rows(
+        self,
+        values: Union[str, Dict[str, Any], DATA_FRAME_TYPE],
+        schema_storage_strategy: SchemaStorageStrategy = None,
+        column_expansion_strategy: ColumnExpansionStrategy = None,
+        dry_run: bool = False,
+        additional_changes: List[
+            Union[
+                "TableSchemaChangeRequest",
+                "UploadToTableRequest",
+                "AppendableRowSetRequest",
+            ]
+        ] = None,
+        *,
+        insert_size_bytes: int = 900 * MB,
+        csv_table_descriptor: Optional[CsvTableDescriptor] = None,
+        read_csv_kwargs: Optional[Dict[str, Any]] = None,
+        to_csv_kwargs: Optional[Dict[str, Any]] = None,
+        job_timeout: int = 600,
+        synapse_client: Optional[Synapse] = None,
+    ) -> None:
+        """
+        Add or update rows in Synapse from the sources defined below. In most cases the
+        result of this function call will append rows to the table. In the case of an
+        update this method works on a full row replacement. What this means is
+        that you may not do a partial update of a row. If you want to update a row
+        you must pass in all the data for that row, or the data for the columns not
+        provided will be set to null.
+
+        If you'd like to update a row see the example `Updating rows in a table` below.
+
+        If you'd like to perform an `upsert` or partial update of a row you may use
+        the `.upsert_rows()` method. See that method for more information.
+
+
+        Note the following behavior for the order of columns:
+
+        - If a column is added via the `add_column` method it will be added at the
+            index you specify, or at the end of the columns list.
+        - If column(s) are added during the contruction of your `Table` instance, ie.
+            `Table(columns=[Column(name="foo")])`, they will be added at the begining
+            of the columns list.
+        - If you use the `store_rows` method and the `schema_storage_strategy` is set to
+            `INFER_FROM_DATA` the columns will be added at the end of the columns list.
+
+
+        **Limitations:**
+
+        - Synapse limits the number of rows that may be stored in a single request to
+            a CSV file that is 1GB. If you are storing a CSV file that is larger than
+            this limit the data will be chunked into smaller requests. This process is
+            done by reading the file once to determine what the row and byte boundries
+            are and calculating the MD5 hash of that portion, then reading the file
+            again to send the data to Synapse. This process is done to ensure that the
+            data is not corrupted during the upload process, in addition Synapse
+            requires the MD5 hash of the data to be sent in the request along with the
+            number of bytes that are being sent.
+        - The limit of 1GB is also enforced when storing a dictionary or a DataFrame.
+            The data will be converted to a CSV format using the `.to_csv()` pandas
+            function. If you are storing more than a 1GB file it is recommended that
+            you store the data as a CSV and use the file path to upload the data. This
+            is due to the fact that the DataFrame chunking process is slower than
+            reading portions of a file on disk and calculating the MD5 hash of that
+            portion.
+
+        The following is a Sequence Daigram that describes the process noted in the
+        limitation above. It shows how the data is chunked into smaller requests when
+        the data exceeds the limit of 1GB, and how portions of the data are read from
+        the CSV file on disk while being uploaded to Synapse.
+
+        ```mermaid
+        sequenceDiagram
+            participant User
+            participant Table
+            participant FileSystem
+            participant Synapse
+
+            User->>Table: store_rows(values)
+
+            alt CSV size > 1GB
+                Table->>Synapse: Apply schema changes before uploading
+                note over Table, FileSystem: Read CSV twice
+                Table->>FileSystem: Read entire CSV (First Pass)
+                FileSystem-->>Table: Compute chunk sizes & MD5 hashes
+
+                loop Read and Upload CSV chunks (Second Pass)
+                    Table->>FileSystem: Read next chunk from CSV
+                    FileSystem-->>Table: Return bytes
+                    Table->>Synapse: Upload CSV chunk
+                    Synapse-->>Table: Return `file_handle_id`
+                    Table->>Synapse: Send 'TableUpdateTransaction' to append/update rows
+                    Synapse-->>Table: Transaction result
+                end
+            else
+                Table->>Synapse: Upload CSV without splitting & Any additional schema changes
+                Synapse-->>Table: Return `file_handle_id`
+                Table->>Synapse: Send `TableUpdateTransaction' to append/update rows
+                Synapse-->>Table: Transaction result
+            end
+
+            Table-->>User: Upload complete
+        ```
+
+        The following is a Sequence Daigram that describes the process noted in the
+        limitation above for DataFrames. It shows how the data is chunked into smaller
+        requests when the data exceeds the limit of 1GB, and how portions of the data
+        are read from the DataFrame while being uploaded to Synapse.
+
+        ```mermaid
+        sequenceDiagram
+            participant User
+            participant Table
+            participant MemoryBuffer
+            participant Synapse
+
+            User->>Table: store_rows(DataFrame)
+
+            loop For all rows in DataFrame in 100 row increments
+                Table->>MemoryBuffer: Convert DataFrame rows to CSV in-memory
+                MemoryBuffer-->>Table: Compute chunk sizes & MD5 hashes
+            end
+
+
+            alt Multiple chunks detected
+                Table->>Synapse: Apply schema changes before uploading
+            end
+
+            loop For all chunks found in first loop
+                loop for all parts in chunk byte boundry
+                    Table->>MemoryBuffer: Read small (< 8MB) part of the chunk
+                    MemoryBuffer-->>Table: Return bytes (with correct offset)
+                    Table->>Synapse: Upload part
+                    Synapse-->>Table: Upload response
+                end
+                Table->>Synapse: Complete upload
+                Synapse-->>Table: Return `file_handle_id`
+                Table->>Synapse: Send 'TableUpdateTransaction' to append/update rows
+                Synapse-->>Table: Transaction result
+            end
+
+            Table-->>User: Upload complete
+        ```
+
+        Arguments:
+            values: Supports storing data from the following sources:
+
+                - A string holding the path to a CSV file. If the `schema_storage_strategy` is set to `None` the data will be uploaded as is. If `schema_storage_strategy` is set to `INFER_FROM_DATA` the data will be read into a [Pandas DataFrame](http://pandas.pydata.org/pandas-docs/stable/api.html#dataframe). The code makes assumptions about the format of the columns in the CSV as detailed in the [csv_to_pandas_df][synapseclient.models.mixins.table_components.csv_to_pandas_df] function. You may pass in additional arguments to the `csv_to_pandas_df` function by passing them in as keyword arguments to this function.
+                - A dictionary where the key is the column name and the value is one or more values. The values will be wrapped into a [Pandas DataFrame](http://pandas.pydata.org/pandas-docs/stable/api.html#dataframe). You may pass in additional arguments to the `pd.DataFrame` function by passing them in as keyword arguments to this function. Read about the available arguments in the [Pandas DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) documentation.
+                - A [Pandas DataFrame](http://pandas.pydata.org/pandas-docs/stable/api.html#dataframe)
+
+            schema_storage_strategy: Determines how to automate the creation of columns
+                based on the data that is being stored. If you want to have full
+                control over the schema you may set this to `None` and create
+                the columns manually.
+
+                The limitation with this behavior is that the columns created may only
+                be of the following types:
+
+                - STRING
+                - LARGETEXT
+                - INTEGER
+                - DOUBLE
+                - BOOLEAN
+                - DATE
+
+                The determination is based on how this pandas function infers the
+                data type: [infer_dtype](https://pandas.pydata.org/docs/reference/api/pandas.api.types.infer_dtype.html)
+
+                This may also only set the `name`, `column_type`, and `maximum_size` of
+                the column when the column is created. If this is used to update the
+                column the `maxium_size` will only be updated depending on the
+                value of `column_expansion_strategy`. The other attributes of the
+                column will be set to the default values on create, or remain the same
+                if the column already exists.
+
+
+                The usage of this feature will never delete a column, shrink a column,
+                or change the type of a column that already exists. If you need to
+                change any of these attributes you must do so after getting the table
+                via a `.get()` call, updating the columns as needed, then calling
+                `.store()` on the table.
+
+            column_expansion_strategy: Determines how to automate the expansion of
+                columns based on the data that is being stored. The options given allow
+                cells with a limit on the length of content (Such as strings) to be
+                expanded to a larger size if the data being stored exceeds the limit.
+                If you want to have full control over the schema you may set this to
+                `None` and create the columns manually. String type columns are the only
+                ones that support this feature.
+
+            dry_run: Log the actions that would be taken, but do not actually perform
+                the actions. This will not print out the data that would be stored or
+                modified as a result of this action. It will print out the actions that
+                would be taken, such as creating a new column, updating a column, or
+                updating table metadata. This is useful for debugging and understanding
+                what actions would be taken without actually performing them.
+
+            additional_changes: Additional changes to the table that should execute
+                within the same transaction as appending or updating rows. This is used
+                as a part of the `upsert_rows` method call to allow for the updating of
+                rows and the updating of the table schema in the same transaction. In
+                most cases you will not need to use this argument.
+
+            insert_size_bytes: The maximum size of data that will be stored to Synapse
+                within a single transaction. The API have a limit of 1GB, but the
+                default is set to 900 MB to allow for some overhead in the request. The
+                implication of this limit is that when you are storing a CSV that is
+                larger than this limit the data will be chunked into smaller requests
+                by reading the file once to determine what the row and byte boundries
+                are and calculating the MD5 hash of that portion, then reading the file
+                again to send the data to Synapse. This process is done to ensure that
+                the data is not corrupted during the upload process, in addition Synapse
+                requires the MD5 hash of the data to be sent in the request along with
+                the number of bytes that are being sent. This argument is also used
+                when storing a dictionary or a DataFrame. The data will be converted to
+                a CSV format using the `.to_csv()` pandas function. When storing data
+                as a DataFrame the minimum that it will be chunked to is 100 rows of
+                data, regardless of if the data is larger than the limit.
+
+            csv_table_descriptor: When passing in a CSV file this will allow you to
+                specify the format of the CSV file. This is only used when the `values`
+                argument is a string holding the path to a CSV file. See
+                [CsvTableDescriptor][synapseclient.models.CsvTableDescriptor]
+                for more information.
+
+            read_csv_kwargs: Additional arguments to pass to the `pd.read_csv` function
+                when reading in a CSV file. This is only used when the `values` argument
+                is a string holding the path to a CSV file and you have set the
+                `schema_storage_strategy` to `INFER_FROM_DATA`. See
+                <https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html>
+                for complete list of supported arguments.
+
+            to_csv_kwargs: Additional arguments to pass to the `pd.DataFrame.to_csv`
+                function when writing the data to a CSV file. This is only used when
+                the `values` argument is a Pandas DataFrame. See
+                <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_csv.html>
+                for complete list of supported arguments.
+
+            job_timeout: The maximum amount of time to wait for a job to complete.
+                This is used when inserting, and updating rows of data. Each individual
+                request to Synapse will be sent as an independent job. If the timeout
+                is reached a `SynapseTimeoutError` will be raised.
+                The default is 600 seconds
+
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            None
+
+        Example: Inserting rows into a table that already has columns
+            This example shows how you may insert rows into a table.
+
+            Suppose we have a table with the following columns:
+
+            | col1 | col2 | col3 |
+            |------|------| -----|
+
+            The following code will insert rows into the table:
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Table
+
+            syn = Synapse()
+            syn.login()
+
+            data_to_insert = {
+                'col1': ['A', 'B', 'C'],
+                'col2': [1, 2, 3],
+                'col3': [1, 2, 3],
+            }
+
+            Table(id="syn1234").store_rows(values=data_to_insert)
+            ```
+
+            The resulting table will look like this:
+
+            | col1 | col2 | col3 |
+            |------|------| -----|
+            | A    | 1    | 1    |
+            | B    | 2    | 2    |
+            | C    | 3    | 3    |
+
+        Example: Inserting rows into a table that does not have columns
+            This example shows how you may insert rows into a table that does not have
+            columns. The columns will be inferred from the data that is being stored.
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Table, SchemaStorageStrategy
+
+            syn = Synapse()
+            syn.login()
+
+            data_to_insert = {
+                'col1': ['A', 'B', 'C'],
+                'col2': [1, 2, 3],
+                'col3': [1, 2, 3],
+            }
+
+            Table(id="syn1234").store_rows(
+                values=data_to_insert,
+                schema_storage_strategy=SchemaStorageStrategy.INFER_FROM_DATA
+            )
+            ```
+
+            The resulting table will look like this:
+
+            | col1 | col2 | col3 |
+            |------|------| -----|
+            | A    | 1    | 1    |
+            | B    | 2    | 2    |
+            | C    | 3    | 3    |
+
+        Example: Using the dry_run option with a SchemaStorageStrategy of INFER_FROM_DATA
+            This example shows how you may use the `dry_run` option with the
+            `SchemaStorageStrategy` set to `INFER_FROM_DATA`. This will show you the
+            actions that would be taken, but not actually perform the actions.
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Table, SchemaStorageStrategy
+
+            syn = Synapse()
+            syn.login()
+
+            data_to_insert = {
+                'col1': ['A', 'B', 'C'],
+                'col2': [1, 2, 3],
+                'col3': [1, 2, 3],
+            }
+
+            Table(id="syn1234").store_rows(
+                values=data_to_insert,
+                dry_run=True,
+                schema_storage_strategy=SchemaStorageStrategy.INFER_FROM_DATA
+            )
+            ```
+
+            The result of running this action will print to the console the actions that
+            would be taken, but not actually perform the actions.
+
+        Example: Updating rows in a table
+            This example shows how you may query for data in a table, update the data,
+            and then store the updated rows back in Synapse.
+
+            Suppose we have a table that has the following data:
+
+
+            | col1 | col2 | col3 |
+            |------|------| -----|
+            | A    | 1    | 1    |
+            | B    | 2    | 2    |
+            | C    | 3    | 3    |
+
+            Behind the scenese the tables also has `ROW_ID` and `ROW_VERSION` columns
+            which are used to identify the row that is being updated. These columns
+            are not shown in the table above, but is included in the data that is
+            returned when querying the table. If you add data that does not have these
+            columns the data will be treated as new rows to be inserted.
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Table, query
+
+            syn = Synapse()
+            syn.login()
+
+            query_results = query(query="select * from syn1234 where col1 in ('A', 'B')")
+
+            # Update `col2` of the row where `col1` is `A` to `22`
+            query_results.loc[query_results['col1'] == 'A', 'col2'] = 22
+
+            # Update `col3` of the row where `col1` is `B` to `33`
+            query_results.loc[query_results['col1'] == 'B', 'col3'] = 33
+
+            Table(id="syn1234").store_rows(values=query_results)
+            ```
+
+            The resulting table will look like this:
+
+            | col1 | col2 | col3 |
+            |------|------| -----|
+            | A    | 22   | 1    |
+            | B    | 2    | 33   |
+            | C    | 3    | 3    |
+
+        """
+        return None
+
+    def delete_rows(
+        self, query: str, *, synapse_client: Optional[Synapse] = None
+    ) -> DATA_FRAME_TYPE:
+        """
+        Delete rows from a table given a query to select rows. The query at a
+        minimum must select the `ROW_ID` and `ROW_VERSION` columns. If you want to
+        inspect the data that will be deleted ahead of time you may use the
+        `.query` method to get the data.
+
+
+        Arguments:
+            query: The query to select the rows to delete. The query at a minimum
+                must select the `ROW_ID` and `ROW_VERSION` columns. See this document
+                that describes the expected syntax of the query:
+                <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/web/controller/TableExamples.html>
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            The results of your query for the rows that were deleted from the table.
+
+        Example: Selecting a row to delete
+            This example shows how you may select a row to delete from a table.
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Table
+
+            syn = Synapse()
+            syn.login()
+
+            Table(id="syn1234").delete_rows(query="SELECT ROW_ID, ROW_VERSION FROM syn1234 WHERE foo = 'asdf'")
+            ```
+
+        Example: Selecting all rows that contain a null value
+            This example shows how you may select a row to delete from a table where
+            a column has a null value.
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Table
+
+            syn = Synapse()
+            syn.login()
+
+            Table(id="syn1234").delete_rows(query="SELECT ROW_ID, ROW_VERSION FROM syn1234 WHERE foo is null")
+            ```
+        """
+        from pandas import DataFrame
+
+        return DataFrame()
+
+    def snapshot(
+        self,
+        comment: str = None,
+        label: str = None,
+        include_activity: bool = True,
+        associate_activity_to_new_version: bool = True,
+        *,
+        synapse_client: Optional[Synapse] = None,
+    ) -> Dict[str, Any]:
+        """
+        Request to create a new snapshot of a table. The provided comment, label, and
+        activity will be applied to the current version thereby creating a snapshot
+        and locking the current version. After the snapshot is created a new version
+        will be started with an 'in-progress' label.
+
+        Arguments:
+            comment: Comment to add to this snapshot to the table.
+            label: Label to add to this snapshot to the table. The label must be unique,
+                if a label is not provided a unique label will be generated.
+            include_activity: If True the activity will be included in snapshot if it
+                exists. In order to include the activity, the activity must have already
+                been stored in Synapse by using the `activity` attribute on the Table
+                and calling the `store()` method on the Table instance. Adding an
+                activity to a snapshot of a table is meant to capture the provenance of
+                the data at the time of the snapshot.
+            associate_activity_to_new_version: If True the activity will be associated
+                with the new version of the table. If False the activity will not be
+                associated with the new version of the table.
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Example: Creating a snapshot of a table
+            Comment and label are optional, but filled in for this example.
+
+                from synapseclient.models import Table
+                from synapseclient import Synapse
+
+                syn = Synapse()
+                syn.login()
+
+                my_table = Table(id="syn1234")
+                my_table.snapshot(
+                    comment="This is a new snapshot comment",
+                    label="This is a unique label"
+                )
+
+        Example: Including the activity (Provenance) in the snapshot and not pulling it forward to the new `in-progress` version of the table.
+            By default this method is set up to include the activity in the snapshot and
+            then pull the activity forward to the new version. If you do not want to
+            include the activity in the snapshot you can set `include_activity` to
+            False. If you do not want to pull the activity forward to the new version
+            you can set `associate_activity_to_new_version` to False.
+
+            See the [activity][synapseclient.models.Activity] attribute on the Table
+            class for more information on how to interact with the activity.
+
+                from synapseclient.models import Table
+                from synapseclient import Synapse
+
+                syn = Synapse()
+                syn.login()
+
+                my_table = Table(id="syn1234")
+                my_table.snapshot(
+                    comment="This is a new snapshot comment",
+                    label="This is a unique label",
+                    include_activity=True,
+                    associate_activity_to_new_version=False
+                )
+
+        Returns:
+            A dictionary that matches: <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/SnapshotResponse.html>
+        """
+        return {}
 
 
 @dataclass()
@@ -40,6 +1082,7 @@ class Table(
     QueryMixin,
     TableUpsertMixin,
     TableStoreMixin,
+    TableSynchronousProtocol,
 ):
     """A Table represents the metadata of a table.
 


### PR DESCRIPTION
**Problem:**

1. The `upsert` functionality is not available within a `View` type FileView/Dataset, and it should be hidden. The idea is that it is replaced by an method called `update` so it does not give the impression that you may insert rows via the function call.
2. The current implementation was causing both `upsert` and `update` functions to be available:
![image](https://github.com/user-attachments/assets/1a067767-cce0-4c72-834e-88010bf2e3a2)


**Solution:**

1. Swap the upsert logic to be a function that can be called. Calling that function from both the upsert/update mixins.
2. Remove the dependency of the update mixin that extends the upsert mixin.


**Testing:**

1. Will be reviewing test runs. I also verified that I was able to load the mkdoc pages