### PR TITLE
[SYNPY-1580] Adds `VirtualTable` OOP Model

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          pip install --upgrade pip
+          python -m pip install --upgrade pip
 
           pip install -e ".[boto3,pandas,pysftp,tests]"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,8 @@ jobs:
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         shell: bash
         run: |
+          pip install --upgrade pip
+
           pip install -e ".[boto3,pandas,pysftp,tests]"
 
           # ensure that numpy c extensions are installed on windows

--- a/docs/reference/experimental/async/virtualtable.md
+++ b/docs/reference/experimental/async/virtualtable.md
@@ -1,0 +1,20 @@
+# VirtualTable
+
+Contained within this file are experimental interfaces for working with the Synapse Python
+Client. Unless otherwise noted these interfaces are subject to change at any time. Use
+at your own risk.
+
+## API reference
+
+::: synapseclient.models.VirtualTable
+    options:
+        inherited_members: true
+        members:
+            - store_async
+            - get_async
+            - delete_async
+            - query_async
+            - query_part_mask_async
+            - get_permissions
+            - get_acl
+            - set_permissions 

--- a/docs/reference/experimental/async/virtualtable.md
+++ b/docs/reference/experimental/async/virtualtable.md
@@ -17,4 +17,4 @@ at your own risk.
             - query_part_mask_async
             - get_permissions
             - get_acl
-            - set_permissions 
+            - set_permissions

--- a/docs/reference/experimental/sync/virtualtable.md
+++ b/docs/reference/experimental/sync/virtualtable.md
@@ -17,4 +17,4 @@ at your own risk.
             - query_part_mask
             - get_permissions
             - get_acl
-            - set_permissions 
+            - set_permissions

--- a/docs/reference/experimental/sync/virtualtable.md
+++ b/docs/reference/experimental/sync/virtualtable.md
@@ -1,0 +1,20 @@
+# VirtualTable
+
+Contained within this file are experimental interfaces for working with the Synapse Python
+Client. Unless otherwise noted these interfaces are subject to change at any time. Use
+at your own risk.
+
+## API reference
+
+::: synapseclient.models.VirtualTable
+    options:
+        inherited_members: true
+        members:
+            - store
+            - get
+            - delete
+            - query
+            - query_part_mask
+            - get_permissions
+            - get_acl
+            - set_permissions 

--- a/docs/tutorials/python/tutorial_scripts/virtualtable.py
+++ b/docs/tutorials/python/tutorial_scripts/virtualtable.py
@@ -1,0 +1,211 @@
+"""Here is where you'll find the code for the VirtualTable tutorial."""
+
+import pandas as pd
+
+from synapseclient import Synapse
+from synapseclient.models import Column, ColumnType, VirtualTable, Project, Table
+
+# Initialize Synapse client
+syn = Synapse()
+syn.login()
+
+# Get the project where we want to create the virtual table
+project = Project(name="My uniquely named project about Alzheimer's Disease").get()
+project_id = project.id
+print(f"Got project with ID: {project_id}")
+
+# Create the first table with some columns and rows
+table1_columns = [
+    Column(name="sample_id", column_type=ColumnType.STRING),
+    Column(name="patient_id", column_type=ColumnType.STRING),
+    Column(name="age", column_type=ColumnType.INTEGER),
+    Column(name="diagnosis", column_type=ColumnType.STRING),
+]
+
+table1 = Table(
+    name="Patient Demographics",
+    parent_id=project_id,
+    columns=table1_columns,
+)
+table1 = table1.store()
+print(f"Created table 1 with ID: {table1.id}")
+
+# Add rows to the first table
+data1 = pd.DataFrame(
+    [
+        {"sample_id": "S1", "patient_id": "P1", "age": 70, "diagnosis": "Alzheimer's"},
+        {"sample_id": "S2", "patient_id": "P2", "age": 65, "diagnosis": "Healthy"},
+        {"sample_id": "S3", "patient_id": "P3", "age": 72, "diagnosis": "Alzheimer's"},
+        {"sample_id": "S4", "patient_id": "P4", "age": 68, "diagnosis": "Healthy"},
+        {"sample_id": "S5", "patient_id": "P5", "age": 75, "diagnosis": "Alzheimer's"},
+        {"sample_id": "S6", "patient_id": "P6", "age": 80, "diagnosis": "Healthy"},
+    ]
+)
+table1.upsert_rows(values=data1, primary_keys=["sample_id"])
+
+# Create the second table with some columns and rows
+table2_columns = [
+    Column(name="sample_id", column_type=ColumnType.STRING),
+    Column(name="gene", column_type=ColumnType.STRING),
+    Column(name="expression_level", column_type=ColumnType.DOUBLE),
+]
+
+table2 = Table(
+    name="Gene Expression Data",
+    parent_id=project_id,
+    columns=table2_columns,
+)
+table2 = table2.store()
+print(f"Created table 2 with ID: {table2.id}")
+
+# Add rows to the second table
+data2 = pd.DataFrame(
+    [
+        {"sample_id": "S1", "gene": "APOE", "expression_level": 2.5},
+        {"sample_id": "S2", "gene": "APP", "expression_level": 1.8},
+        {"sample_id": "S3", "gene": "PSEN1", "expression_level": 3.2},
+        {"sample_id": "S4", "gene": "MAPT", "expression_level": 2.1},
+        {"sample_id": "S5", "gene": "APP", "expression_level": 3.5},
+        {"sample_id": "S7", "gene": "PSEN2", "expression_level": 1.9},
+    ]
+)
+table2.upsert_rows(values=data2, primary_keys=["sample_id"])
+# Note: VirtualTables do not support JOIN or UNION operations in the defining_sql.
+# If you need to combine data from multiple tables, consider using a MaterializedView instead.
+
+
+def create_basic_virtual_table():
+    """
+    Example: Create a basic virtual table with a simple SELECT query.
+    """
+    virtual_table = VirtualTable(
+        name="Patient Data View",
+        description="A virtual table showing patient demographics",
+        parent_id=project_id,
+        defining_sql=f"SELECT * FROM {table1.id}",
+    )
+    virtual_table = virtual_table.store()
+    print(f"Created Virtual Table with ID: {virtual_table.id}")
+
+    virtual_table_id = virtual_table.id
+
+    query = f"SELECT * FROM {virtual_table_id}"
+    query_result: pd.DataFrame = virtual_table.query(
+        query=query, include_row_id_and_row_version=False
+    )
+
+    # Print the results to the console
+    print("Results from the basic virtual table:")
+    print(query_result)
+
+
+def create_virtual_table_with_column_selection():
+    """
+    Example: Create a virtual table that selects only specific columns.
+    """
+    virtual_table = VirtualTable(
+        name="Patient Age View",
+        description="A virtual table showing only patient IDs and ages",
+        parent_id=project_id,
+        defining_sql=f"SELECT patient_id, age FROM {table1.id}",
+    )
+    virtual_table = virtual_table.store()
+    print(f"Created Virtual Table with ID: {virtual_table.id}")
+
+    virtual_table_id = virtual_table.id
+
+    query = f"SELECT * FROM {virtual_table_id}"
+    query_result: pd.DataFrame = virtual_table.query(
+        query=query, include_row_id_and_row_version=False
+    )
+
+    # Print the results to the console
+    print("Results from the virtual table with column selection:")
+    print(query_result)
+
+
+def create_virtual_table_with_filtering():
+    """
+    Example: Create a virtual table with a WHERE clause for filtering.
+    """
+    virtual_table = VirtualTable(
+        name="Alzheimer's Patients",
+        description="A virtual table showing only patients with Alzheimer's",
+        parent_id=project_id,
+        defining_sql=f"SELECT * FROM {table1.id} WHERE diagnosis = 'Alzheimer''s'",
+    )
+    virtual_table = virtual_table.store()
+    print(f"Created Virtual Table with ID: {virtual_table.id}")
+
+    virtual_table_id = virtual_table.id
+
+    query = f"SELECT * FROM {virtual_table_id}"
+    query_result: pd.DataFrame = virtual_table.query(
+        query=query, include_row_id_and_row_version=False
+    )
+
+    # Print the results to the console
+    print("Results from the virtual table with filtering:")
+    print(query_result)
+
+
+def create_virtual_table_with_ordering():
+    """
+    Example: Create a virtual table with an ORDER BY clause.
+    """
+    virtual_table = VirtualTable(
+        name="Patients by Age",
+        description="A virtual table showing patients ordered by age",
+        parent_id=project_id,
+        defining_sql=f"SELECT * FROM {table1.id} ORDER BY age DESC",
+    )
+    virtual_table = virtual_table.store()
+    print(f"Created Virtual Table with ID: {virtual_table.id}")
+
+    virtual_table_id = virtual_table.id
+
+    query = f"SELECT * FROM {virtual_table_id}"
+    query_result: pd.DataFrame = virtual_table.query(
+        query=query, include_row_id_and_row_version=False
+    )
+
+    # Print the results to the console
+    print("Results from the virtual table with ordering:")
+    print(query_result)
+
+
+def create_virtual_table_with_aggregation():
+    """
+    Example: Create a virtual table with an aggregate function.
+    """
+    virtual_table = VirtualTable(
+        name="Diagnosis Count",
+        description="A virtual table showing the count of patients by diagnosis",
+        parent_id=project_id,
+        defining_sql=f"SELECT diagnosis, COUNT(*) AS patient_count FROM {table1.id} GROUP BY diagnosis",
+    )
+    virtual_table = virtual_table.store()
+    print(f"Created Virtual Table with ID: {virtual_table.id}")
+
+    virtual_table_id = virtual_table.id
+
+    query = f"SELECT * FROM {virtual_table_id}"
+    query_result: pd.DataFrame = virtual_table.query(
+        query=query, include_row_id_and_row_version=False
+    )
+
+    # Print the results to the console
+    print("Results from the virtual table with aggregation:")
+    print(query_result)
+
+
+def main():
+    create_basic_virtual_table()
+    create_virtual_table_with_column_selection()
+    create_virtual_table_with_filtering()
+    create_virtual_table_with_ordering()
+    create_virtual_table_with_aggregation()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/tutorials/python/tutorial_scripts/virtualtable.py
+++ b/docs/tutorials/python/tutorial_scripts/virtualtable.py
@@ -3,7 +3,7 @@
 import pandas as pd
 
 from synapseclient import Synapse
-from synapseclient.models import Column, ColumnType, VirtualTable, Project, Table
+from synapseclient.models import Column, ColumnType, Project, Table, VirtualTable
 
 # Initialize Synapse client
 syn = Synapse()

--- a/docs/tutorials/python/virtualtable.md
+++ b/docs/tutorials/python/virtualtable.md
@@ -1,7 +1,7 @@
 # Virtual Tables
 
-Virtual Tables in Synapse allow you to create queryable views based on existing Synapse tables. 
-Unlike Materialized Views, Virtual Tables don't store the results but instead provide a 
+Virtual Tables in Synapse allow you to create queryable views based on existing Synapse tables.
+Unlike Materialized Views, Virtual Tables don't store the results but instead provide a
 view that is evaluated at query time. They're useful for providing different perspectives
 of your data without duplicating the storage.
 

--- a/docs/tutorials/python/virtualtable.md
+++ b/docs/tutorials/python/virtualtable.md
@@ -44,7 +44,7 @@ First, we will create a simple Virtual Table that selects all rows from a table 
 then query it to retrieve the results.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=75-97}
+{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=77-99}
 ```
 
 <details class="example">
@@ -66,7 +66,7 @@ Results from the basic virtual table:
 Next, we'll create a Virtual Table that selects only specific columns from the source table.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=100-129}
+{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=102-124}
 ```
 
 <details class="example">
@@ -88,7 +88,7 @@ Results from the virtual table with column selection:
 We can create a Virtual Table that filters rows from the source table using a WHERE clause.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=132-161}
+{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=127-149}
 ```
 
 <details class="example">
@@ -107,7 +107,7 @@ Results from the virtual table with filtering:
 You can also create a Virtual Table that orders the rows from the source table using an ORDER BY clause.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=164-193}
+{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=152-174}
 ```
 
 <details class="example">
@@ -129,7 +129,7 @@ Results from the virtual table with ordering:
 Finally, we can create a Virtual Table that aggregates data using functions like COUNT, along with GROUP BY.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=196-225}
+{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=177-199}
 ```
 
 <details class="example">

--- a/docs/tutorials/python/virtualtable.md
+++ b/docs/tutorials/python/virtualtable.md
@@ -1,0 +1,160 @@
+# Virtual Tables
+
+Virtual Tables in Synapse allow you to create queryable views based on existing Synapse tables. 
+Unlike Materialized Views, Virtual Tables don't store the results but instead provide a 
+view that is evaluated at query time. They're useful for providing different perspectives
+of your data without duplicating the storage.
+
+This tutorial will walk you through the basics of working with Virtual Tables
+using the Synapse Python client.
+
+## Tutorial Purpose
+In this tutorial, you will:
+
+1. Log in, get your project, and create tables with data
+2. Create and query a basic Virtual Table
+3. Create a Virtual Table with column selection
+4. Create a Virtual Table with filtering
+5. Create a Virtual Table with ordering
+6. Create a Virtual Table with aggregation
+
+## Prerequisites
+* This tutorial assumes that you have a Synapse project.
+* Pandas must also be installed as shown in the [installation documentation](../installation.md).
+
+## 1. Log in, get your project, and create tables with data
+
+Before creating Virtual Tables, we need to log in to Synapse, retrieve your project,
+and create the tables with data that will be used.
+
+You will want to replace `"My uniquely named project about Alzheimer's Disease"` with
+the name of your project.
+
+```python
+{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=3-72}
+```
+
+**Note**: Virtual Tables do not support JOIN or UNION operations in the defining SQL query.
+If you need to combine data from multiple tables, consider using a
+[Materialized View](materializedview.md) instead.
+
+## 2. Create and query a basic Virtual Table
+
+First, we will create a simple Virtual Table that selects all rows from a table and
+then query it to retrieve the results.
+
+```python
+{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=75-97}
+```
+
+<details class="example">
+  <summary>The result of querying your Virtual Table should look like:</summary>
+```
+Results from the basic virtual table:
+  sample_id patient_id  age    diagnosis
+0        S1         P1   70  Alzheimer's
+1        S2         P2   65      Healthy
+2        S3         P3   72  Alzheimer's
+3        S4         P4   68      Healthy
+4        S5         P5   75  Alzheimer's
+5        S6         P6   80      Healthy
+```
+</details>
+
+## 3. Create a Virtual Table with column selection
+
+Next, we'll create a Virtual Table that selects only specific columns from the source table.
+
+```python
+{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=100-129}
+```
+
+<details class="example">
+  <summary>The result of querying your Virtual Table with column selection should look like:</summary>
+```
+Results from the virtual table with column selection:
+  patient_id  age
+0         P1   70
+1         P2   65
+2         P3   72
+3         P4   68
+4         P5   75
+5         P6   80
+```
+</details>
+
+## 4. Create a Virtual Table with filtering
+
+We can create a Virtual Table that filters rows from the source table using a WHERE clause.
+
+```python
+{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=132-161}
+```
+
+<details class="example">
+  <summary>The result of querying your Virtual Table with filtering should look like:</summary>
+```
+Results from the virtual table with filtering:
+  sample_id patient_id  age    diagnosis
+0        S1         P1   70  Alzheimer's
+1        S3         P3   72  Alzheimer's
+2        S5         P5   75  Alzheimer's
+```
+</details>
+
+## 5. Create a Virtual Table with ordering
+
+You can also create a Virtual Table that orders the rows from the source table using an ORDER BY clause.
+
+```python
+{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=164-193}
+```
+
+<details class="example">
+  <summary>The result of querying your Virtual Table with ordering should look like:</summary>
+```
+Results from the virtual table with ordering:
+  sample_id patient_id  age    diagnosis
+0        S6         P6   80      Healthy
+1        S5         P5   75  Alzheimer's
+2        S3         P3   72  Alzheimer's
+3        S1         P1   70  Alzheimer's
+4        S4         P4   68      Healthy
+5        S2         P2   65      Healthy
+```
+</details>
+
+## 6. Create a Virtual Table with aggregation
+
+Finally, we can create a Virtual Table that aggregates data using functions like COUNT, along with GROUP BY.
+
+```python
+{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=196-225}
+```
+
+<details class="example">
+  <summary>The result of querying your Virtual Table with aggregation should look like:</summary>
+```
+Results from the virtual table with aggregation:
+     diagnosis  patient_count
+0  Alzheimer's              3
+1      Healthy              3
+```
+</details>
+
+## Source Code for this Tutorial
+
+<details class="quote">
+  <summary>Click to show me</summary>
+
+```python
+{!docs/tutorials/python/tutorial_scripts/virtualtable.py!}
+```
+</details>
+
+## References
+- [VirtualTable][synapseclient.models.VirtualTable]
+- [Column][synapseclient.models.Column]
+- [Project][synapseclient.models.Project]
+- [syn.login][synapseclient.Synapse.login]
+- [query examples](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/web/controller/TableExamples.html)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,7 @@ nav:
           - Entity View: tutorials/python/entityview.md
           # - Table: tutorials/python/table.md
           # - Using a Table: tutorials/python/table_crud.md
-          - Virtual Table: tutorials/python/virtualtable.md
+          - VirtualTable: tutorials/python/virtualtable.md
           - Dataset: tutorials/python/dataset.md
           - Dataset Collection: tutorials/python/dataset_collection.md
           - Materialized View: tutorials/python/materializedview.md
@@ -84,7 +84,7 @@ nav:
           - Folder: reference/experimental/sync/folder.md
           - File: reference/experimental/sync/file.md
           - Table: reference/experimental/sync/table.md
-          - Virtual Table: reference/experimental/sync/virtualtable.md
+          - VirtualTable: reference/experimental/sync/virtualtable.md
           - Dataset: reference/experimental/sync/dataset.md
           - Dataset Collection: reference/experimental/sync/dataset_collection.md
           - EntityView: reference/experimental/sync/entityview.md
@@ -100,7 +100,7 @@ nav:
               - Folder: reference/experimental/async/folder.md
               - File: reference/experimental/async/file.md
               - Table: reference/experimental/async/table.md
-              - Virtual Table: reference/experimental/async/virtualtable.md
+              - VirtualTable: reference/experimental/async/virtualtable.md
               - Dataset: reference/experimental/async/dataset.md
               - Dataset Collection: reference/experimental/async/dataset_collection.md
               - EntityView: reference/experimental/async/entityview.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
           - Entity View: tutorials/python/entityview.md
           # - Table: tutorials/python/table.md
           # - Using a Table: tutorials/python/table_crud.md
+          - Virtual Table: tutorials/python/virtualtable.md
           - Dataset: tutorials/python/dataset.md
           - Dataset Collection: tutorials/python/dataset_collection.md
           - Materialized View: tutorials/python/materializedview.md
@@ -83,6 +84,7 @@ nav:
           - Folder: reference/experimental/sync/folder.md
           - File: reference/experimental/sync/file.md
           - Table: reference/experimental/sync/table.md
+          - Virtual Table: reference/experimental/sync/virtualtable.md
           - Dataset: reference/experimental/sync/dataset.md
           - Dataset Collection: reference/experimental/sync/dataset_collection.md
           - EntityView: reference/experimental/sync/entityview.md
@@ -98,6 +100,7 @@ nav:
               - Folder: reference/experimental/async/folder.md
               - File: reference/experimental/async/file.md
               - Table: reference/experimental/async/table.md
+              - Virtual Table: reference/experimental/async/virtualtable.md
               - Dataset: reference/experimental/async/dataset.md
               - Dataset Collection: reference/experimental/async/dataset_collection.md
               - EntityView: reference/experimental/async/entityview.md

--- a/synapseclient/api/entity_factory.py
+++ b/synapseclient/api/entity_factory.py
@@ -344,6 +344,7 @@ async def _cast_into_class_type(
         Project,
         SubmissionView,
         Table,
+        VirtualTable,
     )
 
     syn = Synapse.get_client(synapse_client=synapse_client)
@@ -375,6 +376,7 @@ async def _cast_into_class_type(
         concrete_types.ENTITY_VIEW: EntityView,
         concrete_types.MATERIALIZED_VIEW: MaterializedView,
         concrete_types.SUBMISSION_VIEW: SubmissionView,
+        concrete_types.VIRTUAL_TABLE: VirtualTable,
     }
 
     entity_class = ENTITY_TYPE_MAP.get(entity["concreteType"], None)

--- a/synapseclient/core/constants/concrete_types.py
+++ b/synapseclient/core/constants/concrete_types.py
@@ -71,6 +71,7 @@ DATASET_COLLECTION_ENTITY = "org.sagebionetworks.repo.model.table.DatasetCollect
 ENTITY_VIEW = "org.sagebionetworks.repo.model.table.EntityView"
 MATERIALIZED_VIEW = "org.sagebionetworks.repo.model.table.MaterializedView"
 SUBMISSION_VIEW = "org.sagebionetworks.repo.model.table.SubmissionView"
+VIRTUAL_TABLE = "org.sagebionetworks.repo.model.table.VirtualTable"
 
 # upload requests
 MULTIPART_UPLOAD_REQUEST = "org.sagebionetworks.repo.model.file.MultipartUploadRequest"

--- a/synapseclient/core/exceptions.py
+++ b/synapseclient/core/exceptions.py
@@ -81,10 +81,6 @@ class SynapseUploadFailedException(SynapseError):
     """Raised when an upload failed. Should be chained to a cause Exception"""
 
 
-class SynapseQueryError(SynapseError):
-    """Raised when an invalid SQL query is passed to a Synapse Table-like object"""
-
-
 def _get_message(response: httpx.Response, logger: logging.Logger) -> Union[str, None]:
     """Extracts the message body or a response object by checking for a json response
     and returning the reason otherwise getting body.

--- a/synapseclient/core/exceptions.py
+++ b/synapseclient/core/exceptions.py
@@ -81,6 +81,10 @@ class SynapseUploadFailedException(SynapseError):
     """Raised when an upload failed. Should be chained to a cause Exception"""
 
 
+class SynapseQueryError(SynapseError):
+    """Raised when an invalid SQL query is passed to a Synapse Table-like object"""
+
+
 def _get_message(response: httpx.Response, logger: logging.Logger) -> Union[str, None]:
     """Extracts the message body or a response object by checking for a json response
     and returning the reason otherwise getting body.

--- a/synapseclient/models/__init__.py
+++ b/synapseclient/models/__init__.py
@@ -36,6 +36,7 @@ from synapseclient.models.table_components import (
 )
 from synapseclient.models.team import Team, TeamMember
 from synapseclient.models.user import UserPreference, UserProfile
+from synapseclient.models.virtualtable import VirtualTable
 
 __all__ = [
     "Activity",
@@ -80,10 +81,12 @@ __all__ = [
     "TableUpdateTransaction",
     "CsvTableDescriptor",
     "MaterializedView",
-    # Dataset model
+    "VirtualTable",
+    # Dataset models
     "Dataset",
     "EntityRef",
     "DatasetCollection",
+    # Submission models
     "SubmissionView",
 ]
 

--- a/synapseclient/models/mixins/table_components.py
+++ b/synapseclient/models/mixins/table_components.py
@@ -67,7 +67,7 @@ CLASSES_THAT_CONTAIN_ROW_ETAG = [
     "DatasetCollection",
     "SubmissionView",
 ]
-CLASSES_WITH_READ_ONLY_SCHEMA = ["MaterializedView"]
+CLASSES_WITH_READ_ONLY_SCHEMA = ["MaterializedView", "VirtualTable"]
 
 PANDAS_TABLE_TYPE = {
     "floating": "DOUBLE",
@@ -2520,9 +2520,9 @@ class ViewSnapshotMixin:
             snapshot_options=SnapshotRequest(
                 comment=comment,
                 label=label,
-                activity=self.activity.id
-                if self.activity and include_activity
-                else None,
+                activity=(
+                    self.activity.id if self.activity and include_activity else None
+                ),
             ),
         ).send_job_and_wait_async(synapse_client=client)
 
@@ -3535,9 +3535,11 @@ class TableStoreRowMixin:
         )
         progress_bar = tqdm(
             total=total_df_bytes,
-            desc="Splitting DataFrame and uploading chunks"
-            if len(chunks_to_upload) > 1
-            else "Uploading DataFrame",
+            desc=(
+                "Splitting DataFrame and uploading chunks"
+                if len(chunks_to_upload) > 1
+                else "Uploading DataFrame"
+            ),
             unit_scale=True,
             smoothing=0,
             unit="B",

--- a/synapseclient/models/virtualtable.py
+++ b/synapseclient/models/virtualtable.py
@@ -1,3 +1,4 @@
+import re
 from collections import OrderedDict
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
@@ -538,11 +539,7 @@ class VirtualTable(
         # Check for unsupported operations in defining_sql
 
         if self.defining_sql:
-            import re
-
-            # Convert to uppercase for case-insensitive matching
             sql_upper = self.defining_sql.upper()
-
             join_pattern = r"(?:^|\s|\n)JOIN(?:\s|\n|$)"
             union_pattern = r"(?:^|\s|\n)UNION(?:\s|\n|$)"
 

--- a/synapseclient/models/virtualtable.py
+++ b/synapseclient/models/virtualtable.py
@@ -1,0 +1,878 @@
+from collections import OrderedDict
+from copy import deepcopy
+from dataclasses import dataclass, field, replace
+from datetime import date, datetime
+from typing import Dict, List, Optional, Protocol, Union
+
+from typing_extensions import Self
+
+from synapseclient import Synapse
+from synapseclient.core.async_utils import async_to_sync
+from synapseclient.core.constants import concrete_types
+from synapseclient.core.exceptions import SynapseQueryError
+from synapseclient.core.utils import delete_none_keys
+from synapseclient.models import Activity
+from synapseclient.models.mixins.access_control import AccessControllable
+from synapseclient.models.mixins.table_components import (
+    DeleteMixin,
+    GetMixin,
+    QueryMixin,
+    TableBase,
+    TableStoreMixin,
+)
+
+
+class VirtualTableSynchronousProtocol(Protocol):
+    """Protocol defining the synchronous interface for VirtualTable operations."""
+
+    def store(
+        self,
+        dry_run: bool = False,
+        *,
+        job_timeout: int = 600,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "Self":
+        """
+        Store non-row information about a VirtualTable including the annotations.
+
+        Note: Columns in a VirtualTable are determined by the `defining_sql` attribute. To update
+        the columns, you must update the `defining_sql` and store the view.
+
+        Arguments:
+            dry_run: If True, will not actually store the table but will log to
+                the console what would have been stored.
+            job_timeout: The maximum amount of time to wait for a job to complete.
+                This is used when updating the table schema. If the timeout
+                is reached a `SynapseTimeoutError` will be raised.
+                The default is 600 seconds
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            The VirtualTable instance stored in synapse.
+
+        Example: Create a new virtual table with a defining SQL query.
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import VirtualTable
+
+            syn = Synapse()
+            syn.login()
+
+            virtual_table = VirtualTable(
+                name="My Virtual Table",
+                description="A test virtual table",
+                parent_id="syn12345",
+                defining_sql="SELECT * FROM syn67890"
+            )
+            virtual_table = virtual_table.store()
+            print(f"Created Virtual Table with ID: {virtual_table.id}")
+            ```
+
+        Example: Update the defining SQL of an existing virtual table.
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import VirtualTable
+
+            syn = Synapse()
+            syn.login()
+
+            virtual_table = VirtualTable(id="syn12345").get()
+            virtual_table.defining_sql = "SELECT column1, column2 FROM syn67890"
+            virtual_table = virtual_table.store()
+            print("Updated Virtual Table defining SQL.")
+            ```
+
+        Example: Retrieve and update annotations for a virtual table.
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import VirtualTable
+
+            syn = Synapse()
+            syn.login()
+
+            virtual_table = VirtualTable(id="syn12345").get()
+            virtual_table.annotations["key1"] = ["value1"]
+            virtual_table.annotations["key2"] = ["value2"]
+            virtual_table.store()
+            print("Updated annotations for Virtual Table.")
+            ```
+
+        Example: Create a virtual table with a JOIN clause.
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import VirtualTable
+
+            syn = Synapse()
+            syn.login()
+
+            defining_sql = '''
+            SELECT t1.column1 AS new_column1, t2.column2 AS new_column2
+            FROM syn12345 t1
+            JOIN syn67890 t2
+            ON t1.id = t2.foreign_id
+            '''
+
+            virtual_table = VirtualTable(
+                name="Join Virtual Table",
+                description="A virtual table with a JOIN clause",
+                parent_id="syn11111",
+                defining_sql=defining_sql,
+            )
+            virtual_table = virtual_table.store()
+            print(f"Created Virtual Table with ID: {virtual_table.id}")
+            ```
+
+        Example: Create a virtual table with a LEFT JOIN clause.
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import VirtualTable
+
+            syn = Synapse()
+            syn.login()
+
+            defining_sql = '''
+            SELECT t1.column1 AS new_column1, t2.column2 AS new_column2
+            FROM syn12345 t1
+            LEFT JOIN syn67890 t2
+            ON t1.id = t2.foreign_id
+            '''
+
+            virtual_table = VirtualTable(
+                name="Left Join Virtual Table",
+                description="A virtual table with a LEFT JOIN clause",
+                parent_id="syn11111",
+                defining_sql=defining_sql,
+            )
+            virtual_table = virtual_table.store()
+            print(f"Created Virtual Table with ID: {virtual_table.id}")
+            ```
+
+        Example: Create a virtual table with a RIGHT JOIN clause.
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import VirtualTable
+
+            syn = Synapse()
+            syn.login()
+
+            defining_sql = '''
+            SELECT t1.column1 AS new_column1, t2.column2 AS new_column2
+            FROM syn12345 t1
+            RIGHT JOIN syn67890 t2
+            ON t1.id = t2.foreign_id
+            '''
+
+            virtual_table = VirtualTable(
+                name="Right Join Virtual Table",
+                description="A virtual table with a RIGHT JOIN clause",
+                parent_id="syn11111",
+                defining_sql=defining_sql,
+            )
+            virtual_table = virtual_table.store()
+            print(f"Created Virtual Table with ID: {virtual_table.id}")
+            ```
+
+        Example: Create a virtual table with a UNION clause.
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import VirtualTable
+
+            syn = Synapse()
+            syn.login()
+
+            defining_sql = '''
+            SELECT column1 AS new_column1, column2 AS new_column2
+            FROM syn12345
+            UNION
+            SELECT column1 AS new_column1, column2 AS new_column2
+            FROM syn67890
+            '''
+
+            virtual_table = VirtualTable(
+                name="Union Virtual Table",
+                description="A virtual table with a UNION clause",
+                parent_id="syn11111",
+                defining_sql=defining_sql,
+            )
+            virtual_table = virtual_table.store()
+            print(f"Created Virtual Table with ID: {virtual_table.id}")
+            ```
+        """
+        return self
+
+    def get(
+        self,
+        include_columns: bool = True,
+        include_activity: bool = False,
+        *,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "Self":
+        """
+        Get the metadata about the VirtualTable from synapse.
+
+        Arguments:
+            include_columns: If True, will include fully filled column objects in the
+                `.columns` attribute. Defaults to True.
+            include_activity: If True the activity will be included in the VirtualTable
+                if it exists. Defaults to False.
+
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            The VirtualTable instance stored in synapse.
+
+        Example: Getting metadata about a VirtualTable using id
+            Get a VirtualTable by ID and print out the columns and activity. `include_columns`
+            defaults to True and `include_activity` defaults to False. When you need to
+            update existing columns or activity these need to be set to True during the
+            `get` call, then you'll make the changes, and finally call the
+            `.store()` method.
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import VirtualTable
+
+            syn = Synapse()
+            syn.login()
+
+            virtual_table = VirtualTable(id="syn4567").get(include_activity=True)
+            print(virtual_table)
+
+            # Columns are retrieved by default
+            print(virtual_table.columns)
+            print(virtual_table.activity)
+            ```
+
+        Example: Getting metadata about a VirtualTable using name and parent_id
+            Get a VirtualTable by name/parent_id and print out the columns and activity.
+            `include_columns` defaults to True and `include_activity` defaults to
+            False. When you need to update existing columns or activity these need to
+            be set to True during the `get` call, then you'll make the changes,
+            and finally call the `.store()` method.
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import VirtualTable
+
+            syn = Synapse()
+            syn.login()
+
+            virtual_table = VirtualTable(name="my_virtual_table", parent_id="syn1234").get(include_columns=True, include_activity=True)
+            print(virtual_table)
+            print(virtual_table.columns)
+            print(virtual_table.activity)
+            ```
+        """
+        return self
+
+    def delete(self, *, synapse_client: Optional[Synapse] = None) -> None:
+        """Delete the virtual table from synapse. This is not version specific. If you'd like
+        to delete a specific version of the virtual table you must use the
+        [synapseclient.api.delete_entity][] function directly.
+
+        Arguments:
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            None
+
+        Example: Delete a virtual table.
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import VirtualTable
+
+            syn = Synapse()
+            syn.login()
+
+            virtual_table = VirtualTable(id="syn12345")
+            virtual_table.delete()
+            print("Deleted Virtual Table.")
+            ```
+        """
+        return None
+
+
+@dataclass
+@async_to_sync
+class VirtualTable(
+    VirtualTableSynchronousProtocol,
+    AccessControllable,
+    TableBase,
+    TableStoreMixin,
+    DeleteMixin,
+    GetMixin,
+    QueryMixin,
+):
+    """
+    A virtual table is a type of table that is dynamically built from a Synapse
+    SQL query. Its content is read only and based off the `defining_sql` attribute.
+    The SQL of the virtual table may contain JOIN clauses on multiple tables.
+
+    A `VirtualTable` object represents this concept in Synapse:
+    <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/VirtualTable.html>
+
+    Attributes:
+        id: The unique immutable ID for this entity. Once issued, this ID is
+            guaranteed to never change or be re-issued.
+        name: The name of this entity. Must be 256 characters or less. Names may only
+            contain: letters, numbers, spaces, underscores, hyphens, periods, plus
+            signs, apostrophes, and parentheses.
+        description: The description of this entity. Must be 1000 characters or less.
+        etag: Synapse employs an Optimistic Concurrency Control (OCC) scheme to handle
+            concurrent updates. Since the E-Tag changes every time an entity is
+            updated it is used to detect when a client's current representation of an
+            entity is out-of-date.
+        created_on: The date this entity was created.
+        modified_on: The date this entity was last modified. In YYYY-MM-DD-Thh:mm:ss.sssZ
+            format.
+        created_by: The ID of the user that created this entity.
+        modified_by: The ID of the user that last modified this entity.
+        parent_id: The ID of the Entity that is the parent of this entity.
+        version_number: The version number issued to this version on the object.
+        version_label: The version label for this entity.
+        version_comment: The version comment for this entity.
+        is_latest_version: If this is the latest version of the object.
+        columns: (Read Only) The columns of a virtual table are dynamic based on
+            the select statement of the definingSQL. This list of columnIds is for
+            read-only purposes.
+        is_search_enabled: When creating or updating a table or view specifies if full
+            text search should be enabled.
+        defining_sql: The synapse SQL statement that defines the data in the
+            virtual table.
+        annotations: Additional metadata associated with the entityview. The key is
+            the name of your desired annotations. The value is an object containing a
+            list of values (use empty list to represent no values for key) and the
+            value type associated with all values in the list. To remove all
+            annotations set this to an empty dict `{}` or None and store the entity.
+        activity: The Activity model represents the main record of Provenance in
+            Synapse.
+
+    Example: Create a new virtual table with a defining SQL query.
+        &nbsp;
+
+        ```python
+        from synapseclient import Synapse
+        from synapseclient.models import VirtualTable
+
+        syn = Synapse()
+        syn.login()
+
+        virtual_table = VirtualTable(
+            name="My Virtual Table",
+            description="A test virtual table",
+            parent_id="syn12345",
+            defining_sql="SELECT * FROM syn67890"
+        )
+        virtual_table = virtual_table.store()
+        print(f"Created Virtual Table with ID: {virtual_table.id}")
+        ```
+
+    Example: Update the defining SQL of an existing virtual table.
+        &nbsp;
+
+        ```python
+        from synapseclient import Synapse
+        from synapseclient.models import VirtualTable
+
+        syn = Synapse()
+        syn.login()
+
+        virtual_table = VirtualTable(id="syn12345").get()
+        virtual_table.defining_sql = "SELECT column1, column2 FROM syn67890"
+        virtual_table = virtual_table.store()
+        print("Updated Virtual Table defining SQL.")
+        ```
+
+    Example: Delete a virtual table.
+        &nbsp;
+
+        ```python
+        from synapseclient import Synapse
+        from synapseclient.models import VirtualTable
+
+        syn = Synapse()
+        syn.login()
+
+        virtual_table = VirtualTable(id="syn12345")
+        virtual_table.delete()
+        print("Deleted Virtual Table.")
+        ```
+
+    Example: Query data from a virtual table.
+        &nbsp;
+
+        ```python
+        from synapseclient import Synapse
+        from synapseclient.models import query
+
+        syn = Synapse()
+        syn.login()
+
+        query_result = query("SELECT * FROM syn66080386")
+        print(query_result)
+        ```
+
+    Example: Retrieve and update annotations for a virtual table.
+        &nbsp;
+
+        ```python
+        from synapseclient import Synapse
+        from synapseclient.models import VirtualTable
+
+        syn = Synapse()
+        syn.login()
+
+        virtual_table = VirtualTable(id="syn12345").get()
+        virtual_table.annotations["key1"] = ["value1"]
+        virtual_table.annotations["key2"] = ["value2"]
+        virtual_table.store()
+        print("Updated annotations for Virtual Table.")
+        ```
+
+    Example: Create a virtual table with a JOIN clause.
+        &nbsp;
+
+        ```python
+        from synapseclient import Synapse
+        from synapseclient.models import VirtualTable
+
+        syn = Synapse()
+        syn.login()
+
+        defining_sql = '''
+        SELECT t1.column1 AS new_column1, t2.column2 AS new_column2
+        FROM syn12345 t1
+        JOIN syn67890 t2
+        ON t1.id = t2.foreign_id
+        '''
+
+        virtual_table = VirtualTable(
+            name="Join Virtual Table",
+            description="A virtual table with a JOIN clause",
+            parent_id="syn11111",
+            defining_sql=defining_sql,
+        )
+        virtual_table = virtual_table.store()
+        print(f"Created Virtual Table with ID: {virtual_table.id}")
+        ```
+
+    Example: Create a virtual table with a LEFT JOIN clause.
+        &nbsp;
+
+        ```python
+        from synapseclient import Synapse
+        from synapseclient.models import VirtualTable
+
+        syn = Synapse()
+        syn.login()
+
+        defining_sql = '''
+        SELECT t1.column1 AS new_column1, t2.column2 AS new_column2
+        FROM syn12345 t1
+        LEFT JOIN syn67890 t2
+        ON t1.id = t2.foreign_id
+        '''
+
+        virtual_table = VirtualTable(
+            name="Left Join Virtual Table",
+            description="A virtual table with a LEFT JOIN clause",
+            parent_id="syn11111",
+            defining_sql=defining_sql,
+        )
+        virtual_table = virtual_table.store()
+        print(f"Created Virtual Table with ID: {virtual_table.id}")
+        ```
+
+    Example: Create a virtual table with a RIGHT JOIN clause.
+        &nbsp;
+
+        ```python
+        from synapseclient import Synapse
+        from synapseclient.models import VirtualTable
+
+        syn = Synapse()
+        syn.login()
+
+        defining_sql = '''
+        SELECT t1.column1 AS new_column1, t2.column2 AS new_column2
+        FROM syn12345 t1
+        RIGHT JOIN syn67890 t2
+        ON t1.id = t2.foreign_id
+        '''
+
+        virtual_table = VirtualTable(
+            name="Right Join Virtual Table",
+            description="A virtual table with a RIGHT JOIN clause",
+            parent_id="syn11111",
+            defining_sql=defining_sql,
+        )
+        virtual_table = virtual_table.store()
+        print(f"Created Virtual Table with ID: {virtual_table.id}")
+        ```
+
+    Example: Create a virtual table with a UNION clause.
+        &nbsp;
+
+        ```python
+        from synapseclient import Synapse
+        from synapseclient.models import VirtualTable
+
+        syn = Synapse()
+        syn.login()
+
+        defining_sql = '''
+        SELECT column1 AS new_column1, column2 AS new_column2
+        FROM syn12345
+        UNION
+        SELECT column1 AS new_column1, column2 AS new_column2
+        FROM syn67890
+        '''
+
+        virtual_table = VirtualTable(
+            name="Union Virtual Table",
+            description="A virtual table with a UNION clause",
+            parent_id="syn11111",
+            defining_sql=defining_sql,
+        )
+        virtual_table = virtual_table.store()
+        print(f"Created Virtual Table with ID: {virtual_table.id}")
+        ```
+    """
+
+    id: Optional[str] = None
+    """The unique immutable ID for this entity. Once issued, this ID is
+    guaranteed to never change or be re-issued."""
+
+    name: Optional[str] = None
+    """The name of this entity. Must be 256 characters or less. Names may only
+    contain: letters, numbers, spaces, underscores, hyphens, periods, plus
+    signs, apostrophes, and parentheses."""
+
+    description: Optional[str] = None
+    """The description of this entity. Must be 1000 characters or less."""
+
+    etag: Optional[str] = field(default=None, compare=False)
+    """
+    Synapse employs an Optimistic Concurrency Control (OCC) scheme to handle
+    concurrent updates. Since the E-Tag changes every time an entity is
+    updated it is used to detect when a client's current representation of an
+    entity is out-of-date.
+    """
+
+    created_on: Optional[str] = field(default=None, compare=False)
+    """The date this entity was created."""
+
+    modified_on: Optional[str] = field(default=None, compare=False)
+    """The date this entity was last modified. In YYYY-MM-DD-Thh:mm:ss.sssZ
+    format."""
+
+    created_by: Optional[str] = field(default=None, compare=False)
+    """The ID of the user that created this entity."""
+
+    modified_by: Optional[str] = field(default=None, compare=False)
+    """The ID of the user that last modified this entity."""
+
+    parent_id: Optional[str] = None
+    """The ID of the Entity that is the parent of this entity."""
+
+    version_number: Optional[int] = field(default=None, compare=False)
+    """The version number issued to this version on the object."""
+
+    version_label: Optional[str] = None
+    """The version label for this entity."""
+
+    version_comment: Optional[str] = None
+    """The version comment for this entity."""
+
+    is_latest_version: Optional[bool] = field(default=None, compare=False)
+    """If this is the latest version of the object."""
+
+    columns: Optional[OrderedDict] = field(default_factory=OrderedDict, compare=False)
+    """(Read Only) The columns of a virtual table are dynamic based on
+    the select statement of the definingSQL. This list of columnIds is for
+    read-only purposes."""
+
+    is_search_enabled: Optional[bool] = None
+    """When creating or updating a table or view specifies if full text search
+    should be enabled."""
+
+    defining_sql: Optional[str] = None
+    """The synapse SQL statement that defines the data in the virtual
+    table."""
+
+    _last_persistent_instance: Optional["VirtualTable"] = field(
+        default=None, repr=False, compare=False
+    )
+    """The last persistent instance of this object. This is used to determine if the
+    object has been changed and needs to be updated in Synapse."""
+
+    annotations: Optional[
+        Dict[
+            str,
+            Union[
+                List[str],
+                List[bool],
+                List[float],
+                List[int],
+                List[date],
+                List[datetime],
+            ],
+        ]
+    ] = field(default_factory=dict, compare=False)
+    """Additional metadata associated with the entityview. The key is the name
+    of your desired annotations. The value is an object containing a list of
+    values (use empty list to represent no values for key) and the value type
+    associated with all values in the list. To remove all annotations set this
+    to an empty dict `{}` or None and store the entity."""
+
+    activity: Optional[Activity] = field(default=None, compare=False)
+    """The Activity model represents the main record of Provenance in
+    Synapse."""
+
+    @property
+    def has_changed(self) -> bool:
+        """Checks if the object has changed since the last persistent instance."""
+        return self._last_persistent_instance != self
+
+    def _set_last_persistent_instance(self) -> None:
+        """Stash the last time this object interacted with Synapse."""
+        del self._last_persistent_instance
+        self._last_persistent_instance = replace(self)
+        self._last_persistent_instance.activity = (
+            replace(self.activity) if self.activity and self.activity.id else None
+        )
+        self._last_persistent_instance.annotations = (
+            deepcopy(self.annotations) if self.annotations else {}
+        )
+
+    def fill_from_dict(
+        self, entity: Dict, set_annotations: bool = True
+    ) -> "VirtualTable":
+        """
+        Converts the data coming from the Synapse API into this datamodel.
+
+        Arguments:
+            entity: The data coming from the Synapse API
+
+        Returns:
+            The VirtualTable object instance.
+        """
+        self.id = entity.get("id", None)
+        self.name = entity.get("name", None)
+        self.description = entity.get("description", None)
+        self.parent_id = entity.get("parentId", None)
+        self.etag = entity.get("etag", None)
+        self.created_on = entity.get("createdOn", None)
+        self.created_by = entity.get("createdBy", None)
+        self.modified_on = entity.get("modifiedOn", None)
+        self.modified_by = entity.get("modifiedBy", None)
+        self.version_number = entity.get("versionNumber", None)
+        self.version_label = entity.get("versionLabel", None)
+        self.version_comment = entity.get("versionComment", None)
+        self.is_latest_version = entity.get("isLatestVersion", None)
+        self.is_search_enabled = entity.get("isSearchEnabled", False)
+        self.defining_sql = entity.get("definingSQL", None)
+
+        if set_annotations:
+            self.annotations = entity.get("annotations", {})
+
+        return self
+
+    def to_synapse_request(self):
+        """Converts the request to a request expected of the Synapse REST API."""
+
+        entity = {
+            "name": self.name,
+            "description": self.description,
+            "id": self.id,
+            "etag": self.etag,
+            "createdOn": self.created_on,
+            "modifiedOn": self.modified_on,
+            "createdBy": self.created_by,
+            "modifiedBy": self.modified_by,
+            "parentId": self.parent_id,
+            "concreteType": concrete_types.VIRTUAL_TABLE,
+            "versionNumber": self.version_number,
+            "versionLabel": self.version_label,
+            "versionComment": self.version_comment,
+            "isLatestVersion": self.is_latest_version,
+            "isSearchEnabled": self.is_search_enabled,
+            "definingSQL": self.defining_sql,
+        }
+        delete_none_keys(entity)
+        result = {
+            "entity": entity,
+        }
+        delete_none_keys(result)
+        return result
+
+    async def store_async(
+        self,
+        dry_run: bool = False,
+        *,
+        job_timeout: int = 600,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "Self":
+        """
+        Asynchronously store non-row information about a VirtualTable including the annotations.
+
+        Note: Columns in a VirtualTable are determined by the `defining_sql` attribute. To update
+        the columns, you must update the `defining_sql` and store the view.
+
+        Arguments:
+            dry_run: If True, will not actually store the table but will log to
+                the console what would have been stored.
+            job_timeout: The maximum amount of time to wait for a job to complete.
+                This is used when updating the table schema. If the timeout
+                is reached a `SynapseTimeoutError` will be raised.
+                The default is 600 seconds
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            The VirtualTable instance stored in synapse.
+
+        Example: Create a new virtual table with a defining SQL query.
+            &nbsp;
+
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import VirtualTable
+
+            async def main():
+                syn = Synapse()
+                await syn.login_async()
+
+                virtual_table = VirtualTable(
+                    name="My Virtual Table",
+                    description="A test virtual table",
+                    parent_id="syn12345",
+                    defining_sql="SELECT * FROM syn67890"
+                )
+                virtual_table = await virtual_table.store_async()
+                print(f"Created Virtual Table with ID: {virtual_table.id}")
+
+            asyncio.run(main())
+            ```
+
+        Raises:
+            SynapseQueryError: If the defining_sql contains JOIN or UNION operations, which are not supported in VirtualTables.
+        """
+        # Check for unsupported operations in defining_sql
+        if self.defining_sql:
+            sql_upper = self.defining_sql.upper()
+            if "JOIN" in sql_upper or "UNION" in sql_upper:
+                raise SynapseQueryError(
+                    "VirtualTables do not support JOIN or UNION operations in the defining_sql. "
+                    "If you need to combine data from multiple tables, consider using a MaterializedView instead."
+                )
+
+        return await super().store_async(
+            dry_run=dry_run, job_timeout=job_timeout, synapse_client=synapse_client
+        )
+
+    async def get_async(
+        self,
+        include_columns: bool = True,
+        include_activity: bool = False,
+        *,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "Self":
+        """
+        Asynchronously get the metadata about the VirtualTable from synapse.
+
+        Arguments:
+            include_columns: If True, will include fully filled column objects in the
+                `.columns` attribute. Defaults to True.
+            include_activity: If True the activity will be included in the VirtualTable
+                if it exists. Defaults to False.
+
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            The VirtualTable instance stored in synapse.
+
+        Example: Retrieve a virtual table by ID.
+            &nbsp;
+
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import VirtualTable
+
+            async def main():
+                syn = Synapse()
+                await syn.login_async()
+
+                virtual_table = await VirtualTable(id="syn12345").get_async()
+                print(virtual_table)
+
+            asyncio.run(main())
+            ```
+        """
+        return await super().get_async(
+            include_columns=include_columns,
+            include_activity=include_activity,
+            synapse_client=synapse_client,
+        )
+
+    async def delete_async(self, *, synapse_client: Optional[Synapse] = None) -> None:
+        """
+        Asynchronously delete the virtual table from synapse. This is not version specific. If you'd like
+        to delete a specific version of the virtual table you must use the
+        [synapseclient.api.delete_entity][] function directly.
+
+        Arguments:
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            None
+
+        Example: Delete a virtual table.
+            &nbsp;
+
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import VirtualTable
+
+            async def main():
+                syn = Synapse()
+                await syn.login_async()
+
+                virtual_table = VirtualTable(id="syn12345")
+                await virtual_table.delete_async()
+                print("Deleted Virtual Table.")
+
+            asyncio.run(main())
+            ```
+        """
+        await super().delete_async(synapse_client=synapse_client)

--- a/synapseclient/models/virtualtable.py
+++ b/synapseclient/models/virtualtable.py
@@ -536,8 +536,19 @@ class VirtualTable(
             ```
         """
         # Check for unsupported operations in defining_sql
+
         if self.defining_sql:
-            if any(clause in self.defining_sql.upper() for clause in ["JOIN", "UNION"]):
+            import re
+
+            # Convert to uppercase for case-insensitive matching
+            sql_upper = self.defining_sql.upper()
+
+            join_pattern = r"(?:^|\s|\n)JOIN(?:\s|\n|$)"
+            union_pattern = r"(?:^|\s|\n)UNION(?:\s|\n|$)"
+
+            if re.search(join_pattern, sql_upper) or re.search(
+                union_pattern, sql_upper
+            ):
                 raise SynapseQueryError(
                     "VirtualTables do not support JOIN or UNION operations in the defining_sql. "
                     "If you need to combine data from multiple tables, consider using a MaterializedView instead."

--- a/synapseclient/models/virtualtable.py
+++ b/synapseclient/models/virtualtable.py
@@ -10,7 +10,6 @@ from typing_extensions import Self
 from synapseclient import Synapse
 from synapseclient.core.async_utils import async_to_sync
 from synapseclient.core.constants import concrete_types
-from synapseclient.core.exceptions import SynapseQueryError
 from synapseclient.core.utils import delete_none_keys
 from synapseclient.models import Activity
 from synapseclient.models.mixins.access_control import AccessControllable
@@ -54,7 +53,7 @@ class VirtualTableSynchronousProtocol(Protocol):
             The VirtualTable instance stored in synapse.
 
         Raises:
-            SynapseQueryError: If the defining_sql contains JOIN or UNION operations, which are not supported in VirtualTables.
+            ValueError: If the defining_sql contains JOIN or UNION operations, which are not supported in VirtualTables.
 
         Example: Create a new virtual table with a defining SQL query.
             &nbsp;
@@ -237,7 +236,7 @@ class VirtualTable(
             text search should be enabled.
         defining_sql: The synapse SQL statement that defines the data in the
             virtual table. This field may NOT contain JOIN or UNION clauses.
-            If a JOIN or UNION clause is present, a `SynapseQueryError` will be raised
+            If a JOIN or UNION clause is present, a `ValueError` will be raised
             when the `store` method is called.
         annotations: Additional metadata associated with the entityview. The key is
             the name of your desired annotations. The value is an object containing a
@@ -373,7 +372,7 @@ class VirtualTable(
     defining_sql: Optional[str] = None
     """The synapse SQL statement that defines the data in the virtual
     table. This field may NOT contain JOIN or UNION clauses. If a JOIN or UNION
-    clause is present, a `SynapseQueryError` will be raised when the `store`
+    clause is present, a `ValueError` will be raised when the `store`
     method is called."""
 
     _last_persistent_instance: Optional["VirtualTable"] = field(
@@ -510,7 +509,7 @@ class VirtualTable(
             The VirtualTable instance stored in synapse.
 
         Raises:
-            SynapseQueryError: If the defining_sql contains JOIN or UNION operations, which are not supported in VirtualTables.
+            ValueError: If the defining_sql contains JOIN or UNION operations, which are not supported in VirtualTables.
 
         Example: Create a new virtual table with a defining SQL query.
             &nbsp;
@@ -546,7 +545,7 @@ class VirtualTable(
             if re.search(join_pattern, sql_upper) or re.search(
                 union_pattern, sql_upper
             ):
-                raise SynapseQueryError(
+                raise ValueError(
                     "VirtualTables do not support JOIN or UNION operations in the defining_sql. "
                     "If you need to combine data from multiple tables, consider using a MaterializedView instead."
                 )

--- a/tests/integration/synapseclient/models/async/test_virtualtable_async.py
+++ b/tests/integration/synapseclient/models/async/test_virtualtable_async.py
@@ -7,7 +7,7 @@ import pytest
 
 from synapseclient import Synapse
 from synapseclient.core.exceptions import SynapseHTTPError
-from synapseclient.models import Column, ColumnType, VirtualTable, Project, Table
+from synapseclient.models import Column, ColumnType, Project, Table, VirtualTable
 
 
 class TestVirtualTableWithoutData:
@@ -579,10 +579,10 @@ class TestVirtualTableWithData:
         await table.store_rows_async(data, synapse_client=self.syn)
 
         # AND a virtual table with aggregation
-        defining_sql = f"""SELECT 
-            department, 
-            COUNT(*) 
-        FROM {table.id} 
+        defining_sql = f"""SELECT
+            department,
+            COUNT(*)
+        FROM {table.id}
         GROUP BY department"""
 
         virtual_table = VirtualTable(

--- a/tests/integration/synapseclient/models/async/test_virtualtable_async.py
+++ b/tests/integration/synapseclient/models/async/test_virtualtable_async.py
@@ -26,14 +26,11 @@ class TestVirtualTableWithoutData:
         )
 
         # WHEN I try to store the virtual table
-        with pytest.raises(SynapseHTTPError) as e:
+        with pytest.raises(
+            SynapseHTTPError,
+            match="400 Client Error: The definingSQL of the virtual table is required and must not be the empty string.",
+        ):
             await virtual_table.store_async(synapse_client=self.syn)
-
-        # THEN a 400 Client Error should be raised
-        assert (
-            "400 Client Error: The definingSQL of the virtual table is required "
-            "and must not be the empty string." in str(e.value)
-        )
 
     async def test_create_virtual_table_without_columns(
         self, project_model: Project
@@ -58,11 +55,10 @@ class TestVirtualTableWithoutData:
         )
 
         # WHEN I try to store the virtual table
-        with pytest.raises(SynapseHTTPError) as e:
+        with pytest.raises(
+            SynapseHTTPError, match=f"400 Client Error: Schema for {table.id} is empty."
+        ):
             await virtual_table.store_async(synapse_client=self.syn)
-
-        # THEN a 400 Client Error should be raised
-        assert f"400 Client Error: Schema for {table.id} is empty." in str(e.value)
 
     async def test_create_virtual_table_with_columns(
         self, project_model: Project
@@ -120,14 +116,11 @@ class TestVirtualTableWithoutData:
         )
 
         # WHEN I store the virtual table
-        with pytest.raises(SynapseHTTPError) as e:
+        with pytest.raises(
+            SynapseHTTPError,
+            match='400 Client Error: Encountered " <regular_identifier> "INVALID "" .*at line 1, column 1\\.\\nWas expecting one of:',
+        ):
             await virtual_table.store_async(synapse_client=self.syn)
-
-        # THEN the virtual table should not be created
-        assert (
-            '400 Client Error: Encountered " <regular_identifier> "INVALID "" '
-            "at line 1, column 1.\nWas expecting one of:" in str(e.value)
-        )
 
     async def test_update_virtual_table_attributes(
         self, project_model: Project
@@ -219,7 +212,7 @@ class TestVirtualTableWithoutData:
         # THEN the virtual table should be deleted
         with pytest.raises(
             SynapseHTTPError,
-            match=(f"404 Client Error: Entity {virtual_table.id} is in trash can."),
+            match=f"404 Client Error: Entity {virtual_table.id} is in trash can.",
         ):
             await VirtualTable(id=virtual_table.id).get_async(synapse_client=self.syn)
 
@@ -257,6 +250,9 @@ class TestVirtualTableWithData:
         )
         virtual_table = await virtual_table.store_async(synapse_client=self.syn)
         self.schedule_for_cleanup(virtual_table.id)
+
+        # Wait for the virtual table to be ready
+        await asyncio.sleep(2)
 
         # WHEN I query the virtual table
         query_result = await virtual_table.query_async(
@@ -468,6 +464,9 @@ class TestVirtualTableWithData:
         virtual_table = await virtual_table.store_async(synapse_client=self.syn)
         self.schedule_for_cleanup(virtual_table.id)
 
+        # Wait for the virtual table to be ready
+        await asyncio.sleep(2)
+
         # WHEN I query the virtual table
         query_result = await virtual_table.query_async(
             f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
@@ -544,6 +543,9 @@ class TestVirtualTableWithData:
         )
         virtual_table = await virtual_table.store_async(synapse_client=self.syn)
         self.schedule_for_cleanup(virtual_table.id)
+
+        # Wait for the virtual table to be ready
+        await asyncio.sleep(2)
 
         # WHEN I query the virtual table
         query_result = await virtual_table.query_async(

--- a/tests/integration/synapseclient/models/async/test_virtualtable_async.py
+++ b/tests/integration/synapseclient/models/async/test_virtualtable_async.py
@@ -1,0 +1,612 @@
+import asyncio
+import uuid
+from typing import Callable
+
+import pandas as pd
+import pytest
+
+from synapseclient import Synapse
+from synapseclient.core.exceptions import SynapseHTTPError
+from synapseclient.models import Column, ColumnType, VirtualTable, Project, Table
+
+
+class TestVirtualTableWithoutData:
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    async def test_create_empty_virtual_table(self, project_model: Project) -> None:
+        # GIVEN a VirtualTable with an empty definingSQL
+        virtual_table = VirtualTable(
+            name=str(uuid.uuid4()),
+            description="Test virtual table",
+            parent_id=project_model.id,
+            defining_sql="",
+        )
+
+        # WHEN I try to store the virtual table
+        with pytest.raises(SynapseHTTPError) as e:
+            await virtual_table.store_async(synapse_client=self.syn)
+
+        # THEN a 400 Client Error should be raised
+        assert (
+            "400 Client Error: The definingSQL of the virtual table is required "
+            "and must not be the empty string." in str(e.value)
+        )
+
+    async def test_create_virtual_table_without_columns(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with no columns
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a virtual table that uses the table in its defining SQL
+        virtual_table_name = str(uuid.uuid4())
+        virtual_table_description = "Test virtual table"
+        virtual_table = VirtualTable(
+            name=virtual_table_name,
+            parent_id=project_model.id,
+            description=virtual_table_description,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+
+        # WHEN I try to store the virtual table
+        with pytest.raises(SynapseHTTPError) as e:
+            await virtual_table.store_async(synapse_client=self.syn)
+
+        # THEN a 400 Client Error should be raised
+        assert f"400 Client Error: Schema for {table.id} is empty." in str(e.value)
+
+    async def test_create_virtual_table_with_columns(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with columns
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="test_column", column_type=ColumnType.STRING),
+                Column(name="test_column2", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a virtual table that uses the table in its defining SQL
+        virtual_table_name = str(uuid.uuid4())
+        virtual_table_description = "Test virtual table"
+        virtual_table = VirtualTable(
+            name=virtual_table_name,
+            parent_id=project_model.id,
+            description=virtual_table_description,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+
+        # WHEN I store the virtual table
+        virtual_table = await virtual_table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+
+        # THEN the virtual table should be created
+        assert virtual_table.id is not None
+
+        # AND I can retrieve that virtual table from Synapse
+        new_virtual_table_instance = await VirtualTable(id=virtual_table.id).get_async(
+            synapse_client=self.syn
+        )
+        assert new_virtual_table_instance is not None
+        assert new_virtual_table_instance.name == virtual_table_name
+        assert new_virtual_table_instance.id == virtual_table.id
+        assert new_virtual_table_instance.description == virtual_table_description
+
+    async def test_create_virtual_table_with_invalid_sql(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a virtual table with invalid SQL
+        virtual_table_name = str(uuid.uuid4())
+        virtual_table_description = "Test virtual table"
+        virtual_table = VirtualTable(
+            name=virtual_table_name,
+            parent_id=project_model.id,
+            description=virtual_table_description,
+            defining_sql="INVALID SQL",
+        )
+
+        # WHEN I store the virtual table
+        with pytest.raises(SynapseHTTPError) as e:
+            await virtual_table.store_async(synapse_client=self.syn)
+
+        # THEN the virtual table should not be created
+        assert (
+            '400 Client Error: Encountered " <regular_identifier> "INVALID "" '
+            "at line 1, column 1.\nWas expecting one of:" in str(e.value)
+        )
+
+    async def test_update_virtual_table_attributes(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table to use in the defining SQL
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="test_column", column_type=ColumnType.STRING),
+                Column(name="test_column2", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a virtual table
+        original_virtual_table = VirtualTable(
+            name=str(uuid.uuid4()),
+            description="Test virtual table",
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        original_virtual_table = await original_virtual_table.store_async(
+            synapse_client=self.syn
+        )
+        self.schedule_for_cleanup(original_virtual_table.id)
+
+        # AND I update attributes of the virtual table
+        updated_virtual_table = await VirtualTable(
+            id=original_virtual_table.id
+        ).get_async(synapse_client=self.syn)
+        updated_virtual_table.name = str(uuid.uuid4())
+        updated_virtual_table.description = "Updated description"
+        updated_virtual_table.defining_sql = f"SELECT test_column FROM {table.id}"
+        updated_virtual_table = await updated_virtual_table.store_async(
+            synapse_client=self.syn
+        )
+
+        # AND I retrieve the virtual table with its original id
+        retrieved_virtual_table = await VirtualTable(
+            id=original_virtual_table.id
+        ).get_async(synapse_client=self.syn)
+
+        # THEN the virtual table should be updated
+        assert retrieved_virtual_table is not None
+        assert retrieved_virtual_table.name == updated_virtual_table.name
+        assert retrieved_virtual_table.description == updated_virtual_table.description
+        assert (
+            retrieved_virtual_table.defining_sql == updated_virtual_table.defining_sql
+        )
+
+        # AND all versions should have the same id
+        assert (
+            retrieved_virtual_table.id
+            == updated_virtual_table.id
+            == original_virtual_table.id
+        )
+
+    async def test_delete_virtual_table(self, project_model: Project) -> None:
+        # GIVEN a table to use in the defining SQL
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="test_column", column_type=ColumnType.STRING),
+                Column(name="test_column2", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a virtual table
+        virtual_table = VirtualTable(
+            name=str(uuid.uuid4()),
+            description="Test virtual table",
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        virtual_table = await virtual_table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+        assert virtual_table.id is not None
+
+        # WHEN I delete the virtual table
+        await virtual_table.delete_async(synapse_client=self.syn)
+
+        # THEN the virtual table should be deleted
+        with pytest.raises(
+            SynapseHTTPError,
+            match=(f"404 Client Error: Entity {virtual_table.id} is in trash can."),
+        ):
+            await VirtualTable(id=virtual_table.id).get_async(synapse_client=self.syn)
+
+
+class TestVirtualTableWithData:
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    async def test_query_data_from_virtual_table(self, project_model: Project) -> None:
+        # GIVEN a table with data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        await table.store_rows_async(data, synapse_client=self.syn)
+
+        # AND a virtual table that uses the table in its defining SQL
+        virtual_table_name = str(uuid.uuid4())
+        virtual_table = VirtualTable(
+            name=virtual_table_name,
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        virtual_table = await virtual_table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+
+        # WHEN I query the virtual table
+        query_result = await virtual_table.query_async(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the table data
+        assert len(query_result) == 2
+        assert query_result["name"].tolist() == ["Alice", "Bob"]
+        assert query_result["age"].tolist() == [30, 25]
+
+    async def test_update_defining_sql(self, project_model: Project) -> None:
+        # GIVEN a table with data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        await table.store_rows_async(data, synapse_client=self.syn)
+
+        # AND a virtual table that uses the table in its defining SQL
+        virtual_table_name = str(uuid.uuid4())
+        virtual_table = VirtualTable(
+            name=virtual_table_name,
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        virtual_table = await virtual_table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+
+        # WHEN I update the defining SQL of the virtual table
+        virtual_table.defining_sql = f"SELECT name FROM {table.id}"
+        virtual_table = await virtual_table.store_async(synapse_client=self.syn)
+
+        # AND I query the updated virtual table
+        query_result = await virtual_table.query_async(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the updated SQL
+        assert len(query_result) == 2
+        assert query_result["name"].tolist() == ["Alice", "Bob"]
+        assert "age" not in query_result.columns
+
+        # AND the column is not present the next time the `virtual_table` is retrieved
+        retrieved_virtual_table = await VirtualTable(id=virtual_table.id).get_async(
+            synapse_client=self.syn
+        )
+        assert "age" not in retrieved_virtual_table.columns.keys()
+        assert "name" in retrieved_virtual_table.columns.keys()
+
+    async def test_virtual_table_updates_with_table_data(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with columns but no data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="test_name", column_type=ColumnType.STRING),
+                Column(name="test_age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a virtual table that uses the table in its defining SQL
+        virtual_table_name = str(uuid.uuid4())
+        virtual_table = VirtualTable(
+            name=virtual_table_name,
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        virtual_table = await virtual_table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+
+        # Wait a moment for the virtual table to be ready
+        await asyncio.sleep(2)
+
+        # WHEN I query the virtual table before adding data to the table
+        query_result = await virtual_table.query_async(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN no data should be returned
+        assert len(query_result) == 0
+
+        # AND WHEN I add data to the table
+        data = pd.DataFrame({"test_name": ["Alice", "Bob"], "test_age": [30, 25]})
+        await table.store_rows_async(data, synapse_client=self.syn)
+
+        # Wait for the updates to propagate
+        await asyncio.sleep(2)
+
+        # AND I query the virtual table again
+        query_result = await virtual_table.query_async(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the table data
+        assert len(query_result) == 2
+        assert query_result["test_name"].tolist() == ["Alice", "Bob"]
+        assert query_result["test_age"].tolist() == [30, 25]
+
+    async def test_virtual_table_reflects_table_data_removal(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with columns and data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        await table.store_rows_async(data, synapse_client=self.syn)
+
+        # AND a virtual table that uses the table in its defining SQL
+        virtual_table_name = str(uuid.uuid4())
+        virtual_table = VirtualTable(
+            name=virtual_table_name,
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        virtual_table = await virtual_table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+
+        # Wait for the virtual table to be ready
+        await asyncio.sleep(2)
+
+        # WHEN I query the virtual table
+        query_result = await virtual_table.query_async(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the table data
+        assert len(query_result) == 2
+        assert query_result["name"].tolist() == ["Alice", "Bob"]
+        assert query_result["age"].tolist() == [30, 25]
+
+        # AND WHEN I remove data from the table
+        await table.delete_rows_async(
+            query=f"SELECT ROW_ID, ROW_VERSION FROM {table.id}", synapse_client=self.syn
+        )
+
+        # Ensure the table contains no rows after deletion
+        query_result = await table.query_async(
+            f"SELECT * FROM {table.id}", synapse_client=self.syn
+        )
+        assert len(query_result) == 0
+
+        # Wait for changes to propagate to the virtual table
+        await asyncio.sleep(2)
+
+        # AND I query the virtual table again
+        query_result = await virtual_table.query_async(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN no data should be returned
+        assert len(query_result) == 0
+
+    async def test_virtual_table_with_column_selection(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+                Column(name="city", column_type=ColumnType.STRING),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame(
+            {"name": ["Alice", "Bob"], "age": [30, 25], "city": ["New York", "Boston"]}
+        )
+        await table.store_rows_async(data, synapse_client=self.syn)
+
+        # AND a virtual table with column selection
+        virtual_table = VirtualTable(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            defining_sql=f"SELECT name, city FROM {table.id}",
+        )
+        virtual_table = await virtual_table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+
+        # WHEN I query the virtual table
+        query_result = await virtual_table.query_async(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should only include the selected columns
+        assert len(query_result) == 2
+        assert "name" in query_result.columns
+        assert "city" in query_result.columns
+        assert "age" not in query_result.columns
+        assert query_result["name"].tolist() == ["Alice", "Bob"]
+        assert query_result["city"].tolist() == ["New York", "Boston"]
+
+    async def test_virtual_table_with_filtering(self, project_model: Project) -> None:
+        # GIVEN a table with data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame({"name": ["Alice", "Bob", "Charlie"], "age": [30, 25, 35]})
+        await table.store_rows_async(data, synapse_client=self.syn)
+
+        # AND a virtual table with filtering
+        virtual_table = VirtualTable(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id} WHERE age > 25",
+        )
+        virtual_table = await virtual_table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+
+        # WHEN I query the virtual table
+        query_result = await virtual_table.query_async(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should only include filtered rows
+        assert len(query_result) == 2
+        assert set(query_result["name"].tolist()) == {"Alice", "Charlie"}
+        assert set(query_result["age"].tolist()) == {30, 35}
+
+    async def test_virtual_table_with_ordering(self, project_model: Project) -> None:
+        # GIVEN a table with data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame({"name": ["Alice", "Bob", "Charlie"], "age": [30, 25, 35]})
+        await table.store_rows_async(data, synapse_client=self.syn)
+
+        # AND a virtual table with ordering
+        virtual_table = VirtualTable(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id} ORDER BY age DESC",
+        )
+        virtual_table = await virtual_table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+
+        # WHEN I query the virtual table
+        query_result = await virtual_table.query_async(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should be ordered by age descending
+        assert len(query_result) == 3
+        assert query_result["age"].tolist() == [35, 30, 25]
+        assert query_result["name"].tolist() == ["Charlie", "Alice", "Bob"]
+
+    async def test_virtual_table_with_aggregation(self, project_model: Project) -> None:
+        # GIVEN a table with data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="department", column_type=ColumnType.STRING),
+                Column(name="salary", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame(
+            {
+                "department": ["IT", "HR", "IT", "Finance", "HR"],
+                "salary": [70000, 60000, 80000, 90000, 65000],
+            }
+        )
+        await table.store_rows_async(data, synapse_client=self.syn)
+
+        # AND a virtual table with aggregation
+        defining_sql = f"""SELECT 
+            department, 
+            COUNT(*) 
+        FROM {table.id} 
+        GROUP BY department"""
+
+        virtual_table = VirtualTable(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            defining_sql=defining_sql,
+        )
+        virtual_table = await virtual_table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+
+        # Wait for virtual table to be ready
+        await asyncio.sleep(3)
+
+        # WHEN I query the virtual table
+        query_result = await virtual_table.query_async(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should be aggregated
+        assert len(query_result) == 3
+
+        # Sort the result by department to ensure consistent ordering for the test
+        query_result = query_result.sort_values("department").reset_index(drop=True)
+
+        assert query_result["department"].tolist() == ["Finance", "HR", "IT"]
+        # The COUNT(*) column will be the second column
+        assert query_result.iloc[:, 1].tolist() == [1, 2, 2]

--- a/tests/integration/synapseclient/models/synchronous/test_virtualtable.py
+++ b/tests/integration/synapseclient/models/synchronous/test_virtualtable.py
@@ -1,0 +1,607 @@
+import asyncio
+import uuid
+from typing import Callable
+
+import pandas as pd
+import pytest
+
+from synapseclient import Synapse
+from synapseclient.core.exceptions import SynapseHTTPError
+from synapseclient.models import Column, ColumnType, VirtualTable, Project, Table
+
+
+class TestVirtualTableWithoutData:
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    async def test_create_empty_virtual_table(self, project_model: Project) -> None:
+        # GIVEN a VirtualTable with an empty definingSQL
+        virtual_table = VirtualTable(
+            name=str(uuid.uuid4()),
+            description="Test virtual table",
+            parent_id=project_model.id,
+            defining_sql="",
+        )
+
+        # WHEN I try to store the virtual table
+        with pytest.raises(SynapseHTTPError) as e:
+            virtual_table.store(synapse_client=self.syn)
+
+        # THEN a 400 Client Error should be raised
+        assert (
+            "400 Client Error: The definingSQL of the virtual table is required "
+            "and must not be the empty string." in str(e.value)
+        )
+
+    async def test_create_virtual_table_without_columns(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with no columns
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a virtual table that uses the table in its defining SQL
+        virtual_table_name = str(uuid.uuid4())
+        virtual_table_description = "Test virtual table"
+        virtual_table = VirtualTable(
+            name=virtual_table_name,
+            parent_id=project_model.id,
+            description=virtual_table_description,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+
+        # WHEN I try to store the virtual table
+        with pytest.raises(SynapseHTTPError) as e:
+            virtual_table.store(synapse_client=self.syn)
+
+        # THEN a 400 Client Error should be raised
+        assert f"400 Client Error: Schema for {table.id} is empty." in str(e.value)
+
+    async def test_create_virtual_table_with_columns(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with columns
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="test_column", column_type=ColumnType.STRING),
+                Column(name="test_column2", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a virtual table that uses the table in its defining SQL
+        virtual_table_name = str(uuid.uuid4())
+        virtual_table_description = "Test virtual table"
+        virtual_table = VirtualTable(
+            name=virtual_table_name,
+            parent_id=project_model.id,
+            description=virtual_table_description,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+
+        # WHEN I store the virtual table
+        virtual_table = virtual_table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+
+        # THEN the virtual table should be created
+        assert virtual_table.id is not None
+
+        # AND I can retrieve that virtual table from Synapse
+        new_virtual_table_instance = VirtualTable(id=virtual_table.id).get(
+            synapse_client=self.syn
+        )
+        assert new_virtual_table_instance is not None
+        assert new_virtual_table_instance.name == virtual_table_name
+        assert new_virtual_table_instance.id == virtual_table.id
+        assert new_virtual_table_instance.description == virtual_table_description
+
+    async def test_create_virtual_table_with_invalid_sql(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a virtual table with invalid SQL
+        virtual_table_name = str(uuid.uuid4())
+        virtual_table_description = "Test virtual table"
+        virtual_table = VirtualTable(
+            name=virtual_table_name,
+            parent_id=project_model.id,
+            description=virtual_table_description,
+            defining_sql="INVALID SQL",
+        )
+
+        # WHEN I store the virtual table
+        with pytest.raises(SynapseHTTPError) as e:
+            virtual_table.store(synapse_client=self.syn)
+
+        # THEN the virtual table should not be created
+        assert (
+            '400 Client Error: Encountered " <regular_identifier> "INVALID "" '
+            "at line 1, column 1.\nWas expecting one of:" in str(e.value)
+        )
+
+    async def test_update_virtual_table_attributes(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table to use in the defining SQL
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="test_column", column_type=ColumnType.STRING),
+                Column(name="test_column2", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a virtual table
+        original_virtual_table = VirtualTable(
+            name=str(uuid.uuid4()),
+            description="Test virtual table",
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        original_virtual_table = original_virtual_table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(original_virtual_table.id)
+
+        # AND I update attributes of the virtual table
+        updated_virtual_table = VirtualTable(id=original_virtual_table.id).get(
+            synapse_client=self.syn
+        )
+        updated_virtual_table.name = str(uuid.uuid4())
+        updated_virtual_table.description = "Updated description"
+        updated_virtual_table.defining_sql = f"SELECT test_column FROM {table.id}"
+        updated_virtual_table = updated_virtual_table.store(synapse_client=self.syn)
+
+        # AND I retrieve the virtual table with its original id
+        retrieved_virtual_table = VirtualTable(id=original_virtual_table.id).get(
+            synapse_client=self.syn
+        )
+
+        # THEN the virtual table should be updated
+        assert retrieved_virtual_table is not None
+        assert retrieved_virtual_table.name == updated_virtual_table.name
+        assert retrieved_virtual_table.description == updated_virtual_table.description
+        assert (
+            retrieved_virtual_table.defining_sql == updated_virtual_table.defining_sql
+        )
+
+        # AND all versions should have the same id
+        assert (
+            retrieved_virtual_table.id
+            == updated_virtual_table.id
+            == original_virtual_table.id
+        )
+
+    async def test_delete_virtual_table(self, project_model: Project) -> None:
+        # GIVEN a table to use in the defining SQL
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="test_column", column_type=ColumnType.STRING),
+                Column(name="test_column2", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a virtual table
+        virtual_table = VirtualTable(
+            name=str(uuid.uuid4()),
+            description="Test virtual table",
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        virtual_table = virtual_table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+        assert virtual_table.id is not None
+
+        # WHEN I delete the virtual table
+        virtual_table.delete(synapse_client=self.syn)
+
+        # THEN the virtual table should be deleted
+        with pytest.raises(
+            SynapseHTTPError,
+            match=(f"404 Client Error: Entity {virtual_table.id} is in trash can."),
+        ):
+            VirtualTable(id=virtual_table.id).get(synapse_client=self.syn)
+
+
+class TestVirtualTableWithData:
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    async def test_query_data_from_virtual_table(self, project_model: Project) -> None:
+        # GIVEN a table with data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        table.store_rows(data, synapse_client=self.syn)
+
+        # AND a virtual table that uses the table in its defining SQL
+        virtual_table_name = str(uuid.uuid4())
+        virtual_table = VirtualTable(
+            name=virtual_table_name,
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        virtual_table = virtual_table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+
+        # WHEN I query the virtual table
+        query_result = virtual_table.query(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the table data
+        assert len(query_result) == 2
+        assert query_result["name"].tolist() == ["Alice", "Bob"]
+        assert query_result["age"].tolist() == [30, 25]
+
+    async def test_update_defining_sql(self, project_model: Project) -> None:
+        # GIVEN a table with data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        table.store_rows(data, synapse_client=self.syn)
+
+        # AND a virtual table that uses the table in its defining SQL
+        virtual_table_name = str(uuid.uuid4())
+        virtual_table = VirtualTable(
+            name=virtual_table_name,
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        virtual_table = virtual_table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+
+        # WHEN I update the defining SQL of the virtual table
+        virtual_table.defining_sql = f"SELECT name FROM {table.id}"
+        virtual_table = virtual_table.store(synapse_client=self.syn)
+
+        # AND I query the updated virtual table
+        query_result = virtual_table.query(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the updated SQL
+        assert len(query_result) == 2
+        assert query_result["name"].tolist() == ["Alice", "Bob"]
+        assert "age" not in query_result.columns
+
+        # AND the column is not present the next time the `virtual_table` is retrieved
+        retrieved_virtual_table = VirtualTable(id=virtual_table.id).get(
+            synapse_client=self.syn
+        )
+        assert "age" not in retrieved_virtual_table.columns.keys()
+        assert "name" in retrieved_virtual_table.columns.keys()
+
+    async def test_virtual_table_updates_with_table_data(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with columns but no data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="test_name", column_type=ColumnType.STRING),
+                Column(name="test_age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # AND a virtual table that uses the table in its defining SQL
+        virtual_table_name = str(uuid.uuid4())
+        virtual_table = VirtualTable(
+            name=virtual_table_name,
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        virtual_table = virtual_table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+
+        # Wait a moment for the virtual table to be ready
+        await asyncio.sleep(2)
+
+        # WHEN I query the virtual table before adding data to the table
+        query_result = virtual_table.query(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN no data should be returned
+        assert len(query_result) == 0
+
+        # AND WHEN I add data to the table
+        data = pd.DataFrame({"test_name": ["Alice", "Bob"], "test_age": [30, 25]})
+        table.store_rows(data, synapse_client=self.syn)
+
+        # Wait for updates to propagate
+        await asyncio.sleep(2)
+
+        # AND I query the virtual table again
+        query_result = virtual_table.query(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the table data
+        assert len(query_result) == 2
+        assert query_result["test_name"].tolist() == ["Alice", "Bob"]
+        assert query_result["test_age"].tolist() == [30, 25]
+
+    async def test_virtual_table_reflects_table_data_removal(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with columns and data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        table.store_rows(data, synapse_client=self.syn)
+
+        # AND a virtual table that uses the table in its defining SQL
+        virtual_table_name = str(uuid.uuid4())
+        virtual_table = VirtualTable(
+            name=virtual_table_name,
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id}",
+        )
+        virtual_table = virtual_table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+
+        # Wait for the virtual table to be ready
+        await asyncio.sleep(2)
+
+        # WHEN I query the virtual table
+        query_result = virtual_table.query(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should match the table data
+        assert len(query_result) == 2
+        assert query_result["name"].tolist() == ["Alice", "Bob"]
+        assert query_result["age"].tolist() == [30, 25]
+
+        # AND WHEN I remove data from the table
+        table.delete_rows(
+            query=f"SELECT ROW_ID, ROW_VERSION FROM {table.id}", synapse_client=self.syn
+        )
+
+        # Ensure the table contains no rows after deletion
+        query_result = table.query(f"SELECT * FROM {table.id}", synapse_client=self.syn)
+        assert len(query_result) == 0
+
+        # Wait for changes to propagate to the virtual table
+        await asyncio.sleep(2)
+
+        # AND I query the virtual table again
+        query_result = virtual_table.query(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN no data should be returned
+        assert len(query_result) == 0
+
+    async def test_virtual_table_with_column_selection(
+        self, project_model: Project
+    ) -> None:
+        # GIVEN a table with data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+                Column(name="city", column_type=ColumnType.STRING),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame(
+            {"name": ["Alice", "Bob"], "age": [30, 25], "city": ["New York", "Boston"]}
+        )
+        table.store_rows(data, synapse_client=self.syn)
+
+        # AND a virtual table with column selection
+        virtual_table = VirtualTable(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            defining_sql=f"SELECT name, city FROM {table.id}",
+        )
+        virtual_table = virtual_table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+
+        # WHEN I query the virtual table
+        query_result = virtual_table.query(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should only include the selected columns
+        assert len(query_result) == 2
+        assert "name" in query_result.columns
+        assert "city" in query_result.columns
+        assert "age" not in query_result.columns
+        assert query_result["name"].tolist() == ["Alice", "Bob"]
+        assert query_result["city"].tolist() == ["New York", "Boston"]
+
+    async def test_virtual_table_with_filtering(self, project_model: Project) -> None:
+        # GIVEN a table with data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame({"name": ["Alice", "Bob", "Charlie"], "age": [30, 25, 35]})
+        table.store_rows(data, synapse_client=self.syn)
+
+        # AND a virtual table with filtering
+        virtual_table = VirtualTable(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id} WHERE age > 25",
+        )
+        virtual_table = virtual_table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+
+        # WHEN I query the virtual table
+        query_result = virtual_table.query(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should only include filtered rows
+        assert len(query_result) == 2
+        assert set(query_result["name"].tolist()) == {"Alice", "Charlie"}
+        assert set(query_result["age"].tolist()) == {30, 35}
+
+    async def test_virtual_table_with_ordering(self, project_model: Project) -> None:
+        # GIVEN a table with data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="name", column_type=ColumnType.STRING),
+                Column(name="age", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame({"name": ["Alice", "Bob", "Charlie"], "age": [30, 25, 35]})
+        table.store_rows(data, synapse_client=self.syn)
+
+        # AND a virtual table with ordering
+        virtual_table = VirtualTable(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            defining_sql=f"SELECT * FROM {table.id} ORDER BY age DESC",
+        )
+        virtual_table = virtual_table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+
+        # WHEN I query the virtual table
+        query_result = virtual_table.query(
+            f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
+        )
+
+        # THEN the data should be ordered by age descending
+        assert len(query_result) == 3
+        assert query_result["age"].tolist() == [35, 30, 25]
+        assert query_result["name"].tolist() == ["Charlie", "Alice", "Bob"]
+
+    async def test_virtual_table_with_aggregation(self, project_model: Project) -> None:
+        # GIVEN a table with data
+        table_name = str(uuid.uuid4())
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            columns=[
+                Column(name="department", column_type=ColumnType.STRING),
+                Column(name="salary", column_type=ColumnType.INTEGER),
+            ],
+        )
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # Insert data into the table
+        data = pd.DataFrame(
+            {
+                "department": ["IT", "HR", "IT", "Finance", "HR"],
+                "salary": [70000, 60000, 80000, 90000, 65000],
+            }
+        )
+        table.store_rows(data, synapse_client=self.syn)
+
+        # AND a virtual table with aggregation
+        # Define SQL properly with consistent column names
+        defining_sql = f"""SELECT 
+            department, 
+            COUNT(*) as employee_count 
+        FROM {table.id} 
+        GROUP BY department"""
+
+        virtual_table = VirtualTable(
+            name=str(uuid.uuid4()),
+            parent_id=project_model.id,
+            defining_sql=defining_sql,
+        )
+        virtual_table = virtual_table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(virtual_table.id)
+
+        # Wait for virtual table to be ready
+        await asyncio.sleep(3)
+
+        # Query without column names to avoid mismatches
+        query = f"SELECT * FROM {virtual_table.id}"
+
+        # WHEN I query the virtual table
+        query_result = virtual_table.query(query, synapse_client=self.syn)
+
+        # THEN the data should be aggregated
+        assert len(query_result) == 3
+
+        # Sort the result by department to ensure consistent ordering for the test
+        query_result = query_result.sort_values("department").reset_index(drop=True)
+
+        assert query_result["department"].tolist() == ["Finance", "HR", "IT"]
+        assert query_result["employee_count"].tolist() == [1, 2, 2]

--- a/tests/integration/synapseclient/models/synchronous/test_virtualtable.py
+++ b/tests/integration/synapseclient/models/synchronous/test_virtualtable.py
@@ -7,7 +7,7 @@ import pytest
 
 from synapseclient import Synapse
 from synapseclient.core.exceptions import SynapseHTTPError
-from synapseclient.models import Column, ColumnType, VirtualTable, Project, Table
+from synapseclient.models import Column, ColumnType, Project, Table, VirtualTable
 
 
 class TestVirtualTableWithoutData:
@@ -574,10 +574,10 @@ class TestVirtualTableWithData:
 
         # AND a virtual table with aggregation
         # Define SQL properly with consistent column names
-        defining_sql = f"""SELECT 
-            department, 
-            COUNT(*) as employee_count 
-        FROM {table.id} 
+        defining_sql = f"""SELECT
+            department,
+            COUNT(*) as employee_count
+        FROM {table.id}
         GROUP BY department"""
 
         virtual_table = VirtualTable(

--- a/tests/integration/synapseclient/models/synchronous/test_virtualtable.py
+++ b/tests/integration/synapseclient/models/synchronous/test_virtualtable.py
@@ -26,14 +26,12 @@ class TestVirtualTableWithoutData:
         )
 
         # WHEN I try to store the virtual table
-        with pytest.raises(SynapseHTTPError) as e:
+        with pytest.raises(
+            SynapseHTTPError,
+            match="400 Client Error: The definingSQL of the virtual table is required "
+            "and must not be the empty string.",
+        ):
             virtual_table.store(synapse_client=self.syn)
-
-        # THEN a 400 Client Error should be raised
-        assert (
-            "400 Client Error: The definingSQL of the virtual table is required "
-            "and must not be the empty string." in str(e.value)
-        )
 
     async def test_create_virtual_table_without_columns(
         self, project_model: Project
@@ -58,11 +56,10 @@ class TestVirtualTableWithoutData:
         )
 
         # WHEN I try to store the virtual table
-        with pytest.raises(SynapseHTTPError) as e:
+        with pytest.raises(
+            SynapseHTTPError, match=f"400 Client Error: Schema for {table.id} is empty."
+        ):
             virtual_table.store(synapse_client=self.syn)
-
-        # THEN a 400 Client Error should be raised
-        assert f"400 Client Error: Schema for {table.id} is empty." in str(e.value)
 
     async def test_create_virtual_table_with_columns(
         self, project_model: Project
@@ -120,14 +117,12 @@ class TestVirtualTableWithoutData:
         )
 
         # WHEN I store the virtual table
-        with pytest.raises(SynapseHTTPError) as e:
+        with pytest.raises(
+            SynapseHTTPError,
+            match='400 Client Error: Encountered " <regular_identifier> "INVALID "" '
+            "at line 1, column 1.\nWas expecting one of:",
+        ):
             virtual_table.store(synapse_client=self.syn)
-
-        # THEN the virtual table should not be created
-        assert (
-            '400 Client Error: Encountered " <regular_identifier> "INVALID "" '
-            "at line 1, column 1.\nWas expecting one of:" in str(e.value)
-        )
 
     async def test_update_virtual_table_attributes(
         self, project_model: Project
@@ -215,7 +210,7 @@ class TestVirtualTableWithoutData:
         # THEN the virtual table should be deleted
         with pytest.raises(
             SynapseHTTPError,
-            match=(f"404 Client Error: Entity {virtual_table.id} is in trash can."),
+            match=f"404 Client Error: Entity {virtual_table.id} is in trash can.",
         ):
             VirtualTable(id=virtual_table.id).get(synapse_client=self.syn)
 
@@ -253,6 +248,9 @@ class TestVirtualTableWithData:
         )
         virtual_table = virtual_table.store(synapse_client=self.syn)
         self.schedule_for_cleanup(virtual_table.id)
+
+        # Wait for the virtual table to be ready
+        await asyncio.sleep(2)
 
         # WHEN I query the virtual table
         query_result = virtual_table.query(
@@ -462,6 +460,9 @@ class TestVirtualTableWithData:
         virtual_table = virtual_table.store(synapse_client=self.syn)
         self.schedule_for_cleanup(virtual_table.id)
 
+        # Wait for the virtual table to be ready
+        await asyncio.sleep(2)
+
         # WHEN I query the virtual table
         query_result = virtual_table.query(
             f"SELECT * FROM {virtual_table.id}", synapse_client=self.syn
@@ -538,6 +539,9 @@ class TestVirtualTableWithData:
         )
         virtual_table = virtual_table.store(synapse_client=self.syn)
         self.schedule_for_cleanup(virtual_table.id)
+
+        # Wait for the virtual table to be ready
+        await asyncio.sleep(2)
 
         # WHEN I query the virtual table
         query_result = virtual_table.query(

--- a/tests/unit/synapseclient/models/unit_test_virtualtable.py
+++ b/tests/unit/synapseclient/models/unit_test_virtualtable.py
@@ -34,7 +34,9 @@ class TestVirtualTable:
             # THEN I expect a SynapseQueryError to be raised
             with pytest.raises(
                 SynapseQueryError,
-                match="VirtualTables do not support JOIN or UNION operations in the defining_sql. If you need to combine data from multiple tables, consider using a MaterializedView instead.",
+                match="VirtualTables do not support JOIN or UNION operations in the defining_sql. "
+                "If you need to combine data from multiple tables, "
+                "consider using a MaterializedView instead.",
             ):
                 await virtual_table.store_async(synapse_client=self.syn)
 
@@ -59,7 +61,9 @@ class TestVirtualTable:
             # THEN I expect a SynapseQueryError to be raised
             with pytest.raises(
                 SynapseQueryError,
-                match="VirtualTables do not support JOIN or UNION operations in the defining_sql. If you need to combine data from multiple tables, consider using a MaterializedView instead.",
+                match="VirtualTables do not support JOIN or UNION operations in the defining_sql. "
+                "If you need to combine data from multiple tables, "
+                "consider using a MaterializedView instead.",
             ):
                 await virtual_table.store_async(synapse_client=self.syn)
 

--- a/tests/unit/synapseclient/models/unit_test_virtualtable.py
+++ b/tests/unit/synapseclient/models/unit_test_virtualtable.py
@@ -1,0 +1,65 @@
+import pytest
+from unittest.mock import patch
+from synapseclient import Synapse
+from synapseclient.core.exceptions import SynapseQueryError
+from synapseclient.models import VirtualTable
+from synapseclient.models.mixins.table_components import TableStoreMixin
+
+
+class TestVirtualTable:
+    """Tests for VirtualTable validation"""
+
+    @pytest.fixture(autouse=True, scope="function")
+    def init_syn(self, syn: Synapse) -> None:
+        self.syn = syn
+
+    async def test_store_async_with_join_operation_raises_error(self):
+        # GIVEN a VirtualTable with JOIN in the SQL
+        virtual_table = VirtualTable(
+            name="Test Virtual Table",
+            description="A test virtual table",
+            parent_id="syn12345",
+            defining_sql="""
+            SELECT t1.column1, t2.column2 
+            FROM syn12345 t1 
+            JOIN syn67890 t2 
+            ON t1.id = t2.foreign_id
+            """,
+        )
+
+        with patch.object(TableStoreMixin, "store_async") as mock_super_store_async:
+            # WHEN I store the VirtualTable
+            # THEN I expect a SynapseQueryError to be raised
+            with pytest.raises(
+                SynapseQueryError,
+                match="VirtualTables do not support JOIN or UNION operations in the defining_sql. If you need to combine data from multiple tables, consider using a MaterializedView instead.",
+            ):
+                await virtual_table.store_async(synapse_client=self.syn)
+
+            # AND I expect the super().store_async method to not be called
+            mock_super_store_async.assert_not_called()
+
+    async def test_store_async_with_union_operation_raises_error(self):
+        # GIVEN a VirtualTable with UNION in the SQL
+        virtual_table = VirtualTable(
+            name="Test Virtual Table",
+            description="A test virtual table",
+            parent_id="syn12345",
+            defining_sql="""
+            SELECT column1, column2 FROM syn12345
+            UNION
+            SELECT column1, column2 FROM syn67890
+            """,
+        )
+
+        with patch.object(TableStoreMixin, "store_async") as mock_super_store_async:
+            # WHEN I store the VirtualTable
+            # THEN I expect a SynapseQueryError to be raised
+            with pytest.raises(
+                SynapseQueryError,
+                match="VirtualTables do not support JOIN or UNION operations in the defining_sql. If you need to combine data from multiple tables, consider using a MaterializedView instead.",
+            ):
+                await virtual_table.store_async(synapse_client=self.syn)
+
+            # AND I expect the super().store_async method to not be called
+            mock_super_store_async.assert_not_called()

--- a/tests/unit/synapseclient/models/unit_test_virtualtable.py
+++ b/tests/unit/synapseclient/models/unit_test_virtualtable.py
@@ -69,3 +69,27 @@ class TestVirtualTable:
 
             # AND I expect the super().store_async method to not be called
             mock_super_store_async.assert_not_called()
+
+    async def test_store_async_with_valid_sql_calls_super_store(self):
+        # GIVEN a VirtualTable with valid SQL
+        virtual_table = VirtualTable(
+            name="Test Virtual Table",
+            description="A test virtual table",
+            parent_id="syn12345",
+            defining_sql="SELECT column1, column2 FROM syn12345",
+        )
+
+        with patch.object(TableStoreMixin, "store_async") as mock_super_store_async:
+            # Set up the mock to return the virtual_table
+            mock_super_store_async.return_value = virtual_table
+
+            # WHEN I store the VirtualTable
+            result = await virtual_table.store_async(synapse_client=self.syn)
+
+            # THEN I expect the super().store_async method to be called
+            mock_super_store_async.assert_called_once_with(
+                dry_run=False, job_timeout=600, synapse_client=self.syn
+            )
+
+            # AND I expect the result to be the return value from super().store_async
+            assert result == virtual_table

--- a/tests/unit/synapseclient/models/unit_test_virtualtable.py
+++ b/tests/unit/synapseclient/models/unit_test_virtualtable.py
@@ -1,5 +1,7 @@
-import pytest
 from unittest.mock import patch
+
+import pytest
+
 from synapseclient import Synapse
 from synapseclient.core.exceptions import SynapseQueryError
 from synapseclient.models import VirtualTable
@@ -20,9 +22,9 @@ class TestVirtualTable:
             description="A test virtual table",
             parent_id="syn12345",
             defining_sql="""
-            SELECT t1.column1, t2.column2 
-            FROM syn12345 t1 
-            JOIN syn67890 t2 
+            SELECT t1.column1, t2.column2
+            FROM syn12345 t1
+            JOIN syn67890 t2
             ON t1.id = t2.foreign_id
             """,
         )

--- a/tests/unit/synapseclient/models/unit_test_virtualtable.py
+++ b/tests/unit/synapseclient/models/unit_test_virtualtable.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 import pytest
 
 from synapseclient import Synapse
-from synapseclient.core.exceptions import SynapseQueryError
 from synapseclient.models import VirtualTable
 from synapseclient.models.mixins.table_components import TableStoreMixin
 
@@ -31,9 +30,9 @@ class TestVirtualTable:
 
         with patch.object(TableStoreMixin, "store_async") as mock_super_store_async:
             # WHEN I store the VirtualTable
-            # THEN I expect a SynapseQueryError to be raised
+            # THEN I expect a ValueError to be raised
             with pytest.raises(
-                SynapseQueryError,
+                ValueError,
                 match="VirtualTables do not support JOIN or UNION operations in the defining_sql. "
                 "If you need to combine data from multiple tables, "
                 "consider using a MaterializedView instead.",
@@ -58,9 +57,9 @@ class TestVirtualTable:
 
         with patch.object(TableStoreMixin, "store_async") as mock_super_store_async:
             # WHEN I store the VirtualTable
-            # THEN I expect a SynapseQueryError to be raised
+            # THEN I expect a ValueError to be raised
             with pytest.raises(
-                SynapseQueryError,
+                ValueError,
                 match="VirtualTables do not support JOIN or UNION operations in the defining_sql. "
                 "If you need to combine data from multiple tables, "
                 "consider using a MaterializedView instead.",


### PR DESCRIPTION
# **Problem:**

We did not previously have an OOP model representing the Synapse [VirtualTable](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/VirtualTable.html). We should follow the example of the MaterializedView to implement this model, with the exception that JOIN and UNION operations are not supported in the `definingSQL` of `VirtualTable`s.

# **Solution:**

Implemented the `VirtualTable` model, all expected functionality, updated documentation, added a tutorial and examples. Followed #903 as an example because there is a lot of overlap in functionality with `MaterializedView`s.

# **Testing:**

Tested implementation by manually running the code, wrote integration tests and unit tests as needed.

# **Notes:**

There was a compatibility issue causing failures in our CI pipeline with older versions of `pip` so I added a `pip upgrade` line to the build file https://github.com/Sage-Bionetworks/synapsePythonClient/pull/1195/commits/b5dd74657dbd7f2365c26d40ab5dbb77dbf42db4
