### PR TITLE
[SYNPY-1575] Correct regular expression for invalid column name

### DIFF
--- a/synapseclient/models/mixins/table_components.py
+++ b/synapseclient/models/mixins/table_components.py
@@ -402,9 +402,9 @@ class TableStoreMixin:
             await self._append_default_columns(synapse_client=synapse_client)
 
         if self.columns:
-            # check that column names match this regex "^[a-zA-Z0-9,_.]+"
+            # check that column names match this regex "^[a-zA-Z0-9 _\-\.\+\(\)']+$"
             for _, column in self.columns.items():
-                if not re.match(r"^[a-zA-Z0-9,_.]+$", column.name):
+                if not re.match(r"^[a-zA-Z0-9 _\-\.\+\(\)']+$", column.name):
                     raise ValueError(
                         f"Column name '{column.name}' contains invalid characters. "
                         "Names may only contain: letters, numbers, spaces, underscores, "

--- a/tests/unit/synapseclient/mixins/unit_test_table_components.py
+++ b/tests/unit/synapseclient/mixins/unit_test_table_components.py
@@ -629,7 +629,9 @@ class TestViewStoreMixin:
             "col#1",  # Invalid character: #
         ],
     )
-    async def test_store_async_invalid_character_in_column_name(self, invalid_column_name):
+    async def test_store_async_invalid_character_in_column_name(
+        self, invalid_column_name
+    ):
         # GIVEN a TestClass instance with an invalid column name
         test_instance = TestViewStoreMixin.ClassForTest(
             include_default_columns=False,
@@ -664,7 +666,9 @@ class TestViewStoreMixin:
                 "col.5": Column(name="col.5", column_type=ColumnType.STRING, id="id5"),
                 "col+6": Column(name="col+6", column_type=ColumnType.STRING, id="id6"),
                 "col'7": Column(name="col'7", column_type=ColumnType.STRING, id="id7"),
-                "col(8)": Column(name="col(8)", column_type=ColumnType.STRING, id="id8"),
+                "col(8)": Column(
+                    name="col(8)", column_type=ColumnType.STRING, id="id8"
+                ),
             },
         )
 


### PR DESCRIPTION
# **Problem:**

- The regular expression used to verify the names of the column will meet Synapse requirements didn't account for everything that was present in the exception message.

# **Solution:**

- Updating the regular expression and running a unit test with additional values

# **Testing:**

- Unit test to verify regular expression is picking up valid/invalid names
