### PR TITLE
[SYNPY-1244] Add delete permissions/acl functionality

### DIFF
--- a/docs/reference/experimental/async/dataset.md
+++ b/docs/reference/experimental/async/dataset.md
@@ -24,9 +24,10 @@ at your own risk.
             - delete_column
             - reorder_column
             - rename_column
-            - get_permissions
-            - get_acl
-            - set_permissions
+            - get_permissions_async
+            - get_acl_async
+            - set_permissions_async
+            - delete_permissions_async
 ---
 [](){ #entity-ref-reference-async }
 ::: synapseclient.models.EntityRef

--- a/docs/reference/experimental/async/dataset_collection.md
+++ b/docs/reference/experimental/async/dataset_collection.md
@@ -24,9 +24,10 @@ at your own risk.
             - delete_column
             - reorder_column
             - rename_column
-            - get_permissions
-            - get_acl
-            - set_permissions
+            - get_permissions_async
+            - get_acl_async
+            - set_permissions_async
+            - delete_permissions_async
 ---
 [](){ #entity-ref-dataset-collection-reference-async }
 ::: synapseclient.models.EntityRef

--- a/docs/reference/experimental/async/entityview.md
+++ b/docs/reference/experimental/async/entityview.md
@@ -24,6 +24,7 @@ at your own risk.
             - get_acl_async
             - get_permissions_async
             - set_permissions_async
+            - delete_permissions_async
 ---
 
 [](){ #view-type-mask-reference }

--- a/docs/reference/experimental/async/file.md
+++ b/docs/reference/experimental/async/file.md
@@ -21,6 +21,7 @@ at your own risk.
         - get_permissions_async
         - get_acl_async
         - set_permissions_async
+        - delete_permissions_async
 ---
 [](){ #filehandle-reference-async }
 ::: synapseclient.models.file.FileHandle

--- a/docs/reference/experimental/async/folder.md
+++ b/docs/reference/experimental/async/folder.md
@@ -18,3 +18,4 @@ at your own risk.
         - get_permissions_async
         - get_acl_async
         - set_permissions_async
+        - delete_permissions_async

--- a/docs/reference/experimental/async/materializedview.md
+++ b/docs/reference/experimental/async/materializedview.md
@@ -15,6 +15,7 @@ at your own risk.
             - delete_async
             - query_async
             - query_part_mask_async
-            - get_permissions
-            - get_acl
-            - set_permissions
+            - get_permissions_async
+            - get_acl_async
+            - set_permissions_async
+            - delete_permissions_async

--- a/docs/reference/experimental/async/project.md
+++ b/docs/reference/experimental/async/project.md
@@ -17,3 +17,4 @@ at your own risk.
         - get_permissions_async
         - get_acl_async
         - set_permissions_async
+        - delete_permissions_async

--- a/docs/reference/experimental/async/table.md
+++ b/docs/reference/experimental/async/table.md
@@ -23,9 +23,10 @@ at your own risk.
         - delete_column
         - add_column
         - reorder_column
-        - get_permissions
-        - get_acl
-        - set_permissions
+        - get_permissions_async
+        - get_acl_async
+        - set_permissions_async
+        - delete_permissions_async
 
 [](){ #column-reference-async }
 ::: synapseclient.models.Column

--- a/docs/reference/experimental/async/virtualtable.md
+++ b/docs/reference/experimental/async/virtualtable.md
@@ -15,6 +15,7 @@ at your own risk.
             - delete_async
             - query_async
             - query_part_mask_async
-            - get_permissions
-            - get_acl
-            - set_permissions
+            - get_permissions_async
+            - get_acl_async
+            - set_permissions_async
+            - delete_permissions_async

--- a/docs/reference/experimental/sync/dataset.md
+++ b/docs/reference/experimental/sync/dataset.md
@@ -27,6 +27,7 @@ at your own risk.
             - get_permissions
             - get_acl
             - set_permissions
+            - delete_permissions
 ---
 [](){ #entity-ref-reference-sync }
 ::: synapseclient.models.EntityRef

--- a/docs/reference/experimental/sync/dataset_collection.md
+++ b/docs/reference/experimental/sync/dataset_collection.md
@@ -27,6 +27,7 @@ at your own risk.
             - get_permissions
             - get_acl
             - set_permissions
+            - delete_permissions
 ---
 [](){ #entity-ref-dataset-collection-reference-sync }
 ::: synapseclient.models.EntityRef

--- a/docs/reference/experimental/sync/entityview.md
+++ b/docs/reference/experimental/sync/entityview.md
@@ -24,6 +24,7 @@ at your own risk.
             - get_acl
             - get_permissions
             - set_permissions
+            - delete_permissions
 ---
 
 [](){ #view-type-mask-reference-sync }

--- a/docs/reference/experimental/sync/file.md
+++ b/docs/reference/experimental/sync/file.md
@@ -31,6 +31,7 @@ at your own risk.
         - get_permissions
         - get_acl
         - set_permissions
+        - delete_permissions
 ---
 [](){ #filehandle-reference-sync }
 ::: synapseclient.models.file.FileHandle

--- a/docs/reference/experimental/sync/folder.md
+++ b/docs/reference/experimental/sync/folder.md
@@ -29,3 +29,4 @@ at your own risk.
         - get_permissions
         - get_acl
         - set_permissions
+        - delete_permissions

--- a/docs/reference/experimental/sync/materializedview.md
+++ b/docs/reference/experimental/sync/materializedview.md
@@ -19,3 +19,4 @@ at your own risk.
             - get_permissions
             - get_acl
             - set_permissions
+            - delete_permissions

--- a/docs/reference/experimental/sync/project.md
+++ b/docs/reference/experimental/sync/project.md
@@ -28,3 +28,4 @@ at your own risk.
         - get_permissions
         - get_acl
         - set_permissions
+        - delete_permissions

--- a/docs/reference/experimental/sync/submissionview.md
+++ b/docs/reference/experimental/sync/submissionview.md
@@ -23,3 +23,4 @@ at your own risk.
             - get_acl
             - get_permissions
             - set_permissions
+            - delete_permissions

--- a/docs/reference/experimental/sync/table.md
+++ b/docs/reference/experimental/sync/table.md
@@ -37,6 +37,7 @@ at your own risk.
         - get_permissions
         - get_acl
         - set_permissions
+        - delete_permissions
 
 [](){ #column-reference-sync }
 ::: synapseclient.models.Column

--- a/docs/reference/experimental/sync/virtualtable.md
+++ b/docs/reference/experimental/sync/virtualtable.md
@@ -18,3 +18,4 @@ at your own risk.
             - get_permissions
             - get_acl
             - set_permissions
+            - delete_permissions

--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -25,6 +25,7 @@ from .entity_factory import get_from_entity_factory
 from .entity_services import (
     create_access_requirements_if_none,
     delete_entity,
+    delete_entity_acl,
     delete_entity_generated_by,
     get_entities_by_md5,
     get_entity,
@@ -81,6 +82,7 @@ __all__ = [
     "put_entity",
     "post_entity",
     "delete_entity",
+    "delete_entity_acl",
     "get_upload_destination",
     "get_upload_destination_location",
     "create_access_requirements_if_none",

--- a/synapseclient/api/entity_services.py
+++ b/synapseclient/api/entity_services.py
@@ -291,6 +291,60 @@ async def delete_entity(
         )
 
 
+async def delete_entity_acl(
+    entity_id: str,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> None:
+    """
+    Delete the Access Control List (ACL) for a given Entity.
+
+    By default, Entities such as FileEntity and Folder inherit their permission from
+    their containing Project. For such Entities the Project is the Entity's 'benefactor'.
+    This permission inheritance can be overridden by creating an ACL for the Entity.
+    When this occurs the Entity becomes its own benefactor and all permission are
+    determined by its own ACL.
+
+    If the ACL of an Entity is deleted, then its benefactor will automatically be set
+    to its parent's benefactor. The ACL for a Project cannot be deleted.
+
+    Note: The caller must be granted ACCESS_TYPE.CHANGE_PERMISSIONS on the Entity to
+    call this method.
+
+    Arguments:
+        entity_id: The ID of the entity that should have its ACL deleted.
+        synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+    Example: Delete the ACL for entity `syn123`:
+        This will delete the ACL for the entity, making it inherit permissions from
+        its parent.
+
+        ```python
+        import asyncio
+        from synapseclient import Synapse
+        from synapseclient.api import delete_entity_acl
+
+        syn = Synapse()
+        syn.login()
+
+        async def main():
+            await delete_entity_acl(entity_id="syn123")
+
+        asyncio.run(main())
+        ```
+
+    Returns: None
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_delete_async(
+        uri=f"/entity/{entity_id}/acl",
+    )
+
+
 async def get_entity_path(
     entity_id: str,
     *,

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -2725,7 +2725,7 @@ class Synapse(object):
 
         Arguments:
             parent: An id or an object of a Synapse container or None to retrieve all projects
-            includeTypes: Must be a list of entity types (ie. ["folder","file"]) which can be found [here](http://docs.synapse.org/rest/org/sagebionetworks/repo/model/EntityType.html)
+            includeTypes: Must be a list of entity types (ie. ["folder","file"]) which can be found [here](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/EntityType.html)
             sortBy: How results should be sorted. Can be NAME, or CREATED_ON
             sortDirection: The direction of the result sort. Can be ASC, or DESC
 
@@ -2795,12 +2795,19 @@ class Synapse(object):
 
         return entity
 
-    def _getACL(self, entity: Union[Entity, str]) -> Dict[str, Union[str, list]]:
+    def _getACL(
+        self, entity: Union[Entity, str], check_benefactor: bool = True
+    ) -> Dict[str, Union[str, list]]:
         """
         Get the effective Access Control Lists (ACL) for a Synapse Entity.
 
         Arguments:
             entity: A Synapse Entity or Synapse ID
+            check_benefactor: If True (default), check the benefactor for the entity
+                to get the ACL. If False, only check the entity itself.
+                This is useful for checking the ACL of an entity that has local sharing
+                settings, but you want to check the ACL of the entity itself and not
+                the benefactor it may inherit from.
 
         Returns:
             A dictionary of the Entity's ACL
@@ -2808,11 +2815,28 @@ class Synapse(object):
         if hasattr(entity, "getACLURI"):
             uri = entity.getACLURI()
         else:
-            # Get the ACL from the benefactor (which may be the entity itself)
-            benefactor = self._getBenefactor(entity)
-            trace.get_current_span().set_attributes({"synapse.id": benefactor["id"]})
-            uri = "/entity/%s/acl" % (benefactor["id"])
-        return self.restGET(uri)
+            if check_benefactor:
+                # Get the ACL from the benefactor (which may be the entity itself)
+                benefactor = self._getBenefactor(entity)
+                trace.get_current_span().set_attributes(
+                    {"synapse.id": benefactor["id"]}
+                )
+                uri = "/entity/%s/acl" % (benefactor["id"])
+                return self.restGET(uri)
+            else:
+                synid, _ = utils.get_synid_and_version(entity)
+                trace.get_current_span().set_attributes({"synapse.id": synid})
+                uri = "/entity/%s/acl" % (synid)
+                try:
+                    return self.restGET(uri)
+                except SynapseHTTPError as e:
+                    if (
+                        "The requested ACL does not exist. This entity inherits its permissions from:"
+                        in str(e)
+                    ):
+                        # If the entity does not have an ACL, return an empty ACL
+                        return {"resourceAccess": []}
+                    raise e
 
     def _storeACL(
         self, entity: Union[Entity, str], acl: Dict[str, Union[str, list]]
@@ -2889,6 +2913,7 @@ class Synapse(object):
         self,
         entity: Union[Entity, Evaluation, str, collections.abc.Mapping],
         principal_id: str = None,
+        check_benefactor: bool = True,
     ) -> typing.List[str]:
         """
         Get the [ACL](https://rest-docs.synapse.org/rest/org/
@@ -2898,6 +2923,11 @@ class Synapse(object):
         Arguments:
             entity:      An Entity or Synapse ID to lookup
             principal_id: Identifier of a user or group (defaults to PUBLIC users)
+            check_benefactor: If True (default), check the benefactor for the entity
+                to get the ACL. If False, only check the entity itself.
+                This is useful for checking the ACL of an entity that has local sharing
+                settings, but you want to check the ACL of the entity itself and not
+                the benefactor it may inherit from.
 
         Returns:
             An array containing some combination of
@@ -2912,7 +2942,7 @@ class Synapse(object):
             {"synapse.id": id_of(entity), "synapse.principal_id": principal_id}
         )
 
-        acl = self._getACL(entity)
+        acl = self._getACL(entity=entity, check_benefactor=check_benefactor)
 
         team_list = self._find_teams_for_principal(principal_id)
         team_ids = [int(team.id) for team in team_list]

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -2814,6 +2814,7 @@ class Synapse(object):
         """
         if hasattr(entity, "getACLURI"):
             uri = entity.getACLURI()
+            return self.restGET(uri)
         else:
             if check_benefactor:
                 # Get the ACL from the benefactor (which may be the entity itself)

--- a/synapseclient/models/mixins/access_control.py
+++ b/synapseclient/models/mixins/access_control.py
@@ -235,7 +235,10 @@ class AccessControllable(AccessControllableSynchronousProtocol):
         determined by its own ACL.
 
         If the ACL of an Entity is deleted, then its benefactor will automatically be set
-        to its parent's benefactor. The ACL for a Project cannot be deleted.
+        to its parent's benefactor.
+
+        **Special notice for Projects:** The ACL for a Project cannot be deleted, you
+        must individually update or revoke the permissions for each user or group.
 
         Arguments:
             include_self: If True (default), delete the ACL of the current entity.
@@ -411,6 +414,9 @@ class AccessControllable(AccessControllableSynchronousProtocol):
             Exception: For any other errors that may occur during deletion.
         """
         if not entity_info["is_target_type"] and entity_info["entity_type"] is not None:
+            client.logger.debug(
+                f"Skipping ACL deletion for entity {self.id} as its type '{entity_info['entity_type']}' does not match the target types."
+            )
             return
 
         try:

--- a/synapseclient/models/mixins/access_control.py
+++ b/synapseclient/models/mixins/access_control.py
@@ -1,8 +1,10 @@
 import asyncio
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from synapseclient import Synapse
+from synapseclient.api import delete_entity_acl
 from synapseclient.core.async_utils import async_to_sync
+from synapseclient.core.exceptions import SynapseHTTPError
 from synapseclient.models.protocols.access_control_protocol import (
     AccessControllableSynchronousProtocol,
 )
@@ -74,14 +76,32 @@ class AccessControllable(AccessControllableSynchronousProtocol):
         )
 
     async def get_acl_async(
-        self, principal_id: int = None, *, synapse_client: Optional[Synapse] = None
+        self,
+        principal_id: int = None,
+        check_benefactor: bool = True,
+        *,
+        synapse_client: Optional[Synapse] = None,
     ) -> List[str]:
         """
         Get the [ACL][synapseclient.core.models.permission.Permissions.access_types]
         that a user or group has on an Entity.
 
+        Note: If the entity does not have local sharing settings, or ACL set directly
+        on it, this will look up the ACL on the benefactor of the entity. The
+        benefactor is the entity that the current entity inherits its permissions from.
+        The benefactor is usually the parent entity, but it can be any ancestor in the
+        hierarchy. For example, a newly created Project will be its own benefactor,
+        while a new FileEntity's benefactor will start off as its containing Project or
+        Folder. If the entity already has local sharing settings, the benefactor would
+        be itself.
+
         Arguments:
             principal_id: Identifier of a user or group (defaults to PUBLIC users)
+            check_benefactor: If True (default), check the benefactor for the entity
+                to get the ACL. If False, only check the entity itself.
+                This is useful for checking the ACL of an entity that has local sharing
+                settings, but you want to check the ACL of the entity itself and not
+                the benefactor it may inherit from.
             synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.
@@ -97,7 +117,9 @@ class AccessControllable(AccessControllableSynchronousProtocol):
         return await loop.run_in_executor(
             None,
             lambda: Synapse.get_client(synapse_client=synapse_client).get_acl(
-                entity=self.id, principal_id=principal_id
+                entity=self.id,
+                principal_id=principal_id,
+                check_benefactor=check_benefactor,
             ),
         )
 
@@ -193,3 +215,359 @@ class AccessControllable(AccessControllableSynchronousProtocol):
                 overwrite=overwrite,
             ),
         )
+
+    async def delete_permissions_async(
+        self,
+        include_self: bool = True,
+        recursive: bool = False,
+        include_container_content: bool = False,
+        target_entity_types: Optional[List[str]] = None,
+        *,
+        synapse_client: Optional[Synapse] = None,
+    ) -> None:
+        """
+        Delete the Access Control List (ACL) for a given Entity.
+
+        By default, Entities such as FileEntity and Folder inherit their permission from
+        their containing Project. For such Entities the Project is the Entity's 'benefactor'.
+        This permission inheritance can be overridden by creating an ACL for the Entity.
+        When this occurs the Entity becomes its own benefactor and all permission are
+        determined by its own ACL.
+
+        If the ACL of an Entity is deleted, then its benefactor will automatically be set
+        to its parent's benefactor. The ACL for a Project cannot be deleted.
+
+        Arguments:
+            include_self: If True (default), delete the ACL of the current entity.
+                If False, skip deleting the ACL of the current entity and only process
+                children if recursive=True or include_container_content=True.
+            recursive: If True and the entity is a container (e.g., Project or Folder),
+                recursively delete ACLs from all child containers and their children.
+                Only works on classes that support the `sync_from_synapse_async` method.
+            include_container_content: If True, delete ACLs from contents directly within
+                containers (files and folders inside Projects/Folders). Defaults to False.
+            target_entity_types: Specify which entity types to process when deleting ACLs.
+                Allowed values are "folder" and "file" (case-insensitive).
+                If None, defaults to ["folder", "file"].
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            None
+
+        Raises:
+            ValueError: If the entity does not have an ID or if an invalid entity type is provided.
+            SynapseHTTPError: If there are permission issues or if the entity already inherits permissions.
+            Exception: For any other errors that may occur during the process.
+
+        Note: The caller must be granted ACCESS_TYPE.CHANGE_PERMISSIONS on the Entity to
+        call this method.
+
+        Example: Delete permissions for a single entity
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import File
+
+            syn = Synapse()
+            syn.login()
+
+            async def main():
+                await File(id="syn123").delete_permissions_async()
+
+            asyncio.run(main())
+            ```
+
+        Example: Delete permissions recursively for a folder and all its children
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import Folder
+
+            syn = Synapse()
+            syn.login()
+
+            async def main():
+                # Delete permissions for this folder and all container entities (folders) within it recursively
+                await Folder(id="syn123").delete_permissions_async(recursive=True)
+
+                # Delete permissions for all entities within this folder, but not the folder itself
+                await Folder(id="syn123").delete_permissions_async(
+                    include_self=False,
+                    include_container_content=True
+                )
+
+                # Delete permissions only for folder entities within this folder recursively
+                await Folder(id="syn123").delete_permissions_async(
+                    recursive=True,
+                    target_entity_types=["folder"]
+                )
+
+                # Delete all permissions in the entire hierarchy
+                await Folder(id="syn123").delete_permissions_async(
+                    recursive=True,
+                    include_container_content=True
+                )
+            asyncio.run(main())
+            ```
+        """
+        if not self.id:
+            raise ValueError("The entity must have an ID to delete permissions.")
+
+        normalized_types = self._normalize_target_entity_types(target_entity_types)
+        client = Synapse.get_client(synapse_client=synapse_client)
+        entity_info = self._get_entity_type_info(normalized_types)
+
+        if include_self:
+            await self._delete_current_entity_acl(client, entity_info)
+
+        should_process_children = recursive or include_container_content
+        if should_process_children and hasattr(self, "sync_from_synapse_async"):
+            synced = await self._sync_container_structure(client)
+            if not synced:
+                return
+
+            if include_container_content:
+                await self._process_container_contents(
+                    client=client, target_entity_types=normalized_types
+                )
+
+            if recursive and hasattr(self, "folders"):
+                await self._process_folders_recursively(
+                    client=client,
+                    target_entity_types=normalized_types,
+                    include_container_content=include_container_content,
+                )
+
+    def _normalize_target_entity_types(
+        self, target_entity_types: Optional[List[str]]
+    ) -> List[str]:
+        """
+        Normalize and validate the target entity types.
+
+        Arguments:
+            target_entity_types: A list of entity types to validate. If None, returns default types.
+
+        Returns:
+            List[str]: A normalized list (lowercase) of valid entity types.
+
+        Raises:
+            ValueError: If any provided entity type is not in the list of valid types.
+        """
+        valid_types = ["folder", "file"]
+
+        if target_entity_types is None:
+            return valid_types
+
+        normalized_types = [t.lower() for t in target_entity_types]
+
+        invalid_types = [t for t in normalized_types if t not in valid_types]
+        if invalid_types:
+            raise ValueError(
+                f"Invalid entity type(s): {', '.join(invalid_types)}. "
+                f"Allowed values are: {', '.join(valid_types)}"
+            )
+
+        return normalized_types
+
+    def _get_entity_type_info(self, target_entity_types: List[str]) -> Dict[str, Any]:
+        """
+        Determine the entity type and if it's in the target types.
+
+        Arguments:
+            target_entity_types: A list of normalized entity types to check against.
+
+        Returns:
+            Dict[str, Any]: A dictionary containing:
+                - 'entity_type': The detected entity type ('folder', 'file', or None)
+                - 'is_target_type': Whether the entity's type is in the target types
+        """
+        is_folder = hasattr(self, "folders")
+        is_file = self.__class__.__name__.lower() == "file"
+
+        entity_type = "folder" if is_folder else "file" if is_file else None
+        is_target_type = entity_type in target_entity_types if entity_type else False
+
+        return {"entity_type": entity_type, "is_target_type": is_target_type}
+
+    async def _delete_current_entity_acl(
+        self, client: Synapse, entity_info: Dict[str, Any]
+    ) -> None:
+        """
+        Delete the ACL for the current entity if it's a target type or has no specific type.
+
+        Arguments:
+            client: The Synapse client instance to use for API calls.
+            entity_info: Dictionary containing entity type information with keys:
+                - 'entity_type': The detected entity type ('folder', 'file', or None)
+                - 'is_target_type': Whether the entity's type is in the target types
+
+        Returns:
+            None
+
+        Raises:
+            SynapseHTTPError: If there are permission issues or if the entity already inherits permissions.
+            Exception: For any other errors that may occur during deletion.
+        """
+        if not entity_info["is_target_type"] and entity_info["entity_type"] is not None:
+            return
+
+        try:
+            await delete_entity_acl(entity_id=self.id, synapse_client=client)
+            client.logger.debug(f"Deleted ACL for entity {self.id}")
+        except SynapseHTTPError as e:
+            if (
+                e.response.status_code == 403
+                and "Resource already inherits its permissions." in e.response.text
+            ):
+                client.logger.debug(
+                    f"Entity {self.id} already inherits permissions from its parent."
+                )
+            else:
+                client.logger.warning(
+                    f"Failed to delete ACL for entity {self.id}: {str(e)}"
+                )
+        except Exception as e:
+            client.logger.warning(
+                f"Failed to delete ACL for entity {self.id}: {str(e)}"
+            )
+
+    async def _sync_container_structure(self, client: Synapse) -> bool:
+        """
+        Sync the container structure from Synapse and return success status.
+
+        Arguments:
+            client: The Synapse client instance to use for API calls.
+
+        Returns:
+            bool: True if synchronization was successful, False otherwise.
+
+        Raises:
+            Exception: For any errors that may occur during synchronization.
+        """
+        try:
+            await self.sync_from_synapse_async(
+                recursive=False, download_file=False, synapse_client=client
+            )
+            return True
+        except Exception as e:
+            client.logger.warning(
+                f"Failed to sync from Synapse for entity {self.id}: {str(e)}. "
+                f"Cannot process children."
+            )
+            return False
+
+    async def _process_container_contents(
+        self, client: Synapse, target_entity_types: List[str]
+    ) -> None:
+        """
+        Process the direct contents of a container entity.
+
+        Arguments:
+            client: The Synapse client instance to use for API calls.
+            target_entity_types: A list of normalized entity types to process.
+            recursive: Whether recursive processing is being applied in the parent call.
+
+        Returns:
+            None
+        """
+        if "file" in target_entity_types and hasattr(self, "files"):
+            await self._process_files(client)
+
+        if "folder" in target_entity_types and hasattr(self, "folders"):
+            await self._process_direct_folders(client)
+
+    async def _process_files(self, client: Synapse) -> None:
+        """
+        Process the files directly within this container.
+
+        Arguments:
+            client: The Synapse client instance to use for API calls.
+
+        Returns:
+            None
+
+        Raises:
+            Exception: For any errors that may occur during processing, which are caught and logged.
+        """
+        for file in getattr(self, "files", []):
+            if hasattr(file, "delete_permissions_async"):
+                try:
+                    await file.delete_permissions_async(
+                        recursive=False,
+                        include_self=True,
+                        target_entity_types=["file"],
+                        synapse_client=client,
+                    )
+                except Exception as e:
+                    client.logger.warning(
+                        f"Failed to delete ACL for file {file.id}: {str(e)}"
+                    )
+
+    async def _process_direct_folders(self, client: Synapse) -> None:
+        """
+        Process folders directly within this container (non-recursively).
+
+        Arguments:
+            client: The Synapse client instance to use for API calls.
+
+        Returns:
+            None
+
+        Raises:
+            Exception: For any errors that may occur during processing, which are caught and logged.
+        """
+        for folder in getattr(self, "folders", []):
+            if hasattr(folder, "delete_permissions_async"):
+                try:
+                    await folder.delete_permissions_async(
+                        include_self=True,
+                        recursive=False,
+                        include_container_content=False,
+                        target_entity_types=["folder"],
+                        synapse_client=client,
+                    )
+                except Exception as e:
+                    client.logger.warning(
+                        f"Failed to delete ACL for folder {folder.id}: {str(e)}"
+                    )
+
+    async def _process_folders_recursively(
+        self,
+        client: Synapse,
+        target_entity_types: List[str],
+        include_container_content: bool,
+    ) -> None:
+        """
+        Process child folders recursively.
+
+        Arguments:
+            client: The Synapse client instance to use for API calls.
+            target_entity_types: A list of normalized entity types to process.
+            include_container_content: Whether to include the content of containers in processing.
+
+        Returns:
+            None
+
+        Raises:
+            Exception: For any errors that may occur during processing, which are caught and logged.
+        """
+        for folder in getattr(self, "folders", []):
+            if hasattr(folder, "delete_permissions_async"):
+                try:
+                    should_delete_folder_acl = (
+                        "folder" in target_entity_types and include_container_content
+                    )
+
+                    await folder.delete_permissions_async(
+                        include_self=should_delete_folder_acl,
+                        recursive=True,
+                        include_container_content=include_container_content,
+                        target_entity_types=target_entity_types,
+                        synapse_client=client,
+                    )
+                except Exception as e:
+                    client.logger.warning(
+                        f"Failed to delete ACL for folder {folder.id}: {str(e)}"
+                    )

--- a/synapseclient/models/protocols/access_control_protocol.py
+++ b/synapseclient/models/protocols/access_control_protocol.py
@@ -183,7 +183,10 @@ class AccessControllableSynchronousProtocol(Protocol):
         determined by its own ACL.
 
         If the ACL of an Entity is deleted, then its benefactor will automatically be set
-        to its parent's benefactor. The ACL for a Project cannot be deleted.
+        to its parent's benefactor.
+
+        **Special notice for Projects:** The ACL for a Project cannot be deleted, you
+        must individually update or revoke the permissions for each user or group.
 
         Arguments:
             include_self: If True (default), delete the ACL of the current entity.

--- a/tests/integration/synapseclient/models/async/test_permissions_async.py
+++ b/tests/integration/synapseclient/models/async/test_permissions_async.py
@@ -1,7 +1,7 @@
 """Integration tests for ACL on several models."""
 
 import uuid
-from typing import Callable, Optional, Type, Union
+from typing import Callable, Dict, List, Optional, Type, Union
 
 import pytest
 
@@ -147,13 +147,13 @@ class TestAcl:
     async def test_get_acl_through_team(
         self, entity_type, project_model: Project, file: File, table: Table
     ) -> None:
-        # GIVEN an entity created with default permissions
+        # GIVEN a team
+        team = await self.create_team()
+
+        # AND an entity created with default permissions
         entity = await self.create_entity(
             entity_type, project_model, file, table, name_suffix="_test_get_acl_team"
         )
-
-        # AND a team
-        team = await self.create_team()
 
         # AND the user that created the entity
         user = await UserProfile().get_async(synapse_client=self.syn)
@@ -186,7 +186,11 @@ class TestAcl:
     async def test_get_acl_through_multiple_teams(
         self, entity_type, project_model: Project, file: File, table: Table
     ) -> None:
-        # GIVEN an entity created with default permissions
+        # GIVEN two teams
+        team_1 = await self.create_team(description=f"{DESCRIPTION_FAKE_TEAM} - 1")
+        team_2 = await self.create_team(description=f"{DESCRIPTION_FAKE_TEAM} - 2")
+
+        # AND an entity created with default permissions
         entity = await self.create_entity(
             entity_type,
             project_model,
@@ -194,10 +198,6 @@ class TestAcl:
             table,
             name_suffix="_test_get_acl_multiple_teams",
         )
-
-        # AND two teams
-        team_1 = await self.create_team(description=f"{DESCRIPTION_FAKE_TEAM} - 1")
-        team_2 = await self.create_team(description=f"{DESCRIPTION_FAKE_TEAM} - 2")
 
         # AND the user that created the entity
         user = await UserProfile().get_async(synapse_client=self.syn)
@@ -418,15 +418,15 @@ class TestPermissionsForCaller:
         assert set(expected_permissions) == set(permissions.access_types)
 
     async def test_get_permissions_through_teams(self) -> None:
-        # GIVEN a project created with default permissions
+        # GIVEN two teams
+        team_1 = await self.create_team(description=f"{DESCRIPTION_FAKE_TEAM} - 1")
+        team_2 = await self.create_team(description=f"{DESCRIPTION_FAKE_TEAM} - 2")
+
+        # AND a project created with default permissions
         project = await Project(
             name=str(uuid.uuid4()) + "_test_get_permissions_through_teams"
         ).store_async()
         self.schedule_for_cleanup(project.id)
-
-        # AND two teams
-        team_1 = await self.create_team(description=f"{DESCRIPTION_FAKE_TEAM} - 1")
-        team_2 = await self.create_team(description=f"{DESCRIPTION_FAKE_TEAM} - 2")
 
         # AND the current user that created the project
         user = await UserProfile().get_async(synapse_client=self.syn)
@@ -516,3 +516,347 @@ class TestPermissionsForCaller:
             "DOWNLOAD",
         ]
         assert set(expected_permissions) == set(permissions.access_types)
+
+
+class TestDeletePermissions:
+    """Test delete_permissions_async functionality across entities."""
+
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    @pytest.fixture(scope="function")
+    def file(self, schedule_for_cleanup: Callable[..., None]) -> File:
+        filename = utils.make_bogus_uuid_file()
+        schedule_for_cleanup(filename)
+        return File(path=filename)
+
+    async def create_folder_structure(
+        self, project_model: Project
+    ) -> Dict[str, Union[Folder, List[Union[Folder, File]]]]:
+        """Create a folder structure for testing permissions.
+
+        Structure:
+        ```
+        Project_model
+        └── top_level_folder
+            ├── file_1
+            ├── file_2
+            └── folder_1
+                ├── sub_folder_1
+                │   └── file_3
+                └── file_4
+        ```
+        """
+        # Create top level folder
+        top_level_folder = await Folder(
+            name=f"top_level_folder_{uuid.uuid4()}"
+        ).store_async(parent=project_model)
+        self.schedule_for_cleanup(top_level_folder.id)
+
+        # Create 2 files in top level folder
+        file_1 = await File(
+            path=utils.make_bogus_uuid_file(), name=f"file_1_{uuid.uuid4()}"
+        ).store_async(parent=top_level_folder)
+        self.schedule_for_cleanup(file_1.id)
+
+        file_2 = await File(
+            path=utils.make_bogus_uuid_file(), name=f"file_2_{uuid.uuid4()}"
+        ).store_async(parent=top_level_folder)
+        self.schedule_for_cleanup(file_2.id)
+
+        # Create folder_1 in top level folder
+        folder_1 = await Folder(name=f"folder_1_{uuid.uuid4()}").store_async(
+            parent=top_level_folder
+        )
+        self.schedule_for_cleanup(folder_1.id)
+
+        # Create sub_folder_1 in folder_1
+        sub_folder_1 = await Folder(name=f"sub_folder_1_{uuid.uuid4()}").store_async(
+            parent=folder_1
+        )
+        self.schedule_for_cleanup(sub_folder_1.id)
+
+        # Create file_3 in sub_folder_1
+        file_3 = await File(
+            path=utils.make_bogus_uuid_file(), name=f"file_3_{uuid.uuid4()}"
+        ).store_async(parent=sub_folder_1)
+        self.schedule_for_cleanup(file_3.id)
+
+        # Create file_4 in folder_1
+        file_4 = await File(
+            path=utils.make_bogus_uuid_file(), name=f"file_4_{uuid.uuid4()}"
+        ).store_async(parent=folder_1)
+        self.schedule_for_cleanup(file_4.id)
+
+        return {
+            "top_level_folder": top_level_folder,
+            "files": [file_1, file_2],
+            "folder_1": folder_1,
+            "sub_folder_1": sub_folder_1,
+            "file_3": file_3,
+            "file_4": file_4,
+        }
+
+    async def _set_custom_permissions(
+        self, entity: Union[File, Folder, Project]
+    ) -> None:
+        """Helper to set custom permissions on an entity so we can verify deletion."""
+        # Set custom permissions for authenticated users
+        await entity.set_permissions_async(
+            principal_id=AUTHENTICATED_USERS, access_type=["READ"]
+        )
+
+        # Verify permissions were set
+        acl = await entity.get_acl_async(principal_id=AUTHENTICATED_USERS)
+        assert "READ" in acl
+
+        return acl
+
+    async def _verify_permissions_deleted(
+        self, entity: Union[File, Folder, Project]
+    ) -> None:
+        """Helper to verify that permissions have been deleted (entity inherits from parent)."""
+
+        acl = await entity.get_acl_async(
+            principal_id=AUTHENTICATED_USERS, check_benefactor=False
+        )
+
+        assert (
+            not acl
+        ), f"Permissions should be deleted, but they still exist on [id: {entity.id}, name: {entity.name}, {entity.__class__}]."
+
+    async def _verify_permissions_not_deleted(
+        self, entity: Union[File, Folder, Project]
+    ) -> None:
+        """Helper to verify that permissions are still set on an entity."""
+        acl = await entity.get_acl_async(
+            principal_id=AUTHENTICATED_USERS, check_benefactor=False
+        )
+        assert "READ" in acl
+        return True
+
+    async def test_delete_permissions_single_file(
+        self, project_model: Project, file: File
+    ) -> None:
+        """Test deleting permissions on a single file."""
+        # GIVEN a file with custom permissions
+        file.name = f"test_file_{uuid.uuid4()}"
+        stored_file = await file.store_async(parent=project_model)
+        self.schedule_for_cleanup(stored_file.id)
+
+        await self._set_custom_permissions(stored_file)
+
+        # WHEN I delete permissions on the file
+        await stored_file.delete_permissions_async()
+
+        # THEN the permissions should be deleted
+        await self._verify_permissions_deleted(stored_file)
+
+    async def test_delete_permissions_single_folder(
+        self, project_model: Project
+    ) -> None:
+        """Test deleting permissions on a single folder."""
+        # GIVEN folder structure with permissions on top level folder
+        folder_structure = await self.create_folder_structure(project_model)
+        top_level_folder = folder_structure["top_level_folder"]
+
+        await self._set_custom_permissions(top_level_folder)
+
+        # WHEN I delete permissions on the folder
+        await top_level_folder.delete_permissions_async()
+
+        # THEN the permissions should be deleted
+        await self._verify_permissions_deleted(top_level_folder)
+
+    async def test_delete_permissions_skip_self(self, project_model: Project) -> None:
+        """Test deleting permissions with include_self=False."""
+        # GIVEN a folder structure with permissions set on the top level folder
+        folder_structure = await self.create_folder_structure(project_model)
+        top_level_folder = folder_structure["top_level_folder"]
+        files = folder_structure["files"]
+
+        # AND custom permissions are set on top level folder and a file
+        await self._set_custom_permissions(top_level_folder)
+        await self._set_custom_permissions(files[0])
+
+        # WHEN I delete permissions with include_self=False and include_container_content=True
+        await top_level_folder.delete_permissions_async(
+            include_self=False, include_container_content=True
+        )
+
+        # THEN the top level folder permissions should remain
+        assert await self._verify_permissions_not_deleted(top_level_folder)
+
+        # AND the file permissions should be deleted
+        await self._verify_permissions_deleted(files[0])
+
+    async def test_delete_permissions_include_container_content(
+        self, project_model: Project
+    ) -> None:
+        """Test deleting permissions with include_container_content=True."""
+        # GIVEN a folder structure with permissions set on top level folder and files
+        folder_structure = await self.create_folder_structure(project_model)
+        top_level_folder = folder_structure["top_level_folder"]
+        files = folder_structure["files"]
+        folder_1 = folder_structure["folder_1"]
+
+        # AND permissions are set on top level folder, files, and folder_1
+        await self._set_custom_permissions(top_level_folder)
+        await self._set_custom_permissions(files[0])
+        await self._set_custom_permissions(folder_1)
+
+        # WHEN I delete permissions with include_container_content=True but recursive=False
+        await top_level_folder.delete_permissions_async(
+            include_self=True, include_container_content=True, recursive=False
+        )
+
+        # THEN the top level folder permissions should be deleted
+        await self._verify_permissions_deleted(top_level_folder)
+
+        # AND the files permissions should be deleted
+        await self._verify_permissions_deleted(files[0])
+
+        # AND the folder_1 permissions should be deleted
+        await self._verify_permissions_deleted(folder_1)
+
+    async def test_delete_permissions_recursive(self, project_model: Project) -> None:
+        """Test deleting permissions recursively."""
+        # GIVEN a folder structure with permissions set throughout
+        folder_structure = await self.create_folder_structure(project_model)
+        top_level_folder = folder_structure["top_level_folder"]
+        folder_1 = folder_structure["folder_1"]
+        file_3 = folder_structure["file_3"]
+
+        # AND permissions are set on top_level_folder, folder_1, and file_3
+        await self._set_custom_permissions(top_level_folder)
+        await self._set_custom_permissions(folder_1)
+        await self._set_custom_permissions(file_3)
+
+        # WHEN I delete permissions recursively but without container content
+        await top_level_folder.delete_permissions_async(
+            recursive=True, include_container_content=False
+        )
+
+        # THEN the top_level_folder permissions should be deleted
+        await self._verify_permissions_deleted(top_level_folder)
+
+        # AND the folder_1 permissions should remain (because include_container_content=False)
+        await self._verify_permissions_not_deleted(folder_1)
+
+        # BUT the file_3 permissions should remain (because include_container_content=False)
+        assert await self._verify_permissions_not_deleted(file_3)
+
+    async def test_delete_permissions_recursive_with_container_content(
+        self, project_model: Project
+    ) -> None:
+        """Test deleting permissions recursively with container content."""
+        # GIVEN a folder structure with permissions set throughout
+        folder_structure = await self.create_folder_structure(project_model)
+        top_level_folder = folder_structure["top_level_folder"]
+        files = folder_structure["files"]
+        folder_1 = folder_structure["folder_1"]
+        file_3 = folder_structure["file_3"]
+
+        # AND permissions are set on top_level_folder, files, folder_1, and file_3
+        await self._set_custom_permissions(top_level_folder)
+        await self._set_custom_permissions(files[0])
+        await self._set_custom_permissions(folder_1)
+        await self._set_custom_permissions(file_3)
+
+        # WHEN I delete permissions recursively with container content
+        await top_level_folder.delete_permissions_async(
+            recursive=True, include_container_content=True
+        )
+
+        # THEN all permissions should be deleted
+        await self._verify_permissions_deleted(top_level_folder)
+        await self._verify_permissions_deleted(files[0])
+        await self._verify_permissions_deleted(folder_1)
+        await self._verify_permissions_deleted(file_3)
+
+    async def test_delete_permissions_target_entity_types_folder_only(
+        self, project_model: Project
+    ) -> None:
+        """Test deleting permissions with target_entity_types=['folder']."""
+        # GIVEN a folder structure with permissions set throughout
+        folder_structure = await self.create_folder_structure(project_model)
+        top_level_folder = folder_structure["top_level_folder"]
+        files = folder_structure["files"]
+        folder_1 = folder_structure["folder_1"]
+        sub_folder_1 = folder_structure["sub_folder_1"]
+
+        # AND permissions are set on top_level_folder, files, folder_1, and sub_folder_1
+        await self._set_custom_permissions(top_level_folder)
+        await self._set_custom_permissions(files[0])
+        await self._set_custom_permissions(folder_1)
+        await self._set_custom_permissions(sub_folder_1)
+
+        # WHEN I delete permissions recursively but only for folder entity types
+        await top_level_folder.delete_permissions_async(
+            recursive=True,
+            include_container_content=True,
+            target_entity_types=["folder"],
+        )
+
+        # THEN folder permissions should be deleted
+        await self._verify_permissions_deleted(top_level_folder)
+        await self._verify_permissions_deleted(folder_1)
+        await self._verify_permissions_deleted(sub_folder_1)
+
+        # BUT file permissions should remain
+        assert await self._verify_permissions_not_deleted(files[0])
+
+    async def test_delete_permissions_target_entity_types_file_only(
+        self, project_model: Project
+    ) -> None:
+        """Test deleting permissions with target_entity_types=['file']."""
+        # GIVEN a folder structure with permissions set throughout
+        folder_structure = await self.create_folder_structure(project_model)
+        top_level_folder = folder_structure["top_level_folder"]
+        files = folder_structure["files"]
+        folder_1 = folder_structure["folder_1"]
+        file_3 = folder_structure["file_3"]
+        file_4 = folder_structure["file_4"]
+
+        # AND permissions are set on top_level_folder, files, folder_1, file_3, and file_4
+        await self._set_custom_permissions(top_level_folder)
+        await self._set_custom_permissions(files[0])
+        await self._set_custom_permissions(folder_1)
+        await self._set_custom_permissions(file_3)
+        await self._set_custom_permissions(file_4)
+
+        # WHEN I delete permissions recursively but only for file entity types
+        await top_level_folder.delete_permissions_async(
+            recursive=True, include_container_content=True, target_entity_types=["file"]
+        )
+
+        # THEN file permissions should be deleted
+        await self._verify_permissions_deleted(files[0])
+        await self._verify_permissions_deleted(file_3)
+        await self._verify_permissions_deleted(file_4)
+
+        # BUT folder permissions should remain
+        assert await self._verify_permissions_not_deleted(top_level_folder)
+        assert await self._verify_permissions_not_deleted(folder_1)
+
+    async def test_delete_permissions_invalid_entity_type(
+        self, project_model: Project
+    ) -> None:
+        """Test deleting permissions with an invalid entity type."""
+        # GIVEN a folder structure
+        folder_structure = await self.create_folder_structure(project_model)
+        top_level_folder = folder_structure["top_level_folder"]
+
+        # WHEN I try to delete permissions with an invalid entity type
+        # THEN it should raise a ValueError
+        with pytest.raises(ValueError) as exc_info:
+            await top_level_folder.delete_permissions_async(
+                target_entity_types=["invalid_type"]
+            )
+
+        # AND the error message should mention allowed values
+        assert "Invalid entity type" in str(exc_info.value)
+        assert "folder" in str(exc_info.value)
+        assert "file" in str(exc_info.value)

--- a/tests/integration/synapseclient/models/async/test_permissions_async.py
+++ b/tests/integration/synapseclient/models/async/test_permissions_async.py
@@ -859,4 +859,23 @@ class TestDeletePermissions:
         # AND the error message should mention allowed values
         assert "Invalid entity type" in str(exc_info.value)
         assert "folder" in str(exc_info.value)
-        assert "file" in str(exc_info.value)
+
+    async def test_delete_permissions_on_new_project(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test deleting permissions on a newly created project."""
+        # GIVEN a newly created project with custom permissions
+        project = await Project(name=f"test_project_{uuid.uuid4()}").store_async()
+        self.schedule_for_cleanup(project.id)
+
+        # AND custom permissions are set for authenticated users
+        await self._set_custom_permissions(project)
+
+        # WHEN I delete permissions on the project
+        await project.delete_permissions_async()
+
+        # THEN the permissions should not be deleted
+        assert (
+            "Cannot restore inheritance for resource which has no parent."
+            in caplog.text
+        )

--- a/tests/integration/synapseclient/models/synchronous/test_permissions.py
+++ b/tests/integration/synapseclient/models/synchronous/test_permissions.py
@@ -1,7 +1,7 @@
 """Integration tests for ACL on several models."""
 
 import uuid
-from typing import Callable, Optional, Type, Union
+from typing import Callable, Dict, List, Optional, Type, Union
 
 import pytest
 
@@ -147,13 +147,13 @@ class TestAcl:
     async def test_get_acl_through_team(
         self, entity_type, project_model: Project, file: File, table: Table
     ) -> None:
-        # GIVEN an entity created with default permissions
+        # GIVEN a team
+        team = await self.create_team()
+
+        # AND an entity created with default permissions
         entity = await self.create_entity(
             entity_type, project_model, file, table, name_suffix="_test_get_acl_team"
         )
-
-        # AND a team
-        team = await self.create_team()
 
         # AND the user that created the entity
         user = UserProfile().get(synapse_client=self.syn)
@@ -186,7 +186,11 @@ class TestAcl:
     async def test_get_acl_through_multiple_teams(
         self, entity_type, project_model: Project, file: File, table: Table
     ) -> None:
-        # GIVEN an entity created with default permissions
+        # GIVEN two teams
+        team_1 = await self.create_team(description=f"{DESCRIPTION_FAKE_TEAM} - 1")
+        team_2 = await self.create_team(description=f"{DESCRIPTION_FAKE_TEAM} - 2")
+
+        # AND an entity created with default permissions
         entity = await self.create_entity(
             entity_type,
             project_model,
@@ -194,10 +198,6 @@ class TestAcl:
             table,
             name_suffix="_test_get_acl_multiple_teams",
         )
-
-        # AND two teams
-        team_1 = await self.create_team(description=f"{DESCRIPTION_FAKE_TEAM} - 1")
-        team_2 = await self.create_team(description=f"{DESCRIPTION_FAKE_TEAM} - 2")
 
         # AND the user that created the entity
         user = UserProfile().get(synapse_client=self.syn)
@@ -416,15 +416,15 @@ class TestPermissionsForCaller:
         assert set(expected_permissions) == set(permissions.access_types)
 
     async def test_get_permissions_through_teams(self) -> None:
-        # GIVEN a project created with default permissions
+        # GIVEN two teams
+        team_1 = await self.create_team(description=f"{DESCRIPTION_FAKE_TEAM} - 1")
+        team_2 = await self.create_team(description=f"{DESCRIPTION_FAKE_TEAM} - 2")
+
+        # AND a project created with default permissions
         project = Project(
             name=str(uuid.uuid4()) + "_test_get_permissions_through_teams"
         ).store()
         self.schedule_for_cleanup(project.id)
-
-        # AND two teams
-        team_1 = await self.create_team(description=f"{DESCRIPTION_FAKE_TEAM} - 1")
-        team_2 = await self.create_team(description=f"{DESCRIPTION_FAKE_TEAM} - 2")
 
         # AND the current user that created the project
         user = UserProfile().get(synapse_client=self.syn)
@@ -514,3 +514,339 @@ class TestPermissionsForCaller:
             "DOWNLOAD",
         ]
         assert set(expected_permissions) == set(permissions.access_types)
+
+
+class TestDeletePermissions:
+    """Test delete_permissions functionality across entities."""
+
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    @pytest.fixture(scope="function")
+    def file(self, schedule_for_cleanup: Callable[..., None]) -> File:
+        filename = utils.make_bogus_uuid_file()
+        schedule_for_cleanup(filename)
+        return File(path=filename)
+
+    async def create_folder_structure(
+        self, project_model: Project
+    ) -> Dict[str, Union[Folder, List[Union[Folder, File]]]]:
+        """Create a folder structure for testing permissions.
+
+        Structure:
+        ```
+        Project_model
+        └── top_level_folder
+            ├── file_1
+            ├── file_2
+            └── folder_1
+                ├── sub_folder_1
+                │   └── file_3
+                └── file_4
+        ```
+        """
+        # Create top level folder
+        top_level_folder = Folder(name=f"top_level_folder_{uuid.uuid4()}").store(
+            parent=project_model
+        )
+        self.schedule_for_cleanup(top_level_folder.id)
+
+        # Create 2 files in top level folder
+        file_1 = File(
+            path=utils.make_bogus_uuid_file(), name=f"file_1_{uuid.uuid4()}"
+        ).store(parent=top_level_folder)
+        self.schedule_for_cleanup(file_1.id)
+
+        file_2 = File(
+            path=utils.make_bogus_uuid_file(), name=f"file_2_{uuid.uuid4()}"
+        ).store(parent=top_level_folder)
+        self.schedule_for_cleanup(file_2.id)
+
+        # Create folder_1 in top level folder
+        folder_1 = Folder(name=f"folder_1_{uuid.uuid4()}").store(
+            parent=top_level_folder
+        )
+        self.schedule_for_cleanup(folder_1.id)
+
+        # Create sub_folder_1 in folder_1
+        sub_folder_1 = Folder(name=f"sub_folder_1_{uuid.uuid4()}").store(
+            parent=folder_1
+        )
+        self.schedule_for_cleanup(sub_folder_1.id)
+
+        # Create file_3 in sub_folder_1
+        file_3 = File(
+            path=utils.make_bogus_uuid_file(), name=f"file_3_{uuid.uuid4()}"
+        ).store(parent=sub_folder_1)
+        self.schedule_for_cleanup(file_3.id)
+
+        # Create file_4 in folder_1
+        file_4 = File(
+            path=utils.make_bogus_uuid_file(), name=f"file_4_{uuid.uuid4()}"
+        ).store(parent=folder_1)
+        self.schedule_for_cleanup(file_4.id)
+
+        return {
+            "top_level_folder": top_level_folder,
+            "files": [file_1, file_2],
+            "folder_1": folder_1,
+            "sub_folder_1": sub_folder_1,
+            "file_3": file_3,
+            "file_4": file_4,
+        }
+
+    async def _set_custom_permissions(
+        self, entity: Union[File, Folder, Project]
+    ) -> None:
+        """Helper to set custom permissions on an entity so we can verify deletion."""
+        # Set custom permissions for authenticated users
+        entity.set_permissions(principal_id=AUTHENTICATED_USERS, access_type=["READ"])
+
+        # Verify permissions were set
+        acl = entity.get_acl(principal_id=AUTHENTICATED_USERS)
+        assert "READ" in acl
+
+        return acl
+
+    async def _verify_permissions_deleted(
+        self, entity: Union[File, Folder, Project]
+    ) -> None:
+        """Helper to verify that permissions have been deleted (entity inherits from parent)."""
+
+        acl = entity.get_acl(principal_id=AUTHENTICATED_USERS, check_benefactor=False)
+
+        assert (
+            not acl
+        ), f"Permissions should be deleted, but they still exist on [id: {entity.id}, name: {entity.name}, {entity.__class__}]."
+
+    async def _verify_permissions_not_deleted(
+        self, entity: Union[File, Folder, Project]
+    ) -> None:
+        """Helper to verify that permissions are still set on an entity."""
+        acl = entity.get_acl(principal_id=AUTHENTICATED_USERS, check_benefactor=False)
+        assert "READ" in acl
+        return True
+
+    async def test_delete_permissions_single_file(
+        self, project_model: Project, file: File
+    ) -> None:
+        """Test deleting permissions on a single file."""
+        # GIVEN a file with custom permissions
+        file.name = f"test_file_{uuid.uuid4()}"
+        stored_file = file.store(parent=project_model)
+        self.schedule_for_cleanup(stored_file.id)
+
+        await self._set_custom_permissions(stored_file)
+
+        # WHEN I delete permissions on the file
+        stored_file.delete_permissions()
+
+        # THEN the permissions should be deleted
+        await self._verify_permissions_deleted(stored_file)
+
+    async def test_delete_permissions_single_folder(
+        self, project_model: Project
+    ) -> None:
+        """Test deleting permissions on a single folder."""
+        # GIVEN folder structure with permissions on top level folder
+        folder_structure = await self.create_folder_structure(project_model)
+        top_level_folder = folder_structure["top_level_folder"]
+
+        await self._set_custom_permissions(top_level_folder)
+
+        # WHEN I delete permissions on the folder
+        top_level_folder.delete_permissions()
+
+        # THEN the permissions should be deleted
+        await self._verify_permissions_deleted(top_level_folder)
+
+    async def test_delete_permissions_skip_self(self, project_model: Project) -> None:
+        """Test deleting permissions with include_self=False."""
+        # GIVEN a folder structure with permissions set on the top level folder
+        folder_structure = await self.create_folder_structure(project_model)
+        top_level_folder = folder_structure["top_level_folder"]
+        files = folder_structure["files"]
+
+        # AND custom permissions are set on top level folder and a file
+        await self._set_custom_permissions(top_level_folder)
+        await self._set_custom_permissions(files[0])
+
+        # WHEN I delete permissions with include_self=False and include_container_content=True
+        top_level_folder.delete_permissions(
+            include_self=False, include_container_content=True
+        )
+
+        # THEN the top level folder permissions should remain
+        assert await self._verify_permissions_not_deleted(top_level_folder)
+
+        # AND the file permissions should be deleted
+        await self._verify_permissions_deleted(files[0])
+
+    async def test_delete_permissions_include_container_content(
+        self, project_model: Project
+    ) -> None:
+        """Test deleting permissions with include_container_content=True."""
+        # GIVEN a folder structure with permissions set on top level folder and files
+        folder_structure = await self.create_folder_structure(project_model)
+        top_level_folder = folder_structure["top_level_folder"]
+        files = folder_structure["files"]
+        folder_1 = folder_structure["folder_1"]
+
+        # AND permissions are set on top level folder, files, and folder_1
+        await self._set_custom_permissions(top_level_folder)
+        await self._set_custom_permissions(files[0])
+        await self._set_custom_permissions(folder_1)
+
+        # WHEN I delete permissions with include_container_content=True but recursive=False
+        top_level_folder.delete_permissions(
+            include_self=True, include_container_content=True, recursive=False
+        )
+
+        # THEN the top level folder permissions should be deleted
+        await self._verify_permissions_deleted(top_level_folder)
+
+        # AND the files permissions should be deleted
+        await self._verify_permissions_deleted(files[0])
+
+        # AND the folder_1 permissions should be deleted
+        await self._verify_permissions_deleted(folder_1)
+
+    async def test_delete_permissions_recursive(self, project_model: Project) -> None:
+        """Test deleting permissions recursively."""
+        # GIVEN a folder structure with permissions set throughout
+        folder_structure = await self.create_folder_structure(project_model)
+        top_level_folder = folder_structure["top_level_folder"]
+        folder_1 = folder_structure["folder_1"]
+        file_3 = folder_structure["file_3"]
+
+        # AND permissions are set on top_level_folder, folder_1, and file_3
+        await self._set_custom_permissions(top_level_folder)
+        await self._set_custom_permissions(folder_1)
+        await self._set_custom_permissions(file_3)
+
+        # WHEN I delete permissions recursively but without container content
+        top_level_folder.delete_permissions(
+            recursive=True, include_container_content=False
+        )
+
+        # THEN the top_level_folder permissions should be deleted
+        await self._verify_permissions_deleted(top_level_folder)
+
+        # AND the folder_1 permissions should remain (because include_container_content=False)
+        await self._verify_permissions_not_deleted(folder_1)
+
+        # BUT the file_3 permissions should remain (because include_container_content=False)
+        assert await self._verify_permissions_not_deleted(file_3)
+
+    async def test_delete_permissions_recursive_with_container_content(
+        self, project_model: Project
+    ) -> None:
+        """Test deleting permissions recursively with container content."""
+        # GIVEN a folder structure with permissions set throughout
+        folder_structure = await self.create_folder_structure(project_model)
+        top_level_folder = folder_structure["top_level_folder"]
+        files = folder_structure["files"]
+        folder_1 = folder_structure["folder_1"]
+        file_3 = folder_structure["file_3"]
+
+        # AND permissions are set on top_level_folder, files, folder_1, and file_3
+        await self._set_custom_permissions(top_level_folder)
+        await self._set_custom_permissions(files[0])
+        await self._set_custom_permissions(folder_1)
+        await self._set_custom_permissions(file_3)
+
+        # WHEN I delete permissions recursively with container content
+        top_level_folder.delete_permissions(
+            recursive=True, include_container_content=True
+        )
+
+        # THEN all permissions should be deleted
+        await self._verify_permissions_deleted(top_level_folder)
+        await self._verify_permissions_deleted(files[0])
+        await self._verify_permissions_deleted(folder_1)
+        await self._verify_permissions_deleted(file_3)
+
+    async def test_delete_permissions_target_entity_types_folder_only(
+        self, project_model: Project
+    ) -> None:
+        """Test deleting permissions with target_entity_types=['folder']."""
+        # GIVEN a folder structure with permissions set throughout
+        folder_structure = await self.create_folder_structure(project_model)
+        top_level_folder = folder_structure["top_level_folder"]
+        files = folder_structure["files"]
+        folder_1 = folder_structure["folder_1"]
+        sub_folder_1 = folder_structure["sub_folder_1"]
+
+        # AND permissions are set on top_level_folder, files, folder_1, and sub_folder_1
+        await self._set_custom_permissions(top_level_folder)
+        await self._set_custom_permissions(files[0])
+        await self._set_custom_permissions(folder_1)
+        await self._set_custom_permissions(sub_folder_1)
+
+        # WHEN I delete permissions recursively but only for folder entity types
+        top_level_folder.delete_permissions(
+            recursive=True,
+            include_container_content=True,
+            target_entity_types=["folder"],
+        )
+
+        # THEN folder permissions should be deleted
+        await self._verify_permissions_deleted(top_level_folder)
+        await self._verify_permissions_deleted(folder_1)
+        await self._verify_permissions_deleted(sub_folder_1)
+
+        # BUT file permissions should remain
+        assert await self._verify_permissions_not_deleted(files[0])
+
+    async def test_delete_permissions_target_entity_types_file_only(
+        self, project_model: Project
+    ) -> None:
+        """Test deleting permissions with target_entity_types=['file']."""
+        # GIVEN a folder structure with permissions set throughout
+        folder_structure = await self.create_folder_structure(project_model)
+        top_level_folder = folder_structure["top_level_folder"]
+        files = folder_structure["files"]
+        folder_1 = folder_structure["folder_1"]
+        file_3 = folder_structure["file_3"]
+        file_4 = folder_structure["file_4"]
+
+        # AND permissions are set on top_level_folder, files, folder_1, file_3, and file_4
+        await self._set_custom_permissions(top_level_folder)
+        await self._set_custom_permissions(files[0])
+        await self._set_custom_permissions(folder_1)
+        await self._set_custom_permissions(file_3)
+        await self._set_custom_permissions(file_4)
+
+        # WHEN I delete permissions recursively but only for file entity types
+        top_level_folder.delete_permissions(
+            recursive=True, include_container_content=True, target_entity_types=["file"]
+        )
+
+        # THEN file permissions should be deleted
+        await self._verify_permissions_deleted(files[0])
+        await self._verify_permissions_deleted(file_3)
+        await self._verify_permissions_deleted(file_4)
+
+        # BUT folder permissions should remain
+        assert await self._verify_permissions_not_deleted(top_level_folder)
+        assert await self._verify_permissions_not_deleted(folder_1)
+
+    async def test_delete_permissions_invalid_entity_type(
+        self, project_model: Project
+    ) -> None:
+        """Test deleting permissions with an invalid entity type."""
+        # GIVEN a folder structure
+        folder_structure = await self.create_folder_structure(project_model)
+        top_level_folder = folder_structure["top_level_folder"]
+
+        # WHEN I try to delete permissions with an invalid entity type
+        # THEN it should raise a ValueError
+        with pytest.raises(ValueError) as exc_info:
+            top_level_folder.delete_permissions(target_entity_types=["invalid_type"])
+
+        # AND the error message should mention allowed values
+        assert "Invalid entity type" in str(exc_info.value)
+        assert "folder" in str(exc_info.value)
+        assert "file" in str(exc_info.value)

--- a/tests/integration/synapseclient/models/synchronous/test_permissions.py
+++ b/tests/integration/synapseclient/models/synchronous/test_permissions.py
@@ -1,5 +1,6 @@
 """Integration tests for ACL on several models."""
 
+import logging
 import uuid
 from typing import Callable, Dict, List, Optional, Type, Union
 
@@ -855,6 +856,9 @@ class TestDeletePermissions:
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Test deleting permissions on a newly created project."""
+        # Set the log level to capture DEBUG messages
+        caplog.set_level(logging.DEBUG)
+
         # GIVEN a newly created project with custom permissions
         project = await Project(name=f"test_project_{uuid.uuid4()}").store_async()
         self.schedule_for_cleanup(project.id)
@@ -863,10 +867,17 @@ class TestDeletePermissions:
         await self._set_custom_permissions(project)
 
         # WHEN I delete permissions on the project
-        await project.delete_permissions()
+        project.delete_permissions()
 
         # THEN the permissions should not be deleted
-        assert (
+        # Check either for the log message or verify the permissions still exist
+        if (
             "Cannot restore inheritance for resource which has no parent."
             in caplog.text
-        )
+        ):
+            # Original assertion passes if the log is captured
+            assert True
+        else:
+            # Alternatively, verify that the permissions weren't actually deleted
+            # by checking if they still exist
+            assert await self._verify_permissions_not_deleted(project)

--- a/tests/integration/synapseclient/models/synchronous/test_permissions.py
+++ b/tests/integration/synapseclient/models/synchronous/test_permissions.py
@@ -850,3 +850,23 @@ class TestDeletePermissions:
         assert "Invalid entity type" in str(exc_info.value)
         assert "folder" in str(exc_info.value)
         assert "file" in str(exc_info.value)
+
+    async def test_delete_permissions_on_new_project(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test deleting permissions on a newly created project."""
+        # GIVEN a newly created project with custom permissions
+        project = await Project(name=f"test_project_{uuid.uuid4()}").store_async()
+        self.schedule_for_cleanup(project.id)
+
+        # AND custom permissions are set for authenticated users
+        await self._set_custom_permissions(project)
+
+        # WHEN I delete permissions on the project
+        await project.delete_permissions()
+
+        # THEN the permissions should not be deleted
+        assert (
+            "Cannot restore inheritance for resource which has no parent."
+            in caplog.text
+        )

--- a/tests/unit/synapseclient/models/async/unit_test_permissions_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_permissions_async.py
@@ -1,0 +1,301 @@
+"""Unit tests for permissions-related functionality in the AccessControllable mixin."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from synapseclient import Synapse
+from synapseclient.core.exceptions import SynapseHTTPError
+from synapseclient.models import File, Folder
+
+
+class TestDeletePermissionsAsync:
+    """Unit tests for delete_permissions_async method in AccessControllable."""
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.synapse_client = MagicMock(spec=Synapse)
+        self.synapse_client.logger = MagicMock()
+
+        # Mock the Synapse.get_client to return our mock client
+        self.get_client_patcher = patch(
+            "synapseclient.models.mixins.access_control.Synapse.get_client"
+        )
+        self.mock_get_client = self.get_client_patcher.start()
+        self.mock_get_client.return_value = self.synapse_client
+
+        # Mock delete_entity_acl
+        self.delete_acl_patcher = patch(
+            "synapseclient.models.mixins.access_control.delete_entity_acl"
+        )
+        self.mock_delete_acl = self.delete_acl_patcher.start()
+        self.mock_delete_acl.return_value = None
+
+        yield
+
+        # Clean up patchers
+        self.get_client_patcher.stop()
+        self.delete_acl_patcher.stop()
+
+    async def test_delete_permissions_no_id(self):
+        """Test that attempting to delete permissions without an ID raises an error."""
+        # GIVEN a file with no ID
+        file = File()
+
+        # WHEN attempting to delete permissions
+        # THEN a ValueError should be raised
+        with pytest.raises(
+            ValueError, match="The entity must have an ID to delete permissions."
+        ):
+            await file.delete_permissions_async()
+
+    async def test_delete_permissions_invalid_entity_type(self):
+        """Test that providing an invalid entity type raises a ValueError."""
+        # GIVEN a file with an ID
+        file = File(id="syn123")
+
+        # WHEN attempting to delete permissions with an invalid entity type
+        # THEN a ValueError should be raised
+        with pytest.raises(ValueError, match="Invalid entity type"):
+            await file.delete_permissions_async(target_entity_types=["invalid_type"])
+
+    async def test_delete_permissions_already_inherits(self):
+        """Test handling of 403 error when entity already inherits permissions."""
+        # GIVEN a file with an ID
+        file = File(id="syn123")
+
+        # AND a mock HTTP error for already inheriting permissions
+        error_response = MagicMock()
+        error_response.status_code = 403
+        error_response.text = "Resource already inherits its permissions."
+
+        # Create SynapseHTTPError with a message string, not with keyword arguments
+        http_error = SynapseHTTPError(
+            "403 error: Resource already inherits its permissions."
+        )
+        http_error.response = (
+            error_response  # Set the response attribute after creation
+        )
+        self.mock_delete_acl.side_effect = http_error
+
+        # WHEN deleting permissions
+        await file.delete_permissions_async()
+
+        # THEN the delete_entity_acl function should be called
+        self.mock_delete_acl.assert_called_once_with(
+            entity_id="syn123", synapse_client=self.synapse_client
+        )
+
+        # AND a debug log message should be generated
+        self.synapse_client.logger.debug.assert_called_once()
+
+    async def test_delete_permissions_other_http_error(self):
+        """Test handling of other HTTP errors during deletion."""
+        # GIVEN a file with an ID
+        file = File(id="syn123")
+
+        # AND a mock HTTP error for other permission issues
+        error_response = MagicMock()
+        error_response.status_code = 403
+        error_response.text = "Permission denied"
+
+        # Create SynapseHTTPError with a message string, not with keyword arguments
+        http_error = SynapseHTTPError("403 error: Permission denied")
+        http_error.response = (
+            error_response  # Set the response attribute after creation
+        )
+        self.mock_delete_acl.side_effect = http_error
+
+        # WHEN deleting permissions
+        await file.delete_permissions_async()
+
+        # THEN the delete_entity_acl function should be called
+        self.mock_delete_acl.assert_called_once_with(
+            entity_id="syn123", synapse_client=self.synapse_client
+        )
+
+        # AND a warning log message should be generated
+        self.synapse_client.logger.warning.assert_called_once()
+
+    async def test_delete_permissions_skip_self(self):
+        """Test that when include_self=False, the entity's ACL is not deleted."""
+        # GIVEN a file with an ID
+        file = File(id="syn123")
+
+        # WHEN deleting permissions with include_self=False
+        await file.delete_permissions_async(include_self=False)
+
+        # THEN the delete_entity_acl function should not be called
+        self.mock_delete_acl.assert_not_called()
+
+    async def test_delete_permissions_folder_recursive(self):
+        """Test recursive deletion on a folder structure."""
+        # GIVEN a folder with an ID and mocked sync_from_synapse_async method
+        folder = Folder(id="syn123")
+        folder.sync_from_synapse_async = AsyncMock()
+
+        # AND mocked child folders and files
+        child_folder = Folder(id="syn456")
+        child_folder.delete_permissions_async = AsyncMock()
+
+        child_file = File(id="syn789")
+        child_file.delete_permissions_async = AsyncMock()
+
+        # Set up the folder structure
+        folder.folders = [child_folder]
+        folder.files = [child_file]
+
+        # WHEN deleting permissions recursively
+        await folder.delete_permissions_async(
+            recursive=True, include_container_content=True
+        )
+
+        # THEN sync_from_synapse_async should be called
+        folder.sync_from_synapse_async.assert_called_once()
+
+        # AND delete_permissions_async should be called on child folder and file
+        # We use assert_called instead of assert_called_once because the mock may be called multiple times
+        # due to the recursive nature of the delete_permissions_async method
+        assert child_folder.delete_permissions_async.called
+        assert child_file.delete_permissions_async.called
+
+        # AND delete_entity_acl should be called on the folder itself
+        self.mock_delete_acl.assert_called_once_with(
+            entity_id="syn123", synapse_client=self.synapse_client
+        )
+
+    async def test_sync_failure_doesnt_process_children(self):
+        """Test that sync failure prevents processing children."""
+        # GIVEN a folder with an ID and mocked sync_from_synapse_async method that fails
+        folder = Folder(id="syn123")
+        folder.sync_from_synapse_async = AsyncMock(side_effect=Exception("Sync failed"))
+
+        # WHEN deleting permissions recursively
+        await folder.delete_permissions_async(recursive=True)
+
+        # THEN sync_from_synapse_async should be called
+        folder.sync_from_synapse_async.assert_called_once()
+
+        # AND delete_entity_acl should be called on the folder itself
+        self.mock_delete_acl.assert_called_once()
+
+        # AND a warning log message should be generated
+        self.synapse_client.logger.warning.assert_called_once()
+
+    async def test_filter_by_entity_type_folder(self):
+        """Test filtering deletion by folder entity type."""
+        # GIVEN a folder with an ID and child folder and file
+        folder = Folder(id="syn123")
+        folder.sync_from_synapse_async = AsyncMock()
+
+        child_folder = Folder(id="syn456")
+        child_folder.delete_permissions_async = AsyncMock()
+
+        child_file = File(id="syn789")
+        child_file.delete_permissions_async = AsyncMock()
+
+        # Set up the folder structure
+        folder.folders = [child_folder]
+        folder.files = [child_file]
+
+        # WHEN deleting permissions filtered by folder type
+        await folder.delete_permissions_async(
+            recursive=True,
+            include_container_content=True,
+            target_entity_types=["folder"],
+        )
+
+        # THEN sync_from_synapse_async should be called
+        folder.sync_from_synapse_async.assert_called_once()
+
+        # AND delete_permissions_async should be called on child folder
+        # We use assert_called instead of assert_called_once because the mock may be called multiple times
+        assert child_folder.delete_permissions_async.called
+
+        # AND delete_permissions_async should NOT be called on child file
+        child_file.delete_permissions_async.assert_not_called()
+
+        # AND delete_entity_acl should be called on the folder itself
+        self.mock_delete_acl.assert_called_once()
+
+    async def test_filter_by_entity_type_file(self):
+        """Test filtering deletion by file entity type."""
+        # GIVEN a folder with an ID and child folder and file
+        folder = Folder(id="syn123")
+        folder.sync_from_synapse_async = AsyncMock()
+
+        child_folder = Folder(id="syn456")
+        child_folder.delete_permissions_async = AsyncMock()
+
+        child_file = File(id="syn789")
+        child_file.delete_permissions_async = AsyncMock()
+
+        # Set up the folder structure
+        folder.folders = [child_folder]
+        folder.files = [child_file]
+
+        # WHEN deleting permissions filtered by file type
+        await folder.delete_permissions_async(
+            recursive=True, include_container_content=True, target_entity_types=["file"]
+        )
+
+        # THEN sync_from_synapse_async should be called
+        folder.sync_from_synapse_async.assert_called_once()
+
+        # AND delete_permissions_async should NOT be called on child folder for deletion
+        # but will be called for recursion with include_self=False
+        args, kwargs = child_folder.delete_permissions_async.call_args
+        assert kwargs.get("include_self") is False
+
+        # AND delete_permissions_async should be called on child file
+        child_file.delete_permissions_async.assert_called_once()
+
+        # AND delete_entity_acl should NOT be called on the folder itself
+        # because it's not a file
+        self.mock_delete_acl.assert_not_called()
+
+    async def test_case_insensitive_entity_types(self):
+        """Test that entity type matching is case-insensitive."""
+        # GIVEN a folder with an ID
+        folder = Folder(id="syn123")
+
+        # WHEN deleting permissions with mixed-case entity types
+        await folder.delete_permissions_async(target_entity_types=["FoLdEr"])
+
+        # THEN delete_entity_acl should be called
+        self.mock_delete_acl.assert_called_once_with(
+            entity_id="syn123", synapse_client=self.synapse_client
+        )
+
+    async def test_multiple_entity_types(self):
+        """Test handling multiple entity types."""
+        # GIVEN a file with an ID
+        file = File(id="syn123")
+
+        # WHEN deleting permissions with multiple entity types including 'file'
+        await file.delete_permissions_async(target_entity_types=["folder", "file"])
+
+        # THEN delete_entity_acl should be called
+        self.mock_delete_acl.assert_called_once_with(
+            entity_id="syn123", synapse_client=self.synapse_client
+        )
+
+    async def test_general_exception_during_delete(self):
+        """Test handling of general exceptions during deletion."""
+        # GIVEN a file with an ID
+        file = File(id="syn123")
+
+        # AND a general exception during deletion
+        self.mock_delete_acl.side_effect = Exception("General error")
+
+        # WHEN deleting permissions
+        await file.delete_permissions_async()
+
+        # THEN the delete_entity_acl function should be called
+        self.mock_delete_acl.assert_called_once_with(
+            entity_id="syn123", synapse_client=self.synapse_client
+        )
+
+        # AND a warning log message should be generated
+        self.synapse_client.logger.warning.assert_called_once()

--- a/tests/unit/synapseclient/models/unit_test_permissions.py
+++ b/tests/unit/synapseclient/models/unit_test_permissions.py
@@ -1,0 +1,299 @@
+"""Unit tests for permissions-related functionality in the AccessControllable mixin."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from synapseclient import Synapse
+from synapseclient.core.exceptions import SynapseHTTPError
+from synapseclient.models import File, Folder
+
+
+class TestDeletePermissionsAsync:
+    """Unit tests for delete_permissions_async method in AccessControllable."""
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.synapse_client = MagicMock(spec=Synapse)
+        self.synapse_client.logger = MagicMock()
+
+        # Mock the Synapse.get_client to return our mock client
+        self.get_client_patcher = patch(
+            "synapseclient.models.mixins.access_control.Synapse.get_client"
+        )
+        self.mock_get_client = self.get_client_patcher.start()
+        self.mock_get_client.return_value = self.synapse_client
+
+        # Mock delete_entity_acl
+        self.delete_acl_patcher = patch(
+            "synapseclient.models.mixins.access_control.delete_entity_acl"
+        )
+        self.mock_delete_acl = self.delete_acl_patcher.start()
+        self.mock_delete_acl.return_value = None
+
+        yield
+
+        # Clean up patchers
+        self.get_client_patcher.stop()
+        self.delete_acl_patcher.stop()
+
+    async def test_delete_permissions_no_id(self):
+        """Test that attempting to delete permissions without an ID raises an error."""
+        # GIVEN a file with no ID
+        file = File()
+
+        # WHEN attempting to delete permissions
+        # THEN a ValueError should be raised
+        with pytest.raises(
+            ValueError, match="The entity must have an ID to delete permissions."
+        ):
+            file.delete_permissions()
+
+    async def test_delete_permissions_invalid_entity_type(self):
+        """Test that providing an invalid entity type raises a ValueError."""
+        # GIVEN a file with an ID
+        file = File(id="syn123")
+
+        # WHEN attempting to delete permissions with an invalid entity type
+        # THEN a ValueError should be raised
+        with pytest.raises(ValueError, match="Invalid entity type"):
+            file.delete_permissions(target_entity_types=["invalid_type"])
+
+    async def test_delete_permissions_already_inherits(self):
+        """Test handling of 403 error when entity already inherits permissions."""
+        # GIVEN a file with an ID
+        file = File(id="syn123")
+
+        # AND a mock HTTP error for already inheriting permissions
+        error_response = MagicMock()
+        error_response.status_code = 403
+        error_response.text = "Resource already inherits its permissions."
+
+        # Create SynapseHTTPError with a message string, not with keyword arguments
+        http_error = SynapseHTTPError(
+            "403 error: Resource already inherits its permissions."
+        )
+        http_error.response = (
+            error_response  # Set the response attribute after creation
+        )
+        self.mock_delete_acl.side_effect = http_error
+
+        # WHEN deleting permissions
+        file.delete_permissions()
+
+        # THEN the delete_entity_acl function should be called
+        self.mock_delete_acl.assert_called_once_with(
+            entity_id="syn123", synapse_client=self.synapse_client
+        )
+
+        # AND a debug log message should be generated
+        self.synapse_client.logger.debug.assert_called_once()
+
+    async def test_delete_permissions_other_http_error(self):
+        """Test handling of other HTTP errors during deletion."""
+        # GIVEN a file with an ID
+        file = File(id="syn123")
+
+        # AND a mock HTTP error for other permission issues
+        error_response = MagicMock()
+        error_response.status_code = 403
+        error_response.text = "Permission denied"
+
+        # Create SynapseHTTPError with a message string, not with keyword arguments
+        http_error = SynapseHTTPError("403 error: Permission denied")
+        http_error.response = (
+            error_response  # Set the response attribute after creation
+        )
+        self.mock_delete_acl.side_effect = http_error
+
+        # WHEN deleting permissions
+        file.delete_permissions()
+
+        # THEN the delete_entity_acl function should be called
+        self.mock_delete_acl.assert_called_once_with(
+            entity_id="syn123", synapse_client=self.synapse_client
+        )
+
+        # AND a warning log message should be generated
+        self.synapse_client.logger.warning.assert_called_once()
+
+    async def test_delete_permissions_skip_self(self):
+        """Test that when include_self=False, the entity's ACL is not deleted."""
+        # GIVEN a file with an ID
+        file = File(id="syn123")
+
+        # WHEN deleting permissions with include_self=False
+        file.delete_permissions(include_self=False)
+
+        # THEN the delete_entity_acl function should not be called
+        self.mock_delete_acl.assert_not_called()
+
+    async def test_delete_permissions_folder_recursive(self):
+        """Test recursive deletion on a folder structure."""
+        # GIVEN a folder with an ID and mocked sync_from_synapse_async method
+        folder = Folder(id="syn123")
+        folder.sync_from_synapse_async = AsyncMock()
+
+        # AND mocked child folders and files
+        child_folder = Folder(id="syn456")
+        child_folder.delete_permissions_async = AsyncMock()
+
+        child_file = File(id="syn789")
+        child_file.delete_permissions_async = AsyncMock()
+
+        # Set up the folder structure
+        folder.folders = [child_folder]
+        folder.files = [child_file]
+
+        # WHEN deleting permissions recursively
+        folder.delete_permissions(recursive=True, include_container_content=True)
+
+        # THEN sync_from_synapse_async should be called
+        folder.sync_from_synapse_async.assert_called_once()
+
+        # AND delete_permissions_async should be called on child folder and file
+        # We use assert_called instead of assert_called_once because the mock may be called multiple times
+        # due to the recursive nature of the delete_permissions_async method
+        assert child_folder.delete_permissions_async.called
+        assert child_file.delete_permissions_async.called
+
+        # AND delete_entity_acl should be called on the folder itself
+        self.mock_delete_acl.assert_called_once_with(
+            entity_id="syn123", synapse_client=self.synapse_client
+        )
+
+    async def test_sync_failure_doesnt_process_children(self):
+        """Test that sync failure prevents processing children."""
+        # GIVEN a folder with an ID and mocked sync_from_synapse_async method that fails
+        folder = Folder(id="syn123")
+        folder.sync_from_synapse_async = AsyncMock(side_effect=Exception("Sync failed"))
+
+        # WHEN deleting permissions recursively
+        folder.delete_permissions(recursive=True)
+
+        # THEN sync_from_synapse_async should be called
+        folder.sync_from_synapse_async.assert_called_once()
+
+        # AND delete_entity_acl should be called on the folder itself
+        self.mock_delete_acl.assert_called_once()
+
+        # AND a warning log message should be generated
+        self.synapse_client.logger.warning.assert_called_once()
+
+    async def test_filter_by_entity_type_folder(self):
+        """Test filtering deletion by folder entity type."""
+        # GIVEN a folder with an ID and child folder and file
+        folder = Folder(id="syn123")
+        folder.sync_from_synapse_async = AsyncMock()
+
+        child_folder = Folder(id="syn456")
+        child_folder.delete_permissions_async = AsyncMock()
+
+        child_file = File(id="syn789")
+        child_file.delete_permissions_async = AsyncMock()
+
+        # Set up the folder structure
+        folder.folders = [child_folder]
+        folder.files = [child_file]
+
+        # WHEN deleting permissions filtered by folder type
+        folder.delete_permissions(
+            recursive=True,
+            include_container_content=True,
+            target_entity_types=["folder"],
+        )
+
+        # THEN sync_from_synapse_async should be called
+        folder.sync_from_synapse_async.assert_called_once()
+
+        # AND delete_permissions_async should be called on child folder
+        # We use assert_called instead of assert_called_once because the mock may be called multiple times
+        assert child_folder.delete_permissions_async.called
+
+        # AND delete_permissions_async should NOT be called on child file
+        child_file.delete_permissions_async.assert_not_called()
+
+        # AND delete_entity_acl should be called on the folder itself
+        self.mock_delete_acl.assert_called_once()
+
+    async def test_filter_by_entity_type_file(self):
+        """Test filtering deletion by file entity type."""
+        # GIVEN a folder with an ID and child folder and file
+        folder = Folder(id="syn123")
+        folder.sync_from_synapse_async = AsyncMock()
+
+        child_folder = Folder(id="syn456")
+        child_folder.delete_permissions_async = AsyncMock()
+
+        child_file = File(id="syn789")
+        child_file.delete_permissions_async = AsyncMock()
+
+        # Set up the folder structure
+        folder.folders = [child_folder]
+        folder.files = [child_file]
+
+        # WHEN deleting permissions filtered by file type
+        folder.delete_permissions(
+            recursive=True, include_container_content=True, target_entity_types=["file"]
+        )
+
+        # THEN sync_from_synapse_async should be called
+        folder.sync_from_synapse_async.assert_called_once()
+
+        # AND delete_permissions_async should NOT be called on child folder for deletion
+        # but will be called for recursion with include_self=False
+        args, kwargs = child_folder.delete_permissions_async.call_args
+        assert kwargs.get("include_self") is False
+
+        # AND delete_permissions_async should be called on child file
+        child_file.delete_permissions_async.assert_called_once()
+
+        # AND delete_entity_acl should NOT be called on the folder itself
+        # because it's not a file
+        self.mock_delete_acl.assert_not_called()
+
+    async def test_case_insensitive_entity_types(self):
+        """Test that entity type matching is case-insensitive."""
+        # GIVEN a folder with an ID
+        folder = Folder(id="syn123")
+
+        # WHEN deleting permissions with mixed-case entity types
+        folder.delete_permissions(target_entity_types=["FoLdEr"])
+
+        # THEN delete_entity_acl should be called
+        self.mock_delete_acl.assert_called_once_with(
+            entity_id="syn123", synapse_client=self.synapse_client
+        )
+
+    async def test_multiple_entity_types(self):
+        """Test handling multiple entity types."""
+        # GIVEN a file with an ID
+        file = File(id="syn123")
+
+        # WHEN deleting permissions with multiple entity types including 'file'
+        file.delete_permissions(target_entity_types=["folder", "file"])
+
+        # THEN delete_entity_acl should be called
+        self.mock_delete_acl.assert_called_once_with(
+            entity_id="syn123", synapse_client=self.synapse_client
+        )
+
+    async def test_general_exception_during_delete(self):
+        """Test handling of general exceptions during deletion."""
+        # GIVEN a file with an ID
+        file = File(id="syn123")
+
+        # AND a general exception during deletion
+        self.mock_delete_acl.side_effect = Exception("General error")
+
+        # WHEN deleting permissions
+        file.delete_permissions()
+
+        # THEN the delete_entity_acl function should be called
+        self.mock_delete_acl.assert_called_once_with(
+            entity_id="syn123", synapse_client=self.synapse_client
+        )
+
+        # AND a warning log message should be generated
+        self.synapse_client.logger.warning.assert_called_once()


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/SYNPY-1244

# **Problem:**
- When sharing subfolders or specific files with collaborators in private projects, permissions create a complex ACL (Access Control List) structure where:
  - Sharing settings can be hidden deep in folder hierarchies
  - Files don't automatically inherit the parent container's permissions
  - When releasing data, these individual ACLs need to be removed so files properly inherit parent container sharing settings
- There was no mechanism available to delete ACLs in the OOP model, nor was there a way to recursively delete the ACL

# **Solution:**
- Adds new functions to recursively reset permissions on entities within a container
- Implements functionality to determine if an entity inherits ACLs from its parent
- Works with nested folder structures to ensure proper permission inheritance/removal

**See this in the API Reference docs:**
- https://synapsepythonclient--1200.org.readthedocs.build/en/1200/reference/experimental/sync/project/#synapseclient.models.Project.delete_permissions
- https://synapsepythonclient--1200.org.readthedocs.build/en/1200/reference/experimental/sync/folder/#synapseclient.models.Folder.delete_permissions


# **Testing:**
- Automated tests were added to the codebase to:
  - Verify that permission inheritance detection works correctly
  - Ensure recursive permission setting functions properly traverse entity hierarchies
  - Confirm that entity permissions are properly modified by the new functions
  - Test error handling and edge cases