### PR TITLE
[SYNPY-1607] Enum conversion from String

### DIFF
--- a/synapseclient/models/table_components.py
+++ b/synapseclient/models/table_components.py
@@ -497,6 +497,12 @@ class JsonSubColumn:
     def to_synapse_request(self) -> Dict[str, Any]:
         """Converts the Column object into a dictionary that can be passed into the
         REST API."""
+        if self.column_type and isinstance(self.column_type, str):
+            self.column_type = ColumnType(self.column_type)
+
+        if self.facet_type and isinstance(self.facet_type, str):
+            self.facet_type = FacetType(self.facet_type)
+
         result = {
             "name": self.name,
             "columnType": self.column_type.value if self.column_type else None,
@@ -601,6 +607,11 @@ class Column(ColumnSynchronousProtocol):
     def to_synapse_request(self) -> Dict[str, Any]:
         """Converts the Column object into a dictionary that can be passed into the
         REST API."""
+        if self.column_type and isinstance(self.column_type, str):
+            self.column_type = ColumnType(self.column_type)
+
+        if self.facet_type and isinstance(self.facet_type, str):
+            self.facet_type = FacetType(self.facet_type)
         result = {
             "concreteType": concrete_types.COLUMN_MODEL,
             "name": self.name,

--- a/tests/integration/synapseclient/models/async/test_table_async.py
+++ b/tests/integration/synapseclient/models/async/test_table_async.py
@@ -275,6 +275,46 @@ class TestTableCreation:
             results["column_string"], csv_data["column_string"]
         )
 
+    async def test_create_table_with_string_column(
+        self, project_model: Project
+    ) -> None:
+        """Test creating tables with string column configurations."""
+        # GIVEN a table with columns
+        table_name = str(uuid.uuid4())
+        table_description = "Test table with columns"
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            description=table_description,
+            columns=[
+                Column(name="test_column", column_type="STRING"),
+                Column(name="test_column2", column_type="INTEGER"),
+            ],
+        )
+
+        # WHEN I store the table
+        table = await table.store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # THEN the table should be created
+        assert table.id is not None
+
+        # AND I can retrieve that table from Synapse
+        new_table_instance = await Table(id=table.id).get_async(synapse_client=self.syn)
+        assert new_table_instance is not None
+        assert new_table_instance.name == table_name
+        assert new_table_instance.id == table.id
+        assert new_table_instance.description == table_description
+        assert len(new_table_instance.columns) == 2
+        assert new_table_instance.columns["test_column"].name == "test_column"
+        assert (
+            new_table_instance.columns["test_column"].column_type == ColumnType.STRING
+        )
+        assert new_table_instance.columns["test_column2"].name == "test_column2"
+        assert (
+            new_table_instance.columns["test_column2"].column_type == ColumnType.INTEGER
+        )
+
 
 class TestRowStorage:
     @pytest.fixture(autouse=True, scope="function")

--- a/tests/integration/synapseclient/models/synchronous/test_table.py
+++ b/tests/integration/synapseclient/models/synchronous/test_table.py
@@ -265,6 +265,46 @@ class TestTableCreation:
             results["column_string"], csv_data["column_string"]
         )
 
+    async def test_create_table_with_string_column(
+        self, project_model: Project
+    ) -> None:
+        """Test creating tables with string column configurations."""
+        # GIVEN a table with columns
+        table_name = str(uuid.uuid4())
+        table_description = "Test table with columns"
+        table = Table(
+            name=table_name,
+            parent_id=project_model.id,
+            description=table_description,
+            columns=[
+                Column(name="test_column", column_type="STRING"),
+                Column(name="test_column2", column_type="INTEGER"),
+            ],
+        )
+
+        # WHEN I store the table
+        table = table.store(synapse_client=self.syn)
+        self.schedule_for_cleanup(table.id)
+
+        # THEN the table should be created
+        assert table.id is not None
+
+        # AND I can retrieve that table from Synapse
+        new_table_instance = Table(id=table.id).get(synapse_client=self.syn)
+        assert new_table_instance is not None
+        assert new_table_instance.name == table_name
+        assert new_table_instance.id == table.id
+        assert new_table_instance.description == table_description
+        assert len(new_table_instance.columns) == 2
+        assert new_table_instance.columns["test_column"].name == "test_column"
+        assert (
+            new_table_instance.columns["test_column"].column_type == ColumnType.STRING
+        )
+        assert new_table_instance.columns["test_column2"].name == "test_column2"
+        assert (
+            new_table_instance.columns["test_column2"].column_type == ColumnType.INTEGER
+        )
+
 
 class TestRowStorage:
     @pytest.fixture(autouse=True, scope="function")


### PR DESCRIPTION
# **Problem:**

- When defining a ColumnType, or a FacetType you must use the Enum to set these values. This is problematic with the R-client where it won't be possible to create python style classes.

# **Solution:**

- Allow ColumnType and FacetType to be defined from strings, expanding usability

# **Testing:**

- Added integration testing around ColumnType
- I verified that I could install this python branch and hit this logic from R
