### PR TITLE
[SYNPY-1426] Deprecate user and team services in Synapse client

### DIFF
--- a/docs/reference/experimental/async/team.md
+++ b/docs/reference/experimental/async/team.md
@@ -18,3 +18,5 @@ at your own risk.
             - invite_async
             - open_invitations_async
 ---
+
+::: synapseclient.models.TeamMember

--- a/docs/reference/experimental/sync/team.md
+++ b/docs/reference/experimental/sync/team.md
@@ -28,3 +28,6 @@ at your own risk.
             - members
             - invite
             - open_invitations
+---
+
+::: synapseclient.models.TeamMember

--- a/docs/reference/rest_apis.md
+++ b/docs/reference/rest_apis.md
@@ -12,5 +12,15 @@ favor of an auto-generated client derived from the
 [Synapse Open API Spec](https://rest-docs.synapse.org/rest/openapi/openapispecification.json).
 
 
-::: synapseclient.api.entity_bundle_services_v2
+::: synapseclient.api.agent_services
 ::: synapseclient.api.annotations
+::: synapseclient.api.api_client
+::: synapseclient.api.configuration_services
+::: synapseclient.api.entity_bundle_services_v2
+::: synapseclient.api.entity_factory
+::: synapseclient.api.entity_services
+::: synapseclient.api.file_services
+::: synapseclient.api.json_schema_services
+::: synapseclient.api.table_services
+::: synapseclient.api.team_services
+::: synapseclient.api.user_services

--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -8,7 +8,7 @@ from .agent_services import (
     update_session,
 )
 from .annotations import set_annotations, set_annotations_async
-from .api_client import rest_post_paginated_async
+from .api_client import rest_get_paginated_async, rest_post_paginated_async
 from .configuration_services import (
     get_client_authenticated_s3_profile,
     get_config_authentication,
@@ -66,8 +66,25 @@ from .table_services import (
     get_default_columns,
     post_columns,
 )
-from .team_services import post_team_list
-from .user_services import get_user_group_headers_batch
+from .team_services import (
+    create_team,
+    delete_membership_invitation,
+    delete_team,
+    find_team,
+    get_membership_status,
+    get_team,
+    get_team_members,
+    get_team_open_invitations,
+    invite_to_team,
+    post_team_list,
+    send_membership_invitation,
+)
+from .user_services import (
+    get_user_group_headers_batch,
+    get_user_profile_by_id,
+    get_user_profile_by_username,
+    is_user_certified,
+)
 
 __all__ = [
     # annotations
@@ -134,8 +151,22 @@ __all__ = [
     "get_json_schema_derived_keys",
     # api client
     "rest_post_paginated_async",
+    "rest_get_paginated_async",
     # team_services
     "post_team_list",
+    "create_team",
+    "delete_team",
+    "get_team",
+    "find_team",
+    "get_team_members",
+    "send_membership_invitation",
+    "get_team_open_invitations",
+    "get_membership_status",
+    "delete_membership_invitation",
+    "invite_to_team",
     # user_services
     "get_user_group_headers_batch",
+    "get_user_profile_by_id",
+    "get_user_profile_by_username",
+    "is_user_certified",
 ]

--- a/synapseclient/api/api_client.py
+++ b/synapseclient/api/api_client.py
@@ -54,3 +54,59 @@ async def rest_post_paginated_async(
             yield item
         if next_page_token is None:
             break
+
+
+async def rest_get_paginated_async(
+    uri: str,
+    limit: int = 20,
+    offset: int = 0,
+    endpoint: Optional[str] = None,
+    headers: Optional[httpx.Headers] = None,
+    retry_policy: Optional[Dict[str, Any]] = {},
+    requests_session_async_synapse: Optional[httpx.AsyncClient] = None,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+    **kwargs,
+) -> AsyncGenerator[Dict[str, str], None]:
+    """
+    Asynchronously yield items from a paginated GET endpoint.
+
+    Arguments:
+        uri: Endpoint URI for the GET request.
+        limit: How many records should be returned per request
+        offset: At what record offset from the first should iteration start
+        endpoint: Optional server endpoint override.
+        headers: Optional HTTP headers.
+        retry_policy: Optional retry settings.
+        requests_session_async_synapse: Optional async HTTPX client session.
+        kwargs: Additional keyword arguments for the request.
+        synapse_client: Optional Synapse client instance for authentication.
+    Yields:
+        Individual items from each page of the response.
+
+    The limit parameter is set at 20 by default. Using a larger limit results in fewer calls to the service, but if
+    responses are large enough to be a burden on the service they may be truncated.
+    """
+    import sys
+
+    from synapseclient import Synapse
+    from synapseclient.core import utils
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+    prev_num_results = sys.maxsize
+    while prev_num_results > 0:
+        paginated_uri = utils._limit_and_offset(uri, limit=limit, offset=offset)
+        response = await client.rest_get_async(
+            uri=paginated_uri,
+            endpoint=endpoint,
+            headers=headers,
+            retry_policy=retry_policy,
+            requests_session_async_synapse=requests_session_async_synapse,
+            **kwargs,
+        )
+        results = response["results"] if "results" in response else response["children"]
+        prev_num_results = len(results)
+
+        for result in results:
+            offset += 1
+            yield result

--- a/synapseclient/api/api_client.py
+++ b/synapseclient/api/api_client.py
@@ -1,3 +1,4 @@
+import sys
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, Optional
 
 import httpx
@@ -11,7 +12,7 @@ async def rest_post_paginated_async(
     body: Optional[Dict[str, Any]] = None,
     endpoint: Optional[str] = None,
     headers: Optional[httpx.Headers] = None,
-    retry_policy: Optional[Dict[str, Any]] = {},
+    retry_policy: Optional[Dict[str, Any]] = None,
     requests_session_async_synapse: Optional[httpx.AsyncClient] = None,
     *,
     synapse_client: Optional["Synapse"] = None,
@@ -33,6 +34,9 @@ async def rest_post_paginated_async(
         Individual items from each page of the response.
     """
     from synapseclient import Synapse
+
+    if not retry_policy:
+        retry_policy = {}
 
     client = Synapse.get_client(synapse_client=synapse_client)
     next_page_token = None
@@ -62,7 +66,7 @@ async def rest_get_paginated_async(
     offset: int = 0,
     endpoint: Optional[str] = None,
     headers: Optional[httpx.Headers] = None,
-    retry_policy: Optional[Dict[str, Any]] = {},
+    retry_policy: Optional[Dict[str, Any]] = None,
     requests_session_async_synapse: Optional[httpx.AsyncClient] = None,
     *,
     synapse_client: Optional["Synapse"] = None,
@@ -87,10 +91,11 @@ async def rest_get_paginated_async(
     The limit parameter is set at 20 by default. Using a larger limit results in fewer calls to the service, but if
     responses are large enough to be a burden on the service they may be truncated.
     """
-    import sys
-
     from synapseclient import Synapse
     from synapseclient.core import utils
+
+    if not retry_policy:
+        retry_policy = {}
 
     client = Synapse.get_client(synapse_client=synapse_client)
     prev_num_results = sys.maxsize

--- a/synapseclient/api/team_services.py
+++ b/synapseclient/api/team_services.py
@@ -5,6 +5,10 @@
 import json
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
+from synapseclient.api import rest_get_paginated_async
+from synapseclient.core.exceptions import SynapseNotFoundError
+from synapseclient.core.utils import id_of
+
 if TYPE_CHECKING:
     from synapseclient import Synapse
 
@@ -41,3 +45,387 @@ async def post_team_list(
         return response["list"] or None
 
     return None
+
+
+async def create_team(
+    name: str,
+    description: Optional[str] = None,
+    icon: Optional[str] = None,
+    can_public_join: bool = False,
+    can_request_membership: bool = True,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> Dict:
+    """
+    Creates a new team.
+
+    Arguments:
+        name: The name of the team to create.
+        description: A description of the team.
+        icon: The FileHandleID of the icon to be used for the team.
+        can_public_join: Whether the team can be joined by anyone. Defaults to False.
+        can_request_membership: Whether the team can request membership. Defaults to True.
+        synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+    Returns:
+        Dictionary representing the created team
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    request_body = {
+        "name": name,
+        "description": description,
+        "icon": icon,
+        "canPublicJoin": can_public_join,
+        "canRequestMembership": can_request_membership,
+    }
+
+    response = await client.rest_post_async(uri="/team", body=json.dumps(request_body))
+    return response
+
+
+async def delete_team(
+    id: int,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> None:
+    """
+    Deletes a team.
+
+    Arguments:
+        id: The ID of the team to delete.
+        synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    await client.rest_delete_async(uri=f"/team/{id}")
+
+
+async def get_team(
+    id: Union[int, str],
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> Dict:
+    """
+    Finds a team with a given ID or name.
+
+    Arguments:
+        id: The ID or name of the team to retrieve.
+        synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+    Returns:
+        Dictionary representing the team
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    # Retrieves team id
+    teamid = id_of(id)
+    try:
+        int(teamid)
+    except (TypeError, ValueError):
+        if isinstance(id, str):
+            teams = await find_team(id, synapse_client=client)
+            for team in teams:
+                if team.get("name") == id:
+                    teamid = team.get("id")
+                    break
+            else:
+                raise ValueError(f'Can\'t find team "{teamid}"')
+        else:
+            raise ValueError(f'Can\'t find team "{teamid}"')
+
+    response = await client.rest_get_async(uri=f"/team/{teamid}")
+    return response
+
+
+async def find_team(
+    name: str,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> List[Dict]:
+    """
+    Retrieve a Teams matching the supplied name fragment
+
+    Arguments:
+        name: A team name
+        synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+    Returns:
+        List of team dictionaries
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    results = []
+    async for result in rest_get_paginated_async(
+        uri=f"/teams?fragment={name}", synapse_client=client
+    ):
+        results.append(result)
+    return results
+
+
+async def get_team_members(
+    team: Union[int, str],
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> List[Dict]:
+    """
+    Lists the members of the given team.
+
+    Arguments:
+        team: A team ID or name.
+        synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+    Returns:
+        List of team member dictionaries
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    team_id = id_of(team)
+    results = []
+    async for result in rest_get_paginated_async(
+        uri=f"/teamMembers/{team_id}", synapse_client=client
+    ):
+        results.append(result)
+    return results
+
+
+async def send_membership_invitation(
+    team_id: int,
+    invitee_id: Optional[str] = None,
+    invitee_email: Optional[str] = None,
+    message: Optional[str] = None,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> Dict:
+    """
+    Create a membership invitation and send an email notification to the invitee.
+
+    Arguments:
+        team_id: Synapse team ID
+        invitee_id: Synapse username or profile id of user
+        invitee_email: Email of user
+        message: Additional message for the user getting invited to the team.
+        synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+    Returns:
+        MembershipInvitation dictionary
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    invite_request = {"teamId": str(team_id), "message": message}
+    if invitee_email is not None:
+        invite_request["inviteeEmail"] = str(invitee_email)
+    if invitee_id is not None:
+        invite_request["inviteeId"] = str(invitee_id)
+
+    response = await client.rest_post_async(
+        uri="/membershipInvitation", body=json.dumps(invite_request)
+    )
+    return response
+
+
+async def get_team_open_invitations(
+    team: Union[int, str],
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> List[Dict]:
+    """
+    Retrieve the open requests submitted to a Team
+
+    Arguments:
+        team: A team ID or name.
+        synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+    Returns:
+        List of MembershipRequest dictionaries
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    team_id = id_of(team)
+    results = []
+    async for result in rest_get_paginated_async(
+        uri=f"/team/{team_id}/openInvitation", synapse_client=client
+    ):
+        results.append(result)
+    return results
+
+
+async def get_membership_status(
+    user_id: str,
+    team: Union[int, str],
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> Dict:
+    """
+    Retrieve a user's Team Membership Status bundle.
+
+    Arguments:
+        user_id: Synapse user ID
+        team: A team ID or name.
+        synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+    Returns:
+        Dictionary of TeamMembershipStatus: <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/TeamMembershipStatus.html>
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    team_id = id_of(team)
+    uri = f"/team/{team_id}/member/{user_id}/membershipStatus"
+    response = await client.rest_get_async(uri=uri)
+    return response
+
+
+async def delete_membership_invitation(
+    invitation_id: str,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> None:
+    """
+    Delete an invitation. Note: The client must be an administrator of the
+    Team referenced by the invitation or the invitee to make this request.
+
+    Arguments:
+        invitation_id: Open invitation id
+        synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    await client.rest_delete_async(uri=f"/membershipInvitation/{invitation_id}")
+
+
+async def invite_to_team(
+    team: Union[int, str],
+    user: Optional[str] = None,
+    invitee_email: Optional[str] = None,
+    message: Optional[str] = None,
+    force: bool = False,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> Optional[Dict]:
+    """
+    Invite user to a Synapse team via Synapse username or email (choose one or the other)
+
+    Arguments:
+        team: A team ID or name.
+        user: Synapse username or profile id of user
+        invitee_email: Email of user
+        message: Additional message for the user getting invited to the team.
+        force: If an open invitation exists for the invitee, the old invite will be cancelled.
+        synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+    Returns:
+        MembershipInvitation or None if user is already a member
+    """
+    from synapseclient.models import UserProfile
+
+    # Input validation
+    id_email_specified = invitee_email is not None and user is not None
+    id_email_notspecified = invitee_email is None and user is None
+    if id_email_specified or id_email_notspecified:
+        raise ValueError("Must specify either 'user' or 'inviteeEmail'")
+
+    team_id = id_of(team)
+    is_member = False
+    open_invitations = await get_team_open_invitations(
+        team_id, synapse_client=synapse_client
+    )
+
+    if user is not None:
+        try:
+            user_profile = await UserProfile(username=str(user)).get_async(
+                synapse_client=synapse_client
+            )
+        except SynapseNotFoundError:
+            try:
+                user_profile = await UserProfile(id=int(user)).get_async(
+                    synapse_client=synapse_client
+                )
+            except (ValueError, TypeError) as ex:
+                raise SynapseNotFoundError(f'Can\'t find user "{user}"') from ex
+        invitee_id = user_profile.id
+
+        membership_status = await get_membership_status(
+            user_id=invitee_id, team=team_id, synapse_client=synapse_client
+        )
+        is_member = membership_status["isMember"]
+        open_invites_to_user = [
+            invitation
+            for invitation in open_invitations
+            if int(invitation.get("inviteeId")) == invitee_id
+        ]
+    else:
+        invitee_id = None
+        open_invites_to_user = [
+            invitation
+            for invitation in open_invitations
+            if invitation.get("inviteeEmail") == invitee_email
+        ]
+
+    # Only invite if the invitee is not a member and
+    # if invitee doesn't have an open invitation unless force=True
+    if not is_member and (not open_invites_to_user or force):
+        # Delete all old invitations
+        for invite in open_invites_to_user:
+            await delete_membership_invitation(
+                invitation_id=invite["id"], synapse_client=synapse_client
+            )
+        return await send_membership_invitation(
+            team_id,
+            invitee_id=invitee_id,
+            invitee_email=invitee_email,
+            message=message,
+            synapse_client=synapse_client,
+        )
+    else:
+        from synapseclient import Synapse
+
+        client = Synapse.get_client(synapse_client=synapse_client)
+
+        if is_member:
+            not_sent_reason = f"`{user_profile.username}` is already a member"
+        else:
+            not_sent_reason = (
+                f"`{user_profile.username}` already has an open invitation "
+                "Set `force=True` to send new invite."
+            )
+
+        client.logger.warning("No invitation sent: {}".format(not_sent_reason))
+        return None

--- a/synapseclient/api/user_services.py
+++ b/synapseclient/api/user_services.py
@@ -2,7 +2,11 @@
 <https://rest-docs.synapse.org/rest/#org.sagebionetworks.repo.web.controller.UserGroupController>
 """
 
+import urllib.parse as urllib_urlparse
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
+
+from synapseclient.api import rest_get_paginated_async
+from synapseclient.core.exceptions import SynapseHTTPError, SynapseNotFoundError
 
 if TYPE_CHECKING:
     from synapseclient import Synapse
@@ -40,3 +44,185 @@ async def get_user_group_headers_batch(
         return response["children"] or []
 
     return []
+
+
+async def get_user_profile_by_id(
+    id: Optional[int] = None,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> Dict:
+    """
+    Get the details about a Synapse user by ID.
+    Retrieves information on the current user if 'id' is omitted.
+
+    Arguments:
+        id: The ownerId of a user
+        synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+    Returns:
+        The user profile for the user of interest.
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    if id:
+        if not isinstance(id, int):
+            raise TypeError("id must be an 'ownerId' integer")
+    else:
+        id = ""
+
+    uri = f"/userProfile/{id}"
+    response = await client.rest_get_async(uri=uri)
+    return response
+
+
+async def get_user_profile_by_username(
+    username: Optional[str] = None,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> Dict:
+    """
+    Get the details about a Synapse user by username.
+    Retrieves information on the current user if 'username' is omitted or empty string.
+
+    Arguments:
+        username: The userName of a user
+        synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+    Returns:
+        The user profile for the user of interest.
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    is_none = username is None
+    is_str = isinstance(username, str)
+    if not is_str and not is_none:
+        raise TypeError("username must be string or None")
+
+    if is_str:
+        principals = await _find_principals(username, synapse_client=synapse_client)
+        for principal in principals:
+            if principal.get("userName", None).lower() == username.lower():
+                id = principal["ownerId"]
+                break
+        else:
+            raise SynapseNotFoundError(f"Can't find user '{username}'")
+    else:
+        id = ""
+
+    uri = f"/userProfile/{id}"
+    response = await client.rest_get_async(uri=uri)
+    return response
+
+
+async def is_user_certified(
+    user: Union[str, int],
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> bool:
+    """
+    Determines whether a Synapse user is a certified user.
+
+    Arguments:
+        user: Synapse username or Id
+        synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+    Returns:
+        True if the Synapse user is certified
+    """
+
+    # Check if userid or username exists - get user profile first
+    try:
+        # if id is unset or a userID, this will succeed
+        user_id = "" if user is None else int(user)
+    except (TypeError, ValueError):
+        # It's a username, need to look it up
+        if isinstance(user, str):
+            principals = await _find_principals(user, synapse_client=synapse_client)
+            for principal in principals:
+                if principal.get("userName", None).lower() == user.lower():
+                    user_id = principal["ownerId"]
+                    break
+            else:  # no break
+                raise ValueError(f'Can\'t find user "{user}": ')
+        else:
+            raise ValueError(f"Invalid user identifier: {user}")
+
+    # Get passing record
+    try:
+        certification_status = await _get_certified_passing_record(
+            user_id, synapse_client=synapse_client
+        )
+        return certification_status["passed"]
+    except SynapseHTTPError as ex:
+        if ex.response.status_code == 404:
+            # user hasn't taken the quiz
+            return False
+        raise
+
+
+async def _find_principals(
+    query_string: str,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> List[Dict]:
+    """
+    Find users or groups by name or email.
+
+    Arguments:
+        query_string: The string to search for
+        synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+    Returns:
+        A list of userGroupHeader objects with fields displayName, email, firstName, lastName, isIndividual, ownerId
+    """
+
+    uri = "/userGroupHeaders?prefix=%s" % urllib_urlparse.quote(query_string)
+
+    # Collect all results from the paginated endpoint
+    results = []
+    async for result in rest_get_paginated_async(
+        uri=uri, synapse_client=synapse_client
+    ):
+        results.append(result)
+
+    return results
+
+
+async def _get_certified_passing_record(
+    userid: int,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> Dict[str, Union[str, int, bool, list]]:
+    """
+    Retrieve the Passing Record on the User Certification test for the given user.
+
+    Arguments:
+        userid: Synapse user Id
+        synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+    Returns:
+        Synapse Passing Record. A record of whether a given user passed a given test.
+        <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/quiz/PassingRecord.html>
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    response = await client.rest_get_async(
+        uri=f"/user/{userid}/certifiedUserPassingRecord"
+    )
+    return response

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1171,6 +1171,12 @@ class Synapse(object):
         if self._is_logged_in():
             self.restDELETE("/secretKey", endpoint=self.authEndpoint)
 
+    @deprecated(
+        version="4.9.0",
+        reason="To be removed in 5.0.0. "
+        "Moved to the `from_username` method on the `from synapseclient.models import UserProfile` class. "
+        "Check the docstring for the replacement function example.",
+    )
     @functools.lru_cache()
     def get_user_profile_by_username(
         self,
@@ -1178,6 +1184,9 @@ class Synapse(object):
         sessionToken: str = None,
     ) -> UserProfile:
         """
+        **Deprecated with replacement.** This method will be removed in 5.0.0.
+        Use the [from_username][synapseclient.models.UserProfile.from_username] method on the `from synapseclient.models import UserProfile` class.
+
         Get the details about a Synapse user.
         Retrieves information on the current user if 'id' is omitted or is empty string.
 
@@ -1188,14 +1197,34 @@ class Synapse(object):
         Returns:
             The user profile for the user of interest.
 
-        Example: Using this function
+        Example: Using this function (DEPRECATED)
             Getting your own profile
 
                 my_profile = syn.get_user_profile_by_username()
 
             Getting another user's profile
 
-                freds_profile = syn.get_user_profile_by_username('fredcommo')
+                users_profile = syn.get_user_profile_by_username('synapse-service-dpe-team')
+
+        Example: Migration to new method
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import UserProfile
+
+            # Login to Synapse
+            syn = Synapse()
+            syn.login()
+
+            # Get your own profile
+            my_profile = UserProfile().get()
+            print(f"My profile: {my_profile.username}")
+
+            # Get another user's profile by username
+            profile_by_username = UserProfile.from_username(username='synapse-service-dpe-team')
+            print(f"Profile by username: {profile_by_username.username}")
+            ```
         """
         is_none = username is None
         is_str = isinstance(username, str)
@@ -1218,6 +1247,12 @@ class Synapse(object):
             )
         )
 
+    @deprecated(
+        version="4.9.0",
+        reason="To be removed in 5.0.0. "
+        "Moved to the `from_id` method on the `from synapseclient.models import UserProfile` class. "
+        "Check the docstring for the replacement function example.",
+    )
     @functools.lru_cache()
     def get_user_profile_by_id(
         self,
@@ -1225,6 +1260,9 @@ class Synapse(object):
         sessionToken: str = None,
     ) -> UserProfile:
         """
+        **Deprecated with replacement.** This method will be removed in 5.0.0.
+        Use [synapseclient.models.protocols.user_protocol.from_id][] instead.
+
         Get the details about a Synapse user.
         Retrieves information on the current user if 'id' is omitted.
 
@@ -1235,15 +1273,34 @@ class Synapse(object):
         Returns:
             The user profile for the user of interest.
 
-
-        Example: Using this function
+        Example: Using this function (DEPRECATED)
             Getting your own profile
 
                 my_profile = syn.get_user_profile_by_id()
 
             Getting another user's profile
 
-                freds_profile = syn.get_user_profile_by_id(1234567)
+                users_profile = syn.get_user_profile_by_id(3485485)
+
+        Example: Migration to new method
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import UserProfile
+
+            # Login to Synapse
+            syn = Synapse()
+            syn.login()
+
+            # Get your own profile
+            my_profile = UserProfile().get()
+            print(f"My profile: {my_profile.username}")
+
+            # Get another user's profile by ID
+            profile_by_id = UserProfile.from_id(user_id=3485485)
+            print(f"Profile by id: {profile_by_id.username}")
+            ```
         """
         if id:
             if not isinstance(id, int):
@@ -1257,6 +1314,12 @@ class Synapse(object):
             )
         )
 
+    @deprecated(
+        version="4.9.0",
+        reason="To be removed in 5.0.0. "
+        "Moved to the `from_id` and `from_username` methods on the `from synapseclient.models import UserProfile` class. "
+        "Check the docstring for the replacement function example.",
+    )
     @functools.lru_cache()
     def getUserProfile(
         self,
@@ -1264,6 +1327,9 @@ class Synapse(object):
         sessionToken: str = None,
     ) -> UserProfile:
         """
+        **Deprecated with replacement.** This method will be removed in 5.0.0.
+        Use [synapseclient.models.protocols.user_protocol.from_id][] instead.
+
         Get the details about a Synapse user.
         Retrieves information on the current user if 'id' is omitted.
 
@@ -1274,14 +1340,38 @@ class Synapse(object):
         Returns:
             The user profile for the user of interest.
 
-        Example: Using this function
+        Example: Using this function (DEPRECATED)
             Getting your own profile
 
                 my_profile = syn.getUserProfile()
 
             Getting another user's profile
 
-                freds_profile = syn.getUserProfile('fredcommo')
+                users_profile = syn.getUserProfile('synapse-service-dpe-team')
+
+        Example: Migration to new method
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import UserProfile
+
+            # Login to Synapse
+            syn = Synapse()
+            syn.login()
+
+            # Get your own profile
+            my_profile = UserProfile().get()
+            print(f"My profile: {my_profile.username}")
+
+            # Get another user's profile by username
+            profile_by_username = UserProfile.from_username(username='synapse-service-dpe-team')
+            print(f"Profile by username: {profile_by_username.username}")
+
+            # Get another user's profile by ID
+            profile_by_id = UserProfile.from_id(user_id=3485485)
+            print(f"Profile by id: {profile_by_id.username}")
+            ```
         """
         try:
             # if id is unset or a userID, this will succeed
@@ -1309,6 +1399,10 @@ class Synapse(object):
             )
         )
 
+    @deprecated(
+        version="4.9.0",
+        reason="To be removed in 5.0.0. This is a private function and has no direct replacement.",
+    )
     def _findPrincipals(self, query_string: str) -> List[UserGroupHeader]:
         """
         Find users or groups by name or email.
@@ -1333,6 +1427,10 @@ class Synapse(object):
         uri = "/userGroupHeaders?prefix=%s" % urllib_urlparse.quote(query_string)
         return [UserGroupHeader(**result) for result in self._GET_paginated(uri)]
 
+    @deprecated(
+        version="4.9.0",
+        reason="To be removed in 5.0.0. This is a private function and has no direct replacement.",
+    )
     def _get_certified_passing_record(
         self, userid: int
     ) -> Dict[str, Union[str, int, bool, list]]:
@@ -1367,14 +1465,46 @@ class Synapse(object):
                 return None
         return response
 
+    @deprecated(
+        version="4.9.0",
+        reason="To be removed in 5.0.0. "
+        "Moved to the `is_certified` method on the `from synapseclient.models import UserProfile` class. "
+        "Check the docstring for the replacement function example.",
+    )
     def is_certified(self, user: typing.Union[str, int]) -> bool:
-        """Determines whether a Synapse user is a certified user.
+        """
+        **Deprecated with replacement.** This method will be removed in 5.0.0.
+        Use [synapseclient.models.UserProfile.is_certified][] instead.
+
+        Determines whether a Synapse user is a certified user.
 
         Arguments:
             user: Synapse username or Id
 
         Returns:
             True if the Synapse user is certified
+
+        Example: Migration to new method
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import UserProfile
+
+            # Login to Synapse
+            syn = Synapse()
+            syn.login()
+
+            # Check if user is certified by username
+            profile_by_username = UserProfile.from_username(username='synapse-service-dpe-team')
+            user_certified = profile_by_username.is_certified()
+            print(f"User {profile_by_username.username} is certified: {user_certified}")
+
+            # Check if user is certified by ID
+            profile_by_id = UserProfile.from_id(user_id=3485485)
+            user_certified = profile_by_id.is_certified()
+            print(f"User {profile_by_id.username} is certified: {user_certified}")
+            ```
         """
         # Check if userid or username exists
         syn_user = self.getUserProfile(user)
@@ -3029,6 +3159,10 @@ class Synapse(object):
             else:
                 return self.restPOST(uri, json.dumps(acl))
 
+    @deprecated(
+        version="4.9.0",
+        reason="To be removed in 5.0.0. This is a private function and has no direct replacement.",
+    )
     def _getUserbyPrincipalIdOrName(self, principalId: str = None) -> int:
         """
         Given either a string, int or None finds the corresponding user where None implies PUBLIC
@@ -4432,6 +4566,10 @@ class Synapse(object):
         for result in self._GET_paginated(url):
             yield Evaluation(**result)
 
+    @deprecated(
+        version="4.9.0",
+        reason="To be removed in 5.0.0. This is a private function and has no direct replacement.",
+    )
     def _findTeam(self, name: str) -> typing.Iterator[Team]:
         """
         Retrieve a Teams matching the supplied name fragment
@@ -4459,6 +4597,12 @@ class Synapse(object):
         for result in self._GET_paginated(f"/user/{principal_id}/team"):
             yield Team(**result)
 
+    @deprecated(
+        version="4.9.0",
+        reason="To be removed in 5.0.0. "
+        "Moved to the `create` method on the `from synapseclient.models import Team` class. "
+        "Check the docstring for the replacement function example.",
+    )
     def create_team(
         self,
         name: str,
@@ -4468,6 +4612,9 @@ class Synapse(object):
         can_request_membership: bool = True,
     ) -> Team:
         """
+        **Deprecated with replacement.** This method will be removed in 5.0.0.
+        Use [synapseclient.models.Team.create][] instead.
+
         Creates a new team.
 
         Arguments:
@@ -4479,6 +4626,28 @@ class Synapse(object):
 
         Returns:
             An object of type [synapseclient.team.Team][]
+
+        Example: Migration to new method
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Team
+
+            # Login to Synapse
+            syn = Synapse()
+            syn.login()
+
+            # Create a new team
+            new_team = Team(
+                name="My Team",
+                description="A sample team",
+                can_public_join=False,
+                can_request_membership=True
+            )
+            created_team = new_team.create()
+            print(f"Created team: {created_team.name}")
+            ```
         """
         request_body = {
             "name": name,
@@ -4494,18 +4663,52 @@ class Synapse(object):
             )
         )
 
+    @deprecated(
+        version="4.9.0",
+        reason="To be removed in 5.0.0. "
+        "Moved to the `delete` method on the `from synapseclient.models import Team` class. "
+        "Check the docstring for the replacement function example.",
+    )
     def delete_team(self, id: int) -> None:
         """
+        **Deprecated with replacement.** This method will be removed in 5.0.0.
+        Use [synapseclient.models.Team.delete][] instead.
+
         Deletes a team.
 
         Arguments:
             id: The ID of the team to delete.
 
+        Example: Migration to new method
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Team
+
+            # Login to Synapse
+            syn = Synapse()
+            syn.login()
+
+            # Delete a team
+            team = Team(id=12345)
+            team.delete()
+            ```
+
         """
         return self.restDELETE(f"/team/{id}")
 
+    @deprecated(
+        version="4.9.0",
+        reason="To be removed in 5.0.0. "
+        "Moved to the `get`, `from_id`, and `from_name` methods on the `from synapseclient.models import Team` class. "
+        "Check the docstring for the replacement function example.",
+    )
     def getTeam(self, id: Union[int, str]) -> Team:
         """
+        **Deprecated with replacement.** This method will be removed in 5.0.0.
+        Use [synapseclient.models.Team.from_id][] or [synapseclient.models.Team.from_name][] instead.
+
         Finds a team with a given ID or name.
 
         Arguments:
@@ -4513,6 +4716,26 @@ class Synapse(object):
 
         Returns:
             An object of type [synapseclient.team.Team][]
+
+        Example: Migration to new method
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Team
+
+            # Login to Synapse
+            syn = Synapse()
+            syn.login()
+
+            # Get a team by ID
+            team_by_id = Team.from_id(id=12345)
+            print(f"Team by ID: {team_by_id.name}")
+
+            # Get a team by name
+            team_by_name = Team.from_name(name="My Team")
+            print(f"Team by name: {team_by_name.name}")
+            ```
         """
         # Retrieves team id
         teamid = id_of(id)
@@ -4530,10 +4753,19 @@ class Synapse(object):
                 raise ValueError('Can\'t find team "{}"'.format(teamid))
         return Team(**self.restGET("/team/%s" % teamid))
 
+    @deprecated(
+        version="4.9.0",
+        reason="To be removed in 5.0.0. "
+        "Moved to the `members` method on the `from synapseclient.models import Team` class. "
+        "Check the docstring for the replacement function example.",
+    )
     def getTeamMembers(
         self, team: Union[Team, int, str]
     ) -> typing.Generator[TeamMember, None, None]:
         """
+        **Deprecated with replacement.** This method will be removed in 5.0.0.
+        Use [synapseclient.models.Team.members][] instead.
+
         Lists the members of the given team.
 
         Arguments:
@@ -4541,6 +4773,24 @@ class Synapse(object):
 
         Yields:
             A generator over [synapseclient.team.TeamMember][] objects.
+
+        Example: Migration to new method
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Team
+
+            # Login to Synapse
+            syn = Synapse()
+            syn.login()
+
+            # Get team members
+            team = Team.from_id(id=12345)
+            members = team.members()
+            for member in members:
+                print(f"Member: {member.member.user_name}")
+            ```
 
         """
         for result in self._GET_paginated("/teamMembers/{id}".format(id=id_of(team))):
@@ -4575,10 +4825,20 @@ class Synapse(object):
             )
         return docker_digest
 
+    @deprecated(
+        version="4.9.0",
+        reason="To be removed in 5.0.0. "
+        "Moved to the `open_invitations` method on the `from synapseclient.models import Team` class. "
+        "Check the docstring for the replacement function example.",
+    )
     def get_team_open_invitations(
         self, team: Union[Team, int, str]
     ) -> typing.Generator[dict, None, None]:
-        """Retrieve the open requests submitted to a Team
+        """
+        **Deprecated with replacement.** This method will be removed in 5.0.0.
+        Use [synapseclient.models.Team.open_invitations][] instead.
+
+        Retrieve the open requests submitted to a Team
         <https://rest-docs.synapse.org/rest/GET/team/id/openInvitation.html>
 
         Arguments:
@@ -4586,12 +4846,31 @@ class Synapse(object):
 
         Yields:
             Generator of MembershipRequest dictionaries
+
+        Example: Migration to new method
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Team
+
+            # Login to Synapse
+            syn = Synapse()
+            syn.login()
+
+            # Get open invitations for a team
+            team = Team.from_id(id=12345)
+            invitations = team.open_invitations()
+            for invitation in invitations:
+                print(f"Invitation: {invitation}")
+            ```
         """
         teamid = id_of(team)
         request = "/team/{team}/openInvitation".format(team=teamid)
         open_requests = self._GET_paginated(request)
         return open_requests
 
+    # TODO: Deprecate this method after adding it to the Team dataclass. This should call the `synapseclient/api/team_services.py::get_membership_status` function
     def get_membership_status(self, userid, team):
         """Retrieve a user's Team Membership Status bundle.
         <https://rest-docs.synapse.org/rest/GET/team/id/member/principalId/membershipStatus.html>
@@ -4610,6 +4889,10 @@ class Synapse(object):
         membership_status = self.restGET(request)
         return membership_status
 
+    @deprecated(
+        version="4.9.0",
+        reason="To be removed in 5.0.0. This is a private function and has no direct replacement.",
+    )
     def _delete_membership_invitation(self, invitationid: str) -> None:
         """
         Delete an invitation Note: The client must be an administrator of the
@@ -4620,10 +4903,20 @@ class Synapse(object):
         """
         self.restDELETE("/membershipInvitation/{id}".format(id=invitationid))
 
+    @deprecated(
+        version="4.9.0",
+        reason="To be removed in 5.0.0. "
+        "Moved to synapseclient.api.team_services.send_membership_invitation. "
+        "Check the docstring for the replacement function example.",
+    )
     def send_membership_invitation(
         self, teamId, inviteeId=None, inviteeEmail=None, message=None
     ):
-        """Create a membership invitation and send an email notification
+        """
+        **Deprecated with replacement.** This method will be removed in 5.0.0.
+        Use [synapseclient.api.team_services.send_membership_invitation][] instead.
+
+        Create a membership invitation and send an email notification
         to the invitee.
 
         Arguments:
@@ -4635,6 +4928,35 @@ class Synapse(object):
 
         Returns:
             MembershipInvitation
+
+        Example: Migration to new method
+            &nbsp;
+
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.api.team_services import send_membership_invitation
+
+            # Login to Synapse
+            syn = Synapse()
+            syn.login()
+
+            # Send invitation by user ID
+            invitation = asyncio.run(send_membership_invitation(
+                team_id=12345,
+                invitee_id="username_or_user_id",
+                message="Welcome to our team!"
+            ))
+            print(f"Invitation sent: {invitation}")
+
+            # Send invitation by email
+            invitation = asyncio.run(send_membership_invitation(
+                team_id=12345,
+                invitee_email="user@example.com",
+                message="Join our team!"
+            ))
+            print(f"Invitation sent: {invitation}")
+            ```
         """
 
         invite_request = {"teamId": str(teamId), "message": message}
@@ -4648,6 +4970,12 @@ class Synapse(object):
         )
         return response
 
+    @deprecated(
+        version="4.9.0",
+        reason="To be removed in 5.0.0. "
+        "Moved to the `invite` method on the `from synapseclient.models import Team` class. "
+        "Check the docstring for the replacement function example.",
+    )
     def invite_to_team(
         self,
         team: Union[Team, int, str],
@@ -4656,7 +4984,11 @@ class Synapse(object):
         message: str = None,
         force: bool = False,
     ):
-        """Invite user to a Synapse team via Synapse username or email
+        """
+        **Deprecated with replacement.** This method will be removed in 5.0.0.
+        Use [synapseclient.models.Team.invite][] instead.
+
+        Invite user to a Synapse team via Synapse username or email
         (choose one or the other)
 
         Arguments:
@@ -4669,6 +5001,27 @@ class Synapse(object):
 
         Returns:
             MembershipInvitation or None if user is already a member
+
+        Example: Migration to new method
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Team
+
+            # Login to Synapse
+            syn = Synapse()
+            syn.login()
+
+            # Invite a user to a team
+            team = Team.from_id(id=12345)
+            invitation = team.invite(
+                user="username",
+                message="Welcome to the team!",
+                force=True
+            )
+            print(f"Invitation sent: {invitation}")
+            ```
         """
         # Throw error if both user and email is specified and if both not
         # specified

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -1261,7 +1261,7 @@ class Synapse(object):
     ) -> UserProfile:
         """
         **Deprecated with replacement.** This method will be removed in 5.0.0.
-        Use [synapseclient.models.protocols.user_protocol.from_id][] instead.
+        Use [synapseclient.models.UserProfile.from_id][] instead.
 
         Get the details about a Synapse user.
         Retrieves information on the current user if 'id' is omitted.

--- a/synapseclient/models/__init__.py
+++ b/synapseclient/models/__init__.py
@@ -35,7 +35,7 @@ from synapseclient.models.table_components import (
     UploadToTableRequest,
 )
 from synapseclient.models.team import Team, TeamMember
-from synapseclient.models.user import UserPreference, UserProfile
+from synapseclient.models.user import UserGroupHeader, UserPreference, UserProfile
 from synapseclient.models.virtualtable import VirtualTable
 
 __all__ = [
@@ -52,6 +52,7 @@ __all__ = [
     "TeamMember",
     "UserProfile",
     "UserPreference",
+    "UserGroupHeader",
     "Agent",
     "AgentSession",
     "AgentSessionAccessLevel",

--- a/synapseclient/models/protocols/team_protocol.py
+++ b/synapseclient/models/protocols/team_protocol.py
@@ -130,14 +130,18 @@ class TeamSynchronousProtocol(Protocol):
         """Invites a user to a team given the ID field on the Team instance.
 
         Arguments:
-            user: The username of the user to invite.
+            user: The username or ID of the user to invite.
             message: The message to send.
+            force: If True, will send the invite even if the user is already a member
+                or has an open invitation. If False, will not send the invite if the user
+                is already a member or has an open invitation.
+                Defaults to True.
             synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.
 
         Returns:
-            dict: The invite response.
+            The invite response or None if an invite was not sent.
         """
         return {}
 

--- a/synapseclient/models/protocols/team_protocol.py
+++ b/synapseclient/models/protocols/team_protocol.py
@@ -1,7 +1,7 @@
 """Protocol for the specific methods of this class that have synchronous counterparts
 generated at runtime."""
 
-from typing import TYPE_CHECKING, Dict, List, Optional, Protocol
+from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Union
 
 from synapseclient import Synapse
 
@@ -126,7 +126,7 @@ class TeamSynchronousProtocol(Protocol):
         force: bool = True,
         *,
         synapse_client: Optional[Synapse] = None,
-    ) -> Dict[str, str]:
+    ) -> Union[Dict[str, str], None]:
         """Invites a user to a team given the ID field on the Team instance.
 
         Arguments:

--- a/synapseclient/models/user.py
+++ b/synapseclient/models/user.py
@@ -1,8 +1,12 @@
-import asyncio
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Union
 
 from synapseclient import Synapse
+from synapseclient.api import (
+    get_user_profile_by_id,
+    get_user_profile_by_username,
+    is_user_certified,
+)
 from synapseclient.core.async_utils import async_to_sync, otel_trace_method
 from synapseclient.models.protocols.user_protocol import UserProfileSynchronousProtocol
 from synapseclient.team import UserGroupHeader as Synapse_UserGroupHeader
@@ -175,8 +179,7 @@ class UserProfile(UserProfileSynchronousProtocol):
 
         Arguments:
             synapse_user_profile: The dictionary to fill the UserProfile object from.
-                Typically filled from a
-                [Synapse UserProfile](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/UserProfile.html) object.
+                Typically filled from a [Synapse UserProfile](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/UserProfile.html) object.
         """
         self.id = (
             int(synapse_user_profile.get("ownerId", None))
@@ -242,28 +245,17 @@ class UserProfile(UserProfileSynchronousProtocol):
             The UserProfile object.
 
         """
-        loop = asyncio.get_event_loop()
-
         if self.id:
-            synapse_user_profile = await loop.run_in_executor(
-                None,
-                lambda: Synapse.get_client(
-                    synapse_client=synapse_client
-                ).get_user_profile_by_id(id=self.id),
+            synapse_user_profile = await get_user_profile_by_id(
+                id=self.id, synapse_client=synapse_client
             )
         elif self.username:
-            synapse_user_profile = await loop.run_in_executor(
-                None,
-                lambda: Synapse.get_client(
-                    synapse_client=synapse_client
-                ).get_user_profile_by_username(username=self.username),
+            synapse_user_profile = await get_user_profile_by_username(
+                username=self.username, synapse_client=synapse_client
             )
         else:
-            synapse_user_profile = await loop.run_in_executor(
-                None,
-                lambda: Synapse.get_client(
-                    synapse_client=synapse_client
-                ).get_user_profile_by_username(),
+            synapse_user_profile = await get_user_profile_by_username(
+                synapse_client=synapse_client
             )
 
         self.fill_from_dict(synapse_user_profile=synapse_user_profile)
@@ -335,14 +327,9 @@ class UserProfile(UserProfileSynchronousProtocol):
         Raises:
             ValueError: If id nor username is specified.
         """
-        loop = asyncio.get_event_loop()
-
         if self.id or self.username:
-            is_certified = await loop.run_in_executor(
-                None,
-                lambda: Synapse.get_client(synapse_client=synapse_client).is_certified(
-                    user=self.id or self.username
-                ),
+            is_certified = await is_user_certified(
+                user=self.id or self.username, synapse_client=synapse_client
             )
         else:
             raise ValueError("Must specify either id or username")

--- a/synapseclient/team.py
+++ b/synapseclient/team.py
@@ -2,13 +2,49 @@
 Functions that interact with Synapse Teams
 """
 
-
 from synapseclient.core.models.dict_object import DictObject
+from synapseclient.core.utils import deprecated
 
 
+@deprecated(
+    version="4.9.0",
+    reason="To be removed in 5.0.0. "
+    "Moved to the `from synapseclient.models import UserProfile` class. "
+    "Check the docstring for the replacement function example.",
+)
 class UserProfile(DictObject):
     """
+    **Deprecated with replacement.** This class will be removed in 5.0.0.
+    Use `from synapseclient.models import UserProfile` instead.
+
     Information about a Synapse user.  In practice the constructor is not called directly by the client.
+
+    Example: Migration to new method
+        &nbsp;
+
+        ```python
+        # Old approach (DEPRECATED)
+        # from synapseclient.team import UserProfile
+
+        # New approach (RECOMMENDED)
+        from synapseclient import Synapse
+        from synapseclient.models import UserProfile
+
+        syn = Synapse()
+        syn.login()
+
+        # Get your own profile
+        my_profile = UserProfile().get()
+        print(f"My profile: {my_profile.username}")
+
+        # Get another user's profile by username
+        profile_by_username = UserProfile.from_username(username='synapse-service-dpe-team')
+        print(f"Profile by username: {profile_by_username.username}")
+
+        # Get another user's profile by ID
+        profile_by_id = UserProfile.from_id(user_id=3485485)
+        print(f"Profile by id: {profile_by_id.username}")
+        ```
 
     Attributes:
         ownerId: A foreign key to the ID of the 'principal' object for the user.
@@ -36,10 +72,28 @@ class UserProfile(DictObject):
         super(UserProfile, self).__init__(kwargs)
 
 
+@deprecated(
+    version="4.9.0",
+    reason="To be removed in 5.0.0. "
+    "Moved to the `from synapseclient.models import UserGroupHeader` class. "
+    "Check the docstring for the replacement function example.",
+)
 class UserGroupHeader(DictObject):
     """
+    **Deprecated with replacement.** This class will be removed in 5.0.0.
+    Use `from synapseclient.models import UserGroupHeader` instead.
+
     Select metadata about a Synapse principal.
     In practice the constructor is not called directly by the client.
+
+    Example: Migration to new method
+        ```python
+        # Old approach (DEPRECATED)
+        # from synapseclient.team import UserGroupHeader
+
+        # New approach (RECOMMENDED)
+        from synapseclient.models import UserGroupHeader
+        ```
 
     Attributes:
         ownerId A foreign key to the ID of the 'principal' object for the user.
@@ -54,10 +108,51 @@ class UserGroupHeader(DictObject):
         super(UserGroupHeader, self).__init__(kwargs)
 
 
+@deprecated(
+    version="4.9.0",
+    reason="To be removed in 5.0.0. "
+    "Moved to the `from synapseclient.models import Team` class. "
+    "Check the docstring for the replacement function example.",
+)
 class Team(DictObject):
     """
+    **Deprecated with replacement.** This class will be removed in 5.0.0.
+    Use `from synapseclient.models import Team` instead.
+
     Represents a [Synapse Team](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/Team.html).
     User definable fields are:
+
+    Example: Migration to new method
+        &nbsp;
+
+        ```python
+        # Old approach (DEPRECATED)
+        # from synapseclient.team import Team
+
+        # New approach (RECOMMENDED)
+        from synapseclient import Synapse
+        from synapseclient.models import Team
+
+        syn = Synapse()
+        syn.login()
+
+        # Create a new team
+        new_team = Team(name="My Team", description="A sample team")
+        created_team = new_team.create()
+        print(f"Created team: {created_team.name}")
+
+        # Get a team by ID
+        team_by_id = Team.from_id(id=12345)
+        print(f"Team by ID: {team_by_id.name}")
+
+        # Get a team by name
+        team_by_name = Team.from_name(name="My Team")
+        print(f"Team by name: {team_by_name.name}")
+
+        # Get team members
+        members = team_by_id.members()
+        print(f"Team has {len(members)} members")
+        ```
 
     Attributes:
         icon: The fileHandleId for icon image of the Team
@@ -89,10 +184,38 @@ class Team(DictObject):
         return "/team/acl"
 
 
+@deprecated(
+    version="4.9.0",
+    reason="To be removed in 5.0.0. "
+    "Moved to the `from synapseclient.models import TeamMember` class. "
+    "Check the docstring for the replacement function example.",
+)
 class TeamMember(DictObject):
     """
+    **Deprecated with replacement.** This class will be removed in 5.0.0.
+    Use `from synapseclient.models import TeamMember` instead.
+
     Contains information about a user's membership in a Team.
     In practice the constructor is not called directly by the client.
+
+    Example: Migration to new method
+        ```python
+        # Old approach (DEPRECATED)
+        # from synapseclient.team import TeamMember
+
+        # New approach (RECOMMENDED)
+        from synapseclient import Synapse
+        from synapseclient.models import Team, TeamMember
+
+        syn = Synapse()
+        syn.login()
+
+        # Get team members using the new Team model
+        team = Team.from_id(id=12345)
+        members = team.members()
+        for member in members:
+            print(f"Member: {member.member.user_name}")
+        ```
 
     Attributes:
         teamId: The ID of the team

--- a/tests/integration/synapseclient/models/async/test_team_async.py
+++ b/tests/integration/synapseclient/models/async/test_team_async.py
@@ -95,7 +95,7 @@ class TestTeam:
         # THEN the team should no longer exist
         with pytest.raises(
             SynapseHTTPError,
-            match=f"404 Client Error: \nTeam id: '{test_team.id}' does not exist",
+            match=f"404 Client Error: Team id: '{test_team.id}' does not exist",
         ):
             await Team.from_id_async(id=test_team.id)
 

--- a/tests/integration/synapseclient/models/synchronous/test_team.py
+++ b/tests/integration/synapseclient/models/synchronous/test_team.py
@@ -95,7 +95,7 @@ class TestTeam:
         # THEN the team should no longer exist
         with pytest.raises(
             SynapseHTTPError,
-            match=f"404 Client Error: \nTeam id: '{test_team.id}' does not exist",
+            match=f"404 Client Error: Team id: '{test_team.id}' does not exist",
         ):
             Team.from_id(id=test_team.id)
 

--- a/tests/unit/synapseclient/models/async/unit_test_team_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_team_async.py
@@ -1,14 +1,12 @@
 """Tests for the synapseclient.models.team module."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from synapseclient import Synapse
 from synapseclient.models.team import Team, TeamMember
 from synapseclient.models.user import UserGroupHeader
-from synapseclient.team import Team as Synapse_Team
-from synapseclient.team import TeamMember as Synapse_TeamMember
 
 
 class TestTeamMember:
@@ -80,12 +78,10 @@ class TestTeam:
         assert team.modified_by == self.USER
 
     async def test_create(self) -> None:
-        with patch.object(
-            self.syn,
-            "create_team",
-            return_value=Synapse_Team(
-                id=1, name=self.NAME, description=self.DESCRIPTION
-            ),
+        with patch(
+            "synapseclient.models.team.create_team",
+            new_callable=AsyncMock,
+            return_value={"id": 1, "name": self.NAME, "description": self.DESCRIPTION},
         ) as patch_create_team:
             # GIVEN a team object
             team = Team(name=self.NAME, description=self.DESCRIPTION)
@@ -98,6 +94,7 @@ class TestTeam:
                 icon=None,
                 can_public_join=False,
                 can_request_membership=True,
+                synapse_client=self.syn,
             )
             # AND I expect the original team to be returned
             assert team.id == 1
@@ -108,51 +105,49 @@ class TestTeam:
             assert team.can_request_membership is True
 
     async def test_delete(self) -> None:
-        with patch.object(
-            self.syn,
-            "delete_team",
-            return_value=Synapse_Team(id=1, name=self.NAME),
+        with patch(
+            "synapseclient.models.team.delete_team",
+            new_callable=AsyncMock,
+            return_value=None,
         ) as patch_delete_team:
             # GIVEN a team object
             team = Team(id=1, name=self.NAME)
             # WHEN I delete the team
             await team.delete_async(synapse_client=self.syn)
             # THEN I expect the patched method to be called as expected
-            patch_delete_team.assert_called_once_with(id=1)
+            patch_delete_team.assert_called_once_with(id=1, synapse_client=self.syn)
 
     async def test_get_with_id(self) -> None:
-        with patch.object(
-            self.syn,
-            "getTeam",
-            return_value=Synapse_Team(
-                id=1, name=self.NAME, description=self.DESCRIPTION
-            ),
+        with patch(
+            "synapseclient.models.team.get_team",
+            new_callable=AsyncMock,
+            return_value={"id": 1, "name": self.NAME, "description": self.DESCRIPTION},
         ) as patch_from_id:
             # GIVEN a team object with an id
             team = Team(id=1)
             # WHEN I retrieve a team using its id
             team = await team.get_async(synapse_client=self.syn)
             # THEN I expect the patched method to be called as expected
-            patch_from_id.assert_called_once_with(id=1)
+            patch_from_id.assert_called_once_with(id=1, synapse_client=self.syn)
             # AND I expect the intended team to be returned
             assert team.id == 1
             assert team.name == self.NAME
             assert team.description == self.DESCRIPTION
 
     async def test_get_with_name(self) -> None:
-        with patch.object(
-            self.syn,
-            "getTeam",
-            return_value=Synapse_Team(
-                id=1, name=self.NAME, description=self.DESCRIPTION
-            ),
+        with patch(
+            "synapseclient.models.team.get_team",
+            new_callable=AsyncMock,
+            return_value={"id": 1, "name": self.NAME, "description": self.DESCRIPTION},
         ) as patch_from_name:
             # GIVEN a team object with a name
             team = Team(name=self.NAME)
             # WHEN I retrieve a team using its name
             team = await team.get_async(synapse_client=self.syn)
             # THEN I expect the patched method to be called as expected
-            patch_from_name.assert_called_once_with(id=self.NAME)
+            patch_from_name.assert_called_once_with(
+                id=self.NAME, synapse_client=self.syn
+            )
             # AND I expect the intended team to be returned
             assert team.id == 1
             assert team.name == self.NAME
@@ -197,26 +192,28 @@ class TestTeam:
             assert team.description == self.DESCRIPTION
 
     async def test_members(self) -> None:
-        with patch.object(
-            self.syn,
-            "getTeamMembers",
-            return_value=[Synapse_TeamMember(teamId=1, member={})],
+        with patch(
+            "synapseclient.models.team.get_team_members",
+            new_callable=AsyncMock,
+            return_value=[{"teamId": 1, "member": {}}],
         ) as patch_get_team_members:
             # GIVEN a team object
             team = Team(id=1)
             # WHEN I get the team members
             team_members = await team.members_async(synapse_client=self.syn)
             # THEN I expect the patched method to be called as expected
-            patch_get_team_members.assert_called_once_with(team=team)
+            patch_get_team_members.assert_called_once_with(
+                team=1, synapse_client=self.syn
+            )
             # AND I expect the expected team members to be returned
             assert len(team_members) == 1
             assert team_members[0].team_id == 1
             assert isinstance(team_members[0].member, UserGroupHeader)
 
     async def test_invite(self) -> None:
-        with patch.object(
-            self.syn,
-            "invite_to_team",
+        with patch(
+            "synapseclient.models.team.invite_to_team",
+            new_callable=AsyncMock,
             return_value=self.invite_response,
         ) as patch_invite_team_member:
             # GIVEN a team object
@@ -229,18 +226,19 @@ class TestTeam:
             )
             # THEN I expect the patched method to be called as expected
             patch_invite_team_member.assert_called_once_with(
-                team=team,
+                team=1,
                 user=self.USER,
                 message=self.MESSAGE,
                 force=True,
+                synapse_client=self.syn,
             )
             # AND I expect the expected invite to be returned
             assert invite == self.invite_response
 
     async def test_open_invitations(self) -> None:
-        with patch.object(
-            self.syn,
-            "get_team_open_invitations",
+        with patch(
+            "synapseclient.models.team.get_team_open_invitations",
+            new_callable=AsyncMock,
             return_value=[self.invite_response],
         ) as patch_get_open_team_invitations:
             # GIVEN a team object
@@ -250,7 +248,9 @@ class TestTeam:
                 synapse_client=self.syn
             )
             # THEN I expect the patched method to be called as expected
-            patch_get_open_team_invitations.assert_called_once_with(team=team)
+            patch_get_open_team_invitations.assert_called_once_with(
+                team=1, synapse_client=self.syn
+            )
             # AND I expect the expected invitations to be returned
             assert len(open_team_invitations) == 1
             assert open_team_invitations[0] == self.invite_response

--- a/tests/unit/synapseclient/models/async/unit_test_user_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_user_async.py
@@ -1,10 +1,9 @@
 """Tests for the synapseclient.models.user module."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from synapseclient import Synapse
 from synapseclient.models import UserPreference, UserProfile
 from synapseclient.models.user import UserGroupHeader
 from synapseclient.team import UserProfile as Synapse_UserProfile
@@ -50,7 +49,7 @@ class TestUserGroupHeader:
         assert user_group_header.last_name == LAST_NAME
         assert user_group_header.user_name == USER_NAME
         assert user_group_header.email == EMAIL
-        assert user_group_header.is_individual == True
+        assert user_group_header.is_individual
 
 
 class TestUser:
@@ -115,8 +114,8 @@ class TestUser:
         )
         assert user_profile.url == BOGUS_URL
         assert user_profile.team_name == TEAM_NAME
-        assert user_profile.send_email_notifications == True
-        assert user_profile.mark_emailed_messages_as_read == False
+        assert user_profile.send_email_notifications
+        assert not user_profile.mark_emailed_messages_as_read
         assert user_profile.preferences == [
             UserPreference(name=PREFERENCE_1, value=False),
             UserPreference(name=PREFFERENCE_2, value=True),
@@ -128,15 +127,15 @@ class TestUser:
         user_profile = UserProfile(id=123)
 
         # WHEN we get the ID
-        with patch.object(
-            self.syn,
-            "get_user_profile_by_id",
+        with patch(
+            "synapseclient.models.user.get_user_profile_by_id",
+            new_callable=AsyncMock,
             return_value=(self.get_example_synapse_user_profile()),
         ) as mocked_client_call:
             profile = await user_profile.get_async(synapse_client=self.syn)
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(id=123)
+            mocked_client_call.assert_called_once_with(id=123, synapse_client=self.syn)
 
             # AND we should get the profile back
             assert profile.id == 123
@@ -157,8 +156,8 @@ class TestUser:
             )
             assert profile.url == BOGUS_URL
             assert profile.team_name == TEAM_NAME
-            assert profile.send_email_notifications == True
-            assert profile.mark_emailed_messages_as_read == False
+            assert profile.send_email_notifications
+            assert not profile.mark_emailed_messages_as_read
             assert profile.preferences == [
                 UserPreference(name=PREFERENCE_1, value=False),
                 UserPreference(name=PREFFERENCE_2, value=True),
@@ -170,15 +169,17 @@ class TestUser:
         user_profile = UserProfile(username=USER_NAME)
 
         # WHEN we get the ID
-        with patch.object(
-            self.syn,
-            "get_user_profile_by_username",
+        with patch(
+            "synapseclient.models.user.get_user_profile_by_username",
+            new_callable=AsyncMock,
             return_value=(self.get_example_synapse_user_profile()),
         ) as mocked_client_call:
             profile = await user_profile.get_async(synapse_client=self.syn)
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(username=USER_NAME)
+            mocked_client_call.assert_called_once_with(
+                username=USER_NAME, synapse_client=self.syn
+            )
 
             # AND we should get the profile back
             assert profile.id == 123
@@ -199,8 +200,8 @@ class TestUser:
             )
             assert profile.url == BOGUS_URL
             assert profile.team_name == TEAM_NAME
-            assert profile.send_email_notifications == True
-            assert profile.mark_emailed_messages_as_read == False
+            assert profile.send_email_notifications
+            assert not profile.mark_emailed_messages_as_read
             assert profile.preferences == [
                 UserPreference(name=PREFERENCE_1, value=False),
                 UserPreference(name=PREFFERENCE_2, value=True),
@@ -212,15 +213,15 @@ class TestUser:
         user_profile = UserProfile()
 
         # WHEN we get the ID
-        with patch.object(
-            self.syn,
-            "get_user_profile_by_username",
+        with patch(
+            "synapseclient.models.user.get_user_profile_by_username",
+            new_callable=AsyncMock,
             return_value=(self.get_example_synapse_user_profile()),
         ) as mocked_client_call:
             profile = await user_profile.get_async(synapse_client=self.syn)
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with()
+            mocked_client_call.assert_called_once_with(synapse_client=self.syn)
 
             # AND we should get the profile back
             assert profile.id == 123
@@ -241,8 +242,8 @@ class TestUser:
             )
             assert profile.url == BOGUS_URL
             assert profile.team_name == TEAM_NAME
-            assert profile.send_email_notifications == True
-            assert profile.mark_emailed_messages_as_read == False
+            assert profile.send_email_notifications
+            assert not profile.mark_emailed_messages_as_read
             assert profile.preferences == [
                 UserPreference(name=PREFERENCE_1, value=False),
                 UserPreference(name=PREFFERENCE_2, value=True),
@@ -253,15 +254,17 @@ class TestUser:
         # GIVEN no user profile
 
         # WHEN we get from ID
-        with patch.object(
-            self.syn,
-            "get_user_profile_by_id",
+        with patch(
+            "synapseclient.models.user.get_user_profile_by_id",
+            new_callable=AsyncMock,
             return_value=(self.get_example_synapse_user_profile()),
         ) as mocked_client_call:
-            profile = await UserProfile.from_id_async(user_id=123)
+            profile = await UserProfile.from_id_async(
+                user_id=123, synapse_client=self.syn
+            )
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(id=123)
+            mocked_client_call.assert_called_once_with(id=123, synapse_client=self.syn)
 
             # AND we should get the profile back
             assert profile.id == 123
@@ -282,8 +285,8 @@ class TestUser:
             )
             assert profile.url == BOGUS_URL
             assert profile.team_name == TEAM_NAME
-            assert profile.send_email_notifications == True
-            assert profile.mark_emailed_messages_as_read == False
+            assert profile.send_email_notifications
+            assert not profile.mark_emailed_messages_as_read
             assert profile.preferences == [
                 UserPreference(name=PREFERENCE_1, value=False),
                 UserPreference(name=PREFFERENCE_2, value=True),
@@ -294,15 +297,19 @@ class TestUser:
         # GIVEN no user profile
 
         # WHEN we get from ID
-        with patch.object(
-            self.syn,
-            "get_user_profile_by_username",
+        with patch(
+            "synapseclient.models.user.get_user_profile_by_username",
+            new_callable=AsyncMock,
             return_value=(self.get_example_synapse_user_profile()),
         ) as mocked_client_call:
-            profile = await UserProfile.from_username_async(username=USER_NAME)
+            profile = await UserProfile.from_username_async(
+                username=USER_NAME, synapse_client=self.syn
+            )
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(username=USER_NAME)
+            mocked_client_call.assert_called_once_with(
+                username=USER_NAME, synapse_client=self.syn
+            )
 
             # AND we should get the profile back
             assert profile.id == 123
@@ -323,8 +330,8 @@ class TestUser:
             )
             assert profile.url == BOGUS_URL
             assert profile.team_name == TEAM_NAME
-            assert profile.send_email_notifications == True
-            assert profile.mark_emailed_messages_as_read == False
+            assert profile.send_email_notifications
+            assert not profile.mark_emailed_messages_as_read
             assert profile.preferences == [
                 UserPreference(name=PREFERENCE_1, value=False),
                 UserPreference(name=PREFFERENCE_2, value=True),
@@ -336,36 +343,44 @@ class TestUser:
         user_profile = UserProfile(id=123)
 
         # WHEN we check if the user is certified
-        with patch.object(
-            self.syn,
-            "is_certified",
+        with patch(
+            "synapseclient.models.user.is_user_certified",
+            new_callable=AsyncMock,
             return_value=True,
         ) as mocked_client_call:
-            is_certified = await user_profile.is_certified_async()
+            is_certified = await user_profile.is_certified_async(
+                synapse_client=self.syn
+            )
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(user=123)
+            mocked_client_call.assert_called_once_with(
+                user=123, synapse_client=self.syn
+            )
 
             # AND we should get the profile back
-            assert is_certified == True
+            assert is_certified
 
     async def test_is_certified_username(self) -> None:
         # GIVEN a user profile
         user_profile = UserProfile(username=USER_NAME)
 
         # WHEN we check if the user is certified
-        with patch.object(
-            self.syn,
-            "is_certified",
+        with patch(
+            "synapseclient.models.user.is_user_certified",
+            new_callable=AsyncMock,
             return_value=True,
         ) as mocked_client_call:
-            is_certified = await user_profile.is_certified_async()
+            is_certified = await user_profile.is_certified_async(
+                synapse_client=self.syn
+            )
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(user=USER_NAME)
+            mocked_client_call.assert_called_once_with(
+                user=USER_NAME, synapse_client=self.syn
+            )
 
             # AND we should get the profile back
-            assert is_certified == True
+            assert is_certified
 
     async def test_is_certified_neither(self) -> None:
         # GIVEN a user profile
@@ -373,7 +388,7 @@ class TestUser:
 
         # WHEN we check if the user is certified
         with pytest.raises(ValueError) as e:
-            await user_profile.is_certified_async()
+            await user_profile.is_certified_async(synapse_client=self.syn)
 
         # THEN we should get an error
         assert str(e.value) == "Must specify either id or username"

--- a/tests/unit/synapseclient/models/synchronous/unit_test_user.py
+++ b/tests/unit/synapseclient/models/synchronous/unit_test_user.py
@@ -89,8 +89,8 @@ class TestUser:
         )
         assert user_profile.url == BOGUS_URL
         assert user_profile.team_name == TEAM_NAME
-        assert user_profile.send_email_notifications == True
-        assert user_profile.mark_emailed_messages_as_read == False
+        assert user_profile.send_email_notifications
+        assert not user_profile.mark_emailed_messages_as_read
         assert user_profile.preferences == [
             UserPreference(name=PREFERENCE_1, value=False),
             UserPreference(name=PREFFERENCE_2, value=True),
@@ -102,15 +102,14 @@ class TestUser:
         user_profile = UserProfile(id=123)
 
         # WHEN we get the ID
-        with patch.object(
-            self.syn,
-            "get_user_profile_by_id",
+        with patch(
+            "synapseclient.models.user.get_user_profile_by_id",
             return_value=(self.get_example_synapse_user_profile()),
         ) as mocked_client_call:
             profile = user_profile.get(synapse_client=self.syn)
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(id=123)
+            mocked_client_call.assert_called_once_with(id=123, synapse_client=self.syn)
 
             # AND we should get the profile back
             assert profile.id == 123
@@ -131,8 +130,8 @@ class TestUser:
             )
             assert profile.url == BOGUS_URL
             assert profile.team_name == TEAM_NAME
-            assert profile.send_email_notifications == True
-            assert profile.mark_emailed_messages_as_read == False
+            assert profile.send_email_notifications
+            assert not profile.mark_emailed_messages_as_read
             assert profile.preferences == [
                 UserPreference(name=PREFERENCE_1, value=False),
                 UserPreference(name=PREFFERENCE_2, value=True),
@@ -144,15 +143,16 @@ class TestUser:
         user_profile = UserProfile(username=USER_NAME)
 
         # WHEN we get the ID
-        with patch.object(
-            self.syn,
-            "get_user_profile_by_username",
+        with patch(
+            "synapseclient.models.user.get_user_profile_by_username",
             return_value=(self.get_example_synapse_user_profile()),
         ) as mocked_client_call:
             profile = user_profile.get(synapse_client=self.syn)
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(username=USER_NAME)
+            mocked_client_call.assert_called_once_with(
+                username=USER_NAME, synapse_client=self.syn
+            )
 
             # AND we should get the profile back
             assert profile.id == 123
@@ -173,8 +173,8 @@ class TestUser:
             )
             assert profile.url == BOGUS_URL
             assert profile.team_name == TEAM_NAME
-            assert profile.send_email_notifications == True
-            assert profile.mark_emailed_messages_as_read == False
+            assert profile.send_email_notifications
+            assert not profile.mark_emailed_messages_as_read
             assert profile.preferences == [
                 UserPreference(name=PREFERENCE_1, value=False),
                 UserPreference(name=PREFFERENCE_2, value=True),
@@ -186,15 +186,14 @@ class TestUser:
         user_profile = UserProfile()
 
         # WHEN we get the ID
-        with patch.object(
-            self.syn,
-            "get_user_profile_by_username",
+        with patch(
+            "synapseclient.models.user.get_user_profile_by_username",
             return_value=(self.get_example_synapse_user_profile()),
         ) as mocked_client_call:
             profile = user_profile.get(synapse_client=self.syn)
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with()
+            mocked_client_call.assert_called_once_with(synapse_client=self.syn)
 
             # AND we should get the profile back
             assert profile.id == 123
@@ -215,8 +214,8 @@ class TestUser:
             )
             assert profile.url == BOGUS_URL
             assert profile.team_name == TEAM_NAME
-            assert profile.send_email_notifications == True
-            assert profile.mark_emailed_messages_as_read == False
+            assert profile.send_email_notifications
+            assert not profile.mark_emailed_messages_as_read
             assert profile.preferences == [
                 UserPreference(name=PREFERENCE_1, value=False),
                 UserPreference(name=PREFFERENCE_2, value=True),
@@ -227,15 +226,14 @@ class TestUser:
         # GIVEN no user profile
 
         # WHEN we get from ID
-        with patch.object(
-            self.syn,
-            "get_user_profile_by_id",
+        with patch(
+            "synapseclient.models.user.get_user_profile_by_id",
             return_value=(self.get_example_synapse_user_profile()),
         ) as mocked_client_call:
             profile = UserProfile.from_id(user_id=123, synapse_client=self.syn)
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(id=123)
+            mocked_client_call.assert_called_once_with(id=123, synapse_client=self.syn)
 
             # AND we should get the profile back
             assert profile.id == 123
@@ -256,8 +254,8 @@ class TestUser:
             )
             assert profile.url == BOGUS_URL
             assert profile.team_name == TEAM_NAME
-            assert profile.send_email_notifications == True
-            assert profile.mark_emailed_messages_as_read == False
+            assert profile.send_email_notifications
+            assert not profile.mark_emailed_messages_as_read
             assert profile.preferences == [
                 UserPreference(name=PREFERENCE_1, value=False),
                 UserPreference(name=PREFFERENCE_2, value=True),
@@ -268,9 +266,8 @@ class TestUser:
         # GIVEN no user profile
 
         # WHEN we get from ID
-        with patch.object(
-            self.syn,
-            "get_user_profile_by_username",
+        with patch(
+            "synapseclient.models.user.get_user_profile_by_username",
             return_value=(self.get_example_synapse_user_profile()),
         ) as mocked_client_call:
             profile = UserProfile.from_username(
@@ -278,7 +275,9 @@ class TestUser:
             )
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(username=USER_NAME)
+            mocked_client_call.assert_called_once_with(
+                username=USER_NAME, synapse_client=self.syn
+            )
 
             # AND we should get the profile back
             assert profile.id == 123
@@ -299,8 +298,8 @@ class TestUser:
             )
             assert profile.url == BOGUS_URL
             assert profile.team_name == TEAM_NAME
-            assert profile.send_email_notifications == True
-            assert profile.mark_emailed_messages_as_read == False
+            assert profile.send_email_notifications
+            assert not profile.mark_emailed_messages_as_read
             assert profile.preferences == [
                 UserPreference(name=PREFERENCE_1, value=False),
                 UserPreference(name=PREFFERENCE_2, value=True),
@@ -312,36 +311,38 @@ class TestUser:
         user_profile = UserProfile(id=123)
 
         # WHEN we check if the user is certified
-        with patch.object(
-            self.syn,
-            "is_certified",
+        with patch(
+            "synapseclient.models.user.is_user_certified",
             return_value=True,
         ) as mocked_client_call:
             is_certified = user_profile.is_certified(synapse_client=self.syn)
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(user=123)
+            mocked_client_call.assert_called_once_with(
+                user=123, synapse_client=self.syn
+            )
 
             # AND we should get the profile back
-            assert is_certified == True
+            assert is_certified
 
     def test_is_certified_username(self) -> None:
         # GIVEN a user profile
         user_profile = UserProfile(username=USER_NAME)
 
         # WHEN we check if the user is certified
-        with patch.object(
-            self.syn,
-            "is_certified",
+        with patch(
+            "synapseclient.models.user.is_user_certified",
             return_value=True,
         ) as mocked_client_call:
             is_certified = user_profile.is_certified(synapse_client=self.syn)
 
             # THEN we should call the method with this data
-            mocked_client_call.assert_called_once_with(user=USER_NAME)
+            mocked_client_call.assert_called_once_with(
+                user=USER_NAME, synapse_client=self.syn
+            )
 
             # AND we should get the profile back
-            assert is_certified == True
+            assert is_certified
 
     def test_is_certified_neither(self) -> None:
         # GIVEN a user profile


### PR DESCRIPTION
# **Problem:**

- Team and user method in the Synapse core class have been replaced and need to be deprecated
- A handful of new async methods still used the core Synapse class for it's implementation.

# **Solution:**

- Added asynchronous methods for retrieving user profiles by ID and username.
- Implemented a method to check if a user is certified.
- Deprecated several synchronous methods in the Synapse class, providing migration paths to new asynchronous methods in the UserProfile model.
- Updated the Team model to use new asynchronous API functions for team management (create, delete, get members, invite).
- Use UserGroupHeader to manage user group metadata.
- Enhanced documentation with migration examples for deprecated methods.
- Updated tests to reflect changes in error message formatting for non-existent teams.

# **Testing:**

- Manually testing the suggested migrations as well a unit/integration regression testing via the existing tests
