### PR TITLE
[SYNPY-1633] Add membership_status to Team model and Deprecate Old Method

### DIFF
--- a/docs/reference/experimental/async/team.md
+++ b/docs/reference/experimental/async/team.md
@@ -17,6 +17,7 @@ at your own risk.
             - members_async
             - invite_async
             - open_invitations_async
+            - get_user_membership_status_async
 ---
 
 ::: synapseclient.models.TeamMember

--- a/docs/reference/experimental/async/team.md
+++ b/docs/reference/experimental/async/team.md
@@ -21,3 +21,4 @@ at your own risk.
 ---
 
 ::: synapseclient.models.TeamMember
+::: synapseclient.models.TeamMembershipStatus

--- a/docs/reference/experimental/sync/team.md
+++ b/docs/reference/experimental/sync/team.md
@@ -28,6 +28,7 @@ at your own risk.
             - members
             - invite
             - open_invitations
+            - get_user_membership_status
 ---
 
 ::: synapseclient.models.TeamMember

--- a/docs/reference/experimental/sync/team.md
+++ b/docs/reference/experimental/sync/team.md
@@ -32,3 +32,4 @@ at your own risk.
 ---
 
 ::: synapseclient.models.TeamMember
+::: synapseclient.models.TeamMembershipStatus

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -6038,10 +6038,19 @@ class Synapse(object):
             dict of TeamMembershipStatus
 
         Example: Using this function (DEPRECATED)
-        Getting a user's membership status for a team
+            &nbsp;
+            Getting a user's membership status for a team
 
-            status = syn.get_membership_status(user="12345", team="67890")
+            ```python
+            from synapseclient import Synapse
+
+            # Login to Synapse
+            syn = Synapse()
+            syn.login()
+
+            status = syn.get_membership_status(userid="12345", team="67890")
             print(status)
+            ```
 
 
         Example: Migration to new method

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -6023,7 +6023,7 @@ class Synapse(object):
     @deprecated(
         version="4.9.0",
         reason="To be removed in 5.0.0. "
-        "Use the `get_user_membership_status_async` method on the `Team` class from `synapseclient.models` instead. "
+        "Use the `get_user_membership_status` method on the `Team` class from `synapseclient.models` instead. "
         "Check the docstring for the replacement function example.",
     )
     def get_membership_status(self, userid, team):
@@ -6050,11 +6050,21 @@ class Synapse(object):
             ```python
             from synapseclient import Synapse
             from synapseclient.models import Team
-            import asyncio
 
             # Login to Synapse
             syn = Synapse()
             syn.login()
+
+            # Use synchronous version (recommended for most use cases)
+            team = Team.from_id(id="67890")
+            status = team.get_user_membership_status(
+                user_id="12345",
+                team="67890"
+            )
+            print(status)
+
+            # Alternative: Use async version for advanced use cases
+            import asyncio
 
             async def get_membership_status():
                 # Get the team object
@@ -6069,14 +6079,6 @@ class Synapse(object):
 
             # Run the async function
             status = asyncio.run(get_membership_status())
-            print(status)
-
-            # Alternative: Use synchronous version
-            team = Team.from_id(id="67890")
-            status = team.get_user_membership_status(
-                user_id="12345",
-                team="67890"
-            )
             print(status)
             ```
         """

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -6061,23 +6061,6 @@ class Synapse(object):
                 user_id="12345",
             )
             print(status)
-
-            # Alternative: Use async version for advanced use cases
-            import asyncio
-
-            async def get_membership_status():
-                # Get the team object
-                team = await Team.from_id_async(id="67890")
-
-                # Get user's membership status
-                status = await team.get_user_membership_status_async(
-                    user_id="12345"
-                )
-                return status
-
-            # Run the async function
-            status = asyncio.run(get_membership_status())
-            print(status)
             ```
         """
         teamid = id_of(team)

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -6059,7 +6059,6 @@ class Synapse(object):
             team = Team.from_id(id="67890")
             status = team.get_user_membership_status(
                 user_id="12345",
-                team="67890"
             )
             print(status)
 
@@ -6072,8 +6071,7 @@ class Synapse(object):
 
                 # Get user's membership status
                 status = await team.get_user_membership_status_async(
-                    user_id="12345",
-                    team="67890"
+                    user_id="12345"
                 )
                 return status
 

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -6020,7 +6020,12 @@ class Synapse(object):
         open_requests = self._GET_paginated(request)
         return open_requests
 
-    # TODO: Deprecate method in https://sagebionetworks.jira.com/browse/SYNPY-1633
+    @deprecated(
+        version="4.9.0",
+        reason="To be removed in 5.0.0. "
+        "Use the `get_user_membership_status_async` method on the `Team` class from `synapseclient.models` instead. "
+        "Check the docstring for the replacement function example.",
+    )
     def get_membership_status(self, userid, team):
         """Retrieve a user's Team Membership Status bundle.
         <https://rest-docs.synapse.org/rest/GET/team/id/member/principalId/membershipStatus.html>
@@ -6031,6 +6036,49 @@ class Synapse(object):
 
         Returns:
             dict of TeamMembershipStatus
+
+        Example: Using this function (DEPRECATED)
+        Getting a user's membership status for a team
+
+            status = syn.get_membership_status(user="12345", team="67890")
+            print(status)
+
+
+        Example: Migration to new method
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Team
+            import asyncio
+
+            # Login to Synapse
+            syn = Synapse()
+            syn.login()
+
+            async def get_membership_status():
+                # Get the team object
+                team = await Team.from_id_async(id="67890")
+
+                # Get user's membership status
+                status = await team.get_user_membership_status_async(
+                    user_id="12345",
+                    team="67890"
+                )
+                return status
+
+            # Run the async function
+            status = asyncio.run(get_membership_status())
+            print(status)
+
+            # Alternative: Use synchronous version
+            team = Team.from_id(id="67890")
+            status = team.get_user_membership_status(
+                user_id="12345",
+                team="67890"
+            )
+            print(status)
+            ```
         """
         teamid = id_of(team)
         request = "/team/{team}/member/{user}/membershipStatus".format(

--- a/synapseclient/models/__init__.py
+++ b/synapseclient/models/__init__.py
@@ -34,7 +34,7 @@ from synapseclient.models.table_components import (
     TableUpdateTransaction,
     UploadToTableRequest,
 )
-from synapseclient.models.team import Team, TeamMember
+from synapseclient.models.team import Team, TeamMember, TeamMembershipStatus
 from synapseclient.models.user import UserGroupHeader, UserPreference, UserProfile
 from synapseclient.models.virtualtable import VirtualTable
 
@@ -50,6 +50,7 @@ __all__ = [
     "Annotations",
     "Team",
     "TeamMember",
+    "TeamMembershipStatus",
     "UserProfile",
     "UserPreference",
     "UserGroupHeader",

--- a/synapseclient/models/protocols/team_protocol.py
+++ b/synapseclient/models/protocols/team_protocol.py
@@ -163,7 +163,6 @@ class TeamSynchronousProtocol(Protocol):
     def get_user_membership_status(
         self,
         user_id: str,
-        team: Union[int, str],
         *,
         synapse_client: Optional[Synapse] = None,
     ) -> "TeamMembershipStatus":
@@ -173,7 +172,6 @@ class TeamSynchronousProtocol(Protocol):
 
         Arguments:
             user_id: The ID of the user whose membership status is being queried.
-            team: Synapse team ID
             synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.

--- a/synapseclient/models/protocols/team_protocol.py
+++ b/synapseclient/models/protocols/team_protocol.py
@@ -173,7 +173,7 @@ class TeamSynchronousProtocol(Protocol):
 
         Arguments:
             user_id: The ID of the user whose membership status is being queried.
-            team: A team's ID.
+            team: Synapse team ID
             synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.

--- a/synapseclient/models/protocols/team_protocol.py
+++ b/synapseclient/models/protocols/team_protocol.py
@@ -159,3 +159,26 @@ class TeamSynchronousProtocol(Protocol):
             List[dict]: A list of invitations.
         """
         return list({})
+
+    def get_user_membership_status(
+        self,
+        user_id: str,
+        team: Union[int, str],
+        *,
+        synapse_client: Optional[Synapse] = None,
+    ) -> Dict[str, str]:
+        """Retrieve a user's Team Membership Status bundle.
+
+        <https://rest-docs.synapse.org/rest/GET/team/id/member/principalId/membershipStatus.html>
+
+        Arguments:
+            user_id: The ID of the user whose membership status is being queried.
+            team: A team's ID.
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            A dictionary of TeamMembershipStatus
+        """
+        return {}

--- a/synapseclient/models/protocols/team_protocol.py
+++ b/synapseclient/models/protocols/team_protocol.py
@@ -178,6 +178,33 @@ class TeamSynchronousProtocol(Protocol):
 
         Returns:
             TeamMembershipStatus object
+
+        Example:
+          Check if a user is a member of a team
+            This example shows how to check a user's membership status in a team.
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Team
+
+            syn = Synapse()
+            syn.login()
+
+            # Get a team by ID
+            team = Team.from_id(123456)
+
+            # Check membership status for a specific user
+            user_id = "3350396"  # Replace with actual user ID
+            status = team.get_user_membership_status(user_id)
+
+            print(f"User ID: {status.user_id}")
+            print(f"Is member: {status.is_member}")
+            print(f"Can join: {status.can_join}")
+            print(f"Has open invitation: {status.has_open_invitation}")
+            print(f"Has open request: {status.has_open_request}")
+            print(f"Membership approval required: {status.membership_approval_required}")
+            ```
         """
         from synapseclient.models.team import TeamMembershipStatus
 

--- a/synapseclient/models/protocols/team_protocol.py
+++ b/synapseclient/models/protocols/team_protocol.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Union
 from synapseclient import Synapse
 
 if TYPE_CHECKING:
-    from synapseclient.models import Team, TeamMember
+    from synapseclient.models import Team, TeamMember, TeamMembershipStatus
 
 
 class TeamSynchronousProtocol(Protocol):
@@ -166,7 +166,7 @@ class TeamSynchronousProtocol(Protocol):
         team: Union[int, str],
         *,
         synapse_client: Optional[Synapse] = None,
-    ) -> Dict[str, str]:
+    ) -> "TeamMembershipStatus":
         """Retrieve a user's Team Membership Status bundle.
 
         <https://rest-docs.synapse.org/rest/GET/team/id/member/principalId/membershipStatus.html>
@@ -179,6 +179,8 @@ class TeamSynchronousProtocol(Protocol):
                 instance from the Synapse class constructor.
 
         Returns:
-            A dictionary of TeamMembershipStatus
+            TeamMembershipStatus object
         """
-        return {}
+        from synapseclient.models.team import TeamMembershipStatus
+
+        return TeamMembershipStatus().fill_from_dict({})

--- a/synapseclient/models/team.py
+++ b/synapseclient/models/team.py
@@ -448,6 +448,35 @@ class Team(TeamSynchronousProtocol):
 
         Returns:
             TeamMembershipStatus object
+
+        Example: Check if a user is a member of a team
+        This example shows how to check a user's membership status in a team.
+
+        ```python
+        import asyncio
+        from synapseclient import Synapse
+        from synapseclient.models import Team
+
+        syn = Synapse()
+        syn.login()
+
+        async def check_membership():
+            # Get a team by ID
+            team = await Team.from_id_async(123456)
+
+            # Check membership status for a specific user
+            user_id = "3350396"  # Replace with actual user ID
+            status = await team.get_user_membership_status_async(user_id)
+
+            print(f"User ID: {status.user_id}")
+            print(f"Is member: {status.is_member}")
+            print(f"Can join: {status.can_join}")
+            print(f"Has open invitation: {status.has_open_invitation}")
+            print(f"Has open request: {status.has_open_request}")
+            print(f"Membership approval required: {status.membership_approval_required}")
+
+        asyncio.run(check_membership())
+        ```
         """
         from synapseclient import Synapse
 

--- a/synapseclient/models/team.py
+++ b/synapseclient/models/team.py
@@ -365,15 +365,17 @@ class Team(TeamSynchronousProtocol):
         *,
         synapse_client: Optional[Synapse] = None,
     ) -> str:
-        """Retrieve a user's Team Membership Status bundle.
-        <https://rest-docs.synapse.org/rest/GET/team/id/member/principalId/membershipStatus.html>
+        """Retrieve a user's Team Membership Status bundle for this team.
 
         Arguments:
-            user: Synapse user ID
-            team: A [synapseclient.team.Team][] object or a team's ID.
+            user_id: Synapse user ID
+            team: A team's ID.
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
 
         Returns:
-            dict of TeamMembershipStatus
+            A dictionary of TeamMembershipStatus
         """
         from synapseclient import Synapse
 

--- a/synapseclient/models/team.py
+++ b/synapseclient/models/team.py
@@ -369,7 +369,7 @@ class Team(TeamSynchronousProtocol):
 
         Arguments:
             user_id: Synapse user ID
-            team: A team's ID.
+            team: Synapse team ID
             synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.

--- a/synapseclient/models/team.py
+++ b/synapseclient/models/team.py
@@ -61,18 +61,19 @@ class TeamMember:
 class TeamMembershipStatus:
     """
     Contains information about a user's membership status in a Team.
-    In practice the constructor is not called directly by the client.
+    Represents a [Synapse TeamMembershipStatus](<https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/TeamMembershipStatus.html>).
+    User definable fields are:
 
     Attributes:
-        team_id: The synapse ID of the team
-        user_id: The synapse ID of the user
-        is_member: Whether the user is a member of the team
-        has_open_invitation: Whether the user has an open invitation to join the team
-        has_open_request: Whether the user has an open request to join the team
-        can_join: Whether the user can join the team
-        membership_approval_required: Whether membership approval is required for the team
-        has_unmet_access_requirement: Whether the user has unmet access requirements
-        can_send_email: Whether the user can send email to the team
+        team_id: The id of the Team.
+        user_id: The principal id of the user.
+        is_member: true if and only if the user is a member of the team
+        has_open_invitation: true if and only if the user has an open invitation to join the team
+        has_open_request: true if and only if the user has an open request to join the team
+        can_join: true if and only if the user requesting this status information can join the user to the team
+        membership_approval_required: true if and only if team admin approval is required for the user to join the team
+        has_unmet_access_requirement: true if and only if there is at least one unmet access requirement for the user on the team
+        can_send_email: true if and only if the user can send an email to the team
     """
 
     team_id: Optional[str] = None

--- a/synapseclient/models/team.py
+++ b/synapseclient/models/team.py
@@ -435,7 +435,6 @@ class Team(TeamSynchronousProtocol):
     async def get_user_membership_status_async(
         self,
         user_id: str,
-        team: Union[str, int],
         *,
         synapse_client: Optional[Synapse] = None,
     ) -> TeamMembershipStatus:
@@ -443,7 +442,6 @@ class Team(TeamSynchronousProtocol):
 
         Arguments:
             user_id: Synapse user ID
-            team: Synapse team ID
             synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.
@@ -455,6 +453,6 @@ class Team(TeamSynchronousProtocol):
 
         client = Synapse.get_client(synapse_client=synapse_client)
         status = await get_membership_status(
-            user_id=user_id, team=team, synapse_client=client
+            user_id=user_id, team=self.id, synapse_client=client
         )
         return TeamMembershipStatus().fill_from_dict(status)

--- a/synapseclient/models/team.py
+++ b/synapseclient/models/team.py
@@ -7,6 +7,7 @@ from synapseclient import Synapse
 from synapseclient.api import (
     create_team,
     delete_team,
+    get_membership_status,
     get_team,
     get_team_members,
     get_team_open_invitations,
@@ -356,3 +357,28 @@ class Team(TeamSynchronousProtocol):
             team=self.id, synapse_client=synapse_client
         )
         return list(invitations)
+
+    async def get_user_membership_status_async(
+        self,
+        user_id: str,
+        team: Union[str, int],
+        *,
+        synapse_client: Optional[Synapse] = None,
+    ) -> str:
+        """Retrieve a user's Team Membership Status bundle.
+        <https://rest-docs.synapse.org/rest/GET/team/id/member/principalId/membershipStatus.html>
+
+        Arguments:
+            user: Synapse user ID
+            team: A [synapseclient.team.Team][] object or a team's ID.
+
+        Returns:
+            dict of TeamMembershipStatus
+        """
+        from synapseclient import Synapse
+
+        client = Synapse.get_client(synapse_client=synapse_client)
+        status = await get_membership_status(
+            user_id=user_id, team=team, synapse_client=client
+        )
+        return status

--- a/synapseclient/models/team.py
+++ b/synapseclient/models/team.py
@@ -58,6 +58,79 @@ class TeamMember:
 
 
 @dataclass
+class TeamMembershipStatus:
+    """
+    Contains information about a user's membership status in a Team.
+    In practice the constructor is not called directly by the client.
+
+    Attributes:
+        team_id: The synapse ID of the team
+        user_id: The synapse ID of the user
+        is_member: Whether the user is a member of the team
+        has_open_invitation: Whether the user has an open invitation to join the team
+        has_open_request: Whether the user has an open request to join the team
+        can_join: Whether the user can join the team
+        membership_approval_required: Whether membership approval is required for the team
+        has_unmet_access_requirement: Whether the user has unmet access requirements
+        can_send_email: Whether the user can send email to the team
+    """
+
+    team_id: Optional[str] = None
+    """The ID of the team"""
+
+    user_id: Optional[str] = None
+    """The ID of the user"""
+
+    is_member: Optional[bool] = None
+    """Whether the user is a member of the team"""
+
+    has_open_invitation: Optional[bool] = None
+    """Whether the user has an open invitation to join the team"""
+
+    has_open_request: Optional[bool] = None
+    """Whether the user has an open request to join the team"""
+
+    can_join: Optional[bool] = None
+    """Whether the user can join the team"""
+
+    membership_approval_required: Optional[bool] = None
+    """Whether membership approval is required for the team"""
+
+    has_unmet_access_requirement: Optional[bool] = None
+    """Whether the user has unmet access requirements"""
+
+    can_send_email: Optional[bool] = None
+    """Whether the user can send email to the team"""
+
+    def fill_from_dict(
+        self, membership_status_dict: Dict[str, Union[str, bool]]
+    ) -> "TeamMembershipStatus":
+        """
+        Converts a response from the REST API into this dataclass.
+
+        Arguments:
+            membership_status_dict: The response from the REST API.
+
+        Returns:
+            The TeamMembershipStatus object.
+        """
+        self.team_id = membership_status_dict.get("teamId", None)
+        self.user_id = membership_status_dict.get("userId", None)
+        self.is_member = membership_status_dict.get("isMember", None)
+        self.has_open_invitation = membership_status_dict.get("hasOpenInvitation", None)
+        self.has_open_request = membership_status_dict.get("hasOpenRequest", None)
+        self.can_join = membership_status_dict.get("canJoin", None)
+        self.membership_approval_required = membership_status_dict.get(
+            "membershipApprovalRequired", None
+        )
+        self.has_unmet_access_requirement = membership_status_dict.get(
+            "hasUnmetAccessRequirement", None
+        )
+        self.can_send_email = membership_status_dict.get("canSendEmail", None)
+        return self
+
+
+@dataclass
 @async_to_sync
 class Team(TeamSynchronousProtocol):
     """
@@ -364,7 +437,7 @@ class Team(TeamSynchronousProtocol):
         team: Union[str, int],
         *,
         synapse_client: Optional[Synapse] = None,
-    ) -> str:
+    ) -> TeamMembershipStatus:
         """Retrieve a user's Team Membership Status bundle for this team.
 
         Arguments:
@@ -375,7 +448,7 @@ class Team(TeamSynchronousProtocol):
                 instance from the Synapse class constructor.
 
         Returns:
-            A dictionary of TeamMembershipStatus
+            TeamMembershipStatus object
         """
         from synapseclient import Synapse
 
@@ -383,4 +456,4 @@ class Team(TeamSynchronousProtocol):
         status = await get_membership_status(
             user_id=user_id, team=team, synapse_client=client
         )
-        return status
+        return TeamMembershipStatus().fill_from_dict(status)

--- a/tests/integration/synapseclient/models/async/test_team_async.py
+++ b/tests/integration/synapseclient/models/async/test_team_async.py
@@ -157,11 +157,8 @@ class TestTeam:
 
             # THEN the creator should have membership status indicating they are a member
             assert creator_status is not None
-            assert "teamId" in creator_status
-            assert creator_status["teamId"] == str(test_team.id)
-            assert "userId" in creator_status
-            assert "isMember" in creator_status
-            assert creator_status["isMember"] is True
+            assert creator_status.team_id == str(test_team.id)
+            assert creator_status.is_member is True
 
             # WHEN I invite a test user to the team
             invite = await test_team.invite_async(
@@ -177,11 +174,11 @@ class TestTeam:
 
             # THEN the invited user should show they have an open invitation
             assert invited_status is not None
-            assert invited_status["teamId"] == str(test_team.id)
-            assert invited_status["hasOpenInvitation"] is True
-            assert invited_status["membershipApprovalRequired"] is True
-            assert invited_status["canSendEmail"] is True
-            assert invited_status["isMember"] is False
+            assert invited_status.team_id == str(test_team.id)
+            assert invited_status.has_open_invitation is True
+            assert invited_status.membership_approval_required is True
+            assert invited_status.can_send_email is True
+            assert invited_status.is_member is False
 
         finally:
             # Clean up

--- a/tests/integration/synapseclient/models/async/test_team_async.py
+++ b/tests/integration/synapseclient/models/async/test_team_async.py
@@ -156,9 +156,14 @@ class TestTeam:
             )
 
             # THEN the creator should have membership status indicating they are a member
-            assert creator_status is not None
-            assert creator_status.team_id == str(test_team.id)
             assert creator_status.is_member is True
+            assert creator_status.team_id == str(test_team.id)
+            assert creator_status.has_open_invitation is False
+            assert creator_status.has_open_request is False
+            assert creator_status.can_join is True
+            assert creator_status.membership_approval_required is False
+            assert creator_status.has_unmet_access_requirement is False
+            assert creator_status.can_send_email is True
 
             # WHEN I invite a test user to the team
             invite = await test_team.invite_async(

--- a/tests/integration/synapseclient/models/async/test_team_async.py
+++ b/tests/integration/synapseclient/models/async/test_team_async.py
@@ -152,7 +152,7 @@ class TestTeam:
         try:
             # AND I get the membership status for the creator (who should be a member)
             creator_status = await test_team.get_user_membership_status_async(
-                user_id=self.syn.getUserProfile().ownerId, team=test_team.id
+                user_id=self.syn.getUserProfile().ownerId
             )
 
             # THEN the creator should have membership status indicating they are a member
@@ -168,8 +168,7 @@ class TestTeam:
 
             # Check the invited user's status
             invited_status = await test_team.get_user_membership_status_async(
-                user_id=self.syn.getUserProfile(self.TEST_USER).ownerId,
-                team=test_team.id,
+                user_id=self.syn.getUserProfile(self.TEST_USER).ownerId
             )
 
             # THEN the invited user should show they have an open invitation

--- a/tests/integration/synapseclient/models/async/test_team_async.py
+++ b/tests/integration/synapseclient/models/async/test_team_async.py
@@ -169,9 +169,7 @@ class TestTeam:
                 message=self.TEST_MESSAGE,
             )
 
-            # AND accept the invitation by adding the user directly to team
-
-            # Check the invited user's status (should have open invitation)
+            # Check the invited user's status
             invited_status = await test_team.get_user_membership_status_async(
                 user_id=self.syn.getUserProfile(self.TEST_USER).ownerId,
                 team=test_team.id,

--- a/tests/unit/synapseclient/models/synchronous/unit_test_team.py
+++ b/tests/unit/synapseclient/models/synchronous/unit_test_team.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from synapseclient import Synapse
-from synapseclient.models.team import Team, TeamMember
+from synapseclient.models.team import Team, TeamMember, TeamMembershipStatus
 from synapseclient.models.user import UserGroupHeader
 
 
@@ -23,6 +23,38 @@ class TestTeamMember:
         assert team_member.team_id == 1
         assert team_member.member.owner_id == 2
         assert team_member.is_admin is True
+
+
+class TestTeamMembershipStatus:
+    """Tests for the TeamMembershipStatus class."""
+
+    def test_fill_from_dict(self) -> None:
+        # GIVEN a blank TeamMembershipStatus
+        status = TeamMembershipStatus()
+        # WHEN I fill it with a dictionary
+        status.fill_from_dict(
+            {
+                "teamId": "123",
+                "userId": "456",
+                "isMember": False,
+                "hasOpenInvitation": True,
+                "hasOpenRequest": False,
+                "canJoin": False,
+                "membershipApprovalRequired": True,
+                "hasUnmetAccessRequirement": False,
+                "canSendEmail": True,
+            }
+        )
+        # THEN I expect all fields to be set
+        assert status.team_id == "123"
+        assert status.user_id == "456"
+        assert status.is_member is False
+        assert status.has_open_invitation is True
+        assert status.has_open_request is False
+        assert status.can_join is False
+        assert status.membership_approval_required is True
+        assert status.has_unmet_access_requirement is False
+        assert status.can_send_email is True
 
 
 class TestTeam:


### PR DESCRIPTION
# **Problem:**
This method here needs to be deprecated: [synapsePythonClient/synapseclient/client.py at 02d3b38d2a0f043811637064f61ae8b537e4253b · Sage-Bionetworks/synapsePythonClient](https://github.com/Sage-Bionetworks/synapsePythonClient/blob/02d3b38d2a0f043811637064f61ae8b537e4253b/synapseclient/client.py#L5519-L5535)

# **Solution:**
Added a new method called `get_user_membership_status` under team

# **Testing:**
- Ensured that the example in the docstring works
- Surfaced the new function in documentation 
- Added test
