### PR TITLE
fix: update bandit to 1.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.5
+    rev: 1.8.0
     hooks:
       - id: bandit
         args: ["-c", "pyproject.toml"]


### PR DESCRIPTION
# **Problem:**
Got an error in GH action run: 
```
Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repog43qjmdu/py_env-python3/bin/bandit", line 3, in <module>
    from bandit.cli.main import main
  File "/home/runner/.cache/pre-commit/repog43qjmdu/py_env-python3/lib/python3.13/site-packages/bandit/__init__.py", line 5, in <module>
    import pbr.version
ModuleNotFoundError: No module named 'pbr'
Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repog43qjmdu/py_env-python3/bin/bandit", line 3, in <module>
    from bandit.cli.main import main
  File "/home/runner/.cache/pre-commit/repog43qjmdu/py_env-python3/lib/python3.13/site-packages/bandit/__init__.py", line 5, in <module>
    import pbr.version
ModuleNotFoundError: No module named 'pbr'
Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repog43qjmdu/py_env-python3/bin/bandit", line 3, in <module>
    from bandit.cli.main import main
  File "/home/runner/.cache/pre-commit/repog43qjmdu/py_env-python3/lib/python3.13/site-packages/bandit/__init__.py", line 5, in <module>
    import pbr.version
ModuleNotFoundError: No module named 'pbr'
Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repog43qjmdu/py_env-python3/bin/bandit", line 3, in <module>
    from bandit.cli.main import main
  File "/home/runner/.cache/pre-commit/repog43qjmdu/py_env-python3/lib/python3.13/site-packages/bandit/__init__.py", line 5, in <module>
    import pbr.version
ModuleNotFoundError: No module named 'pbr'
```

# **Solution:**
Bandit officially supports Python 3.13 since version 1.8.0: https://github.com/PyCQA/bandit/releases
Pbr is also no longer supported since version 1.7.6 (see their release note: https://github.com/PyCQA/bandit/releases?page=2) 

