### PR TITLE
[SYNPY-1542] Upgrade readthedocs os, python version, and search ranking

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,9 +6,10 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    # alias for the latest 3.x version available on Read the Docs
+    python: "3"
 
 mkdocs:
   configuration: mkdocs.yml
@@ -17,3 +18,8 @@ mkdocs:
 python:
   install:
   - requirements: docs/requirements.txt
+
+# See https://docs.readthedocs.com/platform/stable/config-file/v2.html#search for more options
+search:
+  ranking:
+    reference/*: -1


### PR DESCRIPTION
# **Problem:**

- There are a few settings set on the read the docs side that could use a slight update.


# **Solution:**

- Update the OS and the python version used so that it's unlikely that we are soon to fall behind in supported versions.
- Update search ranking to put the API reference docs lower, this is so that if a user searches for something they are likely to see the tutorial documents first.
 
# **Testing:**

- Will be testing in this PR/branch https://app.readthedocs.org/projects/synapsepythonclient/builds/27555367/

Verified:

1. python version: `global python 3.13.0`
2. The updated OS was used: `"os": "ubuntu-22.04",`
3. Search ranking is putting reference docs lower:
![image](https://github.com/user-attachments/assets/9c762b01-f961-4a59-ba3e-273539dd7789)


