### PR TITLE
[SYNPY-1618] Clean up test resources in Synapse created during integration test runs

### DIFF
--- a/.github/scripts/delete_evaluations.py
+++ b/.github/scripts/delete_evaluations.py
@@ -1,0 +1,70 @@
+import asyncio
+from typing import Set
+
+from synapseclient import Evaluation, Synapse
+
+syn = Synapse()
+syn.login()
+
+# Maximum number of concurrent deletion operations
+MAX_CONCURRENT_DELETIONS = 5
+
+
+async def delete_evaluation(eval_obj: Evaluation) -> str:
+    """Delete an evaluation asynchronously and return the status"""
+    try:
+        # Need to use run_in_executor since the delete function is synchronous
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, lambda: syn.delete(eval_obj))
+        return f"Deleted evaluation {eval_obj.id}"
+    except Exception as e:
+        return f"Failed to delete evaluation {eval_obj.id}: {str(e)}"
+
+
+async def main():
+    # Create a semaphore to limit concurrent operations
+    semaphore = asyncio.Semaphore(MAX_CONCURRENT_DELETIONS)
+
+    # Set to track active tasks
+    pending_tasks: Set[asyncio.Task] = set()
+
+    # Track if we've processed any evaluations
+    processed_any = False
+
+    async def delete_with_semaphore(eval_obj: Evaluation):
+        """Helper function that uses the semaphore to limit concurrency"""
+        async with semaphore:
+            result = await delete_evaluation(eval_obj)
+            print(result)
+            return result
+
+    # Process evaluations as they come in from the paginated iterator
+    for result in syn._GET_paginated(
+        "/evaluation?accessType=DELETE", limit=200, offset=0
+    ):
+        processed_any = True
+        eval_obj = Evaluation(**result)
+
+        # Create a new task for this evaluation
+        task = asyncio.create_task(delete_with_semaphore(eval_obj))
+        pending_tasks.add(task)
+        task.add_done_callback(pending_tasks.discard)
+
+        # Process any completed tasks when we reach MAX_CONCURRENT_DELETIONS
+        if len(pending_tasks) >= MAX_CONCURRENT_DELETIONS:
+            # Wait for at least one task to complete before continuing
+            done, _ = await asyncio.wait(
+                pending_tasks, return_when=asyncio.FIRST_COMPLETED
+            )
+
+    # Wait for all remaining tasks to complete
+    if pending_tasks:
+        await asyncio.gather(*pending_tasks)
+
+    if not processed_any:
+        print("No evaluations found to delete")
+
+
+# Run the async main function
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/.github/scripts/delete_projects.py
+++ b/.github/scripts/delete_projects.py
@@ -1,0 +1,67 @@
+import asyncio
+from typing import Dict, Set
+
+from synapseclient import Synapse
+
+syn = Synapse()
+syn.login()
+
+# Maximum number of concurrent deletion operations
+MAX_CONCURRENT_DELETIONS = 5
+
+
+async def delete_project(project_id: str) -> str:
+    """Delete a project asynchronously and return the result status"""
+    try:
+        # Need to use run_in_executor since the delete function is synchronous
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, lambda: syn.delete(project_id))
+        return f"Deleted {project_id}"
+    except Exception as e:
+        return f"Failed to delete {project_id}: {str(e)}"
+
+
+async def main():
+    # Create a semaphore to limit concurrent operations
+    semaphore = asyncio.Semaphore(MAX_CONCURRENT_DELETIONS)
+
+    # Set to track active tasks
+    pending_tasks: Set[asyncio.Task] = set()
+
+    # Track if we've processed any projects
+    processed_any = False
+
+    async def delete_with_semaphore(project: Dict):
+        """Helper function that uses the semaphore to limit concurrency"""
+        async with semaphore:
+            result = await delete_project(project["id"])
+            print(result)
+            return result
+
+    # Process projects as they come in from the iterator
+    for project in syn.getChildren(parent=None, includeTypes=["project"]):
+        processed_any = True
+
+        # Create a new task for this project
+        task = asyncio.create_task(delete_with_semaphore(project))
+        pending_tasks.add(task)
+        task.add_done_callback(pending_tasks.discard)
+
+        # Process any completed tasks when we reach MAX_CONCURRENT_DELETIONS
+        if len(pending_tasks) >= MAX_CONCURRENT_DELETIONS:
+            # Wait for at least one task to complete before continuing
+            done, _ = await asyncio.wait(
+                pending_tasks, return_when=asyncio.FIRST_COMPLETED
+            )
+
+    # Wait for all remaining tasks to complete
+    if pending_tasks:
+        await asyncio.gather(*pending_tasks)
+
+    if not processed_any:
+        print("No projects found to delete")
+
+
+# Run the async main function
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/.github/scripts/delete_teams.py
+++ b/.github/scripts/delete_teams.py
@@ -1,0 +1,70 @@
+import asyncio
+from typing import Dict, Set
+
+from synapseclient import Synapse
+
+syn = Synapse()
+syn.login()
+
+# Maximum number of concurrent team deletions
+MAX_CONCURRENT_DELETIONS = 5
+
+
+async def delete_team(team_id: str) -> str:
+    """Delete a team asynchronously and return the team_id"""
+    try:
+        # Need to use run_in_executor since the delete_team function is synchronous
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, lambda: syn.delete_team(team_id))
+        return f"Deleted team {team_id}"
+    except Exception as e:
+        return f"Failed to delete team {team_id}: {str(e)}"
+
+
+async def main():
+    # Get all teams for the current user
+    teams = syn._find_teams_for_principal(principal_id=syn.credentials.owner_id)
+
+    # Create a semaphore to limit concurrent operations
+    semaphore = asyncio.Semaphore(MAX_CONCURRENT_DELETIONS)
+
+    # Set to track active tasks
+    pending_tasks: Set[asyncio.Task] = set()
+
+    # Track if we've processed any teams
+    processed_any = False
+
+    async def delete_with_semaphore(team: Dict):
+        """Helper function that uses the semaphore to limit concurrency"""
+        async with semaphore:
+            result = await delete_team(team["id"])
+            print(result)
+            return result
+
+    # Process teams as they come in from the iterator
+    for team in teams:
+        processed_any = True
+
+        # Create a new task for this team
+        task = asyncio.create_task(delete_with_semaphore(team))
+        pending_tasks.add(task)
+        task.add_done_callback(pending_tasks.discard)
+
+        # Process any completed tasks
+        if len(pending_tasks) >= MAX_CONCURRENT_DELETIONS:
+            # Wait for at least one task to complete before continuing
+            done, _ = await asyncio.wait(
+                pending_tasks, return_when=asyncio.FIRST_COMPLETED
+            )
+
+    # Wait for all remaining tasks to complete
+    if pending_tasks:
+        await asyncio.gather(*pending_tasks)
+
+    if not processed_any:
+        print("No teams found to delete")
+
+
+# Run the async main function
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/.github/scripts/empty_trash.py
+++ b/.github/scripts/empty_trash.py
@@ -1,0 +1,70 @@
+import asyncio
+from typing import Set
+
+from synapseclient import Synapse
+
+syn = Synapse()
+syn.login()
+
+# Maximum number of concurrent deletion operations
+MAX_CONCURRENT_DELETIONS = 5
+
+
+async def purge_entity(entity_id: str) -> str:
+    """Purge an entity from trash asynchronously and return the status"""
+    try:
+        # Need to use run_in_executor since the restPUT function is synchronous
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None, lambda: syn.restPUT(uri=f"/trashcan/purge/{entity_id}")
+        )
+        return f"Purged entity {entity_id} from trash"
+    except Exception as e:
+        return f"Failed to purge entity {entity_id}: {str(e)}"
+
+
+async def main():
+    # Create a semaphore to limit concurrent operations
+    semaphore = asyncio.Semaphore(MAX_CONCURRENT_DELETIONS)
+
+    # Set to track active tasks
+    pending_tasks: Set[asyncio.Task] = set()
+
+    # Track if we've processed any entities
+    processed_any = False
+
+    async def purge_with_semaphore(entity_id: str):
+        """Helper function that uses the semaphore to limit concurrency"""
+        async with semaphore:
+            result = await purge_entity(entity_id)
+            print(result)
+            return result
+
+    # Process entities as they come in from the paginated iterator
+    for result in syn._GET_paginated("/trashcan/view", limit=200, offset=0):
+        processed_any = True
+        entity_id = result["entityId"]
+
+        # Create a new task for this entity
+        task = asyncio.create_task(purge_with_semaphore(entity_id))
+        pending_tasks.add(task)
+        task.add_done_callback(pending_tasks.discard)
+
+        # Process any completed tasks when we reach MAX_CONCURRENT_DELETIONS
+        if len(pending_tasks) >= MAX_CONCURRENT_DELETIONS:
+            # Wait for at least one task to complete before continuing
+            done, _ = await asyncio.wait(
+                pending_tasks, return_when=asyncio.FIRST_COMPLETED
+            )
+
+    # Wait for all remaining tasks to complete
+    if pending_tasks:
+        await asyncio.gather(*pending_tasks)
+
+    if not processed_any:
+        print("No entities found in trash to purge")
+
+
+# Run the async main function
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/.github/workflows/test-cleanup.yml
+++ b/.github/workflows/test-cleanup.yml
@@ -64,6 +64,13 @@ jobs:
           pip install numpy
         fi
 
+    - name: Set up Synapse credentials
+      shell: bash
+      run: |
+        # decrypt the encrypted test synapse configuration
+        openssl aes-256-cbc -K ${{ secrets.encrypted_d17283647768_key }} -iv ${{ secrets.encrypted_d17283647768_iv }} -in test.synapseConfig.enc -out test.synapseConfig -d
+        mv test.synapseConfig ~/.synapseConfig
+
     - name: Run evaluation deletion script
       run: |
         python .github/scripts/delete_evaluations.py

--- a/.github/workflows/test-cleanup.yml
+++ b/.github/workflows/test-cleanup.yml
@@ -1,0 +1,76 @@
+name: "Integration test cleanup"
+
+on:
+  schedule:
+    # Run every Friday at 10:00 PM Eastern Time (3:00 AM UTC Saturday)
+    - cron: '0 3 * * 6'
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  cleanup:
+    name: Delete resources
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.13'
+
+    - name: get-dependencies-location
+      shell: bash
+      run: |
+        SITE_PACKAGES_LOCATION=$(python -c "from sysconfig import get_path; print(get_path('purelib'))")
+        SITE_BIN_DIR=$(python3 -c "import os; import platform; import sysconfig; pre = sysconfig.get_config_var('prefix'); bindir = os.path.join(pre, 'Scripts' if platform.system() == 'Windows' else 'bin'); print(bindir)")
+        echo "site_packages_loc=$SITE_PACKAGES_LOCATION" >> $GITHUB_OUTPUT
+        echo "site_bin_dir=$SITE_BIN_DIR" >> $GITHUB_OUTPUT
+      id: get-dependencies
+
+    - name: Cache py-dependencies
+      id: cache-dependencies
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-py-dependencies-cleanup
+      with:
+        path: |
+          ${{ steps.get-dependencies.outputs.site_packages_loc }}
+          ${{ steps.get-dependencies.outputs.site_bin_dir }}
+        key: ${{ runner.os }}-3.13-build-${{ env.cache-name }}-${{ hashFiles('setup.py') }}-v1
+
+    - name: Install py-dependencies
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+
+        pip install -e ".[boto3,pandas,pysftp,tests]"
+
+        # ensure that numpy c extensions are installed on windows
+        # https://stackoverflow.com/a/59346525
+        if [ "${{startsWith(runner.os, 'Windows')}}" == "true" ]; then
+          pip uninstall -y numpy
+          pip uninstall -y setuptools
+          pip install setuptools
+          pip install numpy
+        fi
+
+    - name: Run evaluation deletion script
+      run: |
+        python .github/scripts/delete_evaluations.py
+
+    - name: Run project deletion script
+      run: |
+        python .github/scripts/delete_projects.py
+
+    - name: Run team deletion script
+      run: |
+        python .github/scripts/delete_teams.py
+
+    - name: Run empty trash script
+      run: |
+        python .github/scripts/empty_trash.py

--- a/.github/workflows/test-cleanup.yml
+++ b/.github/workflows/test-cleanup.yml
@@ -1,6 +1,11 @@
 name: "Integration test cleanup"
 
 on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
   schedule:
     # Run every Friday at 10:00 PM Eastern Time (3:00 AM UTC Saturday)
     - cron: '0 3 * * 6'

--- a/.github/workflows/test-cleanup.yml
+++ b/.github/workflows/test-cleanup.yml
@@ -1,11 +1,6 @@
 name: "Integration test cleanup"
 
 on:
-  push:
-    branches:
-      - '**'
-    tags-ignore:
-      - '**'
   schedule:
     # Run every Friday at 10:00 PM Eastern Time (3:00 AM UTC Saturday)
     - cron: '0 3 * * 6'


### PR DESCRIPTION
# **Problem:**

- When integration tests run a failure in another OS or python version causes all test runs to quit out. This can cause resources to continue existing in Synapse and not be cleaned up.

# **Solution:**

- Create some simple test scripts to clean up the resources and run on a weekly cadence to clean up the resources

# **Testing:**

- This Github run was used to verify that the scripts could be run within github: https://github.com/Sage-Bionetworks/synapsePythonClient/actions/runs/15886384891/job/44799278492
