### PR TITLE
[SYNPY-1497] refactored version check to use Pypi for version info

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -821,7 +821,7 @@ class Synapse(object):
 
         # Check version before logging in
         if not self.skip_checks:
-            version_check()
+            version_check(self.logger)
 
         # Make sure to invalidate the existing session
         self.logout()

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -821,7 +821,7 @@ class Synapse(object):
 
         # Check version before logging in
         if not self.skip_checks:
-            version_check(self.logger)
+            version_check(logger=self.logger)
 
         # Make sure to invalidate the existing session
         self.logout()

--- a/synapseclient/core/version_check.py
+++ b/synapseclient/core/version_check.py
@@ -15,82 +15,172 @@ import importlib.resources
 import json
 import re
 import sys
+import urllib.request
+from typing import Optional
 
 import requests
 
 import synapseclient
 
 _VERSION_URL = "https://raw.githubusercontent.com/Sage-Bionetworks/synapsePythonClient/master/synapseclient/synapsePythonClient"  # noqa
+_PYPI_JSON_URL = "https://pypi.org/pypi/synapseclient/json"
+_RELEASE_NOTES_URL = "https://python-docs.synapse.org/news/"
 
 
 def version_check(
-    current_version=None, version_url=_VERSION_URL, check_for_point_releases=False
-):
+    current_version: Optional[str] = None,
+    check_for_point_releases: bool = False,
+    use_local_metadata: bool = False,
+) -> bool:
     """
     Gets the latest version information from version_url and check against the current version.
     Recommends upgrade, if a newer version exists.
 
-    Arguments:
-        current_version: The current version of the entity
-        version_url: The URL of the entity version
-        check_for_point_releases: Bool.
+    This wraps the _version_check function in a try except block.
+    The purpose of this is so that no exception caught running the version check stop the client from running.
+
+    Args:
+        current_version (Optional[str], optional): The current version of the package.
+          Defaults to None.
+          This argument is mainly used for testing.
+        check_for_point_releases (bool, optional):
+          Defaults to False.
+          If True, The whole package versions will be compared (ie. 1.0.0)
+          If False, only the major and minor package version will be compared (ie. 1.0)
+        use_local_metadata (bool, optional):
+          Defaults to False.
+          If True, importlib.resources will be used to get the latest version fo the package
+          If False, the latest version fo the package will be taken from Pypi
 
     Returns:
-        True if current version is the latest release (or higher) version, otherwise False.
+        bool: True if current version is the latest release (or higher) version, otherwise False.
     """
-
     try:
-        if not current_version:
-            current_version = synapseclient.__version__
-
-        version_info = _get_version_info(version_url)
-
-        current_base_version = _strip_dev_suffix(current_version)
-
-        # Check blacklist
-        if (
-            current_base_version in version_info["blacklist"]
-            or current_version in version_info["blacklist"]
+        if not _version_check(
+            current_version, check_for_point_releases, use_local_metadata
         ):
-            msg = (
-                "\nPLEASE UPGRADE YOUR CLIENT\n\nUpgrading your SynapseClient is"
-                " required. Please upgrade your client by typing:\n    pip install"
-                " --upgrade synapseclient\n\n"
-            )
-            raise SystemExit(msg)
-
-        if "message" in version_info:
-            sys.stderr.write(version_info["message"] + "\n")
-
-        levels = 3 if check_for_point_releases else 2
-
-        # Compare with latest version
-        if _version_tuple(current_version, levels=levels) < _version_tuple(
-            version_info["latestVersion"], levels=levels
-        ):
-            sys.stderr.write(
-                "\nUPGRADE AVAILABLE\n\nA more recent version of the Synapse Client"
-                " (%s) is available. Your version (%s) can be upgraded by typing:\n   "
-                " pip install --upgrade synapseclient\n\n"
-                % (
-                    version_info["latestVersion"],
-                    current_version,
-                )
-            )
-            if "releaseNotes" in version_info:
-                sys.stderr.write(
-                    "Python Synapse Client version %s release notes\n\n"
-                    % version_info["latestVersion"]
-                )
-                sys.stderr.write(version_info["releaseNotes"] + "\n\n")
             return False
 
     except Exception as e:
         # Don't prevent the client from running if something goes wrong
-        sys.stderr.write("Exception in version check: %s\n" % (str(e),))
+        sys.stderr.write(f"Exception in version check: {str(e)}\n")
         return False
 
     return True
+
+
+def _version_check(
+    current_version: Optional[str] = None,
+    check_for_point_releases: bool = False,
+    use_local_metadata: bool = False,
+) -> bool:
+    """
+    Gets the latest version information from version_url and check against the current version.
+    Recommends upgrade, if a newer version exists.
+
+    This has been split of from the version_check function to make testing easier.
+
+    Args:
+        current_version (Optional[str], optional): The current version of the package.
+          Defaults to None.
+          This argument is mainly used for testing.
+        check_for_point_releases (bool, optional):
+          Defaults to False.
+          If True, The whole package versions will be compared (ie. 1.0.0)
+          If False, only the major and minor package version will be compared (ie. 1.0)
+        use_local_metadata (bool, optional):
+          Defaults to False.
+          If True, importlib.resources will be used to get the latest version fo the package
+          If False, the latest version fo the package will be taken from Pypi
+
+    Returns:
+        bool: True if current version is the latest release (or higher) version, otherwise False.
+    """
+    if not current_version:
+        current_version = synapseclient.__version__
+    assert isinstance(current_version, str)
+
+    if use_local_metadata:
+        metadata = _get_local_package_metadata()
+        latest_version = metadata["latestVersion"]
+        assert isinstance(latest_version, str)
+    else:
+        latest_version = _get_version_info_from_pypi()
+
+    levels = 3 if check_for_point_releases else 2
+
+    if _is_current_version_behind(current_version, latest_version, levels):
+        _write_package_behind_messages(current_version, latest_version)
+        return False
+    return True
+
+
+def _get_version_info_from_pypi() -> str:
+    """Gets the current release version from PyPi
+
+    Returns:
+        str: The current release version
+    """
+    with urllib.request.urlopen(_PYPI_JSON_URL) as url:
+        data = json.load(url)
+    version = data["info"]["version"]
+    assert isinstance(version, str)
+    return version
+
+
+def _is_current_version_behind(
+    current_version: str, latest_version: str, levels: int
+) -> bool:
+    """
+    Tests if the current version of the package is behind the latest version.
+
+    Args:
+        current_version (str): The current version of a package
+        latest_version (str): The latest version of a package
+        levels (int): The levels of the packages to check. For example:
+          level 1: major versions
+          level 2: minor versions
+          level 3: patch versions
+
+    Returns:
+        bool: True if current version of package is up to date
+    """
+    current_version_str_tuple = _version_tuple(current_version, levels=levels)
+    latest_version_str_tuple = _version_tuple(latest_version, levels=levels)
+
+    # strings are converted to ints because comparisons of versions of different magnitudes
+    #  don't work as strings
+    #  for example 10 > 2, but "10" <  "2"
+    current_version_int_tuple = tuple(
+        int(version_level) for version_level in current_version_str_tuple
+    )
+    latest_version_int_tuple = tuple(
+        int(version_level) for version_level in latest_version_str_tuple
+    )
+
+    return current_version_int_tuple < latest_version_int_tuple
+
+
+def _write_package_behind_messages(
+    current_version: str,
+    latest_version: str,
+) -> None:
+    """_summary_
+
+    Args:
+        current_version (str): The current version of a package
+        latest_version (str): The latest version of a package
+    """
+    sys.stderr.write(
+        "\nUPGRADE AVAILABLE\n\nA more recent version of the Synapse Client"
+        f" ({latest_version}) is available."
+        f" Your version ({current_version}) can be upgraded by typing:\n   "
+        " pip install --upgrade synapseclient\n\n"
+    )
+    sys.stderr.write(
+        f"Python Synapse Client version {latest_version}" " release notes\n\n"
+    )
+    sys.stderr.write(f"{_RELEASE_NOTES_URL}\n\n")
 
 
 def check_for_updates():
@@ -148,13 +238,32 @@ def _strip_dev_suffix(version):
     return re.sub(r"\.dev\d+", "", version)
 
 
-def _version_tuple(version, levels=2):
+def _version_tuple(version: str, levels: int = 2) -> tuple:
     """
-    Take a version number as a string delimited by periods and return a tuple with the desired number of levels.
+    Take a version number as a string delimited by periods and return a tuple with
+      the desired number of levels.
     For example:
 
         print(version_tuple('0.5.1.dev1', levels=2))
         ('0', '5')
+
+    First the version string is split into version levels.
+    If the number of levels is greater than the levels argument(x),
+      only x levels are returned.
+    If the number of levels is lesser than the levels argument(x),
+      "0" strings are used to pad out the return value.
+
+    Args:
+        version (str): A package version in string form such as "1.0.0"
+        levels (int, optional):
+          Defaults to 2.
+          The number of levels deep in the package version to return. "1.0.0", for example:
+            levels=1: only the major version ("1")
+            levels=2: the major and minor version ("1", "0")
+            levels=2: the major, minor, and patch version ("1", "0", "0")
+
+    Returns:
+        Tuple: A tuple of strings where the length is equal to the levels argument.
     """
     v = _strip_dev_suffix(version).split(".")
     v = v[0 : min(len(v), levels)]
@@ -163,16 +272,37 @@ def _version_tuple(version, levels=2):
     return tuple(v)
 
 
-def _get_version_info(version_url=_VERSION_URL):
+def _get_version_info(version_url: Optional[str] = _VERSION_URL) -> dict:
+    """
+    Gets version info from the version_url argument, or locally
+    By default this is the Github for the python client
+    If the version_url argument is None the version info will be obtained locally.
+
+    Args:
+        version_url (str, optional):
+          Defaults to _VERSION_URL.
+          The url to get version info from
+
+    Returns:
+        dict: This will have various fields relating the version of the client
+    """
     if version_url is None:
-        ref = importlib.resources.files("synapseclient").joinpath("synapsePythonClient")
-        with ref.open("r") as fp:
-            pkg_metadata = json.loads(fp.read())
-        return pkg_metadata
-    else:
-        headers = {"Accept": "application/json; charset=UTF-8"}
-        headers.update(synapseclient.USER_AGENT)
-        return requests.get(version_url, headers=headers).json()
+        return _get_local_package_metadata()
+    headers = {"Accept": "application/json; charset=UTF-8"}
+    headers.update(synapseclient.USER_AGENT)
+    return requests.get(version_url, headers=headers).json()
+
+
+def _get_local_package_metadata() -> dict:
+    """Gets version info locally, using importlib.resources
+
+    Returns:
+        dict: This will have various fields relating the version of the client
+    """
+    ref = importlib.resources.files("synapseclient").joinpath("synapsePythonClient")
+    with ref.open("r") as fp:
+        pkg_metadata = json.loads(fp.read())
+    return pkg_metadata
 
 
 # If this file is run as a script, print current version
@@ -187,5 +317,5 @@ if __name__ == "__main__":
         print("ok")
 
     print("Check against local copy of version file:")
-    if version_check(version_url=None):
+    if version_check(use_local_metadata=True):
         print("ok")

--- a/synapseclient/core/version_check.py
+++ b/synapseclient/core/version_check.py
@@ -11,11 +11,11 @@ Print release notes for installed version of client:
 
 """
 
-import importlib
 import json
 import logging
 import re
 import sys
+from importlib.resources import files
 from typing import Any, Optional
 
 import httpx
@@ -37,7 +37,8 @@ def version_check(
     Recommends upgrade, if a newer version exists.
 
     This wraps the _version_check function in a try except block.
-    The purpose of this is so that no exception caught running the version check stops the client from running.
+    The purpose of this is so that no exception caught running the version
+      check stops the client from running.
 
     Arguments:
         current_version: The current version of the package.
@@ -178,7 +179,7 @@ def _get_local_package_metadata() -> dict[str, Any]:
     Returns:
         dict[str, Any]: This will have various fields relating the version of the client
     """
-    ref = importlib.resources.files("synapseclient").joinpath("synapsePythonClient")
+    ref = files("synapseclient").joinpath("synapsePythonClient")
     with ref.open("r") as fp:
         pkg_metadata = json.loads(fp.read())
     return pkg_metadata

--- a/synapseclient/core/version_check.py
+++ b/synapseclient/core/version_check.py
@@ -63,9 +63,14 @@ def version_check(
         ):
             return False
 
+    # Don't prevent the client from running if something goes wrong
     except Exception as e:
-        # Don't prevent the client from running if something goes wrong
-        sys.stderr.write(f"Exception in version check: {str(e)}\n")
+        msg = f"Exception in version check: {str(e)}\n"
+        if logger:
+            logger.info(msg)
+        else:
+            sys.stdout.write(msg)
+            sys.stdout.flush()
         return False
 
     return True

--- a/synapseclient/core/version_check.py
+++ b/synapseclient/core/version_check.py
@@ -37,7 +37,7 @@ def version_check(
     Recommends upgrade, if a newer version exists.
 
     This wraps the _version_check function in a try except block.
-    The purpose of this is so that no exception caught running the version check stop the client from running.
+    The purpose of this is so that no exception caught running the version check stops the client from running.
 
     Args:
         current_version (Optional[str], optional): The current version of the package.
@@ -165,7 +165,9 @@ def _write_package_behind_messages(
     current_version: str,
     latest_version: str,
 ) -> None:
-    """_summary_
+    """
+    This writes the output message for when the installed package version is behind the
+      most recent release.
 
     Args:
         current_version (str): The current version of a package

--- a/synapseclient/core/version_check.py
+++ b/synapseclient/core/version_check.py
@@ -274,7 +274,7 @@ def _version_tuple(version: str, levels: int = 2) -> tuple:
           The number of levels deep in the package version to return. "1.0.0", for example:
             levels=1: only the major version ("1")
             levels=2: the major and minor version ("1", "0")
-            levels=2: the major, minor, and patch version ("1", "0", "0")
+            levels=3: the major, minor, and patch version ("1", "0", "0")
 
     Returns:
         Tuple: A tuple of strings where the length is equal to the levels argument.

--- a/synapseclient/core/version_check.py
+++ b/synapseclient/core/version_check.py
@@ -11,7 +11,7 @@ Print release notes for installed version of client:
 
 """
 
-import importlib.resources
+import importlib
 import json
 import logging
 import re
@@ -49,8 +49,8 @@ def version_check(
           If False, only the major and minor package version will be compared (ie. 1.0)
         use_local_metadata:
           Defaults to False.
-          If True, importlib.resources will be used to get the latest version fo the package
-          If False, the latest version fo the package will be taken from Pypi
+          If True, importlib.resources will be used to get the latest version of the package
+          If False, the latest version of the package will be taken from Pypi
         logger: a logger for logging output
 
     Returns:
@@ -140,7 +140,7 @@ def _version_check(
           If False, only the major and minor package version will be compared (ie. 1.0)
         use_local_metadata:
           Defaults to False.
-          If True, importlib.resources will be used to get the latest version fo the package
+          If True, importlib.resources will be used to get the latest version of the package
         logger: a logger for logging output
 
     Returns:

--- a/tests/integration/synapseclient/core/test_version_check.py
+++ b/tests/integration/synapseclient/core/test_version_check.py
@@ -1,8 +1,8 @@
 """Integration tests for version checking"""
 
+import httpx
 from pytest_mock import MockerFixture
 
-import synapseclient.core.version_check
 from synapseclient.core.version_check import _get_version_info_from_pypi, version_check
 
 
@@ -14,8 +14,8 @@ async def test_version_check(mocker: MockerFixture):
     # Test out of date version
     assert not version_check(current_version="0.0.1")
 
-    # Assert _get_version_info_from_pypi called  when running version_check
-    spy = mocker.spy(synapseclient.core.version_check, "_get_version_info_from_pypi")
+    # Assert httpx.get called  when running version_check
+    spy = mocker.spy(httpx, "get")
     version_check()
     spy.assert_called_once()
 

--- a/tests/integration/synapseclient/core/test_version_check.py
+++ b/tests/integration/synapseclient/core/test_version_check.py
@@ -3,7 +3,11 @@
 import httpx
 from pytest_mock import MockerFixture
 
-from synapseclient.core.version_check import _get_version_info_from_pypi, version_check
+from synapseclient.core.version_check import (
+    _PYPI_JSON_URL,
+    _get_version_info_from_pypi,
+    version_check,
+)
 
 
 async def test_version_check(mocker: MockerFixture):
@@ -17,7 +21,7 @@ async def test_version_check(mocker: MockerFixture):
     # Assert httpx.get called  when running version_check
     spy = mocker.spy(httpx, "get")
     version_check()
-    spy.assert_called_once()
+    spy.assert_called_once_with(_PYPI_JSON_URL)
 
 
 def test_get_version_info_from_pypi():

--- a/tests/integration/synapseclient/core/test_version_check.py
+++ b/tests/integration/synapseclient/core/test_version_check.py
@@ -1,18 +1,23 @@
 """Integration tests for version checking"""
 
+from pytest_mock import MockerFixture
+
+import synapseclient.core.version_check
 from synapseclient.core.version_check import _get_version_info_from_pypi, version_check
 
 
-async def test_version_check():
+async def test_version_check(mocker: MockerFixture):
     """Integration checks for version_check"""
-    # Check current version against pypi version file
-    version_check()
-
     # Should be higher than current version and return true
     assert version_check(current_version="999.999.999")
 
     # Test out of date version
     assert not version_check(current_version="0.0.1")
+
+    # Assert _get_version_info_from_pypi called  when running version_check
+    spy = mocker.spy(synapseclient.core.version_check, "_get_version_info_from_pypi")
+    version_check()
+    spy.assert_called_once()
 
 
 def test_get_version_info_from_pypi():

--- a/tests/integration/synapseclient/core/test_version_check.py
+++ b/tests/integration/synapseclient/core/test_version_check.py
@@ -1,0 +1,20 @@
+"""Integration tests for version checking"""
+
+from synapseclient.core.version_check import _get_version_info_from_pypi, version_check
+
+
+async def test_version_check():
+    """Integration checks for version_check"""
+    # Check current version against pypi version file
+    version_check()
+
+    # Should be higher than current version and return true
+    assert version_check(current_version="999.999.999")
+
+    # Test out of date version
+    assert not version_check(current_version="0.0.1")
+
+
+def test_get_version_info_from_pypi():
+    """Integration test for _get_version_info_from_pypi"""
+    assert _get_version_info_from_pypi()

--- a/tests/integration/synapseclient/integration_test.py
+++ b/tests/integration/synapseclient/integration_test.py
@@ -25,7 +25,6 @@ from synapseclient import (
     client,
 )
 from synapseclient.core.exceptions import SynapseHTTPError, SynapseNoCredentialsError
-from synapseclient.core.version_check import version_check
 
 PUBLIC = 273949  # PrincipalId of public "user"
 AUTHENTICATED_USERS = 273948

--- a/tests/integration/synapseclient/integration_test.py
+++ b/tests/integration/synapseclient/integration_test.py
@@ -327,39 +327,6 @@ async def test_downloadFile(schedule_for_cleanup):
     assert os.path.exists(filename)
 
 
-async def test_version_check():
-    # Check current version against dev-synapsePythonClient version file
-    version_check(
-        version_url="http://dev-versions.synapse.sagebase.org/synapsePythonClient"
-    )
-
-    # Should be higher than current version and return true
-    assert version_check(
-        current_version="999.999.999",
-        version_url="http://dev-versions.synapse.sagebase.org/synapsePythonClient",
-    )
-
-    # Test out of date version
-    assert not version_check(
-        current_version="0.0.1",
-        version_url="http://dev-versions.synapse.sagebase.org/synapsePythonClient",
-    )
-
-    # Test blacklisted version
-    pytest.raises(
-        SystemExit,
-        version_check,
-        current_version="0.0.0",
-        version_url="http://dev-versions.synapse.sagebase.org/synapsePythonClient",
-    )
-
-    # Test bad URL
-    assert not version_check(
-        current_version="999.999.999",
-        version_url="http://dev-versions.synapse.sagebase.org/bad_filename_doesnt_exist",
-    )
-
-
 async def test_provenance(syn, project, schedule_for_cleanup):
     # Create a File Entity
     fname = utils.make_bogus_data_file()

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -229,14 +229,6 @@ def test_extract_filename() -> None:
     assert utils.extract_filename(None, "fname.ext") == "fname.ext"
 
 
-def test_version_check() -> None:
-    from synapseclient.core.version_check import _version_tuple
-
-    assert _version_tuple("0.5.1.dev200", levels=2) == ("0", "5")
-    assert _version_tuple("0.5.1.dev200", levels=3) == ("0", "5", "1")
-    assert _version_tuple("1.6", levels=3) == ("1", "6", "0")
-
-
 def test_normalize_path() -> None:
     # tests should pass on reasonable OSes and also on windows
 

--- a/tests/unit/synapseclient/core/unit_test_version_check.py
+++ b/tests/unit/synapseclient/core/unit_test_version_check.py
@@ -1,0 +1,133 @@
+"""Unit tests for version check functions"""
+
+
+from unittest.mock import patch
+
+import pytest
+
+from synapseclient.core.version_check import (
+    _get_local_package_metadata,
+    _is_current_version_behind,
+    _version_check,
+    _version_tuple,
+)
+
+
+@pytest.mark.parametrize(
+    "current_version, latest_version, check_for_point_releases, expected_result",
+    [
+        # By default only minor and major versions will trigger a False result
+        ("1.0.0", "1.0.0", False, True),
+        ("1.0.0", "1.0.1", False, True),
+        ("1.0.0", "1.1.0", False, False),
+        ("1.0.0", "2.0.0", False, False),
+        # If check_for_point_releases is set to True, patch versions will
+        #  also trigger a false result
+        ("1.0.0", "1.0.0", True, True),
+        ("1.0.0", "1.0.1", True, False),
+        ("1.0.0", "1.1.0", True, False),
+        ("1.0.0", "2.0.0", True, False),
+        # When the current version is ahead, this should always result in True
+        ("2.0.0", "1.0.0", True, True),
+    ],
+)
+def test__version_check_mocked_pypi(
+    current_version: str,
+    latest_version: str,
+    check_for_point_releases: bool,
+    expected_result: bool,
+):
+    """
+    Tests for _version_check function where the version information is obtained from Pypi,
+      but the call is mocked.
+    """
+    with patch(
+        "synapseclient.core.version_check._get_version_info_from_pypi",
+        return_value=latest_version,
+    ):
+        assert (
+            _version_check(current_version, check_for_point_releases) == expected_result
+        )
+
+
+@pytest.mark.parametrize(
+    "current_version, expected_result",
+    [
+        # As of writing this test the current version is 4.7.0, these should always be behind
+        ("4", False),
+        ("4.0", False),
+        ("4.0.0", False),
+        # These should always be ahead
+        ("100", True),
+        ("100.0", True),
+        ("100.0.0", True),
+    ],
+)
+def test__version_check_local(current_version: str, expected_result: bool):
+    """
+    Tests for _version_check function where the version information is obtained locally
+    """
+    assert _version_check(current_version, use_local_metadata=True) == expected_result
+
+
+@pytest.mark.parametrize(
+    "current_version, latest_version, levels, expected_result",
+    [
+        # When versions are equal the current package is never considered behind
+        ("1", "1", 1, False),
+        ("1", "1", 2, False),
+        ("1", "1", 3, False),
+        # Where versions differ by major version, the current package is always considered behind
+        ("1", "2", 1, True),
+        ("1", "2", 2, True),
+        ("1", "2", 3, True),
+        # Where versions only differ by minor version, the current package is only considered behind
+        #  at levels=2 or higher
+        ("1.0", "1.1", 1, False),
+        ("1.0", "1.1", 2, True),
+        ("1.0", "1.1", 3, True),
+        # Where versions only differ by patch, the current package is only considered behind
+        #  at levels=3 or higher
+        ("1.0.0", "1.0.1", 1, False),
+        ("1.0.0", "1.0.1", 2, False),
+        ("1.0.0", "1.0.1", 3, True),
+        # When the current version is ahead, this should result in False
+        ("10.0.0", "2.0.0", 1, False),
+        ("10.0.0", "2.0.0", 2, False),
+        ("10.0.0", "2.0.0", 3, False),
+    ],
+)
+def test_is_current_version_behind(
+    current_version: str, latest_version: str, levels: int, expected_result: bool
+) -> None:
+    """Tests for _is_current_version_behind"""
+    assert (
+        _is_current_version_behind(current_version, latest_version, levels)
+        == expected_result
+    )
+
+
+@pytest.mark.parametrize(
+    "input_version, input_levels, expected_result",
+    [
+        ("0.5.1.dev200", 2, ("0", "5")),
+        ("0.5.1.dev200", 3, ("0", "5", "1")),
+        ("1.6", 3, ("1", "6", "0")),
+        ("1", 1, ("1",)),
+        ("1", 2, ("1", "0")),
+        ("1", 3, ("1", "0", "0")),
+        ("1.1", 1, ("1",)),
+        ("1.1", 2, ("1", "1")),
+        ("1.1", 3, ("1", "1", "0")),
+    ],
+)
+def test_version_tuple(
+    input_version: str, input_levels: int, expected_result: tuple
+) -> None:
+    """Tests for _version_tuple function"""
+    assert _version_tuple(input_version, levels=input_levels) == expected_result
+
+
+def test_get_local_files() -> None:
+    """Tests for _get_local_package_metadata function"""
+    assert _get_local_package_metadata()


### PR DESCRIPTION
[SYNPY-1497]

# **Problem:**
When checking the Python version, `synapseclient.core.version_check.version_check` GitHub was being used to find the latest version. This caused a problem when a version had been pushed into the master branch, but hadn't been updated in Pypi yet.

In addition, while working on this, I found a bug. To compare package versions, the code converts the current and latest versions by spliting them into tuples where each version level is a string. For example, the current version of the client is "4.7.0". This gets converted into a tuple like: `("4", "7", "0')` . These tuples then get comapred: `("4", "6", "9') < ("4", "7", "0')` When tuple comparisons happen the first elements of each are compared, and if those are equal then second elements are compared and so on. 

The problem is that the comparisons are done as strings. This works fine if they are single digits: `"4" < "5"`. But this would be a problem if the version number was in the tens: `"10" < "5"`.


# **Solution:**
1. The `version_control` function now uses a Pypi link rather than Github to get version information.
2. When doing version comparisons the strings are converted to ints first.
3. There was some refactoring and improvement of docstrings in several functions.

# **Testing:**
New testing file: `tests/unit/synapseclient/core/unit_test_version_check.py`
All functions modified or added have tests here now, and some were moved here

New testing file: `tests/integration/synapseclient/core/test_version_check.py`
Tests for `version check` were moved here and simplified.

[SYNPY-1497]: https://sagebionetworks.jira.com/browse/SYNPY-1497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ