### PR TITLE
[SYNPY-1599] Fix line references in JSON schema tutorial and update syn class usage

### DIFF
--- a/docs/tutorials/python/json_schema.md
+++ b/docs/tutorials/python/json_schema.md
@@ -30,7 +30,7 @@ By the end of this tutorial, you will:
 ## 2. Take a Look at the Constants and Structure of the JSON Schema
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=22-49}
+{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=21-49}
 ```
 
 Derived annotations allow you to define default values for annotations based on schema rules, ensuring consistency and reducing manual input errors. As you can see here, you could use derived annotations to prescribe default annotation values. Please read more about derived annotations [here](https://help.synapse.org/docs/JSON-Schemas.3107291536.html#JSONSchemas-DerivedAnnotations).
@@ -39,12 +39,12 @@ Derived annotations allow you to define default values for annotations based on 
 ## 3. Try Create Test Organization and JSON Schema if They Do Not Exist
 Next, try creating a test organization and register a schema if they do not already exist:
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=52-65}
+{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=51-65}
 ```
 
 Note: If you update your schema, you can re-register it with the organization by assigning a new version number to reflect the changes. Synapse does not allow re-creating a schema with the same version number, so please ensure that each schema version within an organization is unique:
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=68-99}
+{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=67-99}
 ```
 
 ## 4. Bind the JSON Schema to the Folder
@@ -53,7 +53,7 @@ After creating the organization, you can now bind your json schema to a test fol
 When you bind the schema, you may also include the boolean property `enable_derived_annotations` to have Synapse automatically calculate derived annotations based on the schema:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=102-108}
+{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=101-108}
 ```
 
 <details class="example">
@@ -76,7 +76,7 @@ JSON schema was bound successfully. Please see details below:
 ## 5. Retrieve the Bound Schema
 Next, we can retrieve the bound schema:
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=111-113}
+{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=110-113}
 ```
 
 <details class="example">
@@ -105,12 +105,12 @@ JSON Schema was retrieved successfully. Please see details below:
 ## 6. Add Invalid Annotations to the Folder and Store, and Validate the Folder against the Schema
 Try adding invalid annotations to your folder: This step and the step below demonstrate how the system handles invalid annotations and how the schema validation process works.
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=116-120}
+{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=115-119}
 ```
 
 Try validating the folder. You should be able to see messages related to invalid annotations.
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=124-126}
+{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=123-125}
 ```
 
 
@@ -146,12 +146,12 @@ This step is only relevant for container entities, such as a folder or a project
 
 Try creating a test file locally and store the file in the folder that we created earlier. Then, try adding invalid annotations to that file. This step demonstrates how the files inside a folder also inherit the schema from the parent entity.
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=130-155}
+{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=129-134}
 ```
 
 You could then use `get_schema_validation_statistics` to get information such as the number of children with invalid annotations inside a container.
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=158-160}
+{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=137-141}
 ```
 
 
@@ -170,7 +170,7 @@ Validation statistics were retrieved successfully. Please see details below:
 
 You could also use `get_invalid_validation` to see more detailed results of all the children inside a container, which includes all validation messages and validation exception details.
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=162-169}
+{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=143-146}
 ```
 
 <details class="example">

--- a/docs/tutorials/python/tutorial_scripts/json_schema.py
+++ b/docs/tutorials/python/tutorial_scripts/json_schema.py
@@ -1,14 +1,13 @@
-import os
 import time
 from pprint import pprint
 
 import synapseclient
+from synapseclient.core.utils import make_bogus_data_file
 from synapseclient.models import File, Folder
 
 # 1. Set up Synapse Python client and retrieve project
 syn = synapseclient.Synapse()
 syn.login()
-client = synapseclient.Synapse().get_client(synapse_client=syn)
 
 # Retrieve test project
 PROJECT_ID = syn.findEntityId(
@@ -19,7 +18,7 @@ PROJECT_ID = syn.findEntityId(
 test_folder = Folder(name="clinical_data_folder", parent_id=PROJECT_ID).store()
 
 # 2. Take a look at the constants and structure of the JSON schema
-ORG_NAME = "myUniqueAlzheimersResearchOrgTurtorial"
+ORG_NAME = "myUniqueAlzheimersResearchOrgTutorial"
 VERSION = "0.0.1"
 NEW_VERSION = "0.0.2"
 
@@ -53,10 +52,10 @@ js = syn.service("json_schema")
 all_orgs = js.list_organizations()
 for org in all_orgs:
     if org["name"] == ORG_NAME:
-        client.logger.info(f"Organization {ORG_NAME} already exists.")
+        syn.logger.info(f"Organization {ORG_NAME} already exists.")
         break
 else:
-    client.logger.info(f"Creating organization {ORG_NAME}.")
+    syn.logger.info(f"Creating organization {ORG_NAME}.")
     js.create_organization(ORG_NAME)
 
 my_test_org = js.JsonSchemaOrganization(ORG_NAME)
@@ -92,7 +91,7 @@ try:
     )
 except synapseclient.core.exceptions.SynapseHTTPError as e:
     if e.response.status_code == 400 and "already exists" in e.response.text:
-        client.logger.warning(
+        syn.logger.warning(
             f"Schema {SCHEMA_NAME} already exists. Please switch to use a new version number."
         )
     else:
@@ -101,15 +100,15 @@ except synapseclient.core.exceptions.SynapseHTTPError as e:
 # 4. Bind the JSON schema to the folder
 schema_uri = ORG_NAME + "-" + SCHEMA_NAME + "-" + VERSION
 bound_schema = test_folder.bind_schema(
-    json_schema_uri=schema_uri, synapse_client=syn, enable_derived_annotations=True
+    json_schema_uri=schema_uri, enable_derived_annotations=True
 )
 json_schema_version_info = bound_schema.json_schema_version_info
-client.logger.info("JSON schema was bound successfully. Please see details below:")
+syn.logger.info("JSON schema was bound successfully. Please see details below:")
 pprint(vars(json_schema_version_info))
 
 # 5. Retrieve the Bound Schema
 schema = test_folder.get_schema()
-client.logger.info("JSON Schema was retrieved successfully. Please see details below:")
+syn.logger.info("JSON Schema was retrieved successfully. Please see details below:")
 pprint(vars(schema))
 
 # 6. Add Invalid Annotations to the Folder and Store
@@ -117,53 +116,31 @@ test_folder.annotations = {
     "patient_id": "1234",
     "cognitive_score": "invalid str",
 }
-test_folder.store(synapse_client=syn)
+test_folder.store()
 
 time.sleep(2)
 
 validation_results = test_folder.validate_schema()
-client.logger.info("Validation was completed. Please see details below:")
+syn.logger.info("Validation was completed. Please see details below:")
 pprint(vars(validation_results))
 
 # 7. Create a File with Invalid Annotations and Upload It
 # Then, view validation statistics and invalid validation results
-if not os.path.exists(os.path.expanduser("~/temp")):
-    os.makedirs(os.path.expanduser("~/temp/testJSONSchemaFiles"), exist_ok=True)
-
-name_of_file = "test_file.txt"
-path_to_file = os.path.join(
-    os.path.expanduser("~/temp/testJSONSchemaFiles"), name_of_file
-)
-
-
-def create_random_file(
-    path: str,
-) -> None:
-    """Create a random file with random data.
-
-    :param path: The path to create the file at.
-    """
-    with open(path, "wb") as f:
-        f.write(os.urandom(1))
-
-
-create_random_file(path_to_file)
+path_to_file = make_bogus_data_file(n=5)
 
 annotations = {"patient_id": "123456", "cognitive_score": "invalid child str"}
 
 child_file = File(path=path_to_file, parent_id=test_folder.id, annotations=annotations)
-child_file = child_file.store(synapse_client=syn)
+child_file = child_file.store()
 time.sleep(2)
 
-validation_statistics = test_folder.get_schema_validation_statistics(synapse_client=syn)
-client.logger.info(
+validation_statistics = test_folder.get_schema_validation_statistics()
+syn.logger.info(
     "Validation statistics were retrieved successfully. Please see details below:"
 )
 pprint(vars(validation_statistics))
 
-invalid_validation = invalid_results = test_folder.get_invalid_validation(
-    synapse_client=syn
-)
+invalid_validation = invalid_results = test_folder.get_invalid_validation()
 for child in invalid_validation:
-    client.logger.info("See details of validation results: ")
+    syn.logger.info("See details of validation results: ")
     pprint(vars(child))


### PR DESCRIPTION
# **Problem:**

1. client = synapseclient.Synapse().get_client(synapse_client=syn) ← this has to be removed in the tutorial.  Or else it causes the large error below
2. The tempfile creation could be done with the builtin tempfile module because that fails with pathing
3. there is a number of test_folder.get_invalid_validation(synapse_client=syn )  The synapse_client=syn isn’t necessary

# **Solution:**

- Updates to tutorial and line numbers

# **Testing:**

- Verified that I could run the tutorial