### PR TITLE
Tech Debt: update SonarCloud action to use sonarqube-scan-action@v5.3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,7 +222,7 @@ jobs:
         if: steps.check_coverage_xml.outputs.files_exists == 'true'
         run: sed -i "s/<source>\/home\/runner\/work\/synapsePythonClient<\/source>/<source>\/github\/workspace<\/source>/g" coverage.xml
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v5.3.1
         if: ${{ always() }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# **Problem:**

- This action is deprecated

# **Solution:**

- Move to the latest non-deprecated version of the drop in replacement action

# **Testing:**

- Will review the run of this branch
