### PR TITLE
[SYNPY-1637] Add 'Contact Us' section with support link in navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
       - Structuring Your Project: explanations/structuring_your_project.md
   - News:
       - news.md
+  - Contact Us: https://sagebionetworks.jira.com/servicedesk/customer/portal/9/group/16/create/206
 
 # Theme configuration
 theme:


### PR DESCRIPTION
# **Problem:**

- It is not clear how to get to our service desk/contact us from the documentation site

# **Solution:**

- Add a Contact us button that links to https://sagebionetworks.jira.com/servicedesk/customer/portal/9/group/16/create/206  

# **Testing:**

- I deployed the mkdocs site locally and verified that the link shows and goes to the destination as expected
<img width="727" height="104" alt="image" src="https://github.com/user-attachments/assets/72e54368-0f21-4341-8a30-cb3459a9f101" />

