### PR TITLE
[SYNPY-1584] Add a buffer.tell when truncating bytes during dataframe upload and drop writing header to csv

### DIFF
--- a/synapseclient/core/upload/upload_utils.py
+++ b/synapseclient/core/upload/upload_utils.py
@@ -89,6 +89,7 @@ def get_partial_dataframe_chunk(
             buffer.truncate(0)
             buffer.write(copy_of_data)
             total_offset = 0
+            number_of_bytes_in_buffer = buffer.tell()
 
         if number_of_bytes_in_buffer >= max_bytes_to_read:
             # Return maximum number of bytes that can be read from the buffer

--- a/synapseclient/core/upload/upload_utils.py
+++ b/synapseclient/core/upload/upload_utils.py
@@ -55,7 +55,6 @@ def get_partial_dataframe_chunk(
         (total_size_of_chunks_being_uploaded - ((part_number - 1) * part_size)),
         part_size,
     )
-    header_written = False
     # TODO: This is an area for optimization. It is possible to avoid writing the entire
     # dataframe to a buffer and then reading the buffer to get the bytes. Instead, we
     # might be able to do something like keeping markers at each 100 row increment how
@@ -68,12 +67,11 @@ def get_partial_dataframe_chunk(
         df.iloc[offset_start:end].to_csv(
             buffer,
             mode="a",
-            header=(part_number == 1 and not header_written),
+            header=False,
             index=False,
             float_format="%.12g",
             **(to_csv_kwargs or {}),
         )
-        header_written = True
         number_of_bytes_in_buffer = buffer.tell()
         # Drop data from the front of the buffer until total_offset is 0
         if total_offset > 0 and total_offset >= number_of_bytes_in_buffer:


### PR DESCRIPTION
# **Problem:**

- In the loop over the Pandas DataFrame to return the bytes for upload into Synapse -- a `.tell()` was not performed after we dropped the X number of bytes from the BytesIO buffer
- When the first chunk of the DataFrame was being written the bytes in the buffer from the header of the DataFrame was causing data to be dropped (Sometimes silently) from the end of the first chunk. In one case there was around 20 missing bytes from a large-text column.
- Bytes from the header were getting skipped at the front of the very first DataFrame

# **Solution:**

- After dropping bytes from the front of the buffer call `.tell()` to re-read `number_of_bytes_in_buffer`
- Removing writing the header to the buffer, instead use the `bytes_to_prepend` argument instead
- Don't skip bytes in the offset for the header, instead let the first chunk be larger to include the column names

# **Testing:**

- I was able to run the scripts that @GiaJordan and @thomasyu888 provided in https://sagebionetworks.jira.com/browse/SYNPY-1565 to verify on an EC2 instance in the service catalog that I could insert 500 rows of data as expected and have it show up in Synapse


