### PR TITLE
[SYNPY-1437] INCOMPLETE/DRAFT - Start the process to move to use the /bundle2 rest API 

### DIFF
--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -20,6 +20,7 @@ from .entity_bundle_services_v2 import (
     get_entity_id_version_bundle2,
     post_entity_bundle2_create,
     put_entity_id_bundle2,
+    store_entity_with_bundle2,
 )
 from .entity_factory import get_from_entity_factory
 from .entity_services import (
@@ -64,6 +65,7 @@ __all__ = [
     "get_entity_id_version_bundle2",
     "post_entity_bundle2_create",
     "put_entity_id_bundle2",
+    "store_entity_with_bundle2",
     # file_services
     "post_file_multipart",
     "put_file_multipart_add",

--- a/synapseclient/api/entity_bundle_services_v2.py
+++ b/synapseclient/api/entity_bundle_services_v2.py
@@ -152,3 +152,92 @@ async def put_entity_id_bundle2(
         + (f"?generatedBy={generated_by}" if generated_by else ""),
         body=json.dumps(request),
     )
+
+
+async def store_entity_with_bundle2(
+    entity: Dict[str, Any],
+    parent_id: Optional[str] = None,
+    acl: Optional[Dict[str, Any]] = None,  # TODO: Consider skipping ACL?
+    annotations: Optional[Dict[str, Any]] = None,
+    activity: Optional[Dict[str, Any]] = None,
+    new_version: bool = False,
+    force_version: bool = False,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> Dict[str, Any]:
+    """
+    Store an entity in Synapse using the bundle2 API endpoints to reduce HTTP calls.
+
+    This function follows a specific flow:
+    1. Determines if the operation is a create or update:
+       - If no ID is provided, searches for the ID via /entity/child
+       - If no ID is found, treats as a Create
+       - If an ID is found, treats as an Update
+
+    2. For Updates:
+       - Retrieves entity by ID and merges with existing data
+       - Updates desired fields in the retrieved object
+       - Pushes modified object with HTTP PUT if there are changes
+
+    3. For Creates:
+       - Creates a new object with desired fields
+       - Pushes the new object with HTTP POST
+
+    Arguments:
+        entity: The entity to store.
+        parent_id: The ID of the parent entity for creation.
+        acl: Access control list for the entity.
+        annotations: Annotations to associate with the entity.
+        activity: Activity to associate with the entity.
+        new_version: If True, create a new version of the entity.
+        force_version: If True, forces a new version of an entity even if nothing has changed.
+        synapse_client: Synapse client instance.
+
+    Returns:
+        The stored entity bundle.
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    # Determine if this is a create or update operation
+    entity_id = entity.get("id", None)
+
+    # Construct bundle request based on provided data
+    bundle_request = {"entity": entity}
+
+    if annotations:
+        bundle_request["annotations"] = annotations
+
+    if acl:
+        bundle_request["accessControlList"] = acl
+
+    if activity:
+        bundle_request["activity"] = activity
+
+    # Handle create or update
+    if not entity_id:
+        # This is a creation
+        client.logger.debug("Creating new entity via bundle2 API")
+
+        # For creation, parent ID is required
+        # TODO: Projects won't have a parent in this case
+        # if parent_id:
+        #     # Add parentId to the entity if not already set
+        #     if not entity.get("parentId"):
+        #         entity["parentId"] = parent_id
+        # elif not entity.get("parentId"):
+        #     raise ValueError("Parent ID must be provided for entity creation")
+
+        # Create entity using bundle2 create endpoint
+        return await post_entity_bundle2_create(
+            request=bundle_request,
+            generated_by=activity.get("id") if activity else None,
+            synapse_client=synapse_client,
+        )
+    else:
+        # This is an update
+        client.logger.debug(f"Updating entity {entity_id} via bundle2 API")
+
+        # For updates we might need to retrieve the existing entity to merge data
+        # Only retrieve if we need

--- a/synapseclient/api/entity_factory.py
+++ b/synapseclient/api/entity_factory.py
@@ -245,7 +245,7 @@ async def _handle_file_entity(
     from synapseclient.models import FileHandle
 
     entity_instance.fill_from_dict(
-        synapse_file=entity_bundle["entity"], set_annotations=False
+        synapse_file=entity_bundle["entity"], annotations=None
     )
 
     # Update entity with FileHandle metadata
@@ -401,7 +401,7 @@ async def _cast_into_class_type(
         )
     else:
         # Handle all other entity types
-        entity_instance.fill_from_dict(entity_bundle["entity"], set_annotations=False)
+        entity_instance.fill_from_dict(entity_bundle["entity"], annotations=None)
 
     if annotations:
         entity_instance.annotations = annotations

--- a/synapseclient/models/dataset.py
+++ b/synapseclient/models/dataset.py
@@ -855,12 +855,12 @@ class Dataset(
             [dataclasses.replace(item) for item in self.items] if self.items else []
         )
 
-    def fill_from_dict(self, entity, set_annotations: bool = True) -> "Self":
+    def fill_from_dict(self, entity, annotations: Dict = None) -> "Self":
         """
         Converts the data coming from the Synapse API into this datamodel.
 
         Arguments:
-            synapse_table: The data coming from the Synapse API
+            entity: The data coming from the Synapse API
 
         Returns:
             The Dataset object instance.
@@ -887,8 +887,8 @@ class Dataset(
             for item in entity.get("items", [])
         ]
 
-        if set_annotations:
-            self.annotations = Annotations.from_dict(entity.get("annotations", {}))
+        if annotations:
+            self.annotations = Annotations.from_dict(annotations.get("annotations", {}))
         return self
 
     def to_synapse_request(self):
@@ -2255,12 +2255,12 @@ class DatasetCollection(
             [dataclasses.replace(item) for item in self.items] if self.items else []
         )
 
-    def fill_from_dict(self, entity, set_annotations: bool = True) -> "Self":
+    def fill_from_dict(self, entity, annotations: Dict = None) -> "Self":
         """
         Converts the data coming from the Synapse API into this datamodel.
 
         Arguments:
-            synapse_table: The data coming from the Synapse API
+            entity: The data coming from the Synapse API
 
         Returns:
             The DatasetCollection object instance.
@@ -2283,8 +2283,8 @@ class DatasetCollection(
             EntityRef(id=item["entityId"], version=item["versionNumber"])
             for item in entity.get("items", [])
         ]
-        if set_annotations:
-            self.annotations = Annotations.from_dict(entity.get("annotations", {}))
+        if annotations:
+            self.annotations = Annotations.from_dict(annotations.get("annotations", {}))
         return self
 
     def to_synapse_request(self):

--- a/synapseclient/models/entityview.py
+++ b/synapseclient/models/entityview.py
@@ -739,9 +739,7 @@ class EntityView(
             deepcopy(self.scope_ids) if self.scope_ids else set()
         )
 
-    def fill_from_dict(
-        self, entity: Dict, set_annotations: bool = True
-    ) -> "EntityView":
+    def fill_from_dict(self, entity: Dict, annotations: Dict = None) -> "EntityView":
         """
         Converts the data coming from the Synapse API into this datamodel.
 
@@ -768,8 +766,8 @@ class EntityView(
         self.view_type_mask = entity.get("viewTypeMask", None)
         self.scope_ids = set(f"syn{id}" for id in entity.get("scopeIds", []))
 
-        if set_annotations:
-            self.annotations = Annotations.from_dict(entity.get("annotations", {}))
+        if annotations:
+            self.annotations = Annotations.from_dict(annotations.get("annotations", {}))
         return self
 
     def to_synapse_request(self):

--- a/synapseclient/models/folder.py
+++ b/synapseclient/models/folder.py
@@ -2,13 +2,14 @@ import asyncio
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from datetime import date, datetime
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from opentelemetry import trace
 
 from synapseclient import Synapse
 from synapseclient.api import get_from_entity_factory
 from synapseclient.core.async_utils import async_to_sync, otel_trace_method
+from synapseclient.core.constants import concrete_types
 from synapseclient.core.exceptions import SynapseError
 from synapseclient.core.utils import delete_none_keys, merge_dataclass_entities
 from synapseclient.entity import Folder as Synapse_Folder
@@ -16,9 +17,10 @@ from synapseclient.models import Annotations, File
 from synapseclient.models.mixins import AccessControllable, StorableContainer
 from synapseclient.models.protocols.folder_protocol import FolderSynchronousProtocol
 from synapseclient.models.services.search import get_id
+from synapseclient.models.services.storable_entity import store_entity
 from synapseclient.models.services.storable_entity_components import (
     FailureStrategy,
-    store_entity_components,
+    store_entity_components_file_folder_only,
 )
 from synapseutils import copy
 
@@ -173,32 +175,53 @@ class Folder(FolderSynchronousProtocol, AccessControllable, StorableContainer):
         )
 
     def fill_from_dict(
-        self, synapse_folder: Synapse_Folder, set_annotations: bool = True
+        self, entity: Synapse_Folder, annotations: Dict = None
     ) -> "Folder":
         """
         Converts a response from the REST API into this dataclass.
 
         Arguments:
-            synapse_file: The response from the REST API.
-            set_annotations: Whether to set the annotations from the response.
+            entity: The response from the REST API.
+            annotations: Optional dictionary containing annotations data.
 
         Returns:
             The Folder object.
         """
-        self.id = synapse_folder.get("id", None)
-        self.name = synapse_folder.get("name", None)
-        self.parent_id = synapse_folder.get("parentId", None)
-        self.description = synapse_folder.get("description", None)
-        self.etag = synapse_folder.get("etag", None)
-        self.created_on = synapse_folder.get("createdOn", None)
-        self.modified_on = synapse_folder.get("modifiedOn", None)
-        self.created_by = synapse_folder.get("createdBy", None)
-        self.modified_by = synapse_folder.get("modifiedBy", None)
-        if set_annotations:
-            self.annotations = Annotations.from_dict(
-                synapse_folder.get("annotations", None)
-            )
+        self.id = entity.get("id", None)
+        self.name = entity.get("name", None)
+        self.parent_id = entity.get("parentId", None)
+        self.description = entity.get("description", None)
+        self.etag = entity.get("etag", None)
+        self.created_on = entity.get("createdOn", None)
+        self.modified_on = entity.get("modifiedOn", None)
+        self.created_by = entity.get("createdBy", None)
+        self.modified_by = entity.get("modifiedBy", None)
+        if annotations:
+            self.annotations = Annotations.from_dict(annotations.get("annotations", {}))
         return self
+
+    def to_synapse_request(self) -> Dict[str, Any]:
+        """
+        Converts this dataclass into a request that can be sent to the Synapse API.
+
+        Returns:
+            A dictionary that can be used in a request to the Synapse API.
+        """
+        entity = {
+            "name": self.name,
+            "description": self.description,
+            "id": self.id,
+            "etag": self.etag,
+            "createdOn": self.created_on,
+            "modifiedOn": self.modified_on,
+            "createdBy": self.created_by,
+            "modifiedBy": self.modified_by,
+            "parentId": self.parent_id,
+            "concreteType": concrete_types.FOLDER_ENTITY,
+        }
+        delete_none_keys(entity)
+
+        return entity
 
     @otel_trace_method(
         method_to_trace_name=lambda self, **kwargs: f"Folder_Store: {self.name}"
@@ -265,28 +288,19 @@ class Folder(FolderSynchronousProtocol, AccessControllable, StorableContainer):
             }
         )
         if self.has_changed:
-            loop = asyncio.get_event_loop()
-            synapse_folder = Synapse_Folder(
-                id=self.id,
-                name=self.name,
-                parent=parent_id,
-                etag=self.etag,
-                description=self.description,
+            entity = await store_entity(
+                entity=self.to_synapse_request(),
+                parent_id=self.parent_id,
+                annotations=Annotations(self.annotations).to_synapse_request()
+                if self.annotations
+                else None,
+                synapse_client=synapse_client,
             )
-            delete_none_keys(synapse_folder)
-            entity = await loop.run_in_executor(
-                None,
-                lambda: Synapse.get_client(synapse_client=synapse_client).store(
-                    obj=synapse_folder,
-                    set_annotations=False,
-                    isRestricted=self.is_restricted,
-                    createOrUpdate=False,
-                ),
+            self.fill_from_dict(
+                entity=entity["entity"], annotations=entity.get("annotations", None)
             )
 
-            self.fill_from_dict(synapse_folder=entity, set_annotations=False)
-
-        await store_entity_components(
+        await store_entity_components_file_folder_only(
             root_resource=self,
             failure_strategy=failure_strategy,
             synapse_client=synapse_client,

--- a/synapseclient/models/materializedview.py
+++ b/synapseclient/models/materializedview.py
@@ -667,7 +667,7 @@ class MaterializedView(
         )
 
     def fill_from_dict(
-        self, entity: Dict, set_annotations: bool = True
+        self, entity: Dict, annotations: Dict = None
     ) -> "MaterializedView":
         """
         Converts the data coming from the Synapse API into this datamodel.
@@ -694,8 +694,8 @@ class MaterializedView(
         self.is_search_enabled = entity.get("isSearchEnabled", False)
         self.defining_sql = entity.get("definingSQL", None)
 
-        if set_annotations:
-            self.annotations = entity.get("annotations", {})
+        if annotations:
+            self.annotations = Annotations.from_dict(annotations.get("annotations", {}))
 
         return self
 

--- a/synapseclient/models/mixins/table_components.py
+++ b/synapseclient/models/mixins/table_components.py
@@ -426,15 +426,15 @@ class TableStoreMixin:
 
         if dry_run:
             client.logger.info(
-                f"[{self.id}:{self.name}]: Dry run enabled. No changes will be made."
+                f"[{self.id or ''}:{self.name}]: Dry run enabled. No changes will be made."
             )
 
         if self.has_changed:
-            if self.id:
-                if dry_run:
-                    client.logger.info(
-                        f"[{self.id}:{self.name}]: Dry run {self.__class__} update, expected changes:"
-                    )
+            if dry_run:
+                client.logger.info(
+                    f"[{self.id or ''}:{self.name}]: Dry run {self.__class__} {('update' if self.id else 'create')}, expected changes:"
+                )
+                if self.id:
                     log_dataclass_diff(
                         logger=client.logger,
                         prefix=f"[{self.id}:{self.name}]: ",
@@ -443,17 +443,6 @@ class TableStoreMixin:
                         fields_to_ignore=["columns", "_last_persistent_instance"],
                     )
                 else:
-                    entity = await put_entity_id_bundle2(
-                        entity_id=self.id,
-                        request=self.to_synapse_request(),
-                        synapse_client=synapse_client,
-                    )
-                    self.fill_from_dict(entity=entity["entity"], set_annotations=False)
-            else:
-                if dry_run:
-                    client.logger.info(
-                        f"[{self.id}:{self.name}]: Dry run {self.__class__} update, expected changes:"
-                    )
                     log_dataclass_diff(
                         logger=client.logger,
                         prefix=f"[{self.name}]: ",
@@ -461,11 +450,24 @@ class TableStoreMixin:
                         obj2=self,
                         fields_to_ignore=["columns", "_last_persistent_instance"],
                     )
-                else:
-                    entity = await post_entity_bundle2_create(
-                        request=self.to_synapse_request(), synapse_client=synapse_client
-                    )
-                    self.fill_from_dict(entity=entity["entity"], set_annotations=False)
+            else:
+                # Use store_entity_with_bundle2 for both creation and update operations
+                from synapseclient.api.entity_bundle_services_v2 import (
+                    store_entity_with_bundle2,
+                )
+                from synapseclient.models import Annotations
+
+                entity = await store_entity_with_bundle2(
+                    entity=self.to_synapse_request(),
+                    parent_id=self.parent_id if not self.id else None,
+                    annotations=Annotations(self.annotations).to_synapse_request()
+                    if self.annotations
+                    else None,
+                    synapse_client=synapse_client,
+                )
+                self.fill_from_dict(
+                    entity=entity["entity"], annotations=entity.get("annotations", None)
+                )
 
         schema_change_request = await self._generate_schema_change_request(
             dry_run=dry_run, synapse_client=synapse_client

--- a/synapseclient/models/services/__init__.py
+++ b/synapseclient/models/services/__init__.py
@@ -3,6 +3,13 @@ from synapseclient.models.services.storable_entity import store_entity
 from synapseclient.models.services.storable_entity_components import (
     FailureStrategy,
     store_entity_components,
+    store_entity_components_file_folder_only,
 )
 
-__all__ = ["store_entity_components", "store_entity", "FailureStrategy", "get_id"]
+__all__ = [
+    "store_entity_components",
+    "store_entity_components_file_folder_only",
+    "store_entity",
+    "FailureStrategy",
+    "get_id",
+]

--- a/synapseclient/models/services/storable_entity.py
+++ b/synapseclient/models/services/storable_entity.py
@@ -1,103 +1,162 @@
 """Script used to store an entity to Synapse."""
 
-from typing import TYPE_CHECKING, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from opentelemetry import trace
 
 from synapseclient import Synapse
 from synapseclient.api import (
     create_access_requirements_if_none,
-    post_entity,
-    put_entity,
+    get_entity_id_bundle2,
+    post_entity_bundle2_create,
+    put_entity_id_bundle2,
 )
 from synapseclient.core.utils import get_properties
 
 if TYPE_CHECKING:
-    from synapseclient.models import File, Folder, Project
+    from synapseclient.models import (
+        Annotations,
+        Dataset,
+        EntityView,
+        File,
+        Folder,
+        Project,
+        Table,
+    )
 
 
 async def store_entity(
-    resource: Union["File", "Folder", "Project"],
+    resource: Union["File", "Folder", "Project", "Table", "Dataset", "EntityView"],
     entity: Dict[str, Union[str, bool, int, float]],
+    parent_id: Optional[str] = None,
+    acl: Optional[Dict[str, Any]] = None,
+    new_version: bool = False,
+    force_version: bool = False,
     *,
     synapse_client: Optional[Synapse] = None,
-) -> bool:
+) -> Dict[str, Any]:
     """
-    Function to store an entity to synapse.
+    Function to store an entity to synapse using the bundle2 service.
 
-    TODO: This function is not complete and is a work in progress.
+    This function handles both creation and update of entities in Synapse:
+    1. For new entities (without an ID):
+       - Creates a new entity with the provided data
+       - Pushes the new entity with bundle2 create endpoint
 
+    2. For existing entities (with an ID):
+       - Updates the entity with the provided data
+       - Pushes the updated entity with bundle2 update endpoint
 
     Arguments:
         resource: The root dataclass instance we are storing data for.
         entity: The entity to store.
+        parent_id: The ID of the parent entity for creation.
+        acl: Access control list for the entity.
+        new_version: If True, create a new version of the entity.
+        force_version: If True, forces a new version of an entity even if nothing has changed.
         synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.
 
     Returns:
-        If a read from Synapse is required to retireve the current state of the entity.
+        The entity data from the stored entity bundle.
     """
-    query_params = {}
-    increment_version = False
-    # Create or update Entity in Synapse
+    from synapseclient.models import Annotations
+
+    # First, handle the activity if it exists and needs to be stored
+    activity_id = None
+    if hasattr(resource, "activity") and resource.activity is not None:
+        # Store the activity first if it doesn't have an ID yet or if it's changed
+        last_persistent_instance = getattr(resource, "_last_persistent_instance", None)
+        activity_changed = (
+            last_persistent_instance is None
+            or last_persistent_instance.activity != resource.activity
+        )
+
+        if not resource.activity.id or activity_changed:
+            resource.activity = await resource.activity.store_async(
+                synapse_client=synapse_client
+            )
+
+        activity_id = resource.activity.id
+
+    # Prepare annotations if they exist
+    annotations = None
+    if hasattr(resource, "annotations") and resource.annotations:
+        annotations = Annotations(resource.annotations).to_synapse_request()
+
+    # Set trace attributes if ID exists
     if resource.id:
         trace.get_current_span().set_attributes({"synapse.id": resource.id})
-        if hasattr(resource, "version_number"):
-            if (
-                resource.version_label
-                and resource.version_label
-                != resource._last_persistent_instance.version_label
-            ):
-                # a versionLabel implicitly implies incrementing
-                increment_version = True
-            elif resource.force_version and resource.version_number:
-                increment_version = True
-                entity["versionLabel"] = str(resource.version_number + 1)
 
-            if increment_version:
-                query_params["newVersion"] = "true"
+    # Handle versioning attributes if not already specified
+    # TODO: force_version is not yet supported in the bundle2 API: https://sagebionetworks.jira.com/browse/PLFM-8313
+    if (
+        not force_version
+        and hasattr(resource, "version_number")
+        and hasattr(resource, "force_version")
+    ):
+        if resource.force_version:
+            force_version = True
 
-        updated_entity = await put_entity(
-            entity_id=resource.id,
-            request=get_properties(entity),
-            new_version=increment_version,
+    # Get parent_id from resource if not specified
+    if parent_id is None:
+        parent_id = getattr(resource, "parent_id", None)
+
+    # Get client
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    # Determine if this is a create or update operation
+    entity_id = entity.get("id", None)
+
+    # Construct bundle request based on provided data
+    bundle_request = {"entity": entity.to_synapse_request()}
+
+    if annotations:
+        bundle_request["annotations"] = annotations
+
+    if acl:
+        bundle_request["accessControlList"] = acl
+
+    if activity_id:
+        bundle_request["activity"] = activity_id
+
+    # Handle create or update
+    if not entity_id:
+        # This is a creation
+        client.logger.debug("Creating new entity via bundle2 API")
+
+        # Create entity using bundle2 create endpoint
+        updated_entity = await post_entity_bundle2_create(
+            request=bundle_request,
+            generated_by=activity_id,
             synapse_client=synapse_client,
         )
     else:
-        # TODO - When Link is implemented this needs to be completed
-        # If Link, get the target name, version number and concrete type and store in link properties
-        # if properties["concreteType"] == "org.sagebionetworks.repo.model.Link":
-        #     target_properties = self._getEntity(
-        #         properties["linksTo"]["targetId"],
-        #         version=properties["linksTo"].get("targetVersionNumber"),
-        #     )
-        #     if target_properties["parentId"] == properties["parentId"]:
-        #         raise ValueError(
-        #             "Cannot create a Link to an entity under the same parent."
-        #         )
-        #     properties["linksToClassName"] = target_properties["concreteType"]
-        #     if (
-        #         target_properties.get("versionNumber") is not None
-        #         and properties["linksTo"].get("targetVersionNumber") is not None
-        #     ):
-        #         properties["linksTo"]["targetVersionNumber"] = target_properties[
-        #             "versionNumber"
-        #         ]
-        #     properties["name"] = target_properties["name"]
+        # This is an update
+        client.logger.debug(f"Updating entity {entity_id} via bundle2 API")
 
-        updated_entity = await post_entity(
-            request=get_properties(entity),
+        # If we're creating a new version or forcing one, we need to update
+        # the entity directly instead of via bundle2
+        updated_entity = await put_entity_id_bundle2(
+            entity_id=entity_id,
+            request=bundle_request,
+            generated_by=activity_id,
             synapse_client=synapse_client,
         )
 
+    # Handle access restrictions if needed
     if hasattr(resource, "is_restricted") and resource.is_restricted:
-        await create_access_requirements_if_none(entity_id=updated_entity.get("id"))
+        await create_access_requirements_if_none(
+            entity_id=updated_entity["entity"].get("id")
+        )
 
+    # Set trace attributes
     trace.get_current_span().set_attributes(
         {
-            "synapse.id": updated_entity.get("id"),
-            "synapse.concrete_type": updated_entity.get("concreteType", ""),
+            "synapse.id": updated_entity["entity"].get("id"),
+            "synapse.concrete_type": updated_entity["entity"].get("concreteType", ""),
         }
     )
-    return updated_entity
+
+    return updated_entity["entity"]

--- a/synapseclient/models/submissionview.py
+++ b/synapseclient/models/submissionview.py
@@ -847,7 +847,7 @@ class SubmissionView(
             deepcopy(self.scope_ids) if self.scope_ids else []
         )
 
-    def fill_from_dict(self, entity, set_annotations: bool = True) -> "Self":
+    def fill_from_dict(self, entity, annotations: Dict = None) -> "Self":
         """
         Converts the data coming from the Synapse API into this datamodel.
 
@@ -873,8 +873,8 @@ class SubmissionView(
         self.is_search_enabled = entity.get("isSearchEnabled", False)
         self.scope_ids = [item for item in entity.get("scopeIds", [])]
 
-        if set_annotations:
-            self.annotations = Annotations.from_dict(entity.get("annotations", {}))
+        if annotations:
+            self.annotations = Annotations.from_dict(annotations.get("annotations", {}))
 
         return self
 

--- a/synapseclient/models/table.py
+++ b/synapseclient/models/table.py
@@ -1349,7 +1349,7 @@ class Table(
         )
 
     def fill_from_dict(
-        self, entity: Synapse_Table, set_annotations: bool = True
+        self, entity: Synapse_Table, annotations: Dict = None
     ) -> "Table":
         """
         Converts the data coming from the Synapse API into this datamodel.
@@ -1375,8 +1375,8 @@ class Table(
         self.is_latest_version = entity.get("isLatestVersion", None)
         self.is_search_enabled = entity.get("isSearchEnabled", False)
 
-        if set_annotations:
-            self.annotations = Annotations.from_dict(entity.get("annotations", {}))
+        if annotations:
+            self.annotations = Annotations.from_dict(annotations.get("annotations", {}))
         return self
 
     def to_synapse_request(self):

--- a/synapseclient/models/virtualtable.py
+++ b/synapseclient/models/virtualtable.py
@@ -11,7 +11,7 @@ from synapseclient import Synapse
 from synapseclient.core.async_utils import async_to_sync
 from synapseclient.core.constants import concrete_types
 from synapseclient.core.utils import delete_none_keys
-from synapseclient.models import Activity, Column
+from synapseclient.models import Activity, Annotations, Column
 from synapseclient.models.mixins.access_control import AccessControllable
 from synapseclient.models.mixins.table_components import (
     DeleteMixin,
@@ -427,7 +427,7 @@ class VirtualTable(
         )
 
     def fill_from_dict(
-        self, entity: Dict[str, Any], set_annotations: bool = True
+        self, entity: Dict[str, Any], annotations: Dict = None
     ) -> "VirtualTable":
         """
         Converts the data coming from the Synapse API into this datamodel.
@@ -454,8 +454,8 @@ class VirtualTable(
         self.is_search_enabled = entity.get("isSearchEnabled", False)
         self.defining_sql = entity.get("definingSQL", None)
 
-        if set_annotations:
-            self.annotations = entity.get("annotations", {})
+        if annotations:
+            self.annotations = Annotations.from_dict(annotations.get("annotations", {}))
 
         return self
 

--- a/tests/unit/synapseclient/mixins/unit_test_table_components.py
+++ b/tests/unit/synapseclient/mixins/unit_test_table_components.py
@@ -85,9 +85,11 @@ class TestTableStoreMixin:
                 },
             }
 
-        def fill_from_dict(self, entity: Any, set_annotations: bool = True) -> None:
+        def fill_from_dict(self, entity: Any, annotations: Dict = {}) -> None:
             """Placeholder for fill_from_dict method"""
             self.__dict__.update(entity)
+            if annotations is not None:
+                self.__dict__.update(annotations)  # TODO: Is this right?
 
     @pytest.fixture(autouse=True, scope="function")
     def init_syn(self, syn: Synapse) -> None:

--- a/tests/unit/synapseclient/models/async/unit_test_dataset_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_dataset_async.py
@@ -61,7 +61,7 @@ class TestDataset:
         # GIVEN an empty Dataset
         dataset = Dataset()
         # WHEN I fill it from a Synapse response
-        dataset.fill_from_dict(self.synapse_response, set_annotations=True)
+        dataset.fill_from_dict(self.synapse_response, annotations=self.synapse_response)
         # THEN I expect the Dataset to be filled with the expected values
         assert dataset.id == self.synapse_response["id"]
         assert dataset.name == self.synapse_response["name"]
@@ -259,7 +259,9 @@ class TestDatasetCollection:
         # GIVEN an empty DatasetCollection
         dataset_collection = DatasetCollection()
         # WHEN I fill it from a Synapse response
-        dataset_collection.fill_from_dict(self.synapse_response, set_annotations=True)
+        dataset_collection.fill_from_dict(
+            self.synapse_response, annotations=self.synapse_response
+        )
         # THEN I expect the DatasetCollection to be filled with the expected values
         assert dataset_collection.id == self.synapse_response["id"]
         assert dataset_collection.name == self.synapse_response["name"]

--- a/tests/unit/synapseclient/models/synchronous/unit_test_project.py
+++ b/tests/unit/synapseclient/models/synchronous/unit_test_project.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from synapseclient import Project as Synapse_Project
 from synapseclient import Synapse
 from synapseclient.core.constants import concrete_types
 from synapseclient.core.constants.concrete_types import FILE_ENTITY
@@ -30,19 +29,6 @@ class TestProject:
     def init_syn(self, syn: Synapse) -> None:
         self.syn = syn
 
-    def get_example_synapse_project_output(self) -> Synapse_Project:
-        return Synapse_Project(
-            id=PROJECT_ID,
-            name=PROJECT_NAME,
-            parentId=PARENT_ID,
-            description=DERSCRIPTION_PROJECT,
-            etag=ETAG,
-            createdOn=CREATED_ON,
-            modifiedOn=MODIFIED_ON,
-            createdBy=CREATED_BY,
-            modifiedBy=MODIFIED_BY,
-        )
-
     def get_example_rest_api_project_output(self) -> Dict[str, str]:
         return {
             "entity": {
@@ -63,7 +49,7 @@ class TestProject:
         # GIVEN an example Synapse Project `get_example_synapse_project_output`
         # WHEN I call `fill_from_dict` with the example Synapse Project
         project_output = Project().fill_from_dict(
-            self.get_example_synapse_project_output()
+            self.get_example_rest_api_project_output().get("entity")
         )
 
         # THEN the Project object should be filled with the example Synapse Project
@@ -87,34 +73,23 @@ class TestProject:
         description = str(uuid.uuid4())
         project.description = description
 
+        # Create the mock return value
+        mock_return_value = self.get_example_rest_api_project_output()
+
         # WHEN I call `store` with the Project object
-        with patch.object(
-            self.syn,
-            "store",
-            return_value=(self.get_example_synapse_project_output()),
+        with patch(
+            "synapseclient.models.project.store_entity_with_bundle2",
+            new_callable=AsyncMock,
+            return_value=mock_return_value,
         ) as mocked_client_call, patch(
             "synapseclient.api.entity_factory.get_entity_id_bundle2",
             new_callable=AsyncMock,
-            return_value=(
-                {
-                    "entity": {
-                        "concreteType": concrete_types.PROJECT_ENTITY,
-                        "id": project.id,
-                    }
-                }
-            ),
+            return_value=mock_return_value,
         ) as mocked_get:
             result = project.store(synapse_client=self.syn)
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(
-                obj=Synapse_Project(
-                    id=project.id,
-                    description=description,
-                ),
-                set_annotations=False,
-                createOrUpdate=False,
-            )
+            mocked_client_call.assert_called_once()
 
             # AND we should call the get method
             mocked_get.assert_called_once()
@@ -246,25 +221,21 @@ class TestProject:
         description = str(uuid.uuid4())
         project.description = description
 
+        # Create the mock return value
+        mock_return_value = self.get_example_rest_api_project_output()
+
         # WHEN I call `store` with the Project object
-        with patch.object(
-            self.syn,
-            "store",
-            return_value=(self.get_example_synapse_project_output()),
-        ) as mocked_store, patch(
+        with patch(
+            "synapseclient.models.project.store_entity_with_bundle2",
+            new_callable=AsyncMock,
+            return_value=mock_return_value,
+        ) as mocked_client_call, patch(
             "synapseclient.api.entity_factory.get_entity_id_bundle2",
         ) as mocked_get:
             result = project.store(synapse_client=self.syn)
 
-            # THEN we should  call store because there are changes
-            mocked_store.assert_called_once_with(
-                obj=Synapse_Project(
-                    id=project.id,
-                    description=description,
-                ),
-                set_annotations=False,
-                createOrUpdate=False,
-            )
+            # THEN we should call store_entity_with_bundle2 because there are changes
+            mocked_client_call.assert_called_once()
 
             # AND we should not call get as we already have
             mocked_get.assert_not_called()
@@ -297,14 +268,17 @@ class TestProject:
         description = str(uuid.uuid4())
         project.description = description
 
+        # Create the mock return value
+        mock_return_value = self.get_example_rest_api_project_output()
+
         # WHEN I call `store` with the Project object
         with patch(
-            "synapseclient.models.project.store_entity_components",
+            "synapseclient.models.project.store_entity_components_file_folder_only",
             return_value=(None),
-        ) as mocked_store_entity_components, patch.object(
-            self.syn,
-            "store",
-            return_value=(self.get_example_synapse_project_output()),
+        ) as mocked_store_entity_components, patch(
+            "synapseclient.models.project.store_entity_with_bundle2",
+            new_callable=AsyncMock,
+            return_value=mock_return_value,
         ) as mocked_client_call, patch(
             "synapseclient.api.entity_factory.get_entity_id_bundle2",
             new_callable=AsyncMock,
@@ -319,15 +293,8 @@ class TestProject:
         ) as mocked_get:
             result = project.store(synapse_client=self.syn)
 
-            # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(
-                obj=Synapse_Project(
-                    id=project.id,
-                    description=description,
-                ),
-                set_annotations=False,
-                createOrUpdate=False,
-            )
+            # THEN we should call store_entity_with_bundle2
+            mocked_client_call.assert_called_once()
 
             # AND we should call the get method
             mocked_get.assert_called_once()
@@ -361,48 +328,45 @@ class TestProject:
         description = str(uuid.uuid4())
         project.description = description
 
+        # Create the mock return value
+        mock_return_value = self.get_example_rest_api_project_output()
+
         # WHEN I call `store` with the Project object
         with patch.object(
             self.syn,
-            "store",
-            return_value=(self.get_example_synapse_project_output()),
-        ) as mocked_client_call, patch.object(
-            self.syn,
             "findEntityId",
             return_value=PROJECT_ID,
-        ) as mocked_get, patch(
+        ) as mocked_find_entity_id, patch(
+            "synapseclient.models.project.store_entity_with_bundle2",
+            new_callable=AsyncMock,
+            return_value=mock_return_value,
+        ) as mocked_client_call, patch(
             "synapseclient.api.entity_factory.get_entity_id_bundle2",
             new_callable=AsyncMock,
             return_value=(
                 {
                     "entity": {
                         "concreteType": concrete_types.PROJECT_ENTITY,
-                        "id": project.id,
+                        "id": PROJECT_ID,
                     }
                 }
             ),
         ) as mocked_get:
             result = project.store(synapse_client=self.syn)
 
-            # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(
-                obj=Synapse_Project(
-                    id=project.id,
-                    name=project.name,
-                    parent=project.parent_id,
-                    description=description,
-                ),
-                set_annotations=False,
-                createOrUpdate=False,
+            # THEN we should call store_entity_with_bundle2
+            mocked_client_call.assert_called_once()
+
+            # AND we should find the entity ID
+            mocked_find_entity_id.assert_called_once_with(
+                name=project.name,
+                parent=project.parent_id,
             )
 
             # AND we should call the get method
             mocked_get.assert_called_once()
 
-            # AND findEntityId should be called
-            mocked_get.assert_called_once()
-
-            # AND the project should be stored
+            # AND the project should be stored with the mock return data
             assert result.id == PROJECT_ID
             assert result.name == PROJECT_NAME
             assert result.parent_id == PARENT_ID


### PR DESCRIPTION
**NOTE:** This is an incomplete solution. All the changes included here are largely un-tested. Development on this jira stopped when I re-discovered that https://sagebionetworks.jira.com/browse/PLFM-8313 blocks us from being able to move to the `/bundle2` rest APIs, as this prevents our ability to forcefully increment entities as available in an API like https://rest-docs.synapse.org/rest/PUT/entity/id.html


# **Problem:**

- All resources that get saved to the Synapse rest API go through a multiple step process to store the entity data, annotations, activity, and association to the entity via several disjointed HTTP calls. APIs like https://rest-docs.synapse.org/rest/PUT/entity/id/bundle2.html and https://rest-docs.synapse.org/rest/POST/entity/bundle2/create.html exist to update or create everything (But activity, as it is a separate call) in a single HTTP request.
- By swapping to use the /bundle2 rest API we can consolidate the storing process for all OOP models and remove duplicated code across the code base.


# **Solution:**

- Starts the process to implement all of the required logic to point the storing of all entities at the `/bundle2` API calls
- Start to drop all usage of the core (And soon to be deprecated/removed) Synapse class functionality in favor or dedicated API call functions

# **Testing:**

- TODO
