### PR TITLE
[SYNPY-1589] Implement "Evaluation" OOP model

### DIFF
--- a/tests/integration/synapseclient/models/async/test_evaluation_async.py
+++ b/tests/integration/synapseclient/models/async/test_evaluation_async.py
@@ -1,0 +1,230 @@
+"""Integration tests for the synapseclient.models.Evaluation class."""
+
+import uuid
+from typing import Callable
+
+import pytest
+
+from synapseclient import Synapse
+from synapseclient.models import Evaluation, Project
+
+
+class TestEvaluationCreation:
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    async def test_create_evaluation(self):
+        # GIVEN a project to work with
+        project = await Project(id=self.syn.store(Project(name="test_project")).id).get_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(project.id)
+
+        # WHEN I create an evaluation
+        evaluation = await Evaluation(name="test_evaluation", parent_id=project.id).store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(evaluation.id)
+
+        # THEN the evaluation should be created
+        assert evaluation.id is not None
+
+
+class TestGetEvaluation:
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    @pytest.fixture(scope="function")
+    async def test_project(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> Project:
+        """Create a test project for evaluation tests."""
+        project = await Project(id=syn.store(Project(name=f"test_project_{uuid.uuid4()}")).id).get_async(synapse_client=syn)
+        schedule_for_cleanup(project.id)
+        return project
+
+    @pytest.fixture(scope="function")
+    async def test_evaluation(self, test_project: Project, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> Evaluation:
+        """Create a test evaluation for get tests."""
+        evaluation = await Evaluation(
+            name=f"test_evaluation_{uuid.uuid4()}", 
+            parent_id=test_project.id
+        ).store_async(synapse_client=syn)
+        schedule_for_cleanup(evaluation.id)
+        return evaluation
+
+    @pytest.fixture(scope="function")
+    async def multiple_evaluations(self, test_project: Project, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> list[Evaluation]:
+        """Create multiple test evaluations for bulk tests."""
+        evaluations = []
+        for i in range(3):
+            evaluation = await Evaluation(
+                name=f"test_evaluation_{i}_{uuid.uuid4()}", 
+                parent_id=test_project.id
+            ).store_async(synapse_client=syn)
+            schedule_for_cleanup(evaluation.id)
+            evaluations.append(evaluation)
+        return evaluations
+
+    async def test_get_evaluation_by_id(self, test_evaluation: Evaluation):
+        # WHEN I get an evaluation by id
+        retrieved_evaluation = await Evaluation(id=test_evaluation.id).get_async(synapse_client=self.syn)
+
+        # THEN the evaluation should be retrieved
+        assert retrieved_evaluation.id == test_evaluation.id
+        assert retrieved_evaluation.name == test_evaluation.name
+
+    async def test_get_evaluation_by_entity(self, test_evaluation: Evaluation, test_project: Project):
+        # WHEN I get an evaluation by a project
+        retrieved_evaluation = await Evaluation(project_id=test_project.id).get_async(synapse_client=self.syn)
+
+        # THEN the evaluation should be retrieved
+        assert retrieved_evaluation.id == test_evaluation.id
+        assert retrieved_evaluation.parent_id == test_project.id
+
+    async def test_get_all_evaluations(self, multiple_evaluations: list[Evaluation], limit: int = 1):
+        # Test 1: Grab evaluations that the user has access to
+        # WHEN a call is made to get all evaluations
+        evaluations = await Evaluation.get_all_evaluations_async(synapse_client=self.syn)
+
+        # THEN the evaluations should be retrieved
+        assert evaluations is not None
+        assert len(evaluations) >= len(multiple_evaluations)
+
+        # Test 2: Grab evaluations that the user has access to and are active
+        # WHEN the active_only parameter is True
+        active_evaluations = await Evaluation.get_all_evaluations_async(synapse_client=self.syn, active_only=True)
+
+        # THEN the active evaluations should be retrieved
+        assert active_evaluations is not None
+
+        # Test 3: Grab evaluations based on a limit
+        # WHEN the limit parameter is set
+        limited_evaluations = await Evaluation.get_all_evaluations_async(synapse_client=self.syn, limit=limit)
+
+        # THEN the evaluations retrieved should match said limit
+        assert len(limited_evaluations) == limit
+
+    async def test_get_available_evaluations(self, multiple_evaluations: list[Evaluation]):
+        # WHEN a call is made to get available evaluations for a given user
+        evaluations = await Evaluation.get_available_evaluations_async(synapse_client=self.syn)
+
+        # THEN the evaluations should be retrieved
+        assert evaluations is not None
+        assert len(evaluations) >= len(multiple_evaluations)
+
+    async def test_get_evaluation_by_name(self, test_evaluation: Evaluation):
+        # WHEN a call is made to get an evaluation by name
+        retrieved_evaluation = await Evaluation.get_evaluation_by_name_async(
+            synapse_client=self.syn, 
+            name=test_evaluation.name
+        )
+
+        # THEN the evaluation should be retrieved
+        assert retrieved_evaluation.id == test_evaluation.id
+        assert retrieved_evaluation.name == test_evaluation.name
+
+
+class TestUpdateEvaluation:
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    @pytest.fixture(scope="function")
+    async def test_project(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> Project:
+        """Create a test project for evaluation tests."""
+        project = await Project(id=syn.store(Project(name=f"test_project_{uuid.uuid4()}")).id).get_async(synapse_client=syn)
+        schedule_for_cleanup(project.id)
+        return project
+
+    @pytest.fixture(scope="function")
+    async def test_evaluation(self, test_project: Project, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> Evaluation:
+        """Create a test evaluation for update tests."""
+        evaluation = await Evaluation(
+            name=f"test_evaluation_{uuid.uuid4()}", 
+            parent_id=test_project.id
+        ).store_async(synapse_client=syn)
+        schedule_for_cleanup(evaluation.id)
+        return evaluation
+
+    async def test_update_evaluation_name(self, test_evaluation: Evaluation):
+        # WHEN I update the evaluation name
+        new_name = f"updated_evaluation_{uuid.uuid4()}"
+        test_evaluation.name = new_name
+        updated_evaluation = await test_evaluation.store_async(synapse_client=self.syn)
+
+        # THEN the evaluation should be updated
+        assert updated_evaluation.name == new_name
+        assert updated_evaluation.id == test_evaluation.id
+
+
+class TestDeleteEvaluation:
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    @pytest.fixture(scope="function")
+    async def test_project(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> Project:
+        """Create a test project for evaluation tests."""
+        project = await Project(id=syn.store(Project(name=f"test_project_{uuid.uuid4()}")).id).get_async(synapse_client=syn)
+        schedule_for_cleanup(project.id)
+        return project
+
+    @pytest.fixture(scope="function")
+    async def test_evaluation(self, test_project: Project, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> Evaluation:
+        """Create a test evaluation for delete tests."""
+        evaluation = await Evaluation(
+            name=f"test_evaluation_{uuid.uuid4()}", 
+            parent_id=test_project.id
+        ).store_async(synapse_client=syn)
+        schedule_for_cleanup(evaluation.id)
+        return evaluation
+
+    async def test_delete_evaluation(self, test_evaluation: Evaluation):
+        # WHEN I delete the evaluation
+        await test_evaluation.delete_async(synapse_client=self.syn)
+
+        # THEN the evaluation should be deleted (attempting to get it should raise an exception)
+        # Note: This test might need adjustment based on how deletion is handled in the API
+        pass
+
+
+class TestEvaluationAccess:
+    @pytest.fixture(autouse=True, scope="function")
+    def init(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> None:
+        self.syn = syn
+        self.schedule_for_cleanup = schedule_for_cleanup
+
+    @pytest.fixture(scope="function")
+    async def test_project(self, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> Project:
+        """Create a test project for evaluation tests."""
+        project = await Project(id=syn.store(Project(name=f"test_project_{uuid.uuid4()}")).id).get_async(synapse_client=syn)
+        schedule_for_cleanup(project.id)
+        return project
+
+    @pytest.fixture(scope="function")
+    async def test_evaluation(self, test_project: Project, syn: Synapse, schedule_for_cleanup: Callable[..., None]) -> Evaluation:
+        """Create a test evaluation for access tests."""
+        evaluation = await Evaluation(
+            name=f"test_evaluation_{uuid.uuid4()}", 
+            parent_id=test_project.id
+        ).store_async(synapse_client=syn)
+        schedule_for_cleanup(evaluation.id)
+        return evaluation
+
+    async def test_get_evaluation_acl(self, test_evaluation: Evaluation):
+        # WHEN I get the evaluation ACL
+        acl = await test_evaluation.get_acl_async(synapse_client=self.syn)
+
+        # THEN the ACL should be retrieved
+        assert acl is not None
+
+    async def test_update_evaluation_acl(self, test_evaluation: Evaluation):
+        # WHEN I update the evaluation ACL
+        # Note: This test might need adjustment based on ACL update implementation
+        pass
+
+    async def test_get_evaluation_permissions(self, test_evaluation: Evaluation):
+        # WHEN I get evaluation permissions
+        # Note: This test might need adjustment based on permissions implementation
+        pass


### PR DESCRIPTION
# **Problem:**

This work is part of the ongoing effort to refactor the Synapse Python Client using object-oriented principles, following the pattern established in https://sagebionetworks.jira.com/browse/SYNPY-1418.

We currently to not have an OOP model for communications to the [Evaluation API services](https://rest-docs.synapse.org/rest/index.html#org.sagebionetworks.repo.web.controller.EvaluationController) provided by the Synapse platform.

# **Solution:**

- [ ] A new `DataClass` is introduced following the official attributes of an [Evaluation entity](https://rest-docs.synapse.org/rest/org/sagebionetworks/evaluation/model/Evaluation.html) on Synapse.
- [ ] Communications to the following services are supported:

Create evaluation: https://rest-docs.synapse.org/rest/POST/evaluation.html 
Get evaluation by ID: https://rest-docs.synapse.org/rest/GET/evaluation/evalId.html 
Get evaluations by entity: https://rest-docs.synapse.org/rest/GET/entity/id/evaluation.html 
Get all evaluations: https://rest-docs.synapse.org/rest/GET/evaluation.html 
Get available evaluations: https://rest-docs.synapse.org/rest/GET/evaluation/available.html 
Find evaluation by name: https://rest-docs.synapse.org/rest/GET/evaluation/name/name.html 
Update evaluation: https://rest-docs.synapse.org/rest/PUT/evaluation/evalId.html 
Delete evaluation: https://rest-docs.synapse.org/rest/DELETE/evaluation/evalId.html 
Get ACL: https://rest-docs.synapse.org/rest/GET/evaluation/evalId/acl.html 
Update ACL: https://rest-docs.synapse.org/rest/PUT/evaluation/acl.html 
Get permissions: https://rest-docs.synapse.org/rest/GET/evaluation/evalId/permissions.html 

- [ ] async/sync methods are introduced to the `DataClass`
- [ ] async/sync Integration tests are introduced
- [ ] Our Synapse Python Client documentation (using mkdocs) is updated for this model
- [ ] A tutorial is made for popular use-cases of this model

# **Testing:**

- [ ] Passing integration tests
- [ ] Passing documentation build
- [ ] Running through the tutorial presents no issues
