### PR TITLE
[SYNPY-1244] Clarify docstrings with `delete_permissions` function and `recursive` behavior

### DIFF
--- a/synapseclient/models/mixins/access_control.py
+++ b/synapseclient/models/mixins/access_control.py
@@ -219,8 +219,8 @@ class AccessControllable(AccessControllableSynchronousProtocol):
     async def delete_permissions_async(
         self,
         include_self: bool = True,
-        recursive: bool = False,
         include_container_content: bool = False,
+        recursive: bool = False,
         target_entity_types: Optional[List[str]] = None,
         *,
         synapse_client: Optional[Synapse] = None,
@@ -242,16 +242,15 @@ class AccessControllable(AccessControllableSynchronousProtocol):
 
         Arguments:
             include_self: If True (default), delete the ACL of the current entity.
-                If False, skip deleting the ACL of the current entity and only process
-                children if recursive=True and include_container_content=True.
+                If False, skip deleting the ACL of the current entity.
+            include_container_content: If True, delete ACLs from contents directly within
+                containers (files and folders inside self). This must be set to
+                True for recursive to have any effect. Defaults to False.
             recursive: If True and the entity is a container (e.g., Project or Folder),
                 recursively process child containers. Note that this must be used with
                 include_container_content=True to have any effect. Setting recursive=True
                 with include_container_content=False will raise a ValueError.
                 Only works on classes that support the `sync_from_synapse_async` method.
-            include_container_content: If True, delete ACLs from contents directly within
-                containers (files and folders inside Projects/Folders). This must be set to
-                True for recursive to have any effect. Defaults to False.
             target_entity_types: Specify which entity types to process when deleting ACLs.
                 Allowed values are "folder" and "file" (case-insensitive).
                 If None, defaults to ["folder", "file"].

--- a/synapseclient/models/protocols/access_control_protocol.py
+++ b/synapseclient/models/protocols/access_control_protocol.py
@@ -166,9 +166,9 @@ class AccessControllableSynchronousProtocol(Protocol):
 
     def delete_permissions(
         self,
-        recursive: bool = False,
         include_self: bool = True,
         include_container_content: bool = False,
+        recursive: bool = False,
         target_entity_types: Optional[List[str]] = None,
         *,
         synapse_client: Optional[Synapse] = None,
@@ -190,16 +190,15 @@ class AccessControllableSynchronousProtocol(Protocol):
 
         Arguments:
             include_self: If True (default), delete the ACL of the current entity.
-                If False, skip deleting the ACL of the current entity and only process
-                children if recursive=True and include_container_content=True.
+                If False, skip deleting the ACL of the current entity.
+            include_container_content: If True, delete ACLs from contents directly within
+                containers (files and folders inside self). This must be set to
+                True for recursive to have any effect. Defaults to False.
             recursive: If True and the entity is a container (e.g., Project or Folder),
                 recursively process child containers. Note that this must be used with
                 include_container_content=True to have any effect. Setting recursive=True
                 with include_container_content=False will raise a ValueError.
                 Only works on classes that support the `sync_from_synapse_async` method.
-            include_container_content: If True, delete ACLs from contents directly within
-                containers (files and folders inside Projects/Folders). This must be set to
-                True for recursive to have any effect. Defaults to False.
             target_entity_types: Specify which entity types to process when deleting ACLs.
                 Allowed values are "folder" and "file" (case-insensitive).
                 If None, defaults to ["folder", "file"].

--- a/tests/integration/synapseclient/models/async/test_permissions_async.py
+++ b/tests/integration/synapseclient/models/async/test_permissions_async.py
@@ -736,9 +736,13 @@ class TestDeletePermissions:
         await self._set_custom_permissions(file_3)
 
         # WHEN I delete permissions recursively but without container content
-        await top_level_folder.delete_permissions_async(
-            recursive=True, include_container_content=False
-        )
+        with pytest.raises(
+            ValueError,
+            match="When recursive=True, include_container_content must also be True",
+        ) as exc_info:
+            await top_level_folder.delete_permissions_async(
+                recursive=True, include_container_content=False
+            )
 
         # THEN the top_level_folder permissions should be deleted
         await self._verify_permissions_deleted(top_level_folder)
@@ -746,7 +750,7 @@ class TestDeletePermissions:
         # AND the folder_1 permissions should remain (because include_container_content=False)
         await self._verify_permissions_not_deleted(folder_1)
 
-        # BUT the file_3 permissions should remain (because include_container_content=False)
+        # AND the file_3 permissions should remain (because include_container_content=False)
         assert await self._verify_permissions_not_deleted(file_3)
 
     async def test_delete_permissions_recursive_with_container_content(

--- a/tests/integration/synapseclient/models/synchronous/test_permissions.py
+++ b/tests/integration/synapseclient/models/synchronous/test_permissions.py
@@ -727,10 +727,14 @@ class TestDeletePermissions:
         await self._set_custom_permissions(folder_1)
         await self._set_custom_permissions(file_3)
 
-        # WHEN I delete permissions recursively but without container content
-        top_level_folder.delete_permissions(
-            recursive=True, include_container_content=False
-        )
+        with pytest.raises(
+            ValueError,
+            match="When recursive=True, include_container_content must also be True",
+        ) as exc_info:
+            # WHEN I delete permissions recursively but without container content
+            top_level_folder.delete_permissions(
+                recursive=True, include_container_content=False
+            )
 
         # THEN the top_level_folder permissions should be deleted
         await self._verify_permissions_deleted(top_level_folder)
@@ -738,7 +742,7 @@ class TestDeletePermissions:
         # AND the folder_1 permissions should remain (because include_container_content=False)
         await self._verify_permissions_not_deleted(folder_1)
 
-        # BUT the file_3 permissions should remain (because include_container_content=False)
+        # AND the file_3 permissions should remain (because include_container_content=False)
         assert await self._verify_permissions_not_deleted(file_3)
 
     async def test_delete_permissions_recursive_with_container_content(

--- a/tests/unit/synapseclient/models/unit_test_permissions.py
+++ b/tests/unit/synapseclient/models/unit_test_permissions.py
@@ -163,24 +163,6 @@ class TestDeletePermissionsAsync:
             entity_id="syn123", synapse_client=self.synapse_client
         )
 
-    async def test_sync_failure_doesnt_process_children(self):
-        """Test that sync failure prevents processing children."""
-        # GIVEN a folder with an ID and mocked sync_from_synapse_async method that fails
-        folder = Folder(id="syn123")
-        folder.sync_from_synapse_async = AsyncMock(side_effect=Exception("Sync failed"))
-
-        # WHEN deleting permissions recursively
-        folder.delete_permissions(recursive=True)
-
-        # THEN sync_from_synapse_async should be called
-        folder.sync_from_synapse_async.assert_called_once()
-
-        # AND delete_entity_acl should be called on the folder itself
-        self.mock_delete_acl.assert_called_once()
-
-        # AND a warning log message should be generated
-        self.synapse_client.logger.warning.assert_called_once()
-
     async def test_filter_by_entity_type_folder(self):
         """Test filtering deletion by folder entity type."""
         # GIVEN a folder with an ID and child folder and file
@@ -297,3 +279,21 @@ class TestDeletePermissionsAsync:
 
         # AND a warning log message should be generated
         self.synapse_client.logger.warning.assert_called_once()
+
+    async def test_invalid_recursive_without_include_container_content(self):
+        """Test that setting recursive=True without include_container_content=True raises ValueError."""
+        # GIVEN a folder with an ID
+        folder = Folder(id="syn123")
+
+        # WHEN attempting to delete permissions with recursive=True but include_container_content=False
+        # THEN a ValueError should be raised
+        with pytest.raises(
+            ValueError,
+            match="When recursive=True, include_container_content must also be True",
+        ):
+            folder.delete_permissions(recursive=True, include_container_content=False)
+
+        # AND the delete_entity_acl function should still be called for the folder itself
+        self.mock_delete_acl.assert_called_once_with(
+            entity_id="syn123", synapse_client=self.synapse_client
+        )


### PR DESCRIPTION
# **Problem:**

- The docstring for the `recursive` flag implied incorrect behavior of the function when used in conjunction with `include_container_content`

# **Solution:**

- Update docstring and examples to clarify behavior
- Raise a ValueError exception when falling into a situation that will cause no actions to be taken

# **Testing:**

- Verified updated behavior and unit test