### PR TITLE
[SYNPY-1599]: add json schema mixin class 

### DIFF
--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -8,6 +8,7 @@ from .agent_services import (
     update_session,
 )
 from .annotations import set_annotations, set_annotations_async
+from .api_client import rest_post_paginated_async
 from .configuration_services import (
     get_client_authenticated_s3_profile,
     get_config_authentication,
@@ -48,6 +49,15 @@ from .file_services import (
     put_file_multipart_add,
     put_file_multipart_complete,
 )
+from .json_schema_services import (
+    bind_json_schema_to_entity,
+    delete_json_schema_from_entity,
+    get_invalid_json_schema_validation,
+    get_json_schema_derived_keys,
+    get_json_schema_from_entity,
+    get_json_schema_validation_statistics,
+    validate_entity_with_json_schema,
+)
 from .table_services import (
     ViewEntityType,
     ViewTypeMask,
@@ -55,18 +65,6 @@ from .table_services import (
     get_default_columns,
     post_columns,
 )
-
-from .json_schema_services import (
-    bind_json_schema_to_entity,
-    get_json_schema_from_entity,
-    delete_json_schema_from_entity,
-    validate_entity_with_json_schema,
-    get_json_schema_validation_statistics,
-    get_invalid_json_schema_validation,
-    get_json_schema_derived_keys,
-)
-
-from .api_client import rest_post_paginated_async
 
 __all__ = [
     # annotations
@@ -130,6 +128,6 @@ __all__ = [
     "get_json_schema_validation_statistics",
     "get_invalid_json_schema_validation",
     "get_json_schema_derived_keys",
-    # api client 
+    # api client
     "rest_post_paginated_async",
 ]

--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -56,6 +56,18 @@ from .table_services import (
     post_columns,
 )
 
+from .json_schema_services import (
+    bind_json_schema_to_entity,
+    get_json_schema_from_entity,
+    delete_json_schema_from_entity,
+    validate_entity_with_json_schema,
+    get_json_schema_validation_statistics,
+    get_invalid_json_schema_validation,
+    get_json_schema_derived_keys,
+)
+
+from .api_client import rest_post_paginated_async
+
 __all__ = [
     # annotations
     "set_annotations",
@@ -110,4 +122,14 @@ __all__ = [
     "get_default_columns",
     "ViewTypeMask",
     "ViewEntityType",
+    # json schema services
+    "bind_json_schema_to_entity",
+    "get_json_schema_from_entity",
+    "delete_json_schema_from_entity",
+    "validate_entity_with_json_schema",
+    "get_json_schema_validation_statistics",
+    "get_invalid_json_schema_validation",
+    "get_json_schema_derived_keys",
+    # api client 
+    "rest_post_paginated_async",
 ]

--- a/synapseclient/api/api_client.py
+++ b/synapseclient/api/api_client.py
@@ -1,0 +1,54 @@
+from typing import Dict, Any, AsyncGenerator, Optional, TYPE_CHECKING
+import httpx
+
+if TYPE_CHECKING:
+    from synapseclient import Synapse
+
+async def rest_post_paginated_async(
+    uri: str,
+    body: Dict[str, Any] = None,
+    endpoint: str = None,
+    headers: httpx.Headers = None,
+    retry_policy: Dict[str, Any] = {},
+    requests_session_async_synapse: httpx.AsyncClient = None,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+    **kwargs,
+) -> AsyncGenerator[Dict[str, str], None]:
+    """
+    Asynchronously yield items from a paginated POST endpoint.
+
+    Arguments:
+        uri: Endpoint URI for the POST request.
+        body: Request payload dictionary.
+        endpoint: Optional server endpoint override.
+        headers: Optional HTTP headers.
+        retry_policy: Optional retry settings.
+        requests_session_async_synapse: Optional async HTTPX client session.
+        kwargs: Additional keyword arguments for the request.
+
+    Yields:
+        Individual items from each page of the response.
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+    next_page_token = None
+    while True:
+        if next_page_token is not None:
+            body = body or {}
+            body["nextPageToken"] = next_page_token
+        response = await client.rest_post_async(
+            uri=uri,
+            body=body,
+            endpoint=endpoint,
+            headers=headers,
+            retry_policy=retry_policy,
+            requests_session_async_synapse=requests_session_async_synapse,
+            **kwargs,
+        )
+        next_page_token = response.get("nextPageToken")
+        for item in response.get("page", []):
+            yield item
+        if next_page_token is None:
+            break

--- a/synapseclient/api/api_client.py
+++ b/synapseclient/api/api_client.py
@@ -1,8 +1,10 @@
-from typing import Dict, Any, AsyncGenerator, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, Optional
+
 import httpx
 
 if TYPE_CHECKING:
     from synapseclient import Synapse
+
 
 async def rest_post_paginated_async(
     uri: str,

--- a/synapseclient/api/json_schema_services.py
+++ b/synapseclient/api/json_schema_services.py
@@ -1,0 +1,180 @@
+import json 
+from typing import TYPE_CHECKING, Optional, AsyncGenerator
+from synapseclient.api.api_client import rest_post_paginated_async
+
+if TYPE_CHECKING:
+    from synapseclient import Synapse
+
+async def bind_json_schema_to_entity(synapse_id: str, json_schema_uri: str, *, synapse_client: Optional["Synapse"] = None) -> dict[str, str|int|bool]:
+    """Bind a JSON schema to an entity
+
+    Arguments:
+        json_schema_uri: JSON schema URI
+        entity:          Synapse Entity or Synapse Id
+        synapse_client:  If not passed in and caching was not disabled by
+                         `Synapse.allow_client_caching(False)` this will use the last created
+                         instance from the Synapse class constructor
+    Returns:
+        A dictionary with the following structure:
+
+        {
+            "jsonSchemaVersionInfo": {
+                "organizationId": str,
+                "organizationName": str,
+                "schemaId": str,
+                "schemaName": str,
+                "versionId": str,
+                "$id": str (unique identifier for the schema),
+                "semanticVersion": str,
+                "jsonSHA256Hex": str,
+                "createdOn": str (ISO datetime),
+                "createdBy": str (synapse user ID),
+            },
+            "objectId": int,
+            "objectType": str,
+            "createdOn": str (ISO datetime),
+            "createdBy": str (synapse user ID),
+            "enableDerivedAnnotations": bool
+        }
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+    request_body = {"entityId": synapse_id, "schema$id": json_schema_uri}
+    return await client.rest_put_async(uri=f"/entity/{synapse_id}/schema/binding", body=json.dumps(request_body))
+
+async def get_json_schema_from_entity(synapse_id: str, *, synapse_client: Optional["Synapse"] = None) -> dict[str, str|int|bool]:
+    """Get bound schema from entity
+
+    Arguments:
+        synapse_id:      Synapse Id
+        synapse_client:  If not passed in and caching was not disabled by
+                         `Synapse.allow_client_caching(False)` this will use the last created
+                         instance from the Synapse class constructor
+
+    Returns:
+        A dictionary with the following structure:
+        {
+            "jsonSchemaVersionInfo": {
+                "organizationId": str,
+                "organizationName": str,
+                "schemaId": str,
+                "schemaName": str,
+                "versionId": str,
+                "$id": str (unique identifier for the schema),
+                "semanticVersion": str,
+                "jsonSHA256Hex": str,
+                "createdOn": str (ISO datetime),
+                "createdBy": str (synapse user ID),
+            },
+            "objectId": int,
+            "objectType": str,
+            "createdOn": str (ISO datetime),
+            "createdBy": str (synapse user ID),
+            "enableDerivedAnnotations": bool
+        }
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_get_async(uri=f"/entity/{synapse_id}/schema/binding")
+
+
+async def delete_json_schema_from_entity(synapse_id: str, *, synapse_client: Optional["Synapse"] = None) -> None:
+    """Delete bound schema from entity
+    Arguments:
+        synapse_id:      Synapse Id
+        synapse_client:  If not passed in and caching was not disabled by
+                         `Synapse.allow_client_caching(False)` this will use the last created
+                         instance from the Synapse class constructor
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_delete_async(uri=f"/entity/{synapse_id}/schema/binding")
+
+async def validate_entity_with_json_schema(
+    synapse_id: str, *, synapse_client: Optional["Synapse"] = None
+) -> dict[str, str|bool]:
+    """Get validation results of an entity against bound JSON schema
+
+    Arguments:
+        synapse_id:      Synapse Id
+        synapse_client:  If not passed in and caching was not disabled by
+                         `Synapse.allow_client_caching(False)` this will use the last created
+                         instance from the Synapse class constructor
+
+    Returns:
+        {
+            "objectId": str,         # Synapse ID of the object (e.g., "syn12345678")
+            "objectType": str,       # Type of the object (e.g., "entity")
+            "objectEtag": str,       # ETag of the object at the time of validation
+            "schema$id": str,        # Full URL of the bound schema version
+            "isValid": bool,         # True if the object content conforms to the schema
+            "validatedOn": str       # ISO 8601 timestamp of when validation occurred
+        }
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_get_async(uri=f"/entity/{synapse_id}/schema/validation")
+
+
+async def get_json_schema_validation_statistics(
+    synapse_id: str, *, synapse_client: Optional["Synapse"] = None
+) -> dict[str, int|str]:
+    """Get the summary statistic of json schema validation results for
+        a container entity
+     Arguments:
+        synapse_id:      Synapse Id
+        synapse_client:  If not passed in and caching was not disabled by
+                         `Synapse.allow_client_caching(False)` this will use the last created
+                         instance from the Synapse class constructor
+
+    Returns:
+        {
+            "containerId": str,              # Synapse ID of the parent container
+            "totalNumberOfChildren": int,    # Total number of child entities
+            "numberOfValidChildren": int,    # Number of children that passed validation
+            "numberOfInvalidChildren": int,  # Number of children that failed validation
+            "numberOfUnknownChildren": int,  # Number of children with unknown validation status
+            "generatedOn": str               # ISO 8601 timestamp when this summary was generated
+        }
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_get_async(uri=f"/entity/{synapse_id}/schema/validation/statistics")
+
+async def get_invalid_json_schema_validation(synapse_id: str, *, synapse_client: Optional["Synapse"] = None) -> AsyncGenerator[dict[str, str], None]:
+    """Get a single page of invalid JSON schema validation results for a container Entity
+        (Project or Folder).
+
+        Arguments:
+            synapse_id:      Synapse Id
+            synapse_client:  If not passed in and caching was not disabled by
+                             `Synapse.allow_client_caching(False)` this will use the last created
+                             instance from the Synapse class constructor"""
+
+    request_body = {"containerId": synapse_id}
+    response = rest_post_paginated_async(f"/entity/{synapse_id}/schema/validation/invalid", body=json.dumps(request_body), synapse_client=synapse_client)
+    async for item in response:
+        yield item
+    
+async def get_json_schema_derived_keys(
+    synapse_id: str, *, synapse_client: Optional["Synapse"] = None
+) -> dict[str, list[str]]:
+    """Retrieve derived JSON schema keys for a given Synapse entity.
+
+    Args:
+        synapse_id (str): The Synapse ID of the entity for which to retrieve derived keys.
+
+    Returns:
+        dict: A dictionary containing the derived keys associated with the entity.
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+    return await client.rest_get_async(uri=f"/entity/{synapse_id}/derivedKeys")
+
+

--- a/synapseclient/api/json_schema_services.py
+++ b/synapseclient/api/json_schema_services.py
@@ -154,7 +154,19 @@ async def get_invalid_json_schema_validation(synapse_id: str, *, synapse_client:
             synapse_id:      Synapse Id
             synapse_client:  If not passed in and caching was not disabled by
                              `Synapse.allow_client_caching(False)` this will use the last created
-                             instance from the Synapse class constructor"""
+                             instance from the Synapse class constructor
+
+    Example usage:
+    async def main():
+        gen = get_invalid_json_schema_validation(synapse_client=syn, synapse_id=dataset_folder)
+        try:
+            while True:
+                item = await anext(gen)
+                print(item)
+        except StopAsyncIteration:
+            print("All items processed.")
+    asyncio.run(main())
+    """
 
     request_body = {"containerId": synapse_id}
     response = rest_post_paginated_async(f"/entity/{synapse_id}/schema/validation/invalid", body=json.dumps(request_body), synapse_client=synapse_client)

--- a/synapseclient/api/json_schema_services.py
+++ b/synapseclient/api/json_schema_services.py
@@ -1,11 +1,15 @@
-import json 
-from typing import TYPE_CHECKING, Optional, AsyncGenerator
+import json
+from typing import TYPE_CHECKING, AsyncGenerator, Optional
+
 from synapseclient.api.api_client import rest_post_paginated_async
 
 if TYPE_CHECKING:
     from synapseclient import Synapse
 
-async def bind_json_schema_to_entity(synapse_id: str, json_schema_uri: str, *, synapse_client: Optional["Synapse"] = None) -> dict[str, str|int|bool]:
+
+async def bind_json_schema_to_entity(
+    synapse_id: str, json_schema_uri: str, *, synapse_client: Optional["Synapse"] = None
+) -> dict[str, str | int | bool]:
     """Bind a JSON schema to an entity
 
     Arguments:
@@ -41,9 +45,14 @@ async def bind_json_schema_to_entity(synapse_id: str, json_schema_uri: str, *, s
 
     client = Synapse.get_client(synapse_client=synapse_client)
     request_body = {"entityId": synapse_id, "schema$id": json_schema_uri}
-    return await client.rest_put_async(uri=f"/entity/{synapse_id}/schema/binding", body=json.dumps(request_body))
+    return await client.rest_put_async(
+        uri=f"/entity/{synapse_id}/schema/binding", body=json.dumps(request_body)
+    )
 
-async def get_json_schema_from_entity(synapse_id: str, *, synapse_client: Optional["Synapse"] = None) -> dict[str, str|int|bool]:
+
+async def get_json_schema_from_entity(
+    synapse_id: str, *, synapse_client: Optional["Synapse"] = None
+) -> dict[str, str | int | bool]:
     """Get bound schema from entity
 
     Arguments:
@@ -80,7 +89,9 @@ async def get_json_schema_from_entity(synapse_id: str, *, synapse_client: Option
     return await client.rest_get_async(uri=f"/entity/{synapse_id}/schema/binding")
 
 
-async def delete_json_schema_from_entity(synapse_id: str, *, synapse_client: Optional["Synapse"] = None) -> None:
+async def delete_json_schema_from_entity(
+    synapse_id: str, *, synapse_client: Optional["Synapse"] = None
+) -> None:
     """Delete bound schema from entity
     Arguments:
         synapse_id:      Synapse Id
@@ -93,9 +104,10 @@ async def delete_json_schema_from_entity(synapse_id: str, *, synapse_client: Opt
     client = Synapse.get_client(synapse_client=synapse_client)
     return await client.rest_delete_async(uri=f"/entity/{synapse_id}/schema/binding")
 
+
 async def validate_entity_with_json_schema(
     synapse_id: str, *, synapse_client: Optional["Synapse"] = None
-) -> dict[str, str|bool]:
+) -> dict[str, str | bool]:
     """Get validation results of an entity against bound JSON schema
 
     Arguments:
@@ -122,7 +134,7 @@ async def validate_entity_with_json_schema(
 
 async def get_json_schema_validation_statistics(
     synapse_id: str, *, synapse_client: Optional["Synapse"] = None
-) -> dict[str, int|str]:
+) -> dict[str, int | str]:
     """Get the summary statistic of json schema validation results for
         a container entity
      Arguments:
@@ -144,9 +156,14 @@ async def get_json_schema_validation_statistics(
     from synapseclient import Synapse
 
     client = Synapse.get_client(synapse_client=synapse_client)
-    return await client.rest_get_async(uri=f"/entity/{synapse_id}/schema/validation/statistics")
+    return await client.rest_get_async(
+        uri=f"/entity/{synapse_id}/schema/validation/statistics"
+    )
 
-async def get_invalid_json_schema_validation(synapse_id: str, *, synapse_client: Optional["Synapse"] = None) -> AsyncGenerator[dict[str, str], None]:
+
+async def get_invalid_json_schema_validation(
+    synapse_id: str, *, synapse_client: Optional["Synapse"] = None
+) -> AsyncGenerator[dict[str, str], None]:
     """Get a single page of invalid JSON schema validation results for a container Entity
         (Project or Folder).
 
@@ -169,10 +186,15 @@ async def get_invalid_json_schema_validation(synapse_id: str, *, synapse_client:
     """
 
     request_body = {"containerId": synapse_id}
-    response = rest_post_paginated_async(f"/entity/{synapse_id}/schema/validation/invalid", body=json.dumps(request_body), synapse_client=synapse_client)
+    response = rest_post_paginated_async(
+        f"/entity/{synapse_id}/schema/validation/invalid",
+        body=json.dumps(request_body),
+        synapse_client=synapse_client,
+    )
     async for item in response:
         yield item
-    
+
+
 async def get_json_schema_derived_keys(
     synapse_id: str, *, synapse_client: Optional["Synapse"] = None
 ) -> dict[str, list[str]]:
@@ -188,5 +210,3 @@ async def get_json_schema_derived_keys(
 
     client = Synapse.get_client(synapse_client=synapse_client)
     return await client.rest_get_async(uri=f"/entity/{synapse_id}/derivedKeys")
-
-

--- a/synapseclient/models/folder.py
+++ b/synapseclient/models/folder.py
@@ -13,7 +13,11 @@ from synapseclient.core.exceptions import SynapseError
 from synapseclient.core.utils import delete_none_keys, merge_dataclass_entities
 from synapseclient.entity import Folder as Synapse_Folder
 from synapseclient.models import Annotations, File
-from synapseclient.models.mixins import AccessControllable, StorableContainer
+from synapseclient.models.mixins import (
+    AccessControllable,
+    JSONSchema,
+    StorableContainer,
+)
 from synapseclient.models.protocols.folder_protocol import FolderSynchronousProtocol
 from synapseclient.models.services.search import get_id
 from synapseclient.models.services.storable_entity_components import (
@@ -28,7 +32,9 @@ if TYPE_CHECKING:
 
 @dataclass()
 @async_to_sync
-class Folder(FolderSynchronousProtocol, AccessControllable, StorableContainer):
+class Folder(
+    FolderSynchronousProtocol, AccessControllable, StorableContainer, JSONSchema
+):
     """Folder is a hierarchical container for organizing data in Synapse.
 
     Attributes:

--- a/synapseclient/models/mixins/__init__.py
+++ b/synapseclient/models/mixins/__init__.py
@@ -2,10 +2,12 @@
 
 from synapseclient.models.mixins.access_control import AccessControllable
 from synapseclient.models.mixins.asynchronous_job import AsynchronousCommunicator
+from synapseclient.models.mixins.json_schema import JSONSchema
 from synapseclient.models.mixins.storable_container import StorableContainer
 
 __all__ = [
     "AccessControllable",
     "StorableContainer",
     "AsynchronousCommunicator",
+    "JSONSchema",
 ]

--- a/synapseclient/models/mixins/json_schema.py
+++ b/synapseclient/models/mixins/json_schema.py
@@ -1,0 +1,168 @@
+from typing import TYPE_CHECKING, AsyncGenerator, Optional
+
+from synapseclient.api.json_schema_services import (
+    bind_json_schema_to_entity,
+    delete_json_schema_from_entity,
+    get_invalid_json_schema_validation,
+    get_json_schema_derived_keys,
+    get_json_schema_from_entity,
+    get_json_schema_validation_statistics,
+    validate_entity_with_json_schema,
+)
+
+if TYPE_CHECKING:
+    from synapseclient import Synapse
+
+
+class JSONSchema:
+    """
+    Mixin class to provide JSON schema functionality.
+    This class is intended to be used with classes that represent Synapse entities.
+    It provides methods to bind, delete, and validate JSON schemas associated with the entity.
+    """
+
+    id: Optional[str] = None
+
+    async def bind_json_schema_to_entity(
+        self, json_schema_uri: str, *, synapse_client: Optional["Synapse"] = None
+    ) -> dict[str, str | int | bool]:
+        """Bind a JSON schema to an entity"""
+        return await bind_json_schema_to_entity(
+            synapse_id=self.id,
+            json_schema_uri=json_schema_uri,
+            synapse_client=synapse_client,
+        )
+
+    async def get_json_schema_from_entity(
+        self, *, synapse_client: Optional["Synapse"] = None
+    ) -> dict[str, str | int | bool]:
+        """Get bound schema from entity
+
+        Arguments:
+            synapse_id:      Synapse Id
+            synapse_client:  If not passed in and caching was not disabled by
+                            `Synapse.allow_client_caching(False)` this will use the last created
+                            instance from the Synapse class constructor
+
+        Returns:
+            A dictionary with the following structure:
+            {
+                "jsonSchemaVersionInfo": {
+                    "organizationId": str,
+                    "organizationName": str,
+                    "schemaId": str,
+                    "schemaName": str,
+                    "versionId": str,
+                    "$id": str (unique identifier for the schema),
+                    "semanticVersion": str,
+                    "jsonSHA256Hex": str,
+                    "createdOn": str (ISO datetime),
+                    "createdBy": str (synapse user ID),
+                },
+                "objectId": int,
+                "objectType": str,
+                "createdOn": str (ISO datetime),
+                "createdBy": str (synapse user ID),
+                "enableDerivedAnnotations": bool
+            }
+        """
+        return await get_json_schema_from_entity(
+            synapse_id=self.id, synapse_client=synapse_client
+        )
+
+    async def delete_json_schema_from_entity(
+        self, *, synapse_client: Optional["Synapse"] = None
+    ) -> None:
+        """Delete bound schema from entity
+        Arguments:
+            synapse_id:      Synapse Id
+            synapse_client:  If not passed in and caching was not disabled by
+                            `Synapse.allow_client_caching(False)` this will use the last created
+                            instance from the Synapse class constructor
+        """
+        return await delete_json_schema_from_entity(
+            synapse_id=self.id, synapse_client=synapse_client
+        )
+
+    async def validate_entity_with_json_schema(
+        self, *, synapse_client: Optional["Synapse"] = None
+    ) -> dict[str, str | bool]:
+        """Get validation results of an entity against bound JSON schema
+
+        Arguments:
+            synapse_id:      Synapse Id
+            synapse_client:  If not passed in and caching was not disabled by
+                            `Synapse.allow_client_caching(False)` this will use the last created
+                            instance from the Synapse class constructor
+
+        Returns:
+            {
+                "objectId": str,         # Synapse ID of the object (e.g., "syn12345678")
+                "objectType": str,       # Type of the object (e.g., "entity")
+                "objectEtag": str,       # ETag of the object at the time of validation
+                "schema$id": str,        # Full URL of the bound schema version
+                "isValid": bool,         # True if the object content conforms to the schema
+                "validatedOn": str       # ISO 8601 timestamp of when validation occurred
+            }
+        """
+        return await validate_entity_with_json_schema(
+            synapse_id=self.id, synapse_client=synapse_client
+        )
+
+    async def get_json_schema_validation_statistics(
+        self, *, synapse_client: Optional["Synapse"] = None
+    ) -> dict[str, int | str]:
+        """Get the summary statistic of json schema validation results for
+            a container entity
+        Arguments:
+            synapse_id:      Synapse Id
+            synapse_client:  If not passed in and caching was not disabled by
+                            `Synapse.allow_client_caching(False)` this will use the last created
+                            instance from the Synapse class constructor
+
+        Returns:
+            {
+                "containerId": str,              # Synapse ID of the parent container
+                "totalNumberOfChildren": int,    # Total number of child entities
+                "numberOfValidChildren": int,    # Number of children that passed validation
+                "numberOfInvalidChildren": int,  # Number of children that failed validation
+                "numberOfUnknownChildren": int,  # Number of children with unknown validation status
+                "generatedOn": str               # ISO 8601 timestamp when this summary was generated
+            }
+        """
+        return await get_json_schema_validation_statistics(
+            synapse_id=self.id, synapse_client=synapse_client
+        )
+
+    async def get_invalid_json_schema_validation(
+        self, *, synapse_client: Optional["Synapse"] = None
+    ) -> AsyncGenerator[dict[str, str], None]:
+        """Get a single page of invalid JSON schema validation results for a container Entity
+        (Project or Folder).
+
+        Arguments:
+            synapse_id:      Synapse Id
+            synapse_client:  If not passed in and caching was not disabled by
+                            `Synapse.allow_client_caching(False)` this will use the last created
+                            instance from the Synapse class constructor
+        """
+        gen = get_invalid_json_schema_validation(
+            synapse_client=synapse_client, synapse_id=self.id
+        )
+        async for item in gen:
+            yield item
+
+    async def get_json_schema_derived_keys(
+        self, *, synapse_client: Optional["Synapse"] = None
+    ) -> dict[str, list[str]]:
+        """Retrieve derived JSON schema keys for a given Synapse entity.
+
+        Args:
+            synapse_id (str): The Synapse ID of the entity for which to retrieve derived keys.
+
+        Returns:
+            dict: A dictionary containing the derived keys associated with the entity.
+        """
+        return await get_json_schema_derived_keys(
+            synapse_id=self.id, synapse_client=synapse_client
+        )


### PR DESCRIPTION
# **Problem:**
* We currently do not have an easy interface to bind, validate, and unbind jsonschemas. 
* We currently don’t have a function that handles asynchronous POST requests with pagination.

# **Solution:**
* Add json schema mixin and have Folder, File entities to inherit from the JSON SCHEMA mixin 
* Add a function in `api_client.py` to handle asynchronous POST requests with pagination

# **Testing:**

