### PR TITLE
[TECH DEBT] Update tutorials to use `sync` interfaces for documentation and patch several links

### DIFF
--- a/docs/explanations/manifest_tsv.md
+++ b/docs/explanations/manifest_tsv.md
@@ -15,33 +15,34 @@ Any additional columns will be added as annotations.
 
 ### Required fields:
 
-| Field | Meaning | Example |
-| --- | --- | --- |
-| path | local file path or URL | /path/to/local/file.txt |
-| parent | synapse id | syn1235 |
+| Field  | Meaning                | Example                 |
+|--------|------------------------|-------------------------|
+| path   | local file path or URL | /path/to/local/file.txt |
+| parent | synapse id             | syn1235                 |
 
 ### Common fields:
 
-| Field | Meaning | Example |
-| --- | --- | --- |
-| name | name of file in Synapse | Example_file |
-| forceVersion | whether to update version | False |
+| Field        | Meaning                   | Example      |
+|--------------|---------------------------|--------------|
+| name         | name of file in Synapse   | Example_file |
+| forceVersion | whether to update version | False        |
 
 ### Activity/Provenance fields:
 
 Each of these are individual examples and is what you would find in a row in each of these columns. To clarify, "syn1235;/path/to_local/file.txt" below states that you would like both "syn1234" and "/path/to_local/file.txt" added as items used to generate a file. You can also specify one item by specifying "syn1234"
 
-| Field | Meaning | Example |
-| --- | --- | --- |
-| used | List of items used to generate file | "syn1235;/path/to_local/file.txt" |
-| executed | List of items executed | "https://github.org/;/path/to_local/code.py" |
-| activityName | Name of activity in provenance | "Ran normalization" |
-| activityDescription | Text description on what was done | "Ran algorithm xyx with parameters..." |
+| Field               | Meaning                             | Example                                      |
+|---------------------|-------------------------------------|----------------------------------------------|
+| used                | List of items used to generate file | "syn1235;/path/to_local/file.txt"            |
+| executed            | List of items executed              | "https://github.org/;/path/to_local/code.py" |
+| activityName        | Name of activity in provenance      | "Ran normalization"                          |
+| activityDescription | Text description on what was done   | "Ran algorithm xyx with parameters..."       |
 
 See:
 
 - [Activity][synapseclient.Activity]
 
+[](){ #manifest-tsv-explanation-annotations }
 ### Annotations:
 
 Any columns that are not in the reserved names described above will be interpreted as annotations of the file
@@ -54,6 +55,8 @@ Adding 4 annotations to each row:
 | /path/file2.txt | syn12433 | baz | 2.71 | [value_1,value_2] | [1,2,3] | [test 123, test 456]
 | /path/file3.txt | syn12455 | zzz | 3.52 | [value_3,value_4] | [42, 56, 77] | [a single annotation]
 
+
+[](){ #manifest-tsv-explanation-multiple-annotations }
 #### Multiple values of annotations per key
 Using multiple values for a single annotation should be used sparingly as it makes it more
 difficult for you to manage the data. However, it is supported.
@@ -66,22 +69,22 @@ double quotes.
 
 This is an annotation with 2 values:
 
-| path | parent | annot1 |
-| --- | --- | --- |
+| path            | parent  | annot1                                          |
+|-----------------|---------|-------------------------------------------------|
 | /path/file1.txt | syn1243 | [my first annotation, "my, second, annotation"] |
 
 
 This is an annotation with 4 value:
 
-| path | parent | annot1 |
-| --- | --- | --- |
+| path            | parent  | annot1                                        |
+|-----------------|---------|-----------------------------------------------|
 | /path/file1.txt | syn1243 | [my first annotation, my, second, annotation] |
 
 
 This is an annotation with 1 value:
 
-| path | parent | annot1 |
-| --- | --- | --- |
+| path            | parent  | annot1                     |
+|-----------------|---------|----------------------------|
 | /path/file1.txt | syn1243 | my, sentence, with, commas |
 
 
@@ -91,18 +94,20 @@ See:
 
 ### Other optional fields:
 
-| Field | Meaning | Example |
-| --- | --- | --- |
-| synapseStore | Boolean describing whether to upload files | True |
-| contentType | content type of file to overload defaults | text/html |
+| Field        | Meaning                                    | Example   |
+|--------------|--------------------------------------------|-----------|
+| synapseStore | Boolean describing whether to upload files | True      |
+| contentType  | content type of file to overload defaults  | text/html |
 
+
+[](){ #manifest-tsv-explanation-example-file }
 ### Example manifest file
 
-| path | parent | annot1 | annot2 | collection_date | used | executed |
-| --- | --- | --- | --- | --- | --- | --- |
-| /path/file1.txt | syn1243 | "bar" | 3.1415 | 2023-12-04 07:00:00+00:00 | "syn124;/path/file2.txt" | "https://github.org/foo/bar" |
-| /path/file2.txt | syn12433 | "baz" | 2.71 | 2001-01-01 15:00:00+07:00 | "" | "https://github.org/foo/baz" |
-| /path/file3.txt | syn12455 | "zzz" | 3.52 | 2023-12-04T07:00:00Z | "" | "https://github.org/foo/zzz" |
+| path            | parent   | annot1 | annot2 | collection_date           | used                     | executed                     |
+|-----------------|----------|--------|--------|---------------------------|--------------------------|------------------------------|
+| /path/file1.txt | syn1243  | "bar"  | 3.1415 | 2023-12-04 07:00:00+00:00 | "syn124;/path/file2.txt" | "https://github.org/foo/bar" |
+| /path/file2.txt | syn12433 | "baz"  | 2.71   | 2001-01-01 15:00:00+07:00 | ""                       | "https://github.org/foo/baz" |
+| /path/file3.txt | syn12455 | "zzz"  | 3.52   | 2023-12-04T07:00:00Z      | ""                       | "https://github.org/foo/zzz" |
 
 ### Dates in the manifest file
 Dates within the manifest file will always be written as [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format in UTC without milliseconds. For example: `2023-12-20T16:55:08Z`.

--- a/docs/news.md
+++ b/docs/news.md
@@ -123,7 +123,7 @@ stored in the `~/.synapseConfig` file.
 ## 4.3.0 (2024-05-30)
 ### Highlights
 - **New tutorial:**
-    - [Uploading data in bulk](../tutorials/python/upload_data_in_bulk)
+    - [Uploading data in bulk](tutorials/python/upload_data_in_bulk.md)
     is our newest tutorial. It covers the basics of working with manifest files to manage synapse projects.
 - **Updates to syncToSynapse:**
     - The `syncToSynapse` function has been refactored to improve performance and
@@ -167,7 +167,7 @@ stored in the `~/.synapseConfig` file.
 
 ### Highlights
 - **New Downloading Data in Bulk Tutorial**
-    - See [Downloading data in bulk tutorial](https://python-docs.synapse.org/tutorials/python/download_data_in_bulk/) for more details on downloading data in bulk from Synapse.
+    - See [Downloading data in bulk tutorial][tutorial-downloading-data-in-bulk] for more details on downloading data in bulk from Synapse.
 - **Downloading Files Troubleshooting Improvement**
     - Improved error logging for when users are downloading files using commands like `get-download-list` from Synapse.
 
@@ -222,27 +222,27 @@ stored in the `~/.synapseConfig` file.
 
 -   **Only authentication through Personal Access Token**
     **(aka: Authentication bearer token) is supported**. Review the
-    [Authentication document](https://python-docs.synapse.org/tutorials/authentication/)
+    [Authentication document][tutorial-authentication]
     for information on setting up your usage of a Personal Access Token to authenticate
     with Synapse.
 -   **Date type Annotations on Synapse entities are now timezone aware**. Review our
-    [reference documentation for Annotations](https://python-docs.synapse.org/reference/annotations/).
+    [reference documentation for Annotations][synapseclient.annotations].
     The [`pytz` package](https://pypi.org/project/pytz/) is recommended if you regularly
     work with data across time zones.
     - If you do not set the `tzinfo` field on a date or datetime instance we will use the
         timezone of the machine where the code is executing.
     - If you are using the
-        [Manifest TSV](https://python-docs.synapse.org/explanations/manifest_tsv/#annotations)
+        [Manifest TSV][manifest-tsv-explanation-annotations]
         for bulk actions on your projects you'll now see that
         [synapseutils.sync.syncFromSynapse][] will store dates as `YYYY-MM-DDTHH:MM:SSZ`.
         Review our documentation for an
-        [example manifest file](https://python-docs.synapse.org/explanations/manifest_tsv/#example-manifest-file).
+        [example manifest file][manifest-tsv-explanation-example-file].
         Additionally, if you'd like to upload an annotation in a specific timezone please
         make sure that it is in [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601).
         If you do not specify a timezone it is assumed to use the timezone of the machine
         where the code is executing.
 -   **Support for annotations with multiple values through the**
-    [**Manifest TSV**](https://python-docs.synapse.org/explanations/manifest_tsv/#multiple-values-of-annotations-per-key)
+    [**Manifest TSV**][manifest-tsv-explanation-multiple-annotations]
     with the usage of a comma delimited bracket wrapped list. Any manifest files wishing
     to take advantage of multi-value annotations need to match this format. Examples:
     - `["Annotation, with a comma", another annotation]`
@@ -253,7 +253,7 @@ stored in the `~/.synapseConfig` file.
     that you'll
     [provide the Data Processing and Engineering team feedback on areas we can improve](https://sagebionetworks.jira.com/servicedesk/customer/portal/5/group/7).
 -   Expansion of the available Python Tutorials can be found
-    [starting here](https://python-docs.synapse.org/tutorials/python_client/).
+    [starting here][tutorials-home].
 
 ### Bug Fixes
 -  \[[SYNPY-1357](https://sagebionetworks.jira.com/browse/SYNPY-1357)\] - Manifest does not support annotations with multiple values
@@ -925,7 +925,7 @@ stored in the `~/.synapseConfig` file.
     syn = synapseclient.Synapse(cache_root_dir=<directory path>)
     ```
 
--   A [helper method](index.html#synapseclient.Synapse.is_certified) on
+-   A [helper method][synapseclient.Synapse.is_certified] on
     the Synapse object has been added to enable obtaining the Synapse
     certification quiz status of a user.
 
@@ -981,7 +981,7 @@ stored in the `~/.synapseConfig` file.
 -   This version addresses an issue with downloads being retried
     unsuccessfully after encountering certain types of errors.
 -   A
-    [create_snapshot_version](index.html#synapseclient.Synapse.create_snapshot_version)
+    [create_snapshot_version][synapseclient.Synapse.create_snapshot_version]
     function is added for making table and view snapshots.
 
 ### Bug Fixes
@@ -1008,9 +1008,9 @@ stored in the `~/.synapseConfig` file.
 ### Highlights
 
 -   Files that are part of
-    [syncFromSynapse](https://python-docs.synapse.org/build/html/synapseutils.html#synapseutils.sync.syncFromSynapse)
+    [syncFromSynapse][synapseutils.sync.syncFromSynapse]
     and
-    [syncToSynapse](https://python-docs.synapse.org/build/html/synapseutils.html#synapseutils.sync.syncToSynapse)
+    [syncToSynapse][synapseutils.sync.syncToSynapse]
     operations (`synapse get -r` and `synapse sync` in the command line
     client, respectively) are transferred in in parallel threads rather
     than serially, substantially improving the performance of these
@@ -1056,7 +1056,7 @@ stored in the `~/.synapseConfig` file.
 ### Highlights
 
 -   This version includes a performance improvement for
-    [syncFromSynapse](https://python-docs.synapse.org/build/html/synapseutils.html#synapseutils.sync.syncFromSynapse)
+    [syncFromSynapse][synapseutils.sync.syncFromSynapse]
     downloads of deep folder hierarchies to local filesystem locations
     outside of the [Synapse
     cache](https://help.synapse.org/docs/Downloading-Data-Programmatically.2003796248.html#DownloadingDataProgrammatically-DownloadingFiles).
@@ -1837,8 +1837,7 @@ Below are the full list of issues addressed by this release:
 Release 1.7 is a large bugfix release with several new features. The
 main ones include:
 
--   We have expanded the [synapseutils
-    packages](python-docs.synapse.org/build/html/synapseutils.html#module-synapseutils)
+-   We have expanded the [synapseutils packages][synapseutils]
     to add the ability to:
 
     > -   Bulk upload files to synapse (synapseutils.syncToSynapse).

--- a/docs/reference/experimental/async/activity.md
+++ b/docs/reference/experimental/async/activity.md
@@ -6,6 +6,7 @@ at your own risk.
 
 ## API Reference
 
+[](){ #activity-reference-async }
 ::: synapseclient.models.Activity
     options:
       members:
@@ -14,11 +15,13 @@ at your own risk.
         - delete_async
         - disassociate_from_entity_async
 ---
+[](){ #used-entity-reference-async }
 ::: synapseclient.models.UsedEntity
     options:
       filters:
       - "!"
 ---
+[](){ #used-url-reference-async }
 ::: synapseclient.models.UsedURL
     options:
       filters:

--- a/docs/reference/experimental/async/agent.md
+++ b/docs/reference/experimental/async/agent.md
@@ -6,6 +6,7 @@ at your own risk.
 
 ## API reference
 
+[](){ #agent-reference-async }
 ::: synapseclient.models.Agent
     options:
         members:
@@ -16,6 +17,7 @@ at your own risk.
             - prompt_async
             - get_chat_history
 ---
+[](){ #agent-session-reference-async }
 ::: synapseclient.models.AgentSession
     options:
         members:
@@ -24,6 +26,7 @@ at your own risk.
             - update_async
             - prompt_async
 ---
+[](){ #agent-prompt-reference-async }
 ::: synapseclient.models.AgentPrompt
     options:
         inherited_members: true

--- a/docs/reference/experimental/async/dataset.md
+++ b/docs/reference/experimental/async/dataset.md
@@ -6,6 +6,7 @@ at your own risk.
 
 ## API reference
 
+[](){ #dataset-reference-async }
 ::: synapseclient.models.Dataset
     options:
         inherited_members: true
@@ -27,5 +28,6 @@ at your own risk.
             - get_acl
             - set_permissions
 ---
+[](){ #entity-ref-reference-async }
 ::: synapseclient.models.EntityRef
 ---

--- a/docs/reference/experimental/async/dataset_collection.md
+++ b/docs/reference/experimental/async/dataset_collection.md
@@ -6,6 +6,7 @@ at your own risk.
 
 ## API reference
 
+[](){ #dataset-collection-reference-async }
 ::: synapseclient.models.DatasetCollection
     options:
         inherited_members: true
@@ -27,5 +28,6 @@ at your own risk.
             - get_acl
             - set_permissions
 ---
+[](){ #entity-ref-dataset-collection-reference-async }
 ::: synapseclient.models.EntityRef
 ---

--- a/docs/reference/experimental/async/entityview.md
+++ b/docs/reference/experimental/async/entityview.md
@@ -6,6 +6,7 @@ at your own risk.
 
 ## API reference
 
+[](){ #entityview-reference-async }
 ::: synapseclient.models.EntityView
     options:
         inherited_members: true
@@ -23,4 +24,8 @@ at your own risk.
             - get_acl_async
             - get_permissions_async
             - set_permissions_async
+---
+
+[](){ #view-type-mask-reference }
+::: synapseclient.api.ViewTypeMask
 ---

--- a/docs/reference/experimental/async/file.md
+++ b/docs/reference/experimental/async/file.md
@@ -6,6 +6,7 @@ at your own risk.
 
 ## API Reference
 
+[](){ #file-reference-async }
 ::: synapseclient.models.File
     options:
         inherited_members: true
@@ -21,6 +22,7 @@ at your own risk.
         - get_acl_async
         - set_permissions_async
 ---
+[](){ #filehandle-reference-async }
 ::: synapseclient.models.file.FileHandle
     options:
       filters:

--- a/docs/reference/experimental/async/table.md
+++ b/docs/reference/experimental/async/table.md
@@ -6,6 +6,7 @@ at your own risk.
 
 ## API Reference
 
+[](){ #table-reference-async }
 ::: synapseclient.models.Table
     options:
         inherited_members: true
@@ -26,24 +27,39 @@ at your own risk.
         - get_acl
         - set_permissions
 
+[](){ #column-reference-async }
 ::: synapseclient.models.Column
     options:
         members:
 
+[](){ #schema-storage-strategy-reference-async }
 ::: synapseclient.models.SchemaStorageStrategy
+[](){ #column-expansion-strategy-reference-async }
 ::: synapseclient.models.ColumnExpansionStrategy
 
+[](){ #facet-type-reference-async }
 ::: synapseclient.models.FacetType
+[](){ #column-type-reference-async }
 ::: synapseclient.models.ColumnType
+[](){ #json-sub-column-reference-async }
 ::: synapseclient.models.JsonSubColumn
 
 
+[](){ #column-change-reference-async }
 ::: synapseclient.models.ColumnChange
+[](){ #partial-row-reference-async }
 ::: synapseclient.models.PartialRow
+[](){ #partial-row-set-reference-async }
 ::: synapseclient.models.PartialRowSet
+[](){ #table-schema-change-request-reference-async }
 ::: synapseclient.models.TableSchemaChangeRequest
+[](){ #appendable-row-set-request-reference-async }
 ::: synapseclient.models.AppendableRowSetRequest
+[](){ #upload-to-table-request-reference-async }
 ::: synapseclient.models.UploadToTableRequest
+[](){ #table-update-transaction-reference-async }
 ::: synapseclient.models.TableUpdateTransaction
+[](){ #csv-table-descriptor-reference-async }
 ::: synapseclient.models.CsvTableDescriptor
+[](){ #csv-to-pandas-df-reference-async }
 ::: synapseclient.models.mixins.table_components.csv_to_pandas_df

--- a/docs/reference/experimental/async/team.md
+++ b/docs/reference/experimental/async/team.md
@@ -6,6 +6,7 @@ at your own risk.
 
 ## API Reference
 
+[](){ #team-reference-async }
 ::: synapseclient.models.Team
     options:
         members:

--- a/docs/reference/experimental/async/user_profile.md
+++ b/docs/reference/experimental/async/user_profile.md
@@ -6,6 +6,7 @@ at your own risk.
 
 ## API Reference
 
+[](){ #user-profile-reference-async }
 ::: synapseclient.models.UserProfile
     options:
       inherited_members: true
@@ -15,5 +16,6 @@ at your own risk.
       - from_username_async
       - is_certified_async
 ---
+[](){ #user-preference-reference-async }
 ::: synapseclient.models.UserPreference
 ---

--- a/docs/reference/experimental/sync/activity.md
+++ b/docs/reference/experimental/sync/activity.md
@@ -1,3 +1,4 @@
+[](){ #activity-reference-sync }
 # Activity
 
 Contained within this file are experimental interfaces for working with the Synapse Python
@@ -24,11 +25,13 @@ at your own risk.
         - store
         - delete
 ---
+[](){ #used-entity-reference-sync }
 ::: synapseclient.models.UsedEntity
     options:
       filters:
       - "!"
 ---
+[](){ #used-url-reference-sync }
 ::: synapseclient.models.UsedURL
     options:
       filters:

--- a/docs/reference/experimental/sync/agent.md
+++ b/docs/reference/experimental/sync/agent.md
@@ -1,3 +1,4 @@
+[](){ #agent-reference-sync }
 # Agent
 
 Contained within this file are experimental interfaces for working with the Synapse Python
@@ -27,6 +28,7 @@ at your own risk.
             - prompt
             - get_chat_history
 ---
+[](){ #agent-session-reference-sync }
 ::: synapseclient.models.AgentSession
     options:
         inherited_members: true
@@ -36,7 +38,7 @@ at your own risk.
             - update
             - prompt
 ---
+[](){ #agent-prompt-reference-sync }
 ::: synapseclient.models.AgentPrompt
     options:
         inherited_members: true
----

--- a/docs/reference/experimental/sync/dataset.md
+++ b/docs/reference/experimental/sync/dataset.md
@@ -1,3 +1,4 @@
+[](){ #dataset-reference-sync }
 # Dataset
 
 Contained within this file are experimental interfaces for working with the Synapse Python
@@ -27,5 +28,6 @@ at your own risk.
             - get_acl
             - set_permissions
 ---
+[](){ #entity-ref-reference-sync }
 ::: synapseclient.models.EntityRef
 ---

--- a/docs/reference/experimental/sync/dataset_collection.md
+++ b/docs/reference/experimental/sync/dataset_collection.md
@@ -1,3 +1,4 @@
+[](){ #dataset-collection-reference-sync }
 # Dataset Collection
 
 Contained within this file are experimental interfaces for working with the Synapse Python
@@ -27,5 +28,6 @@ at your own risk.
             - get_acl
             - set_permissions
 ---
+[](){ #entity-ref-dataset-collection-reference-sync }
 ::: synapseclient.models.EntityRef
 ---

--- a/docs/reference/experimental/sync/entityview.md
+++ b/docs/reference/experimental/sync/entityview.md
@@ -1,3 +1,4 @@
+[](){ #entityview-reference-sync }
 # EntityView
 
 Contained within this file are experimental interfaces for working with the Synapse Python
@@ -23,4 +24,8 @@ at your own risk.
             - get_acl
             - get_permissions
             - set_permissions
+---
+
+[](){ #view-type-mask-reference-sync }
+::: synapseclient.api.ViewTypeMask
 ---

--- a/docs/reference/experimental/sync/file.md
+++ b/docs/reference/experimental/sync/file.md
@@ -1,3 +1,4 @@
+[](){ #file-reference-sync }
 # File
 
 Contained within this file are experimental interfaces for working with the Synapse Python
@@ -31,6 +32,7 @@ at your own risk.
         - get_acl
         - set_permissions
 ---
+[](){ #filehandle-reference-sync }
 ::: synapseclient.models.file.FileHandle
     options:
       filters:

--- a/docs/reference/experimental/sync/folder.md
+++ b/docs/reference/experimental/sync/folder.md
@@ -1,3 +1,4 @@
+[](){ #folder-reference-sync }
 # Folder
 
 Contained within this file are experimental interfaces for working with the Synapse Python

--- a/docs/reference/experimental/sync/materializedview.md
+++ b/docs/reference/experimental/sync/materializedview.md
@@ -1,3 +1,4 @@
+[](){ #materializedview-reference-sync }
 # MaterializedView
 
 Contained within this file are experimental interfaces for working with the Synapse Python

--- a/docs/reference/experimental/sync/project.md
+++ b/docs/reference/experimental/sync/project.md
@@ -1,3 +1,4 @@
+[](){ #project-reference-sync }
 # Project
 
 Contained within this file are experimental interfaces for working with the Synapse Python

--- a/docs/reference/experimental/sync/submissionview.md
+++ b/docs/reference/experimental/sync/submissionview.md
@@ -1,3 +1,4 @@
+[](){ #submissionview-reference-sync }
 # SubmissionView
 
 Contained within this file are experimental interfaces for working with the Synapse Python
@@ -22,4 +23,3 @@ at your own risk.
             - get_acl
             - get_permissions
             - set_permissions
----

--- a/docs/reference/experimental/sync/table.md
+++ b/docs/reference/experimental/sync/table.md
@@ -1,3 +1,4 @@
+[](){ #table-reference-sync }
 # Table
 
 Contained within this file are experimental interfaces for working with the Synapse Python
@@ -37,24 +38,39 @@ at your own risk.
         - get_acl
         - set_permissions
 
+[](){ #column-reference-sync }
 ::: synapseclient.models.Column
     options:
         members:
 
+[](){ #schema-storage-strategy-reference-sync }
 ::: synapseclient.models.SchemaStorageStrategy
+[](){ #column-expansion-strategy-reference-sync }
 ::: synapseclient.models.ColumnExpansionStrategy
 
+[](){ #facet-type-reference-sync }
 ::: synapseclient.models.FacetType
+[](){ #column-type-reference-sync }
 ::: synapseclient.models.ColumnType
+[](){ #json-sub-column-reference-sync }
 ::: synapseclient.models.JsonSubColumn
 
 
+[](){ #column-change-reference-sync }
 ::: synapseclient.models.ColumnChange
+[](){ #partial-row-reference-sync }
 ::: synapseclient.models.PartialRow
+[](){ #partial-row-set-reference-sync }
 ::: synapseclient.models.PartialRowSet
+[](){ #table-schema-change-request-reference-sync }
 ::: synapseclient.models.TableSchemaChangeRequest
+[](){ #appendable-row-set-request-reference-sync }
 ::: synapseclient.models.AppendableRowSetRequest
+[](){ #upload-to-table-request-reference-sync }
 ::: synapseclient.models.UploadToTableRequest
+[](){ #table-update-transaction-reference-sync }
 ::: synapseclient.models.TableUpdateTransaction
+[](){ #csv-table-descriptor-reference-sync }
 ::: synapseclient.models.CsvTableDescriptor
+[](){ #csv-to-pandas-df-reference-sync }
 ::: synapseclient.models.mixins.table_components.csv_to_pandas_df

--- a/docs/reference/experimental/sync/team.md
+++ b/docs/reference/experimental/sync/team.md
@@ -1,3 +1,4 @@
+[](){ #team-reference-sync }
 # Team
 
 Contained within this file are experimental interfaces for working with the Synapse Python
@@ -27,4 +28,3 @@ at your own risk.
             - members
             - invite
             - open_invitations
----

--- a/docs/reference/experimental/sync/user_profile.md
+++ b/docs/reference/experimental/sync/user_profile.md
@@ -1,3 +1,4 @@
+[](){ #user-profile-reference-sync }
 # UserProfile
 
 Contained within this file are experimental interfaces for working with the Synapse Python
@@ -15,5 +16,6 @@ at your own risk.
         - from_username
         - is_certified
 ---
+[](){ #user-preference-reference-sync }
 ::: synapseclient.models.UserPreference
 ---

--- a/docs/tutorials/authentication.md
+++ b/docs/tutorials/authentication.md
@@ -1,3 +1,4 @@
+[](){ #tutorial-authentication }
 # Authentication
 
 There are multiple ways one can login to Synapse. We recommend users to choose the method that fits their workflow.

--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -13,6 +13,7 @@ pip install --upgrade synapseclient
 pip show synapseclient
 ```
 
+[](){ #pypi }
 ## Installation Guide For: PyPI Users
 
 The [synapseclient](https://pypi.python.org/pypi/synapseclient/) package is available from PyPI. It can be installed or upgraded with pip. Due to the nature of Python, we highly recommend you set up your python environment with [conda](https://www.anaconda.com/products/distribution) or [pyenv](https://github.com/pyenv/pyenv) and create virtual environments to control your Python dependencies for your work.

--- a/docs/tutorials/python/annotation.md
+++ b/docs/tutorials/python/annotation.md
@@ -122,7 +122,7 @@ files in the synapse web UI. It should look similar to:
 ## References used in this tutorial
 
 - [Annotations][synapseclient.Annotations]
-- [File][synapseclient.File]
+- [File][file-reference-sync]
 - [syn.login][synapseclient.Synapse.login]
 - [syn.findEntityId][synapseclient.Synapse.findEntityId]
 - [syn.getChildren][synapseclient.Synapse.getChildren]

--- a/docs/tutorials/python/dataset.md
+++ b/docs/tutorials/python/dataset.md
@@ -119,8 +119,8 @@ Finally, let's save a snapshot of the dataset. This creates a read-only version 
 </details>
 
 ## References
-- [Dataset](../../reference/experimental/sync/dataset.md)
-- [Column][synapseclient.models.Column]
+- [Dataset][dataset-reference-sync]
+- [Column][column-reference-sync]
 - [syn.login][synapseclient.Synapse.login]
-- [Project](../../reference/experimental/sync/project.md)
+- [Project][project-reference-sync]
 - [query examples](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/web/controller/TableExamples.html)

--- a/docs/tutorials/python/dataset_collection.md
+++ b/docs/tutorials/python/dataset_collection.md
@@ -105,8 +105,8 @@ Finally, let's save a snapshot of the Dataset Collection. This creates a read-on
 </details>
 
 ## References
-- [DatasetCollection](../../reference/experimental/sync/dataset_collection.md)
-- [Dataset](../../reference/experimental/sync/dataset.md)
-- [Project](../../reference/experimental/sync/project.md)
-- [Column][synapseclient.models.Column]
+- [DatasetCollection][dataset-collection-reference-sync]
+- [Dataset][dataset-reference-sync]
+- [Project][project-reference-sync]
+- [Column][column-reference-sync]
 - [syn.login][synapseclient.Synapse.login]

--- a/docs/tutorials/python/download_data_in_bulk.md
+++ b/docs/tutorials/python/download_data_in_bulk.md
@@ -1,3 +1,4 @@
+[](){ #tutorial-downloading-data-in-bulk }
 # Downloading data in bulk
 Contained within this tutorial is an experimental interface for working with the
 Synapse Python Client. These interfaces are subject to change at any time.

--- a/docs/tutorials/python/entityview.md
+++ b/docs/tutorials/python/entityview.md
@@ -134,8 +134,8 @@ Synapse web UI. It should look similar to:
 
 ## References used in this tutorial
 
-- [EntityView](../../reference/experimental/sync/entityview.md)
-- [Column][synapseclient.models.Column]
+- [EntityView][entityview-reference-sync]
+- [Column][column-reference-sync]
 - [syn.login][synapseclient.Synapse.login]
-- [Project](../../reference/experimental/sync/project.md)
+- [Project][project-reference-sync]
 - [query examples](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/web/controller/TableExamples.html)

--- a/docs/tutorials/python/file.md
+++ b/docs/tutorials/python/file.md
@@ -139,7 +139,7 @@ Now that you have created your files you'll be able to inspect this on the Files
 
 ## References used in this tutorial
 
-- [File][synapseclient.File]
+- [File][file-reference-sync]
 - [syn.login][synapseclient.Synapse.login]
 - [syn.findEntityId][synapseclient.Synapse.findEntityId]
 - [syn.store][synapseclient.Synapse.store]

--- a/docs/tutorials/python/folder.md
+++ b/docs/tutorials/python/folder.md
@@ -100,7 +100,7 @@ Now that you have created your folders you'll be able to inspect this on the Fil
 
 ## References used in this tutorial
 
-- [Folder][synapseclient.Folder]
+- [Folder][folder-reference-sync]
 - [syn.login][synapseclient.Synapse.login]
 - [syn.findEntityId][synapseclient.Synapse.findEntityId]
 - [syn.store][synapseclient.Synapse.store]

--- a/docs/tutorials/python/materializedview.md
+++ b/docs/tutorials/python/materializedview.md
@@ -165,8 +165,8 @@ Results from the materialized view with UNION:
 </details>
 
 ## References
-- [MaterializedView][synapseclient.models.MaterializedView]
-- [Column][synapseclient.models.Column]
-- [Project][synapseclient.models.Project]
+- [MaterializedView][materializedview-reference-sync]
+- [Column][column-reference-sync]
+- [Project][project-reference-sync]
 - [syn.login][synapseclient.Synapse.login]
 - [query examples](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/web/controller/TableExamples.html)

--- a/docs/tutorials/python/project.md
+++ b/docs/tutorials/python/project.md
@@ -96,7 +96,7 @@ I just got my project: My uniquely named project about Alzheimer's Disease, id: 
 
 ## References used in this tutorial
 
-- [Project][synapseclient.Project]
+- [Project][project-reference-sync]
 - [syn.login][synapseclient.Synapse.login]
 - [syn.store][synapseclient.Synapse.store]
 - [syn.get][synapseclient.Synapse.get]

--- a/docs/tutorials/python/submissionview.md
+++ b/docs/tutorials/python/submissionview.md
@@ -125,7 +125,7 @@ time the snapshot was created. This is useful for historical analysis or auditin
 </details>
 
 ## References
-- [SubmissionView][synapseclient.models.SubmissionView]
+- [SubmissionView][submissionview-reference-sync]
 - [Evaluation][synapseclient.evaluation]
 - [syn.submit][synapseclient.Synapse.submit]
 - [syn.getSubmissionStatus][synapseclient.Synapse.getSubmissionStatus]
@@ -133,7 +133,7 @@ time the snapshot was created. This is useful for historical analysis or auditin
 - [syn.getSubmissions][synapseclient.Synapse.getSubmissions]
 - [syn.getSubmissionBundles][synapseclient.Synapse.getSubmissionBundles]
 - [syn.store][synapseclient.Synapse.store]
-- [Column][synapseclient.models.Column]
-- [Project][synapseclient.models.Project]
+- [Column][column-reference-sync]
+- [Project][project-reference-sync]
 - [syn.login][synapseclient.Synapse.login]
 - [query examples](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/web/controller/TableExamples.html)

--- a/docs/tutorials/python_client.md
+++ b/docs/tutorials/python_client.md
@@ -1,3 +1,5 @@
+[](){ #tutorials-home }
+
 # Working with the Python client
 
 Welcome to the Synapse Python client! In the following tutorials you'll create a

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -184,7 +184,8 @@ plugins:
             show_signature_annotations: True
             signature_crossrefs: True
 
-  - autorefs
+  - autorefs:
+      resolve_closest: True
   - termynal:
       prompt_literal_start:
         - "$"
@@ -216,3 +217,4 @@ markdown_extensions:
 
   - toc:
       permalink: true
+  - attr_list


### PR DESCRIPTION
# **Problem:**

- The links from the tutorial pages were getting sent to the first link that was found (Which was the `async` documentation). The preference in this context is to instead send users to the `sync` documentation.

See "References" section https://python-docs.synapse.org/en/latest/tutorials/python/materializedview/#references where `MaterializedView` links to https://python-docs.synapse.org/en/latest/reference/experimental/async/materializedview/#synapseclient.models.MaterializedView instead of the expected https://python-docs.synapse.org/en/latest/reference/experimental/sync/materializedview/#synapseclient.models.MaterializedView

# **Solution:**

Using https://github.com/mkdocstrings/autorefs?tab=readme-ov-file#markdown-anchors to accomplish the task

- Updated manifest_tsv.md to improve table formatting for required, common, activity/provenance, and optional fields.
- Revised news.md to correct tutorial links
- Added reference anchors in async API documentation for activity, agent, dataset, dataset collection, entity view, file, folder, materialized view, project, submission view, table, team, and user profile.
- Updated tutorial documentation to include new reference links for datasets, dataset collections, entity views, files, folders, materialized views, projects, and submission views.
- Enhanced the Python client tutorial with a new home anchor for easier navigation.
- Configured mkdocs.yml to enable attribute lists in markdown for better documentation structure.

# **Testing:**

- I ran mkdocs locally `mkdocs serve` and checked that the links were forwarding as expected

Check out the changes here: https://synapsepythonclient--1196.org.readthedocs.build/en/1196/tutorials/python/materializedview/#references
