### PR TITLE
fix: remove unnecessary line in pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,6 @@ verify_ssl = true
 
 [packages]
 synapseclient = {file = ".", editable = true, path = "."}
-paramiko = "<4.0.0"
 
 [requires]
 python_version = "3.12.6"


### PR DESCRIPTION
# **Problem:**
Patch: https://github.com/Sage-Bionetworks/synapsePythonClient/pull/1231
Remove `paramiko = "<4.0.0"` in Pipfile. 