### PR TITLE
[SYNPY-1198] Handle S3 upload errors by retrying without ACL for IBM buckets

### DIFF
--- a/synapseclient/core/remote_file_storage_wrappers.py
+++ b/synapseclient/core/remote_file_storage_wrappers.py
@@ -6,7 +6,6 @@ import urllib.parse as urllib_parse
 from contextlib import contextmanager
 from typing import Union
 
-from boto3.exceptions import S3UploadFailedError
 from tqdm import tqdm
 
 from synapseclient.core.retry import with_retry
@@ -195,6 +194,7 @@ class S3ClientWrapper:
 
         S3ClientWrapper._attempt_import_boto3()
         import boto3.s3.transfer
+        from boto3.exceptions import S3UploadFailedError
 
         transfer_config = boto3.s3.transfer.TransferConfig(
             **(transfer_config_kwargs or {})


### PR DESCRIPTION
# **Problem:**

- When uploading to an IBM based object storage bucket you would get the following error:

```
boto3.exceptions.S3UploadFailedError: Failed to upload /home/ec2-user/temp/test_file.txt to synpy-1198-ibm-bucket-testing/48b69ddc-9f28-4063-9f93-8efa7f262a15/test_file.txt: An error occurred (InvalidRequest) when calling the PutObject operation: Invalid canned ACL
```

- The error is received because IBM does not support more granular permissions and uses a different permissions schema that S3 uses as described in: https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html

# **Solution:**

- First try to upload the object with the additional setting - and if it fails due to the canned acl error, upload it without the setting
- This solution is ok because the default behavior for IBM based buckets is that **"By default, all objects are private. Only the owner has full access control."** (Source: https://ibm.github.io/ibm-cos-sdk-python/reference/services/s3/bucket/put_object.html)

From google gemini:

> Based on the behavior of modern S3-compatible services, the object owner would be the bucket owner, not the user who uploaded the file.

> This is a critical distinction from the legacy S3 access control model. In the classic "Object writer" model (one of the three AWS S3 Object Ownership settings), the user who uploads an object automatically becomes its owner. This model often required complex ACLs to grant the bucket owner access to the objects within their own bucket.  

> However, both modern AWS S3 and IBM Cloud Object Storage operate on a different, more streamlined principle. IBM's default behavior is functionally equivalent to the AWS S3 Bucket owner enforced setting. When this setting is enabled, ACLs are disabled, and the bucket owner automatically gains full control over every object in the bucket, regardless of who uploads it. Access to the data is then managed exclusively through bucket and IAM policies, simplifying permissions management.   


# **Testing:**

- I created an IBM based bucket and verified that I could upload content into a Synapse folder


Console logs:

```
Uploading to endpoint: [https://s3.us-east.cloud-object-storage.appdomain.cloud] bucket: [synpy-1198-ibm-bucket-testing]: 36.0B [00:00, 72.7B/s, test_file_2.txt]              


Uploaded file: File(id='syn69352228', name='test_file_2.txt', path='/home/ec2-user/temp/test_file_2.txt', description=None, parent_id='syn69343577', version_label='1', version_comment=None, data_file_handle_id='162281220', external_url=None, activity=None, annotations={}, content_type='text/plain', content_size=18, content_md5=None, etag='1300162a-1d7a-400e-847e-365692ba21ff', created_on='2025-09-02T17:27:49.703Z', modified_on='2025-09-02T17:27:49.703Z', created_by='3481671', modified_by='3481671', version_number=1, is_latest_version=True, file_handle=FileHandle(id='162281220', etag='0e568085-9064-4236-85ff-e0812250a77b', created_by='3481671', created_on='2025-09-02T17:27:50.000Z', modified_on='2025-09-02T17:27:50.000Z', concrete_type='org.sagebionetworks.repo.model.file.ExternalObjectStoreFileHandle', content_type='text/plain', content_md5='4da35fb739818827117780d1ae4df345', file_name='test_file_2.txt', storage_location_id=42493, content_size=18, status='AVAILABLE', bucket_name=None, key=None, preview_id=None, is_preview=None, external_url=None))
```


<img width="1838" height="363" alt="image" src="https://github.com/user-attachments/assets/f0d5be06-5aac-4c1b-b556-1189aaaf0fde" />


