### PR TITLE
[SYNPY-1579] Introduce the materialized view

### DIFF
--- a/docs/reference/experimental/async/materializedview.md
+++ b/docs/reference/experimental/async/materializedview.md
@@ -1,0 +1,20 @@
+# MaterializedView
+
+Contained within this file are experimental interfaces for working with the Synapse Python
+Client. Unless otherwise noted these interfaces are subject to change at any time. Use
+at your own risk.
+
+## API reference
+
+::: synapseclient.models.MaterializedView
+    options:
+        inherited_members: true
+        members:
+            - store_async
+            - get_async
+            - delete_async
+            - query_async
+            - query_part_mask_async
+            - get_permissions
+            - get_acl
+            - set_permissions

--- a/docs/reference/experimental/sync/materializedview.md
+++ b/docs/reference/experimental/sync/materializedview.md
@@ -1,0 +1,20 @@
+# MaterializedView
+
+Contained within this file are experimental interfaces for working with the Synapse Python
+Client. Unless otherwise noted these interfaces are subject to change at any time. Use
+at your own risk.
+
+## API reference
+
+::: synapseclient.models.MaterializedView
+    options:
+        inherited_members: true
+        members:
+            - store
+            - get
+            - delete
+            - query
+            - query_part_mask
+            - get_permissions
+            - get_acl
+            - set_permissions

--- a/docs/tutorials/python/materializedview.md
+++ b/docs/tutorials/python/materializedview.md
@@ -1,0 +1,170 @@
+# Materialized Views
+
+Materialized Views in Synapse allow you to create queryable views that store the
+results of a Synapse SQL statement. These views are useful for combining, filtering, or
+transforming data from multiple tables into a single, queryable entity.
+
+This tutorial will walk you through the basics of working with Materialized Views
+using the Synapse Python client.
+
+## Tutorial Purpose
+In this tutorial, you will:
+
+1. Log in, get your project, and create tables with data
+2. Create and query a Materialized View
+3. Create and query a Materialized View with a JOIN clause
+4. Create and query a Materialized View with a LEFT JOIN clause
+5. Create and query a Materialized View with a RIGHT JOIN clause
+6. Create and query a Materialized View with a UNION clause
+
+## Prerequisites
+* This tutorial assumes that you have a Synapse project.
+* Pandas must also be installed as shown in the [installation documentation](../installation.md).
+
+## 1. Log in, get your project, and create tables with data
+
+Before creating Materialized Views, we need to log in to Synapse, retrieve your project,
+and create the tables with data that will be used in the views.
+
+You will want to replace `"My uniquely named project about Alzheimer's Disease"` with
+the name of your project.
+
+```python
+{!docs/tutorials/python/tutorial_scripts/materializedview.py!lines=3-72}
+```
+
+## 2. Create and query a Materialized View
+
+First, we will create a simple Materialized View that selects all rows from a table and
+then query it to retrieve the results.
+
+```python
+{!docs/tutorials/python/tutorial_scripts/materializedview.py!lines=75-97}
+```
+
+<details class="example">
+  <summary>The result of querying your Materialized View should look like:</summary>
+```
+Results from the materialized view:
+  sample_id patient_id  age    diagnosis
+0        S1         P1   70  Alzheimer's
+1        S2         P2   65      Healthy
+2        S3         P3   72  Alzheimer's
+3        S4         P4   68      Healthy
+4        S5         P5   75  Alzheimer's
+5        S6         P6   80      Healthy
+```
+</details>
+
+## 3. Create and query a Materialized View with a JOIN clause
+
+Next, we will create a Materialized View that combines data from two tables using a JOIN
+clause and then query it to retrieve the results.
+
+```python
+{!docs/tutorials/python/tutorial_scripts/materializedview.py!lines=100-130}
+```
+
+<details class="example">
+  <summary>The result of querying your Materialized View with a JOIN clause should look
+  like:</summary>
+```
+Results from the materialized view with JOIN:
+  sample_id patient_id  age    diagnosis   gene  expression_level
+0        S1         P1   70  Alzheimer's   APOE               2.5
+1        S2         P2   65      Healthy    APP               1.8
+2        S3         P3   72  Alzheimer's  PSEN1               3.2
+3        S4         P4   68      Healthy   MAPT               2.1
+4        S5         P5   75  Alzheimer's    APP               3.5
+```
+</details>
+
+## 4. Create and query a Materialized View with a LEFT JOIN clause
+
+We can also create a Materialized View that includes all rows from one table and matches
+rows from another table using a LEFT JOIN clause and then query it to retrieve the
+results.
+
+```python
+{!docs/tutorials/python/tutorial_scripts/materializedview.py!lines=133-163}
+```
+
+<details class="example">
+  <summary>The result of querying your Materialized View with a LEFT JOIN clause should
+  look like:</summary>
+```
+Results from the materialized view with LEFT JOIN:
+  sample_id patient_id  age    diagnosis   gene  expression_level
+0        S1         P1   70  Alzheimer's   APOE               2.5
+1        S2         P2   65      Healthy    APP               1.8
+2        S3         P3   72  Alzheimer's  PSEN1               3.2
+3        S4         P4   68      Healthy   MAPT               2.1
+4        S5         P5   75  Alzheimer's    APP               3.5
+5        S6         P6   80      Healthy    NaN               NaN
+```
+</details>
+
+## 5. Create and query a Materialized View with a RIGHT JOIN clause
+
+Similarly, we can create a Materialized View that includes all rows from one table and
+matches rows from another table using a RIGHT JOIN clause and then query it to retrieve
+the results.
+
+```python
+{!docs/tutorials/python/tutorial_scripts/materializedview.py!lines=166-196}
+```
+
+<details class="example">
+  <summary>The result of querying your Materialized View with a RIGHT JOIN clause should
+  look like:</summary>
+```
+  sample_id patient_id   age    diagnosis   gene  expression_level
+0        S1         P1  70.0  Alzheimer's   APOE               2.5
+1        S2         P2  65.0      Healthy    APP               1.8
+2        S3         P3  72.0  Alzheimer's  PSEN1               3.2
+3        S4         P4  68.0      Healthy   MAPT               2.1
+4        S5         P5  75.0  Alzheimer's    APP               3.5
+5       NaN        NaN   NaN          NaN  PSEN2               1.9
+```
+</details>
+
+## 6. Create and query a Materialized View with a UNION clause
+
+Finally, we can create a Materialized View that combines rows from two tables using a
+UNION clause and then query it to retrieve the results.
+
+```python
+{!docs/tutorials/python/tutorial_scripts/materializedview.py!lines=199-229}
+```
+
+<details class="example">
+  <summary>The result of querying your Materialized View with a UNION clause should look
+  like:</summary>
+```
+Results from the materialized view with UNION:
+  sample_id
+0        S1
+1        S2
+2        S3
+3        S4
+4        S5
+5        S6
+6        S7
+```
+</details>
+
+## Source Code for this Tutorial
+
+<details class="quote">
+  <summary>Click to show me</summary>
+
+```python
+{!docs/tutorials/python/tutorial_scripts/materializedview.py!}
+```
+</details>
+
+## References
+- [MaterializedView][synapseclient.models.MaterializedView]
+- [Column][synapseclient.models.Column]
+- [Project][synapseclient.models.Project]
+- [syn.login][synapseclient.Synapse.login]

--- a/docs/tutorials/python/materializedview.md
+++ b/docs/tutorials/python/materializedview.md
@@ -118,13 +118,14 @@ the results.
   <summary>The result of querying your Materialized View with a RIGHT JOIN clause should
   look like:</summary>
 ```
+Results from the materialized view with RIGHT JOIN:
   sample_id patient_id   age    diagnosis   gene  expression_level
 0        S1         P1  70.0  Alzheimer's   APOE               2.5
 1        S2         P2  65.0      Healthy    APP               1.8
 2        S3         P3  72.0  Alzheimer's  PSEN1               3.2
 3        S4         P4  68.0      Healthy   MAPT               2.1
 4        S5         P5  75.0  Alzheimer's    APP               3.5
-5       NaN        NaN   NaN          NaN  PSEN2               1.9
+5        S7        NaN   NaN          NaN  PSEN2               1.9
 ```
 </details>
 

--- a/docs/tutorials/python/tutorial_scripts/materializedview.py
+++ b/docs/tutorials/python/tutorial_scripts/materializedview.py
@@ -12,7 +12,7 @@ syn.login()
 # Get the project where we want to create the materialized view
 project = Project(name="My uniquely named project about Alzheimer's Disease").get()
 project_id = project.id
-print(f"Created project with ID: {project_id}")
+print(f"Got project with ID: {project_id}")
 
 # Create the first table with some columns and rows
 table1_columns = [
@@ -168,7 +168,7 @@ def create_materialized_view_with_right_join():
     Example: Create a materialized view with a RIGHT JOIN clause.
     """
     defining_sql = f"""
-    SELECT t1.sample_id AS sample_id, t1.patient_id AS patient_id, t1.age AS age, t1.diagnosis AS diagnosis,
+    SELECT t2.sample_id AS sample_id, t1.patient_id AS patient_id, t1.age AS age, t1.diagnosis AS diagnosis,
            t2.gene AS gene, t2.expression_level AS expression_level
     FROM {table1.id} t1
     RIGHT JOIN {table2.id} t2

--- a/docs/tutorials/python/tutorial_scripts/materializedview.py
+++ b/docs/tutorials/python/tutorial_scripts/materializedview.py
@@ -1,0 +1,241 @@
+"""Here is where you'll find the code for the MaterializedView tutorial."""
+
+import pandas as pd
+
+from synapseclient import Synapse
+from synapseclient.models import Column, ColumnType, MaterializedView, Project, Table
+
+# Initialize Synapse client
+syn = Synapse()
+syn.login()
+
+# Get the project where we want to create the materialized view
+project = Project(name="My uniquely named project about Alzheimer's Disease").get()
+project_id = project.id
+print(f"Created project with ID: {project_id}")
+
+# Create the first table with some columns and rows
+table1_columns = [
+    Column(name="sample_id", column_type=ColumnType.STRING),
+    Column(name="patient_id", column_type=ColumnType.STRING),
+    Column(name="age", column_type=ColumnType.INTEGER),
+    Column(name="diagnosis", column_type=ColumnType.STRING),
+]
+
+table1 = Table(
+    name="Patient Demographics",
+    parent_id=project_id,
+    columns=table1_columns,
+)
+table1 = table1.store()
+print(f"Created table 1 with ID: {table1.id}")
+
+# Add rows to the first table
+data1 = pd.DataFrame(
+    [
+        {"sample_id": "S1", "patient_id": "P1", "age": 70, "diagnosis": "Alzheimer's"},
+        {"sample_id": "S2", "patient_id": "P2", "age": 65, "diagnosis": "Healthy"},
+        {"sample_id": "S3", "patient_id": "P3", "age": 72, "diagnosis": "Alzheimer's"},
+        {"sample_id": "S4", "patient_id": "P4", "age": 68, "diagnosis": "Healthy"},
+        {"sample_id": "S5", "patient_id": "P5", "age": 75, "diagnosis": "Alzheimer's"},
+        {"sample_id": "S6", "patient_id": "P6", "age": 80, "diagnosis": "Healthy"},
+    ]
+)
+table1.upsert_rows(values=data1, primary_keys=["sample_id"])
+
+# Create the second table with some columns and rows
+table2_columns = [
+    Column(name="sample_id", column_type=ColumnType.STRING),
+    Column(name="gene", column_type=ColumnType.STRING),
+    Column(name="expression_level", column_type=ColumnType.DOUBLE),
+]
+
+table2 = Table(
+    name="Gene Expression Data",
+    parent_id=project_id,
+    columns=table2_columns,
+)
+table2 = table2.store()
+print(f"Created table 2 with ID: {table2.id}")
+
+# Add rows to the second table
+data2 = pd.DataFrame(
+    [
+        {"sample_id": "S1", "gene": "APOE", "expression_level": 2.5},
+        {"sample_id": "S2", "gene": "APP", "expression_level": 1.8},
+        {"sample_id": "S3", "gene": "PSEN1", "expression_level": 3.2},
+        {"sample_id": "S4", "gene": "MAPT", "expression_level": 2.1},
+        {"sample_id": "S5", "gene": "APP", "expression_level": 3.5},
+        {"sample_id": "S7", "gene": "PSEN2", "expression_level": 1.9},
+    ]
+)
+table2.upsert_rows(values=data2, primary_keys=["sample_id"])
+
+
+def create_materialized_view():
+    """
+    Example: Create a new materialized view with a defining SQL query.
+    """
+    materialized_view = MaterializedView(
+        name="Patient Data View",
+        description="A view combining patient demographics and gene expression data",
+        parent_id=project_id,
+        defining_sql=f"SELECT * FROM {table1.id}",
+    )
+    materialized_view = materialized_view.store()
+    print(f"Created Materialized View with ID: {materialized_view.id}")
+
+    materialized_view_id = materialized_view.id
+
+    query = f"SELECT * FROM {materialized_view_id}"
+    query_result: pd.DataFrame = materialized_view.query(
+        query=query, include_row_id_and_row_version=False
+    )
+
+    # Print the results to the console
+    print("Results from the materialized view:")
+    print(query_result)
+
+
+def create_materialized_view_with_join():
+    """
+    Example: Create a materialized view with a JOIN clause.
+    """
+    defining_sql = f"""
+    SELECT t1.sample_id AS sample_id, t1.patient_id AS patient_id, t1.age AS age, t1.diagnosis AS diagnosis,
+           t2.gene AS gene, t2.expression_level AS expression_level
+    FROM {table1.id} t1
+    JOIN {table2.id} t2
+    ON t1.sample_id = t2.sample_id
+    """
+
+    materialized_view = MaterializedView(
+        name="Joined Patient Data View",
+        description="A materialized view joining patient demographics with gene expression data",
+        parent_id=project_id,
+        defining_sql=defining_sql,
+    )
+    materialized_view = materialized_view.store()
+    print(f"Created Materialized View with ID: {materialized_view.id}")
+
+    materialized_view_id = materialized_view.id
+
+    query = f"SELECT * FROM {materialized_view_id}"
+    query_result: pd.DataFrame = materialized_view.query(
+        query=query, include_row_id_and_row_version=False
+    )
+
+    # Print the results to the console
+    print("Results from the materialized view with JOIN:")
+    print(query_result)
+
+
+def create_materialized_view_with_left_join():
+    """
+    Example: Create a materialized view with a LEFT JOIN clause.
+    """
+    defining_sql = f"""
+    SELECT t1.sample_id AS sample_id, t1.patient_id AS patient_id, t1.age AS age, t1.diagnosis AS diagnosis,
+           t2.gene AS gene, t2.expression_level AS expression_level
+    FROM {table1.id} t1
+    LEFT JOIN {table2.id} t2
+    ON t1.sample_id = t2.sample_id
+    """
+
+    materialized_view = MaterializedView(
+        name="Left Joined Patient Data View",
+        description="A materialized view with a LEFT JOIN clause, including all patients even if they lack gene expression data",
+        parent_id=project_id,
+        defining_sql=defining_sql,
+    )
+    materialized_view = materialized_view.store()
+    print(f"Created Materialized View with ID: {materialized_view.id}")
+
+    materialized_view_id = materialized_view.id
+
+    query = f"SELECT * FROM {materialized_view_id}"
+    query_result: pd.DataFrame = materialized_view.query(
+        query=query, include_row_id_and_row_version=False
+    )
+
+    # Print the results to the console
+    print("Results from the materialized view with LEFT JOIN:")
+    print(query_result)
+
+
+def create_materialized_view_with_right_join():
+    """
+    Example: Create a materialized view with a RIGHT JOIN clause.
+    """
+    defining_sql = f"""
+    SELECT t1.sample_id AS sample_id, t1.patient_id AS patient_id, t1.age AS age, t1.diagnosis AS diagnosis,
+           t2.gene AS gene, t2.expression_level AS expression_level
+    FROM {table1.id} t1
+    RIGHT JOIN {table2.id} t2
+    ON t1.sample_id = t2.sample_id
+    """
+
+    materialized_view = MaterializedView(
+        name="Right Joined Patient Data View",
+        description="A materialized view with a RIGHT JOIN clause, including all gene expression data even if no patient matches",
+        parent_id=project_id,
+        defining_sql=defining_sql,
+    )
+    materialized_view = materialized_view.store()
+    print(f"Created Materialized View with ID: {materialized_view.id}")
+
+    materialized_view_id = materialized_view.id
+
+    query = f"SELECT * FROM {materialized_view_id}"
+    query_result: pd.DataFrame = materialized_view.query(
+        query=query, include_row_id_and_row_version=False
+    )
+
+    # Print the results to the console
+    print("Results from the materialized view with RIGHT JOIN:")
+    print(query_result)
+
+
+def create_materialized_view_with_union():
+    """
+    Example: Create a materialized view with a UNION clause.
+    """
+    defining_sql = f"""
+    SELECT t1.sample_id AS sample_id
+    FROM {table1.id} t1
+    UNION
+    SELECT t2.sample_id AS sample_id
+    FROM {table2.id} t2
+    """
+
+    materialized_view = MaterializedView(
+        name="Union Patient Data View",
+        description="A materialized view with a UNION clause",
+        parent_id=project_id,
+        defining_sql=defining_sql,
+    )
+    materialized_view = materialized_view.store()
+    print(f"Created Materialized View with ID: {materialized_view.id}")
+
+    materialized_view_id = materialized_view.id
+
+    query = f"SELECT * FROM {materialized_view_id}"
+    query_result: pd.DataFrame = materialized_view.query(
+        query=query, include_row_id_and_row_version=False
+    )
+
+    # Print the results to the console
+    print("Results from the materialized view with UNION:")
+    print(query_result)
+
+
+def main():
+    create_materialized_view()
+    create_materialized_view_with_join()
+    create_materialized_view_with_left_join()
+    create_materialized_view_with_right_join()
+    create_materialized_view_with_union()
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
           # - Table: tutorials/python/table.md
           # - Using a Table: tutorials/python/table_crud.md
           - Dataset: tutorials/python/dataset.md
+          - Materialized View: tutorials/python/materializedview.md
           # - Sharing Settings: tutorials/python/sharing_settings.md
           # - Wiki: tutorials/python/wiki.md
           # - Team: tutorials/python/team.md
@@ -82,6 +83,7 @@ nav:
           - Table: reference/experimental/sync/table.md
           - Dataset: reference/experimental/sync/dataset.md
           - EntityView: reference/experimental/sync/entityview.md
+          - MaterializedView: reference/experimental/sync/materializedview.md
           - Activity: reference/experimental/sync/activity.md
           - Team: reference/experimental/sync/team.md
           - UserProfile: reference/experimental/sync/user_profile.md
@@ -94,6 +96,7 @@ nav:
               - Table: reference/experimental/async/table.md
               - Dataset: reference/experimental/async/dataset.md
               - EntityView: reference/experimental/async/entityview.md
+              - MaterializedView: reference/experimental/async/materializedview.md
               - Activity: reference/experimental/async/activity.md
               - Team: reference/experimental/async/team.md
               - UserProfile: reference/experimental/async/user_profile.md

--- a/synapseclient/api/entity_factory.py
+++ b/synapseclient/api/entity_factory.py
@@ -375,6 +375,14 @@ async def _cast_into_class_type(
         entity = entity_to_update.fill_from_dict(
             entity=entity_bundle["entity"], set_annotations=False
         )
+    elif entity["concreteType"] == concrete_types.MATERIALIZED_VIEW:
+        if not entity_to_update:
+            from models.materializedview import MaterializedView
+
+            entity_to_update = MaterializedView()
+        entity = entity_to_update.fill_from_dict(
+            entity=entity_bundle["entity"], set_annotations=False
+        )
     else:
         raise ValueError(
             f"Attempting to retrieve an unsupported entity type of {entity['concreteType']}."

--- a/synapseclient/core/constants/concrete_types.py
+++ b/synapseclient/core/constants/concrete_types.py
@@ -68,6 +68,7 @@ PROJECT_ENTITY = "org.sagebionetworks.repo.model.Project"
 TABLE_ENTITY = "org.sagebionetworks.repo.model.table.TableEntity"
 DATASET_ENTITY = "org.sagebionetworks.repo.model.table.Dataset"
 ENTITY_VIEW = "org.sagebionetworks.repo.model.table.EntityView"
+MATERIALIZED_VIEW = "org.sagebionetworks.repo.model.table.MaterializedView"
 
 # upload requests
 MULTIPART_UPLOAD_REQUEST = "org.sagebionetworks.repo.model.file.MultipartUploadRequest"

--- a/synapseclient/models/__init__.py
+++ b/synapseclient/models/__init__.py
@@ -11,6 +11,7 @@ from synapseclient.models.dataset import Dataset, EntityRef
 from synapseclient.models.entityview import EntityView, ViewTypeMask
 from synapseclient.models.file import File, FileHandle
 from synapseclient.models.folder import Folder
+from synapseclient.models.materializedview import MaterializedView
 from synapseclient.models.mixins.table_components import QueryMixin
 from synapseclient.models.project import Project
 from synapseclient.models.services import FailureStrategy
@@ -77,6 +78,7 @@ __all__ = [
     "UploadToTableRequest",
     "TableUpdateTransaction",
     "CsvTableDescriptor",
+    "MaterializedView",
     # Dataset model
     "Dataset",
     "EntityRef",

--- a/synapseclient/models/materializedview.py
+++ b/synapseclient/models/materializedview.py
@@ -1,0 +1,865 @@
+from collections import OrderedDict
+from copy import deepcopy
+from dataclasses import dataclass, field, replace
+from datetime import date, datetime
+from typing import Dict, List, Optional, Protocol, Union
+
+from typing_extensions import Self
+
+from synapseclient import Synapse
+from synapseclient.core.async_utils import async_to_sync
+from synapseclient.core.constants import concrete_types
+from synapseclient.core.utils import delete_none_keys
+from synapseclient.models import Activity
+from synapseclient.models.mixins.access_control import AccessControllable
+from synapseclient.models.mixins.table_components import (
+    DeleteMixin,
+    GetMixin,
+    QueryMixin,
+    TableBase,
+    ViewStoreMixin,
+)
+
+
+class MaterializedViewSynchronousProtocol(Protocol):
+    """Protocol defining the synchronous interface for MaterializedView operations."""
+
+    def store(
+        self,
+        dry_run: bool = False,
+        *,
+        job_timeout: int = 600,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "Self":
+        """
+        Store non-row information about a MaterializedView including the annotations.
+
+        Note: Columns in a MaterializedView are determined by the `defining_sql` attribute. To update
+        the columns, you must update the `defining_sql` and store the view.
+
+        Arguments:
+            dry_run: If True, will not actually store the table but will log to
+                the console what would have been stored.
+            job_timeout: The maximum amount of time to wait for a job to complete.
+                This is used when updating the table schema. If the timeout
+                is reached a `SynapseTimeoutError` will be raised.
+                The default is 600 seconds
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            The MaterializedView instance stored in synapse.
+
+        Example: Create a new materialized view with a defining SQL query.
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import MaterializedView
+
+            syn = Synapse()
+            syn.login()
+
+            materialized_view = MaterializedView(
+                name="My Materialized View",
+                description="A test materialized view",
+                parent_id="syn12345",
+                defining_sql="SELECT * FROM syn67890"
+            )
+            materialized_view = materialized_view.store()
+            print(f"Created Materialized View with ID: {materialized_view.id}")
+            ```
+
+        Example: Update the defining SQL of an existing materialized view.
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import MaterializedView
+
+            syn = Synapse()
+            syn.login()
+
+            materialized_view = MaterializedView(id="syn12345").get()
+            materialized_view.defining_sql = "SELECT column1, column2 FROM syn67890"
+            materialized_view = materialized_view.store()
+            print("Updated Materialized View defining SQL.")
+            ```
+
+        Example: Retrieve and update annotations for a materialized view.
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import MaterializedView
+
+            syn = Synapse()
+            syn.login()
+
+            materialized_view = MaterializedView(id="syn12345").get()
+            materialized_view.annotations["key1"] = ["value1"]
+            materialized_view.annotations["key2"] = ["value2"]
+            materialized_view.store()
+            print("Updated annotations for Materialized View.")
+            ```
+
+        Example: Create a materialized view with a JOIN clause.
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import MaterializedView
+
+            syn = Synapse()
+            syn.login()
+
+            defining_sql = '''
+            SELECT t1.column1 AS new_column1, t2.column2 AS new_column2
+            FROM syn12345 t1
+            JOIN syn67890 t2
+            ON t1.id = t2.foreign_id
+            '''
+
+            materialized_view = MaterializedView(
+                name="Join Materialized View",
+                description="A materialized view with a JOIN clause",
+                parent_id="syn11111",
+                defining_sql=defining_sql,
+            )
+            materialized_view = materialized_view.store()
+            print(f"Created Materialized View with ID: {materialized_view.id}")
+            ```
+
+        Example: Create a materialized view with a LEFT JOIN clause.
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import MaterializedView
+
+            syn = Synapse()
+            syn.login()
+
+            defining_sql = '''
+            SELECT t1.column1 AS new_column1, t2.column2 AS new_column2
+            FROM syn12345 t1
+            LEFT JOIN syn67890 t2
+            ON t1.id = t2.foreign_id
+            '''
+
+            materialized_view = MaterializedView(
+                name="Left Join Materialized View",
+                description="A materialized view with a LEFT JOIN clause",
+                parent_id="syn11111",
+                defining_sql=defining_sql,
+            )
+            materialized_view = materialized_view.store()
+            print(f"Created Materialized View with ID: {materialized_view.id}")
+            ```
+
+        Example: Create a materialized view with a RIGHT JOIN clause.
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import MaterializedView
+
+            syn = Synapse()
+            syn.login()
+
+            defining_sql = '''
+            SELECT t1.column1 AS new_column1, t2.column2 AS new_column2
+            FROM syn12345 t1
+            RIGHT JOIN syn67890 t2
+            ON t1.id = t2.foreign_id
+            '''
+
+            materialized_view = MaterializedView(
+                name="Right Join Materialized View",
+                description="A materialized view with a RIGHT JOIN clause",
+                parent_id="syn11111",
+                defining_sql=defining_sql,
+            )
+            materialized_view = materialized_view.store()
+            print(f"Created Materialized View with ID: {materialized_view.id}")
+            ```
+
+        Example: Create a materialized view with a UNION clause.
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import MaterializedView
+
+            syn = Synapse()
+            syn.login()
+
+            defining_sql = '''
+            SELECT column1 AS new_column1, column2 AS new_column2
+            FROM syn12345
+            UNION
+            SELECT column1 AS new_column1, column2 AS new_column2
+            FROM syn67890
+            '''
+
+            materialized_view = MaterializedView(
+                name="Union Materialized View",
+                description="A materialized view with a UNION clause",
+                parent_id="syn11111",
+                defining_sql=defining_sql,
+            )
+            materialized_view = materialized_view.store()
+            print(f"Created Materialized View with ID: {materialized_view.id}")
+            ```
+        """
+        return self
+
+    def get(
+        self,
+        include_columns: bool = True,
+        include_activity: bool = False,
+        *,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "Self":
+        """
+        Get the metadata about the MaterializedView from synapse.
+
+        Arguments:
+            include_columns: If True, will include fully filled column objects in the
+                `.columns` attribute. Defaults to True.
+            include_activity: If True the activity will be included in the MaterializedView
+                if it exists. Defaults to False.
+
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            The MaterializedView instance stored in synapse.
+
+        Example: Getting metadata about a MaterializedView using id
+            Get a MaterializedView by ID and print out the columns and activity. `include_columns`
+            defaults to True and `include_activity` defaults to False. When you need to
+            update existing columns or activity these need to be set to True during the
+            `get` call, then you'll make the changes, and finally call the
+            `.store()` method.
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import MaterializedView
+
+            syn = Synapse()
+            syn.login()
+
+            materialized_view = MaterializedView(id="syn4567").get(include_activity=True)
+            print(materialized_view)
+
+            # Columns are retrieved by default
+            print(materialized_view.columns)
+            print(materialized_view.activity)
+            ```
+
+        Example: Getting metadata about a MaterializedView using name and parent_id
+            Get a MaterializedView by name/parent_id and print out the columns and activity.
+            `include_columns` defaults to True and `include_activity` defaults to
+            False. When you need to update existing columns or activity these need to
+            be set to True during the `get` call, then you'll make the changes,
+            and finally call the `.store()` method.
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import MaterializedView
+
+            syn = Synapse()
+            syn.login()
+
+            materialized_view = MaterializedView(name="my_materialized_view", parent_id="syn1234").get(include_columns=True, include_activity=True)
+            print(materialized_view)
+            print(materialized_view.columns)
+            print(materialized_view.activity)
+            ```
+        """
+        return self
+
+    def delete(self, *, synapse_client: Optional[Synapse] = None) -> None:
+        """Delete the materialized view from synapse. This is not version specific. If you'd like
+        to delete a specific version of the materialized view you must use the
+        [synapseclient.api.delete_entity][] function directly.
+
+        Arguments:
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            None
+
+        Example: Delete a materialized view.
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import MaterializedView
+
+            syn = Synapse()
+            syn.login()
+
+            materialized_view = MaterializedView(id="syn12345")
+            materialized_view.delete()
+            print("Deleted Materialized View.")
+            ```
+        """
+        return None
+
+
+@dataclass
+@async_to_sync
+class MaterializedView(
+    MaterializedViewSynchronousProtocol,
+    AccessControllable,
+    TableBase,
+    ViewStoreMixin,
+    DeleteMixin,
+    GetMixin,
+    QueryMixin,
+):
+    """
+    A materialized view is a type of table that is automatically built from a Synapse
+    SQL query. Its content is read only and based off the `defining_sql` attribute.
+    The SQL of the materialized view may contain JOIN clauses on multiple tables.
+
+    A `MaterializedView` object represents this concept in Synapse:
+    <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/MaterializedView.html>
+
+    Attributes:
+        id: The unique immutable ID for this entity. Once issued, this ID is
+            guaranteed to never change or be re-issued.
+        name: The name of this entity. Must be 256 characters or less. Names may only
+            contain: letters, numbers, spaces, underscores, hyphens, periods, plus
+            signs, apostrophes, and parentheses.
+        description: The description of this entity. Must be 1000 characters or less.
+        etag: Synapse employs an Optimistic Concurrency Control (OCC) scheme to handle
+            concurrent updates. Since the E-Tag changes every time an entity is
+            updated it is used to detect when a client's current representation of an
+            entity is out-of-date.
+        created_on: The date this entity was created.
+        modified_on: The date this entity was last modified. In YYYY-MM-DD-Thh:mm:ss.sssZ
+            format.
+        created_by: The ID of the user that created this entity.
+        modified_by: The ID of the user that last modified this entity.
+        parent_id: The ID of the Entity that is the parent of this entity.
+        version_number: The version number issued to this version on the object.
+        version_label: The version label for this entity.
+        version_comment: The version comment for this entity.
+        is_latest_version: If this is the latest version of the object.
+        columns: (Read Only) The columns of a materialized view are dynamic based on
+            the select statement of the definingSQL. This list of columnIds is for
+            read-only purposes.
+        is_search_enabled: When creating or updating a table or view specifies if full
+            text search should be enabled.
+        defining_sql: The synapse SQL statement that defines the data in the
+            materialized view.
+        annotations: Additional metadata associated with the entityview. The key is
+            the name of your desired annotations. The value is an object containing a
+            list of values (use empty list to represent no values for key) and the
+            value type associated with all values in the list. To remove all
+            annotations set this to an empty dict `{}` or None and store the entity.
+        activity: The Activity model represents the main record of Provenance in
+            Synapse.
+
+    Example: Create a new materialized view with a defining SQL query.
+        &nbsp;
+
+        ```python
+        from synapseclient import Synapse
+        from synapseclient.models import MaterializedView
+
+        syn = Synapse()
+        syn.login()
+
+        materialized_view = MaterializedView(
+            name="My Materialized View",
+            description="A test materialized view",
+            parent_id="syn12345",
+            defining_sql="SELECT * FROM syn67890"
+        )
+        materialized_view = materialized_view.store()
+        print(f"Created Materialized View with ID: {materialized_view.id}")
+        ```
+
+    Example: Update the defining SQL of an existing materialized view.
+        &nbsp;
+
+        ```python
+        from synapseclient import Synapse
+        from synapseclient.models import MaterializedView
+
+        syn = Synapse()
+        syn.login()
+
+        materialized_view = MaterializedView(id="syn12345").get()
+        materialized_view.defining_sql = "SELECT column1, column2 FROM syn67890"
+        materialized_view = materialized_view.store()
+        print("Updated Materialized View defining SQL.")
+        ```
+
+    Example: Delete a materialized view.
+        &nbsp;
+
+        ```python
+        from synapseclient import Synapse
+        from synapseclient.models import MaterializedView
+
+        syn = Synapse()
+        syn.login()
+
+        materialized_view = MaterializedView(id="syn12345")
+        materialized_view.delete()
+        print("Deleted Materialized View.")
+        ```
+
+    Example: Query data from a materialized view.
+        &nbsp;
+
+        ```python
+        from synapseclient import Synapse
+        from synapseclient.models import query
+
+        syn = Synapse()
+        syn.login()
+
+        query_result = query("SELECT * FROM syn66080386")
+        print(query_result)
+        ```
+
+    Example: Retrieve and update annotations for a materialized view.
+        &nbsp;
+
+        ```python
+        from synapseclient import Synapse
+        from synapseclient.models import MaterializedView
+
+        syn = Synapse()
+        syn.login()
+
+        materialized_view = MaterializedView(id="syn12345").get()
+        materialized_view.annotations["key1"] = ["value1"]
+        materialized_view.annotations["key2"] = ["value2"]
+        materialized_view.store()
+        print("Updated annotations for Materialized View.")
+        ```
+
+    Example: Create a materialized view with a JOIN clause.
+        &nbsp;
+
+        ```python
+        from synapseclient import Synapse
+        from synapseclient.models import MaterializedView
+
+        syn = Synapse()
+        syn.login()
+
+        defining_sql = '''
+        SELECT t1.column1 AS new_column1, t2.column2 AS new_column2
+        FROM syn12345 t1
+        JOIN syn67890 t2
+        ON t1.id = t2.foreign_id
+        '''
+
+        materialized_view = MaterializedView(
+            name="Join Materialized View",
+            description="A materialized view with a JOIN clause",
+            parent_id="syn11111",
+            defining_sql=defining_sql,
+        )
+        materialized_view = materialized_view.store()
+        print(f"Created Materialized View with ID: {materialized_view.id}")
+        ```
+
+    Example: Create a materialized view with a LEFT JOIN clause.
+        &nbsp;
+
+        ```python
+        from synapseclient import Synapse
+        from synapseclient.models import MaterializedView
+
+        syn = Synapse()
+        syn.login()
+
+        defining_sql = '''
+        SELECT t1.column1 AS new_column1, t2.column2 AS new_column2
+        FROM syn12345 t1
+        LEFT JOIN syn67890 t2
+        ON t1.id = t2.foreign_id
+        '''
+
+        materialized_view = MaterializedView(
+            name="Left Join Materialized View",
+            description="A materialized view with a LEFT JOIN clause",
+            parent_id="syn11111",
+            defining_sql=defining_sql,
+        )
+        materialized_view = materialized_view.store()
+        print(f"Created Materialized View with ID: {materialized_view.id}")
+        ```
+
+    Example: Create a materialized view with a RIGHT JOIN clause.
+        &nbsp;
+
+        ```python
+        from synapseclient import Synapse
+        from synapseclient.models import MaterializedView
+
+        syn = Synapse()
+        syn.login()
+
+        defining_sql = '''
+        SELECT t1.column1 AS new_column1, t2.column2 AS new_column2
+        FROM syn12345 t1
+        RIGHT JOIN syn67890 t2
+        ON t1.id = t2.foreign_id
+        '''
+
+        materialized_view = MaterializedView(
+            name="Right Join Materialized View",
+            description="A materialized view with a RIGHT JOIN clause",
+            parent_id="syn11111",
+            defining_sql=defining_sql,
+        )
+        materialized_view = materialized_view.store()
+        print(f"Created Materialized View with ID: {materialized_view.id}")
+        ```
+
+    Example: Create a materialized view with a UNION clause.
+        &nbsp;
+
+        ```python
+        from synapseclient import Synapse
+        from synapseclient.models import MaterializedView
+
+        syn = Synapse()
+        syn.login()
+
+        defining_sql = '''
+        SELECT column1 AS new_column1, column2 AS new_column2
+        FROM syn12345
+        UNION
+        SELECT column1 AS new_column1, column2 AS new_column2
+        FROM syn67890
+        '''
+
+        materialized_view = MaterializedView(
+            name="Union Materialized View",
+            description="A materialized view with a UNION clause",
+            parent_id="syn11111",
+            defining_sql=defining_sql,
+        )
+        materialized_view = materialized_view.store()
+        print(f"Created Materialized View with ID: {materialized_view.id}")
+        ```
+    """
+
+    id: Optional[str] = None
+    """The unique immutable ID for this entity. Once issued, this ID is
+    guaranteed to never change or be re-issued."""
+
+    name: Optional[str] = None
+    """The name of this entity. Must be 256 characters or less. Names may only
+    contain: letters, numbers, spaces, underscores, hyphens, periods, plus
+    signs, apostrophes, and parentheses."""
+
+    description: Optional[str] = None
+    """The description of this entity. Must be 1000 characters or less."""
+
+    etag: Optional[str] = field(default=None, compare=False)
+    """
+    Synapse employs an Optimistic Concurrency Control (OCC) scheme to handle
+    concurrent updates. Since the E-Tag changes every time an entity is
+    updated it is used to detect when a client's current representation of an
+    entity is out-of-date.
+    """
+
+    created_on: Optional[str] = field(default=None, compare=False)
+    """The date this entity was created."""
+
+    modified_on: Optional[str] = field(default=None, compare=False)
+    """The date this entity was last modified. In YYYY-MM-DD-Thh:mm:ss.sssZ
+    format."""
+
+    created_by: Optional[str] = field(default=None, compare=False)
+    """The ID of the user that created this entity."""
+
+    modified_by: Optional[str] = field(default=None, compare=False)
+    """The ID of the user that last modified this entity."""
+
+    parent_id: Optional[str] = None
+    """The ID of the Entity that is the parent of this entity."""
+
+    version_number: Optional[int] = field(default=None, compare=False)
+    """The version number issued to this version on the object."""
+
+    version_label: Optional[str] = None
+    """The version label for this entity."""
+
+    version_comment: Optional[str] = None
+    """The version comment for this entity."""
+
+    is_latest_version: Optional[bool] = field(default=None, compare=False)
+    """If this is the latest version of the object."""
+
+    columns: Optional[OrderedDict] = field(default_factory=OrderedDict, compare=False)
+    """(Read Only) The columns of a materialized view are dynamic based on
+    the select statement of the definingSQL. This list of columnIds is for
+    read-only purposes."""
+
+    is_search_enabled: Optional[bool] = None
+    """When creating or updating a table or view specifies if full text search
+    should be enabled."""
+
+    defining_sql: Optional[str] = None
+    """The synapse SQL statement that defines the data in the materialized
+    view."""
+
+    _last_persistent_instance: Optional["MaterializedView"] = field(
+        default=None, repr=False, compare=False
+    )
+    """The last persistent instance of this object. This is used to determine if the
+    object has been changed and needs to be updated in Synapse."""
+
+    annotations: Optional[
+        Dict[
+            str,
+            Union[
+                List[str],
+                List[bool],
+                List[float],
+                List[int],
+                List[date],
+                List[datetime],
+            ],
+        ]
+    ] = field(default_factory=dict, compare=False)
+    """Additional metadata associated with the entityview. The key is the name
+    of your desired annotations. The value is an object containing a list of
+    values (use empty list to represent no values for key) and the value type
+    associated with all values in the list. To remove all annotations set this
+    to an empty dict `{}` or None and store the entity."""
+
+    activity: Optional[Activity] = field(default=None, compare=False)
+    """The Activity model represents the main record of Provenance in
+    Synapse."""
+
+    @property
+    def has_changed(self) -> bool:
+        """Checks if the object has changed since the last persistent instance."""
+        return self._last_persistent_instance != self
+
+    def _set_last_persistent_instance(self) -> None:
+        """Stash the last time this object interacted with Synapse."""
+        del self._last_persistent_instance
+        self._last_persistent_instance = replace(self)
+        self._last_persistent_instance.activity = (
+            replace(self.activity) if self.activity and self.activity.id else None
+        )
+        self._last_persistent_instance.annotations = (
+            deepcopy(self.annotations) if self.annotations else {}
+        )
+
+    def fill_from_dict(
+        self, entity: Dict, set_annotations: bool = True
+    ) -> "MaterializedView":
+        """
+        Converts the data coming from the Synapse API into this datamodel.
+
+        Arguments:
+            entity: The data coming from the Synapse API
+
+        Returns:
+            The MaterializedView object instance.
+        """
+        self.id = entity.get("id", None)
+        self.name = entity.get("name", None)
+        self.description = entity.get("description", None)
+        self.parent_id = entity.get("parentId", None)
+        self.etag = entity.get("etag", None)
+        self.created_on = entity.get("createdOn", None)
+        self.created_by = entity.get("createdBy", None)
+        self.modified_on = entity.get("modifiedOn", None)
+        self.modified_by = entity.get("modifiedBy", None)
+        self.version_number = entity.get("versionNumber", None)
+        self.version_label = entity.get("versionLabel", None)
+        self.version_comment = entity.get("versionComment", None)
+        self.is_latest_version = entity.get("isLatestVersion", None)
+        self.is_search_enabled = entity.get("isSearchEnabled", False)
+        self.defining_sql = entity.get("definingSQL", None)
+
+        if set_annotations:
+            self.annotations = entity.get("annotations", {})
+
+        return self
+
+    def to_synapse_request(self):
+        """Converts the request to a request expected of the Synapse REST API."""
+
+        entity = {
+            "name": self.name,
+            "description": self.description,
+            "id": self.id,
+            "etag": self.etag,
+            "createdOn": self.created_on,
+            "modifiedOn": self.modified_on,
+            "createdBy": self.created_by,
+            "modifiedBy": self.modified_by,
+            "parentId": self.parent_id,
+            "concreteType": concrete_types.MATERIALIZED_VIEW,
+            "versionNumber": self.version_number,
+            "versionLabel": self.version_label,
+            "versionComment": self.version_comment,
+            "isLatestVersion": self.is_latest_version,
+            "isSearchEnabled": self.is_search_enabled,
+            "definingSQL": self.defining_sql,
+        }
+        delete_none_keys(entity)
+        result = {
+            "entity": entity,
+        }
+        delete_none_keys(result)
+        return result
+
+    async def store_async(
+        self,
+        dry_run: bool = False,
+        *,
+        job_timeout: int = 600,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "Self":
+        """
+        Asynchronously store non-row information about a MaterializedView including the annotations.
+
+        Note: Columns in a MaterializedView are determined by the `defining_sql` attribute. To update
+        the columns, you must update the `defining_sql` and store the view.
+
+        Arguments:
+            dry_run: If True, will not actually store the table but will log to
+                the console what would have been stored.
+            job_timeout: The maximum amount of time to wait for a job to complete.
+                This is used when updating the table schema. If the timeout
+                is reached a `SynapseTimeoutError` will be raised.
+                The default is 600 seconds
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            The MaterializedView instance stored in synapse.
+
+        Example: Create a new materialized view with a defining SQL query.
+            &nbsp;
+
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import MaterializedView
+
+            async def main():
+                syn = Synapse()
+                await syn.login_async()
+
+                materialized_view = MaterializedView(
+                    name="My Materialized View",
+                    description="A test materialized view",
+                    parent_id="syn12345",
+                    defining_sql="SELECT * FROM syn67890"
+                )
+                materialized_view = await materialized_view.store_async()
+                print(f"Created Materialized View with ID: {materialized_view.id}")
+
+            asyncio.run(main())
+            ```
+        """
+        return await super().store_async(
+            dry_run=dry_run, job_timeout=job_timeout, synapse_client=synapse_client
+        )
+
+    async def get_async(
+        self,
+        include_columns: bool = True,
+        include_activity: bool = False,
+        *,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "Self":
+        """
+        Asynchronously get the metadata about the MaterializedView from synapse.
+
+        Arguments:
+            include_columns: If True, will include fully filled column objects in the
+                `.columns` attribute. Defaults to True.
+            include_activity: If True the activity will be included in the MaterializedView
+                if it exists. Defaults to False.
+
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            The MaterializedView instance stored in synapse.
+
+        Example: Retrieve a materialized view by ID.
+            &nbsp;
+
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import MaterializedView
+
+            async def main():
+                syn = Synapse()
+                await syn.login_async()
+
+                materialized_view = await MaterializedView(id="syn12345").get_async()
+                print(materialized_view)
+
+            asyncio.run(main())
+            ```
+        """
+        return await super().get_async(
+            include_columns=include_columns,
+            include_activity=include_activity,
+            synapse_client=synapse_client,
+        )
+
+    async def delete_async(self, *, synapse_client: Optional[Synapse] = None) -> None:
+        """
+        Asynchronously delete the materialized view from synapse. This is not version specific. If you'd like
+        to delete a specific version of the materialized view you must use the
+        [synapseclient.api.delete_entity][] function directly.
+
+        Arguments:
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            None
+
+        Example: Delete a materialized view.
+            &nbsp;
+
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import MaterializedView
+
+            async def main():
+                syn = Synapse()
+                await syn.login_async()
+
+                materialized_view = MaterializedView(id="syn12345")
+                await materialized_view.delete_async()
+                print("Deleted Materialized View.")
+
+            asyncio.run(main())
+            ```
+        """
+        await super().delete_async(synapse_client=synapse_client)

--- a/synapseclient/models/mixins/table_components.py
+++ b/synapseclient/models/mixins/table_components.py
@@ -62,6 +62,7 @@ from synapseclient.models.table_components import (
 )
 
 CLASSES_THAT_CONTAIN_ROW_ETAG = ["Dataset", "EntityView"]
+CLASSES_WITH_READ_ONLY_SCHEMA = ["MaterializedView"]
 
 PANDAS_TABLE_TYPE = {
     "floating": "DOUBLE",
@@ -216,7 +217,11 @@ class TableStoreMixin:
             of the table. If there are no changes to the columns this method will
             return `None`.
         """
-        if not self.has_columns_changed or not self.columns:
+        if (
+            self.__class__.__name__ in CLASSES_WITH_READ_ONLY_SCHEMA
+            or not self.has_columns_changed
+            or not self.columns
+        ):
             return None
 
         column_name_to_id = {}
@@ -401,7 +406,10 @@ class TableStoreMixin:
         ):
             await self._append_default_columns(synapse_client=synapse_client)
 
-        if self.columns:
+        if (
+            self.__class__.__name__ not in CLASSES_WITH_READ_ONLY_SCHEMA
+            and self.columns
+        ):
             # check that column names match this regex "^[a-zA-Z0-9 _\-\.\+\(\)']+$"
             for _, column in self.columns.items():
                 if not re.match(r"^[a-zA-Z0-9 _\-\.\+\(\)']+$", column.name):

--- a/tests/integration/synapseclient/models/async/test_materializedview_async.py
+++ b/tests/integration/synapseclient/models/async/test_materializedview_async.py
@@ -1,0 +1,730 @@
+import asyncio
+import uuid
+from typing import Callable
+
+import pandas as pd
+import pytest
+
+from synapseclient import Synapse
+from synapseclient.core.exceptions import SynapseHTTPError
+from synapseclient.models import Column, ColumnType, MaterializedView, Project, Table
+
+
+class TestMaterializedViewWithoutData:
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    async def test_create_empty_materialized_view(self, project_model: Project) -> None:
+        # GIVEN a MaterializedView with an empty definingSQL
+        materialized_view = MaterializedView(
+            name=str(uuid.uuid4()),
+            description="Test materialized view",
+            parent_id=project_model.id,
+            defining_sql="",
+        )
+
+        # WHEN I try to store the materialized view
+        with pytest.raises(SynapseHTTPError) as e:
+            await materialized_view.store_async(synapse_client=self.syn)
+
+        # THEN a 400 Client Error should be raised
+        assert (
+            "400 Client Error: The definingSQL of the materialized view is required "
+            "and must not be the empty string." in str(e.value)
+        )
+
+    async def test_create_materialized_view_without_columns(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with columns
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a materialized view that uses the table in its defining SQL
+        materialized_view_name = str(uuid.uuid4())
+        materialized_view_description = "Test materialized view"
+        materialized_view = MaterializedView(
+            name=materialized_view_name,
+            parent_id=project_model.id,
+            description=materialized_view_description,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+
+        # WHEN I try to store the materialized view
+        with pytest.raises(SynapseHTTPError) as e:
+            await materialized_view.store_async(synapse_client=self.syn)
+
+        # THEN a 400 Client Error should be raised
+        assert f"400 Client Error: Schema for {table.id} is empty." in str(e.value)
+
+    async def test_create_materialized_view_with_columns(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with columns
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="test_column", column_type=ColumnType.STRING),
+                Column(name="test_column2", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a materialized view that uses the table in its defining SQL
+        materialized_view_name = str(uuid.uuid4())
+        materialized_view_description = "Test materialized view"
+        materialized_view = MaterializedView(
+            name=materialized_view_name,
+            parent_id=project_model.id,
+            description=materialized_view_description,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+
+        # WHEN I store the materialized view
+        materialized_view = await materialized_view.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # THEN the materialized view should be created
+        assert materialized_view.id is not None
+
+        # AND I can retrieve that materialized view from Synapse
+        new_materialized_view_instance = await MaterializedView(
+            id=materialized_view.id
+        ).get_async(synapse_client=self.syn)
+        assert new_materialized_view_instance is not None
+        assert new_materialized_view_instance.name == materialized_view_name
+        assert new_materialized_view_instance.id == materialized_view.id
+        assert (
+            new_materialized_view_instance.description == materialized_view_description
+        )
+
+    async def test_create_materialized_view_with_invalid_sql(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a materialized view with invalid SQL
+        materialized_view_name = str(uuid.uuid4())
+        materialized_view_description = "Test materialized view"
+        materialized_view = MaterializedView(
+            name=materialized_view_name,
+            parent_id=project_model.id,
+            description=materialized_view_description,
+            defining_sql="INVALID SQL",
+        )
+
+        # WHEN I store the materialized view
+        with pytest.raises(SynapseHTTPError) as e:
+            await materialized_view.store_async(synapse_client=self.syn)
+
+        # THEN the materialized view should not be created
+        assert (
+            '400 Client Error: Encountered " <regular_identifier> "INVALID "" '
+            "at line 1, column 1.\nWas expecting one of:" in str(e.value)
+        )
+
+    async def test_update_materialized_view_attributes(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table to use in the defining SQL
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="test_column", column_type=ColumnType.STRING),
+                Column(name="test_column2", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a materialized view
+        original_materialized_view = MaterializedView(
+            name=str(uuid.uuid4()),
+            description="Test materialized view",
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        original_materialized_view = await original_materialized_view.store_async(
+            synapse_client=self.syn
+        )
+        self.schedule_for_cleanup(original_materialized_view.id)
+
+        # AND I update attributes of the materialized view
+        updated_materialized_view = await MaterializedView(
+            id=original_materialized_view.id
+        ).get_async(synapse_client=self.syn)
+        updated_materialized_view.name = str(uuid.uuid4())
+        updated_materialized_view.description = "Updated description"
+        updated_materialized_view.defining_sql = f"SELECT test_column FROM {table.id}"
+        updated_materialized_view = await updated_materialized_view.store_async(
+            synapse_client=self.syn
+        )
+
+        # AND I retrieve the materialized view with its original id
+        retrieved_materialized_view = await MaterializedView(
+            id=original_materialized_view.id
+        ).get_async(synapse_client=self.syn)
+
+        # THEN the materialized view should be updated
+        assert retrieved_materialized_view is not None
+        assert retrieved_materialized_view.name == updated_materialized_view.name
+        assert (
+            retrieved_materialized_view.description
+            == updated_materialized_view.description
+        )
+        assert (
+            retrieved_materialized_view.defining_sql
+            == updated_materialized_view.defining_sql
+        )
+
+        # AND all versions should have the same id
+        assert (
+            retrieved_materialized_view.id
+            == updated_materialized_view.id
+            == original_materialized_view.id
+        )
+
+    async def test_delete_materialized_view(self, project_model: Project) -> None:
+        # GIVEN a table to use in the defining SQL
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="test_column", column_type=ColumnType.STRING),
+                Column(name="test_column2", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a materialized view
+        materialized_view = MaterializedView(
+            name=str(uuid.uuid4()),
+            description="Test materialized view",
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        materialized_view = await materialized_view.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+        assert materialized_view.id is not None
+
+        # WHEN I delete the materialized view
+        await materialized_view.delete_async(synapse_client=self.syn)
+
+        # THEN the materialized view should be deleted
+        with pytest.raises(
+            SynapseHTTPError,
+            match=(f"404 Client Error: Entity {materialized_view.id} is in trash can."),
+        ):
+            await MaterializedView(id=materialized_view.id).get_async(
+                synapse_client=self.syn
+            )
+
+
+class TestMaterializedViewWithData:
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    async def test_query_data_from_materialized_view(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        await table.store_rows_async(data, synapse_client=self.syn)
+
+        # AND a materialized view that uses the table in its defining SQL
+        materialized_view_name = str(uuid.uuid4())
+        materialized_view = MaterializedView(
+            name=materialized_view_name,
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        materialized_view = await materialized_view.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # WHEN I query the materialized view
+        query_result = await materialized_view.query_async(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the table data
+        assert len(query_result) == 2
+        assert query_result["name"].tolist() == ["Alice", "Bob"]
+        assert query_result["age"].tolist() == [30, 25]
+
+    async def test_update_defining_sql(self, project_model: Project) -> None:
+        # GIVEN a table with data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        await table.store_rows_async(data, synapse_client=self.syn)
+
+        # AND a materialized view that uses the table in its defining SQL
+        materialized_view_name = str(uuid.uuid4())
+        materialized_view = MaterializedView(
+            name=materialized_view_name,
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        materialized_view = await materialized_view.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # WHEN I update the defining SQL of the materialized view
+        materialized_view.defining_sql = f"SELECT name FROM {table.id}"
+        materialized_view = await materialized_view.store_async(synapse_client=self.syn)
+
+        # AND I query the updated materialized view
+        query_result = await materialized_view.query_async(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+        await asyncio.sleep(5)
+        # Since the materialized view is eventually consistent, we need to query twice
+        query_result = await materialized_view.query_async(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the updated SQL
+        assert len(query_result) == 2
+        assert query_result["name"].tolist() == ["Alice", "Bob"]
+        assert "age" not in query_result.columns
+
+        # AND the column is not present the next time the `materialized_view` is retrieved
+        retrieved_materialized_view = await MaterializedView(
+            id=materialized_view.id
+        ).get_async(synapse_client=self.syn)
+        assert "age" not in retrieved_materialized_view.columns.keys()
+        assert "name" in retrieved_materialized_view.columns.keys()
+
+    async def test_materialized_view_updates_with_table_data(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with columns but no data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a materialized view that uses the table in its defining SQL
+        materialized_view_name = str(uuid.uuid4())
+        materialized_view = MaterializedView(
+            name=materialized_view_name,
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        materialized_view = await materialized_view.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # WHEN I query the materialized view before adding data to the table
+        query_result = await materialized_view.query_async(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN no data should be returned
+        assert len(query_result) == 0
+
+        # AND WHEN I add data to the table
+        data = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        await table.store_rows_async(data, synapse_client=self.syn)
+
+        # AND I query the materialized view again
+        query_result = await materialized_view.query_async(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+        await asyncio.sleep(5)
+        # Since the materialized view is eventually consistent, we need to query twice
+        query_result = await materialized_view.query_async(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the table data
+        assert len(query_result) == 2
+        assert query_result["name"].tolist() == ["Alice", "Bob"]
+        assert query_result["age"].tolist() == [30, 25]
+
+    async def test_materialized_view_reflects_table_data_removal(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with columns and data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        await table.store_rows_async(data, synapse_client=self.syn)
+
+        # AND a materialized view that uses the table in its defining SQL
+        materialized_view_name = str(uuid.uuid4())
+        materialized_view = MaterializedView(
+            name=materialized_view_name,
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        materialized_view = await materialized_view.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # WHEN I query the materialized view
+        query_result = await materialized_view.query_async(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the table data
+        assert len(query_result) == 2
+        assert query_result["name"].tolist() == ["Alice", "Bob"]
+        assert query_result["age"].tolist() == [30, 25]
+
+        # AND WHEN I remove data from the table
+        await table.delete_rows_async(
+            query=f"SELECT ROW_ID, ROW_VERSION FROM {table.id}", synapse_client=self.syn
+        )
+
+        # Ensure the table contains no rows after deletion
+        query_result = await table.query_async(
+            f"SELECT * FROM {table.id}", synapse_client=self.syn
+        )
+        assert len(query_result) == 0
+
+        # AND I query the materialized view again
+        query_result = await materialized_view.query_async(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+        await asyncio.sleep(5)
+        # Since the materialized view is eventually consistent, we need to query twice
+        query_result = await materialized_view.query_async(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN no data should be returned
+        assert len(query_result) == 0
+
+    async def test_query_part_mask_async(self, project_model: Project) -> None:
+        # GIVEN a table with data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        await table.store_rows_async(data, synapse_client=self.syn)
+
+        # AND a materialized view that uses the table in its defining SQL
+        materialized_view_name = str(uuid.uuid4())
+        materialized_view = MaterializedView(
+            name=materialized_view_name,
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        materialized_view = await materialized_view.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # WHEN I query the materialized view using query_part_mask_async
+        QUERY_RESULTS = 0x1
+        QUERY_COUNT = 0x2
+        LAST_UPDATED_ON = 0x80
+
+        # Combine the part mask values using bitwise OR
+        part_mask = QUERY_RESULTS | QUERY_COUNT | LAST_UPDATED_ON
+
+        query_result = await materialized_view.query_part_mask_async(
+            query=f"SELECT * FROM {materialized_view.id}",
+            part_mask=part_mask,
+            synapse_client=self.syn,
+        )
+
+        # THEN the data should match the table data
+        assert query_result is not None
+        assert len(query_result.result) == 2
+        assert query_result.result["name"].tolist() == ["Alice", "Bob"]
+        assert query_result.result["age"].tolist() == [30, 25]
+
+        assert query_result.count == 2
+        assert query_result.last_updated_on is not None
+
+    async def test_materialized_view_with_left_join(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN two tables with data
+        table1 = Table(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            columns=[
+                Column(name="unique_identifier", column_type=ColumnType.INTEGER),
+                Column(name="name", column_type=ColumnType.STRING),
+            ],
+        )
+        table1 = await table1.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table1.id)
+
+        table2 = Table(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            columns=[
+                Column(name="unique_identifier", column_type=ColumnType.INTEGER),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table2 = await table2.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table2.id)
+
+        # Insert data into the tables
+        data1 = pd.DataFrame({"unique_identifier": [1, 2], "name": ["Alice", "Bob"]})
+        await table1.store_rows_async(data1, synapse_client=self.syn)
+
+        data2 = pd.DataFrame({"unique_identifier": [1, 3], "age": [30, 40]})
+        await table2.store_rows_async(data2, synapse_client=self.syn)
+
+        # AND a materialized view with a LEFT JOIN
+        materialized_view = MaterializedView(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            defining_sql=(
+                f"SELECT t1.unique_identifier as unique_identifier, t1.name as name, "
+                f"t2.age as age FROM {table1.id} t1 LEFT JOIN {table2.id} t2 "
+                f"ON t1.unique_identifier = t2.unique_identifier"
+            ),
+        )
+        materialized_view = await materialized_view.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # WHEN I query the materialized view
+        query_result = await materialized_view.query_async(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the LEFT JOIN result
+        assert len(query_result) == 2
+        assert query_result["unique_identifier"].tolist() == [1, 2]
+        assert query_result["name"].tolist() == ["Alice", "Bob"]
+        assert query_result["age"][0] == 30
+        assert pd.isna(query_result["age"][1])
+
+    async def test_materialized_view_with_right_join(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN two tables with data
+        table1 = Table(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            columns=[
+                Column(name="unique_identifier", column_type=ColumnType.INTEGER),
+                Column(name="name", column_type=ColumnType.STRING),
+            ],
+        )
+        table1 = await table1.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table1.id)
+
+        table2 = Table(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            columns=[
+                Column(name="unique_identifier", column_type=ColumnType.INTEGER),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table2 = await table2.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table2.id)
+
+        # Insert data into the tables
+        data1 = pd.DataFrame({"unique_identifier": [1, 2], "name": ["Alice", "Bob"]})
+        await table1.store_rows_async(data1, synapse_client=self.syn)
+
+        data2 = pd.DataFrame({"unique_identifier": [1, 3], "age": [30, 40]})
+        await table2.store_rows_async(data2, synapse_client=self.syn)
+
+        # AND a materialized view with a RIGHT JOIN
+        materialized_view = MaterializedView(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            defining_sql=(
+                f"SELECT t2.unique_identifier as unique_identifier, t1.name as name, "
+                f"t2.age as age FROM {table1.id} t1 RIGHT JOIN {table2.id} t2 "
+                f"ON t1.unique_identifier = t2.unique_identifier"
+            ),
+        )
+        materialized_view = await materialized_view.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # WHEN I query the materialized view
+        query_result = await materialized_view.query_async(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the RIGHT JOIN result
+        assert len(query_result) == 2
+        assert query_result["unique_identifier"].tolist() == [1, 3]
+        assert query_result["name"][0] == "Alice"
+        assert pd.isna(query_result["name"][1])
+        assert query_result["age"].tolist() == [30, 40]
+
+    async def test_materialized_view_with_inner_join(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN two tables with data
+        table1 = Table(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            columns=[
+                Column(name="unique_identifier", column_type=ColumnType.INTEGER),
+                Column(name="name", column_type=ColumnType.STRING),
+            ],
+        )
+        table1 = await table1.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table1.id)
+
+        table2 = Table(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            columns=[
+                Column(name="unique_identifier", column_type=ColumnType.INTEGER),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table2 = await table2.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table2.id)
+
+        # Insert data into the tables
+        data1 = pd.DataFrame({"unique_identifier": [1, 2], "name": ["Alice", "Bob"]})
+        await table1.store_rows_async(data1, synapse_client=self.syn)
+
+        data2 = pd.DataFrame({"unique_identifier": [1, 3], "age": [30, 40]})
+        await table2.store_rows_async(data2, synapse_client=self.syn)
+
+        # AND a materialized view with an INNER JOIN
+        materialized_view = MaterializedView(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            defining_sql=(
+                f"SELECT t1.unique_identifier as unique_identifier, t1.name as name, "
+                f"t2.age as age FROM {table1.id} t1 INNER JOIN {table2.id} t2 "
+                f"ON t1.unique_identifier = t2.unique_identifier"
+            ),
+        )
+        materialized_view = await materialized_view.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # WHEN I query the materialized view
+        query_result = await materialized_view.query_async(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the INNER JOIN result
+        assert len(query_result) == 1
+        assert query_result["unique_identifier"].tolist() == [1]
+        assert query_result["name"].tolist() == ["Alice"]
+        assert query_result["age"].tolist() == [30]
+
+    async def test_materialized_view_with_union(self, project_model: Project) -> None:
+        # GIVEN two tables with data
+        table1 = Table(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            columns=[
+                Column(name="unique_identifier", column_type=ColumnType.INTEGER),
+                Column(name="name", column_type=ColumnType.STRING),
+            ],
+        )
+        table1 = await table1.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table1.id)
+
+        table2 = Table(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            columns=[
+                Column(name="unique_identifier", column_type=ColumnType.INTEGER),
+                Column(name="name", column_type=ColumnType.STRING),
+            ],
+        )
+        table2 = await table2.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table2.id)
+
+        # Insert data into the tables
+        data1 = pd.DataFrame({"unique_identifier": [1, 2], "name": ["Alice", "Bob"]})
+        await table1.store_rows_async(data1, synapse_client=self.syn)
+
+        data2 = pd.DataFrame(
+            {"unique_identifier": [3, 4], "name": ["Charlie", "Diana"]}
+        )
+        await table2.store_rows_async(data2, synapse_client=self.syn)
+
+        # AND a materialized view with a UNION
+        materialized_view = MaterializedView(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            defining_sql=(
+                f"SELECT unique_identifier as unique_identifier, name as name "
+                f"FROM {table1.id} UNION SELECT unique_identifier as unique_identifier, "
+                f"name as name FROM {table2.id}"
+            ),
+        )
+        materialized_view = await materialized_view.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # WHEN I query the materialized view
+        query_result = await materialized_view.query_async(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the UNION result
+        assert len(query_result) == 4
+        assert query_result["unique_identifier"].tolist() == [1, 2, 3, 4]
+        assert query_result["name"].tolist() == ["Alice", "Bob", "Charlie", "Diana"]

--- a/tests/integration/synapseclient/models/async/test_materializedview_async.py
+++ b/tests/integration/synapseclient/models/async/test_materializedview_async.py
@@ -38,7 +38,7 @@ class TestMaterializedViewWithoutData:
     async def test_create_materialized_view_without_columns(
         self, project_model: Project
     ) -> None:
-        # GIVEN a table with columns
+        # GIVEN a table with no columns
         table_name = str(uuid.uuid4())
         table = Table(
             name=table_name,

--- a/tests/integration/synapseclient/models/synchronous/test_materializedview.py
+++ b/tests/integration/synapseclient/models/synchronous/test_materializedview.py
@@ -38,7 +38,7 @@ class TestMaterializedViewWithoutData:
     async def test_create_materialized_view_without_columns(
         self, project_model: Project
     ) -> None:
-        # GIVEN a table with columns
+        # GIVEN a table with no columns
         table_name = str(uuid.uuid4())
         table = Table(
             name=table_name,

--- a/tests/integration/synapseclient/models/synchronous/test_materializedview.py
+++ b/tests/integration/synapseclient/models/synchronous/test_materializedview.py
@@ -1,0 +1,726 @@
+import asyncio
+import uuid
+from typing import Callable
+
+import pandas as pd
+import pytest
+
+from synapseclient import Synapse
+from synapseclient.core.exceptions import SynapseHTTPError
+from synapseclient.models import Column, ColumnType, MaterializedView, Project, Table
+
+
+class TestMaterializedViewWithoutData:
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    async def test_create_empty_materialized_view(self, project_model: Project) -> None:
+        # GIVEN a MaterializedView with an empty definingSQL
+        materialized_view = MaterializedView(
+            name=str(uuid.uuid4()),
+            description="Test materialized view",
+            parent_id=project_model.id,
+            defining_sql="",
+        )
+
+        # WHEN I try to store the materialized view
+        with pytest.raises(SynapseHTTPError) as e:
+            materialized_view.store(synapse_client=self.syn)
+
+        # THEN a 400 Client Error should be raised
+        assert (
+            "400 Client Error: The definingSQL of the materialized view is required "
+            "and must not be the empty string." in str(e.value)
+        )
+
+    async def test_create_materialized_view_without_columns(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with columns
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a materialized view that uses the table in its defining SQL
+        materialized_view_name = str(uuid.uuid4())
+        materialized_view_description = "Test materialized view"
+        materialized_view = MaterializedView(
+            name=materialized_view_name,
+            parent_id=project_model.id,
+            description=materialized_view_description,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+
+        # WHEN I try to store the materialized view
+        with pytest.raises(SynapseHTTPError) as e:
+            materialized_view.store(synapse_client=self.syn)
+
+        # THEN a 400 Client Error should be raised
+        assert f"400 Client Error: Schema for {table.id} is empty." in str(e.value)
+
+    async def test_create_materialized_view_with_columns(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with columns
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="test_column", column_type=ColumnType.STRING),
+                Column(name="test_column2", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a materialized view that uses the table in its defining SQL
+        materialized_view_name = str(uuid.uuid4())
+        materialized_view_description = "Test materialized view"
+        materialized_view = MaterializedView(
+            name=materialized_view_name,
+            parent_id=project_model.id,
+            description=materialized_view_description,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+
+        # WHEN I store the materialized view
+        materialized_view = materialized_view.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # THEN the materialized view should be created
+        assert materialized_view.id is not None
+
+        # AND I can retrieve that materialized view from Synapse
+        new_materialized_view_instance = MaterializedView(id=materialized_view.id).get(
+            synapse_client=self.syn
+        )
+        assert new_materialized_view_instance is not None
+        assert new_materialized_view_instance.name == materialized_view_name
+        assert new_materialized_view_instance.id == materialized_view.id
+        assert (
+            new_materialized_view_instance.description == materialized_view_description
+        )
+
+    async def test_create_materialized_view_with_invalid_sql(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a materialized view with invalid SQL
+        materialized_view_name = str(uuid.uuid4())
+        materialized_view_description = "Test materialized view"
+        materialized_view = MaterializedView(
+            name=materialized_view_name,
+            parent_id=project_model.id,
+            description=materialized_view_description,
+            defining_sql="INVALID SQL",
+        )
+
+        # WHEN I store the materialized view
+        with pytest.raises(SynapseHTTPError) as e:
+            materialized_view.store(synapse_client=self.syn)
+
+        # THEN the materialized view should not be created
+        assert (
+            '400 Client Error: Encountered " <regular_identifier> "INVALID "" '
+            "at line 1, column 1.\nWas expecting one of:" in str(e.value)
+        )
+
+    async def test_update_materialized_view_attributes(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table to use in the defining SQL
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="test_column", column_type=ColumnType.STRING),
+                Column(name="test_column2", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a materialized view
+        original_materialized_view = MaterializedView(
+            name=str(uuid.uuid4()),
+            description="Test materialized view",
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        original_materialized_view = original_materialized_view.store(
+            synapse_client=self.syn
+        )
+        self.schedule_for_cleanup(original_materialized_view.id)
+
+        # AND I update attributes of the materialized view
+        updated_materialized_view = MaterializedView(
+            id=original_materialized_view.id
+        ).get(synapse_client=self.syn)
+        updated_materialized_view.name = str(uuid.uuid4())
+        updated_materialized_view.description = "Updated description"
+        updated_materialized_view.defining_sql = f"SELECT test_column FROM {table.id}"
+        updated_materialized_view = updated_materialized_view.store(
+            synapse_client=self.syn
+        )
+
+        # AND I retrieve the materialized view with its original id
+        retrieved_materialized_view = MaterializedView(
+            id=original_materialized_view.id
+        ).get(synapse_client=self.syn)
+
+        # THEN the materialized view should be updated
+        assert retrieved_materialized_view is not None
+        assert retrieved_materialized_view.name == updated_materialized_view.name
+        assert (
+            retrieved_materialized_view.description
+            == updated_materialized_view.description
+        )
+        assert (
+            retrieved_materialized_view.defining_sql
+            == updated_materialized_view.defining_sql
+        )
+
+        # AND all versions should have the same id
+        assert (
+            retrieved_materialized_view.id
+            == updated_materialized_view.id
+            == original_materialized_view.id
+        )
+
+    async def test_delete_materialized_view(self, project_model: Project) -> None:
+        # GIVEN a table to use in the defining SQL
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="test_column", column_type=ColumnType.STRING),
+                Column(name="test_column2", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a materialized view
+        materialized_view = MaterializedView(
+            name=str(uuid.uuid4()),
+            description="Test materialized view",
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        materialized_view = materialized_view.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+        assert materialized_view.id is not None
+
+        # WHEN I delete the materialized view
+        materialized_view.delete(synapse_client=self.syn)
+
+        # THEN the materialized view should be deleted
+        with pytest.raises(
+            SynapseHTTPError,
+            match=(f"404 Client Error: Entity {materialized_view.id} is in trash can."),
+        ):
+            MaterializedView(id=materialized_view.id).get(synapse_client=self.syn)
+
+
+class TestMaterializedViewWithData:
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    async def test_query_data_from_materialized_view(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        table.store_rows(data, synapse_client=self.syn)
+
+        # AND a materialized view that uses the table in its defining SQL
+        materialized_view_name = str(uuid.uuid4())
+        materialized_view = MaterializedView(
+            name=materialized_view_name,
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        materialized_view = materialized_view.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # WHEN I query the materialized view
+        query_result = materialized_view.query(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the table data
+        assert len(query_result) == 2
+        assert query_result["name"].tolist() == ["Alice", "Bob"]
+        assert query_result["age"].tolist() == [30, 25]
+
+    async def test_update_defining_sql(self, project_model: Project) -> None:
+        # GIVEN a table with data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        table.store_rows(data, synapse_client=self.syn)
+
+        # AND a materialized view that uses the table in its defining SQL
+        materialized_view_name = str(uuid.uuid4())
+        materialized_view = MaterializedView(
+            name=materialized_view_name,
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        materialized_view = materialized_view.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # WHEN I update the defining SQL of the materialized view
+        materialized_view.defining_sql = f"SELECT name FROM {table.id}"
+        materialized_view = materialized_view.store(synapse_client=self.syn)
+
+        # AND I query the updated materialized view
+        query_result = materialized_view.query(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+        await asyncio.sleep(5)
+        # Since the materialized view is eventually consistent, we need to query twice
+        query_result = materialized_view.query(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the updated SQL
+        assert len(query_result) == 2
+        assert query_result["name"].tolist() == ["Alice", "Bob"]
+        assert "age" not in query_result.columns
+
+        # AND the column is not present the next time the `materialized_view` is retrieved
+        retrieved_materialized_view = MaterializedView(id=materialized_view.id).get(
+            synapse_client=self.syn
+        )
+        assert "age" not in retrieved_materialized_view.columns.keys()
+        assert "name" in retrieved_materialized_view.columns.keys()
+
+    async def test_materialized_view_updates_with_table_data(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with columns but no data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a materialized view that uses the table in its defining SQL
+        materialized_view_name = str(uuid.uuid4())
+        materialized_view = MaterializedView(
+            name=materialized_view_name,
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        materialized_view = materialized_view.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # WHEN I query the materialized view before adding data to the table
+        query_result = materialized_view.query(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN no data should be returned
+        assert len(query_result) == 0
+
+        # AND WHEN I add data to the table
+        data = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        table.store_rows(data, synapse_client=self.syn)
+
+        # AND I query the materialized view again
+        query_result = materialized_view.query(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+        await asyncio.sleep(5)
+        # Since the materialized view is eventually consistent, we need to query twice
+        query_result = materialized_view.query(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the table data
+        assert len(query_result) == 2
+        assert query_result["name"].tolist() == ["Alice", "Bob"]
+        assert query_result["age"].tolist() == [30, 25]
+
+    async def test_materialized_view_reflects_table_data_removal(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with columns and data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        table.store_rows(data, synapse_client=self.syn)
+
+        # AND a materialized view that uses the table in its defining SQL
+        materialized_view_name = str(uuid.uuid4())
+        materialized_view = MaterializedView(
+            name=materialized_view_name,
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        materialized_view = materialized_view.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # WHEN I query the materialized view
+        query_result = materialized_view.query(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the table data
+        assert len(query_result) == 2
+        assert query_result["name"].tolist() == ["Alice", "Bob"]
+        assert query_result["age"].tolist() == [30, 25]
+
+        # AND WHEN I remove data from the table
+        table.delete_rows(
+            query=f"SELECT ROW_ID, ROW_VERSION FROM {table.id}", synapse_client=self.syn
+        )
+
+        # Ensure the table contains no rows after deletion
+        query_result = table.query(f"SELECT * FROM {table.id}", synapse_client=self.syn)
+        assert len(query_result) == 0
+
+        # AND I query the materialized view again
+        query_result = materialized_view.query(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+        await asyncio.sleep(5)
+        # Since the materialized view is eventually consistent, we need to query twice
+        query_result = materialized_view.query(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN no data should be returned
+        assert len(query_result) == 0
+
+    async def test_query_part_mask(self, project_model: Project) -> None:
+        # GIVEN a table with data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        table.store_rows(data, synapse_client=self.syn)
+
+        # AND a materialized view that uses the table in its defining SQL
+        materialized_view_name = str(uuid.uuid4())
+        materialized_view = MaterializedView(
+            name=materialized_view_name,
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        materialized_view = materialized_view.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # WHEN I query the materialized view using query_part_mask
+        QUERY_RESULTS = 0x1
+        QUERY_COUNT = 0x2
+        LAST_UPDATED_ON = 0x80
+
+        # Combine the part mask values using bitwise OR
+        part_mask = QUERY_RESULTS | QUERY_COUNT | LAST_UPDATED_ON
+
+        query_result = materialized_view.query_part_mask(
+            query=f"SELECT * FROM {materialized_view.id}",
+            part_mask=part_mask,
+            synapse_client=self.syn,
+        )
+
+        # THEN the data should match the table data
+        assert query_result is not None
+        assert len(query_result.result) == 2
+        assert query_result.result["name"].tolist() == ["Alice", "Bob"]
+        assert query_result.result["age"].tolist() == [30, 25]
+
+        assert query_result.count == 2
+        assert query_result.last_updated_on is not None
+
+    async def test_materialized_view_with_left_join(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN two tables with data
+        table1 = Table(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            columns=[
+                Column(name="unique_identifier", column_type=ColumnType.INTEGER),
+                Column(name="name", column_type=ColumnType.STRING),
+            ],
+        )
+        table1 = table1.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table1.id)
+
+        table2 = Table(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            columns=[
+                Column(name="unique_identifier", column_type=ColumnType.INTEGER),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table2 = table2.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table2.id)
+
+        # Insert data into the tables
+        data1 = pd.DataFrame({"unique_identifier": [1, 2], "name": ["Alice", "Bob"]})
+        table1.store_rows(data1, synapse_client=self.syn)
+
+        data2 = pd.DataFrame({"unique_identifier": [1, 3], "age": [30, 40]})
+        table2.store_rows(data2, synapse_client=self.syn)
+
+        # AND a materialized view with a LEFT JOIN
+        materialized_view = MaterializedView(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            defining_sql=(
+                f"SELECT t1.unique_identifier as unique_identifier, t1.name as name, "
+                f"t2.age as age FROM {table1.id} t1 LEFT JOIN {table2.id} t2 "
+                f"ON t1.unique_identifier = t2.unique_identifier"
+            ),
+        )
+        materialized_view = materialized_view.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # WHEN I query the materialized view
+        query_result = materialized_view.query(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the LEFT JOIN result
+        assert len(query_result) == 2
+        assert query_result["unique_identifier"].tolist() == [1, 2]
+        assert query_result["name"].tolist() == ["Alice", "Bob"]
+        assert query_result["age"][0] == 30
+        assert pd.isna(query_result["age"][1])
+
+    async def test_materialized_view_with_right_join(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN two tables with data
+        table1 = Table(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            columns=[
+                Column(name="unique_identifier", column_type=ColumnType.INTEGER),
+                Column(name="name", column_type=ColumnType.STRING),
+            ],
+        )
+        table1 = table1.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table1.id)
+
+        table2 = Table(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            columns=[
+                Column(name="unique_identifier", column_type=ColumnType.INTEGER),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table2 = table2.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table2.id)
+
+        # Insert data into the tables
+        data1 = pd.DataFrame({"unique_identifier": [1, 2], "name": ["Alice", "Bob"]})
+        table1.store_rows(data1, synapse_client=self.syn)
+
+        data2 = pd.DataFrame({"unique_identifier": [1, 3], "age": [30, 40]})
+        table2.store_rows(data2, synapse_client=self.syn)
+
+        # AND a materialized view with a RIGHT JOIN
+        materialized_view = MaterializedView(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            defining_sql=(
+                f"SELECT t2.unique_identifier as unique_identifier, t1.name as name, "
+                f"t2.age as age FROM {table1.id} t1 RIGHT JOIN {table2.id} t2 "
+                f"ON t1.unique_identifier = t2.unique_identifier"
+            ),
+        )
+        materialized_view = materialized_view.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # WHEN I query the materialized view
+        query_result = materialized_view.query(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the RIGHT JOIN result
+        assert len(query_result) == 2
+        assert query_result["unique_identifier"].tolist() == [1, 3]
+        assert query_result["name"][0] == "Alice"
+        assert pd.isna(query_result["name"][1])
+        assert query_result["age"].tolist() == [30, 40]
+
+    async def test_materialized_view_with_inner_join(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN two tables with data
+        table1 = Table(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            columns=[
+                Column(name="unique_identifier", column_type=ColumnType.INTEGER),
+                Column(name="name", column_type=ColumnType.STRING),
+            ],
+        )
+        table1 = table1.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table1.id)
+
+        table2 = Table(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            columns=[
+                Column(name="unique_identifier", column_type=ColumnType.INTEGER),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table2 = table2.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table2.id)
+
+        # Insert data into the tables
+        data1 = pd.DataFrame({"unique_identifier": [1, 2], "name": ["Alice", "Bob"]})
+        table1.store_rows(data1, synapse_client=self.syn)
+
+        data2 = pd.DataFrame({"unique_identifier": [1, 3], "age": [30, 40]})
+        table2.store_rows(data2, synapse_client=self.syn)
+
+        # AND a materialized view with an INNER JOIN
+        materialized_view = MaterializedView(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            defining_sql=(
+                f"SELECT t1.unique_identifier as unique_identifier, t1.name as name, "
+                f"t2.age as age FROM {table1.id} t1 INNER JOIN {table2.id} t2 "
+                f"ON t1.unique_identifier = t2.unique_identifier"
+            ),
+        )
+        materialized_view = materialized_view.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # WHEN I query the materialized view
+        query_result = materialized_view.query(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the INNER JOIN result
+        assert len(query_result) == 1
+        assert query_result["unique_identifier"].tolist() == [1]
+        assert query_result["name"].tolist() == ["Alice"]
+        assert query_result["age"].tolist() == [30]
+
+    async def test_materialized_view_with_union(self, project_model: Project) -> None:
+        # GIVEN two tables with data
+        table1 = Table(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            columns=[
+                Column(name="unique_identifier", column_type=ColumnType.INTEGER),
+                Column(name="name", column_type=ColumnType.STRING),
+            ],
+        )
+        table1 = table1.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table1.id)
+
+        table2 = Table(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            columns=[
+                Column(name="unique_identifier", column_type=ColumnType.INTEGER),
+                Column(name="name", column_type=ColumnType.STRING),
+            ],
+        )
+        table2 = table2.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table2.id)
+
+        # Insert data into the tables
+        data1 = pd.DataFrame({"unique_identifier": [1, 2], "name": ["Alice", "Bob"]})
+        table1.store_rows(data1, synapse_client=self.syn)
+
+        data2 = pd.DataFrame(
+            {"unique_identifier": [3, 4], "name": ["Charlie", "Diana"]}
+        )
+        table2.store_rows(data2, synapse_client=self.syn)
+
+        # AND a materialized view with a UNION
+        materialized_view = MaterializedView(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            defining_sql=(
+                f"SELECT unique_identifier as unique_identifier, name as name "
+                f"FROM {table1.id} UNION SELECT unique_identifier as unique_identifier, "
+                f"name as name FROM {table2.id}"
+            ),
+        )
+        materialized_view = materialized_view.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(materialized_view.id)
+
+        # WHEN I query the materialized view
+        query_result = materialized_view.query(
+            f"SELECT * FROM {materialized_view.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the UNION result
+        assert len(query_result) == 4
+        assert query_result["unique_identifier"].tolist() == [1, 2, 3, 4]
+        assert query_result["name"].tolist() == ["Alice", "Bob", "Charlie", "Diana"]


### PR DESCRIPTION
# **Problem:**

- The https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/MaterializedView.html concept does not exist in the OOP mode

# **Solution:**

- Create the MaterializedView class, a tutorial for the changes, and a bunch of different examples

# **Testing:**

- Manual testing to verify the changes behave as expected
- A tutorial to showcase the model
- Integration tests verifying the changes


**Links to resources:**

1. Tutorial: https://synapsepythonclient--1190.org.readthedocs.build/en/1190/tutorials/python/materializedview/
2. Sync API Reference: https://synapsepythonclient--1190.org.readthedocs.build/en/1190/reference/experimental/sync/materializedview/
3. Async API Reference: https://synapsepythonclient--1190.org.readthedocs.build/en/1190/reference/experimental/async/materializedview/