### PR TITLE
[SYNPY-1653] Create RecordSet, Grid, and CurationTask classes

### DIFF
--- a/synapseclient/api/__init__.py
+++ b/synapseclient/api/__init__.py
@@ -16,6 +16,13 @@ from .configuration_services import (
     get_config_section_dict,
     get_transfer_config,
 )
+from .curation_services import (
+    create_curation_task,
+    delete_curation_task,
+    get_curation_task,
+    list_curation_tasks,
+    update_curation_task,
+)
 from .entity_bundle_services_v2 import (
     get_entity_id_bundle2,
     get_entity_id_version_bundle2,
@@ -233,6 +240,12 @@ __all__ = [
     "get_membership_status",
     "delete_membership_invitation",
     "invite_to_team",
+    # curation_services
+    "create_curation_task",
+    "delete_curation_task",
+    "get_curation_task",
+    "list_curation_tasks",
+    "update_curation_task",
     # user_services
     "get_user_bundle",
     "get_user_by_principal_id_or_name",

--- a/synapseclient/api/curation_services.py
+++ b/synapseclient/api/curation_services.py
@@ -1,0 +1,148 @@
+"""This module is responsible for exposing the services defined at:
+<https://rest-docs.synapse.org#org.sagebionetworks.repo.web.controller.CurationTaskController>
+"""
+
+import json
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, Optional, Union
+
+from synapseclient.api.api_client import rest_post_paginated_async
+
+if TYPE_CHECKING:
+    from synapseclient import Synapse
+
+
+async def create_curation_task(
+    curation_task: Dict[str, Union[str, int, Dict[str, Any]]],
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> Dict[str, Union[str, int]]:
+    """
+    Create a CurationTask associated with a project.
+
+    POST /curation/task
+
+    Arguments:
+        curation_task: The complete CurationTask object to create.
+        synapse_client: If not passed in and caching was not disabled by
+            `Synapse.allow_client_caching(False)` this will use the last created
+            instance from the Synapse class constructor.
+
+    Returns:
+        The created CurationTask.
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    return await client.rest_post_async(
+        uri="/curation/task", body=json.dumps(curation_task)
+    )
+
+
+async def get_curation_task(
+    task_id: int,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> Dict[str, Union[str, int]]:
+    """
+    Get a CurationTask by its ID.
+
+    Arguments:
+        task_id: The unique identifier of the task.
+        synapse_client: If not passed in and caching was not disabled by
+            `Synapse.allow_client_caching(False)` this will use the last created
+            instance from the Synapse class constructor.
+
+    Returns:
+        The CurationTask.
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    return await client.rest_get_async(uri=f"/curation/task/{task_id}")
+
+
+async def update_curation_task(
+    task_id: int,
+    curation_task: Dict[str, Union[str, int, Dict[str, Any]]],
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> Dict[str, Union[str, int]]:
+    """
+    Update a CurationTask.
+
+    PUT /curation/task/{taskId}
+
+    Arguments:
+        task_id: The unique identifier of the task.
+        curation_task: The complete CurationTask object to update.
+        synapse_client: If not passed in and caching was not disabled by
+            `Synapse.allow_client_caching(False)` this will use the last created
+            instance from the Synapse class constructor.
+
+    Returns:
+        The updated CurationTask.
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    return await client.rest_put_async(
+        uri=f"/curation/task/{task_id}", body=json.dumps(curation_task)
+    )
+
+
+async def delete_curation_task(
+    task_id: int,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> None:
+    """
+    Delete a CurationTask.
+
+    Arguments:
+        task_id: The unique identifier of the task.
+        synapse_client: If not passed in and caching was not disabled by
+            `Synapse.allow_client_caching(False)` this will use the last created
+            instance from the Synapse class constructor.
+
+    Returns:
+        None
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    await client.rest_delete_async(uri=f"/curation/task/{task_id}")
+
+
+async def list_curation_tasks(
+    project_id: str,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> AsyncGenerator[Dict[str, Any], None]:
+    """
+    Generator to get a list of CurationTasks for a project.
+
+    POST /curation/task/list
+
+    Arguments:
+        project_id: The synId of the project.
+        synapse_client: If not passed in and caching was not disabled by
+            `Synapse.allow_client_caching(False)` this will use the last created
+            instance from the Synapse class constructor.
+
+    Yields:
+        Individual CurationTask objects from each page of the response.
+    """
+    from synapseclient import Synapse
+
+    client = Synapse.get_client(synapse_client=synapse_client)
+
+    request_body = {"projectId": project_id}
+
+    async for item in rest_post_paginated_async(
+        "/curation/task/list", body=request_body, synapse_client=client
+    ):
+        yield item

--- a/synapseclient/api/entity_factory.py
+++ b/synapseclient/api/entity_factory.py
@@ -342,6 +342,7 @@ async def _cast_into_class_type(
         Folder,
         MaterializedView,
         Project,
+        RecordSet,
         SubmissionView,
         Table,
         VirtualTable,
@@ -375,6 +376,7 @@ async def _cast_into_class_type(
         concrete_types.DATASET_COLLECTION_ENTITY: DatasetCollection,
         concrete_types.ENTITY_VIEW: EntityView,
         concrete_types.MATERIALIZED_VIEW: MaterializedView,
+        concrete_types.RECORD_SET_ENTITY: RecordSet,
         concrete_types.SUBMISSION_VIEW: SubmissionView,
         concrete_types.VIRTUAL_TABLE: VirtualTable,
     }
@@ -389,7 +391,10 @@ async def _cast_into_class_type(
     entity_instance = entity_to_update or entity_class()
 
     # Handle special case for File entities
-    if entity["concreteType"] == concrete_types.FILE_ENTITY:
+    if (
+        entity["concreteType"] == concrete_types.FILE_ENTITY
+        or entity["concreteType"] == concrete_types.RECORD_SET_ENTITY
+    ):
         entity_instance = await _handle_file_entity(
             entity_instance=entity_instance,
             entity_bundle=entity_bundle,

--- a/synapseclient/core/constants/concrete_types.py
+++ b/synapseclient/core/constants/concrete_types.py
@@ -65,6 +65,7 @@ FILE_ENTITY = "org.sagebionetworks.repo.model.FileEntity"
 FOLDER_ENTITY = "org.sagebionetworks.repo.model.Folder"
 LINK_ENTITY = "org.sagebionetworks.repo.model.Link"
 PROJECT_ENTITY = "org.sagebionetworks.repo.model.Project"
+RECORD_SET_ENTITY = "org.sagebionetworks.repo.model.RecordSet"
 TABLE_ENTITY = "org.sagebionetworks.repo.model.table.TableEntity"
 DATASET_ENTITY = "org.sagebionetworks.repo.model.table.Dataset"
 DATASET_COLLECTION_ENTITY = "org.sagebionetworks.repo.model.table.DatasetCollection"
@@ -105,3 +106,18 @@ QUERY_BUNDLE_REQUEST = "org.sagebionetworks.repo.model.table.QueryBundleRequest"
 QUERY_RESULT = "org.sagebionetworks.repo.model.table.QueryResult"
 
 QUERY_TABLE_CSV_RESULT = "org.sagebionetworks.repo.model.table.DownloadFromTableResult"
+
+# Curation Task Types
+CURATION_TASK = "org.sagebionetworks.repo.model.curation.CurationTask"
+FILE_BASED_METADATA_TASK_PROPERTIES = (
+    "org.sagebionetworks.repo.model.curation.metadata.FileBasedMetadataTaskProperties"
+)
+RECORD_BASED_METADATA_TASK_PROPERTIES = (
+    "org.sagebionetworks.repo.model.curation.metadata.RecordBasedMetadataTaskProperties"
+)
+
+# Grid Session Types
+CREATE_GRID_REQUEST = "org.sagebionetworks.repo.model.grid.CreateGridRequest"
+GRID_RECORD_SET_EXPORT_REQUEST = (
+    "org.sagebionetworks.repo.model.grid.GridRecordSetExportRequest"
+)

--- a/synapseclient/models/__init__.py
+++ b/synapseclient/models/__init__.py
@@ -7,6 +7,11 @@ from synapseclient.models.agent import (
     AgentSessionAccessLevel,
 )
 from synapseclient.models.annotations import Annotations
+from synapseclient.models.curation import (
+    CurationTask,
+    FileBasedMetadataTaskProperties,
+    RecordBasedMetadataTaskProperties,
+)
 from synapseclient.models.dataset import Dataset, DatasetCollection, EntityRef
 from synapseclient.models.entityview import EntityView, ViewTypeMask
 from synapseclient.models.file import File, FileHandle
@@ -14,6 +19,7 @@ from synapseclient.models.folder import Folder
 from synapseclient.models.materializedview import MaterializedView
 from synapseclient.models.mixins.table_components import QueryMixin
 from synapseclient.models.project import Project
+from synapseclient.models.recordset import RecordSet
 from synapseclient.models.services import FailureStrategy
 from synapseclient.models.submissionview import SubmissionView
 from synapseclient.models.table import Table
@@ -58,10 +64,14 @@ __all__ = [
     "FileHandle",
     "Folder",
     "Project",
+    "RecordSet",
     "Annotations",
     "Team",
     "TeamMember",
     "TeamMembershipStatus",
+    "CurationTask",
+    "FileBasedMetadataTaskProperties",
+    "RecordBasedMetadataTaskProperties",
     "UserProfile",
     "UserPreference",
     "UserGroupHeader",

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -1,0 +1,807 @@
+"""
+Curation Task dataclasses for managing Curation Tasks in Synapse.
+
+Curation tasks are used to guide data contributors through the process of contributing
+data or metadata in Synapse.
+"""
+
+from dataclasses import dataclass, field, replace
+from typing import Any, AsyncGenerator, Dict, Optional, Union
+
+from opentelemetry import trace
+
+from synapseclient import Synapse
+from synapseclient.api import (
+    create_curation_task,
+    delete_curation_task,
+    get_curation_task,
+    list_curation_tasks,
+    update_curation_task,
+)
+from synapseclient.core.async_utils import async_to_sync
+from synapseclient.core.constants.concrete_types import (
+    CREATE_GRID_REQUEST,
+    FILE_BASED_METADATA_TASK_PROPERTIES,
+    GRID_RECORD_SET_EXPORT_REQUEST,
+    RECORD_BASED_METADATA_TASK_PROPERTIES,
+)
+from synapseclient.core.utils import delete_none_keys, merge_dataclass_entities
+from synapseclient.models.mixins.asynchronous_job import AsynchronousCommunicator
+from synapseclient.models.recordset import ValidationSummary
+from synapseclient.models.table_components import Query
+
+
+@dataclass
+class FileBasedMetadataTaskProperties:
+    """
+    A CurationTaskProperties for file-based data, describing where data is uploaded
+    and a view which contains the annotations.
+
+    Represents a [Synapse FileBasedMetadataTaskProperties](https://rest-docs.synapse.org/org/sagebionetworks/repo/model/curation/metadata/FileBasedMetadataTaskProperties.html).
+
+    Attributes:
+        upload_folder_id: The synId of the folder where data files of this type are to be uploaded
+        file_view_id: The synId of the FileView that shows all data of this type
+    """
+
+    upload_folder_id: Optional[str] = None
+    """The synId of the folder where data files of this type are to be uploaded"""
+
+    file_view_id: Optional[str] = None
+    """The synId of the FileView that shows all data of this type"""
+
+    def fill_from_dict(
+        self, synapse_response: Union[Dict[str, Any], Any]
+    ) -> "FileBasedMetadataTaskProperties":
+        """
+        Converts a response from the REST API into this dataclass.
+
+        Arguments:
+            synapse_response: The response from the REST API.
+
+        Returns:
+            The FileBasedMetadataTaskProperties object.
+        """
+        self.upload_folder_id = synapse_response.get("uploadFolderId", None)
+        self.file_view_id = synapse_response.get("fileViewId", None)
+        return self
+
+    def to_synapse_request(self) -> Dict[str, Any]:
+        """
+        Converts this dataclass to a dictionary suitable for a Synapse REST API request.
+
+        Returns:
+            A dictionary representation of this object for API requests.
+        """
+        request_dict = {"concreteType": FILE_BASED_METADATA_TASK_PROPERTIES}
+        if self.upload_folder_id is not None:
+            request_dict["uploadFolderId"] = self.upload_folder_id
+        if self.file_view_id is not None:
+            request_dict["fileViewId"] = self.file_view_id
+        return request_dict
+
+
+@dataclass
+class RecordBasedMetadataTaskProperties:
+    """
+    A CurationTaskProperties for record-based metadata.
+
+    Represents a [Synapse RecordBasedMetadataTaskProperties](https://rest-docs.synapse.org/org/sagebionetworks/repo/model/curation/metadata/RecordBasedMetadataTaskProperties.html).
+
+    Attributes:
+        record_set_id: The synId of the RecordSet that will contain all record-based metadata
+    """
+
+    record_set_id: Optional[str] = None
+    """The synId of the RecordSet that will contain all record-based metadata"""
+
+    def fill_from_dict(
+        self, synapse_response: Union[Dict[str, Any], Any]
+    ) -> "RecordBasedMetadataTaskProperties":
+        """
+        Converts a response from the REST API into this dataclass.
+
+        Arguments:
+            synapse_response: The response from the REST API.
+
+        Returns:
+            The RecordBasedMetadataTaskProperties object.
+        """
+        self.record_set_id = synapse_response.get("recordSetId", None)
+        return self
+
+    def to_synapse_request(self) -> Dict[str, Any]:
+        """
+        Converts this dataclass to a dictionary suitable for a Synapse REST API request.
+
+        Returns:
+            A dictionary representation of this object for API requests.
+        """
+        request_dict = {"concreteType": RECORD_BASED_METADATA_TASK_PROPERTIES}
+        if self.record_set_id is not None:
+            request_dict["recordSetId"] = self.record_set_id
+        return request_dict
+
+
+def _create_task_properties_from_dict(
+    properties_dict: Dict[str, Any]
+) -> Union[FileBasedMetadataTaskProperties, RecordBasedMetadataTaskProperties]:
+    """
+    Factory method to create the appropriate FileBasedMetadataTaskProperties/RecordBasedMetadataTaskProperties
+    based on the concreteType.
+
+    Arguments:
+        properties_dict: Dictionary containing task properties data
+
+    Returns:
+        The appropriate FileBasedMetadataTaskProperties/RecordBasedMetadataTaskProperties instance
+    """
+    concrete_type = properties_dict.get("concreteType", "")
+
+    if concrete_type == FILE_BASED_METADATA_TASK_PROPERTIES:
+        return FileBasedMetadataTaskProperties().fill_from_dict(properties_dict)
+    elif concrete_type == RECORD_BASED_METADATA_TASK_PROPERTIES:
+        return RecordBasedMetadataTaskProperties().fill_from_dict(properties_dict)
+    else:
+        raise ValueError(
+            f"Unknown concreteType for CurationTaskProperties: {concrete_type}"
+        )
+
+
+async def _get_existing_curation_task_id(
+    project_id: str,
+    data_type: str,
+    synapse_client: Optional[Synapse] = None,
+) -> Optional[int]:
+    """
+    Helper function to find an existing curation task by project_id and data_type.
+
+    Arguments:
+        project_id: The synId of the project.
+        data_type: The data type to search for.
+        synapse_client: The Synapse client to use.
+
+    Returns:
+        The task_id if found, None otherwise.
+    """
+    async for task_dict in list_curation_tasks(
+        project_id=project_id, synapse_client=synapse_client
+    ):
+        if task_dict.get("dataType") == data_type:
+            return task_dict.get("taskId")
+    return None
+
+
+# TODO: Create Sync Protocol for all methods
+# TODO: Double check all docstrings to include explict examples
+@dataclass
+@async_to_sync
+class CurationTask:
+    """
+    The CurationTask provides instructions for a Data Contributor on how data or metadata
+    of a specific type should be both added to a project and curated.
+
+    Represents a [Synapse CurationTask](https://rest-docs.synapse.org/org/sagebionetworks/repo/model/curation/CurationTask.html).
+
+    Attributes:
+        task_id: The unique identifier issued to this task when it was created
+        data_type: Will match the data type that a contributor plans to contribute
+        project_id: The synId of the project
+        instructions: Instructions to the data contributor
+        task_properties: The properties of a CurationTask. This can be either
+            FileBasedMetadataTaskProperties or RecordBasedMetadataTaskProperties.
+        etag: Synapse employs an Optimistic Concurrency Control (OCC) scheme to handle
+            concurrent updates. Since the E-Tag changes every time an entity is updated
+            it is used to detect when a client's current representation of an entity is
+            out-of-date.
+        created_on: (Read Only) The date this task was created
+        modified_on: (Read Only) The date this task was last modified
+        created_by: (Read Only) The ID of the user that created this task
+        modified_by: (Read Only) The ID of the user that last modified this task
+    """
+
+    task_id: Optional[int] = None
+    """The unique identifier issued to this task when it was created"""
+
+    data_type: Optional[str] = None
+    """Will match the data type that a contributor plans to contribute. The dataType must be unique within a project"""
+
+    project_id: Optional[str] = None
+    """The synId of the project"""
+
+    instructions: Optional[str] = None
+    """Instructions to the data contributor"""
+
+    task_properties: Optional[
+        Union[FileBasedMetadataTaskProperties, RecordBasedMetadataTaskProperties]
+    ] = None
+    """The properties of a CurationTask"""
+
+    etag: Optional[str] = None
+    """Synapse employs an Optimistic Concurrency Control (OCC) scheme to handle concurrent updates. Since the E-Tag changes every time an entity is updated it is used to detect when a client's current representation of an entity is out-of-date"""
+
+    created_on: Optional[str] = None
+    """(Read Only) The date this task was created"""
+
+    modified_on: Optional[str] = None
+    """(Read Only) The date this task was last modified"""
+
+    created_by: Optional[str] = None
+    """(Read Only) The ID of the user that created this task"""
+
+    modified_by: Optional[str] = None
+    """(Read Only) The ID of the user that last modified this task"""
+
+    _last_persistent_instance: Optional["CurationTask"] = field(
+        default=None, repr=False, compare=False
+    )
+    """The last persistent instance of this object. This is used to determine if the
+    object has been changed and needs to be updated in Synapse."""
+
+    @property
+    def has_changed(self) -> bool:
+        """Determines if the object has been changed and needs to be updated in Synapse."""
+        return (
+            not self._last_persistent_instance or self._last_persistent_instance != self
+        )
+
+    def _set_last_persistent_instance(self) -> None:
+        """Stash the last time this object interacted with Synapse. This is used to
+        determine if the object has been changed and needs to be updated in Synapse."""
+        del self._last_persistent_instance
+        self._last_persistent_instance = replace(self)
+
+    def fill_from_dict(
+        self, synapse_response: Union[Dict[str, Any], Any]
+    ) -> "CurationTask":
+        """
+        Converts a response from the REST API into this dataclass.
+
+        Arguments:
+            synapse_response: The response from the REST API.
+
+        Returns:
+            The CurationTask object.
+        """
+        self.task_id = (
+            int(synapse_response.get("taskId", None))
+            if synapse_response.get("taskId", None)
+            else None
+        )
+        self.data_type = synapse_response.get("dataType", None)
+        self.project_id = synapse_response.get("projectId", None)
+        self.instructions = synapse_response.get("instructions", None)
+        self.etag = synapse_response.get("etag", None)
+        self.created_on = synapse_response.get("createdOn", None)
+        self.modified_on = synapse_response.get("modifiedOn", None)
+        self.created_by = synapse_response.get("createdBy", None)
+        self.modified_by = synapse_response.get("modifiedBy", None)
+
+        task_properties_dict = synapse_response.get("taskProperties", None)
+        if task_properties_dict:
+            self.task_properties = _create_task_properties_from_dict(
+                task_properties_dict
+            )
+
+        return self
+
+    def to_synapse_request(self) -> Dict[str, Any]:
+        """
+        Converts this dataclass to a dictionary suitable for a Synapse REST API request.
+
+        Returns:
+            A dictionary representation of this object for API requests.
+        """
+        request_dict = {}
+        request_dict["taskId"] = self.task_id
+        request_dict["dataType"] = self.data_type
+        request_dict["projectId"] = self.project_id
+        request_dict["instructions"] = self.instructions
+        request_dict["etag"] = self.etag
+        request_dict["createdOn"] = self.created_on
+        request_dict["modifiedOn"] = self.modified_on
+        request_dict["createdBy"] = self.created_by
+        request_dict["modifiedBy"] = self.modified_by
+
+        if self.task_properties is not None:
+            request_dict["taskProperties"] = self.task_properties.to_synapse_request()
+
+        delete_none_keys(request_dict)
+        return request_dict
+
+    async def get_async(
+        self, *, synapse_client: Optional[Synapse] = None
+    ) -> "CurationTask":
+        """
+        Gets a CurationTask from Synapse by ID.
+
+        Arguments:
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            CurationTask: The CurationTask object.
+
+        Raises:
+            ValueError: If the CurationTask object does not have a task_id.
+        """
+        if not self.task_id:
+            raise ValueError("task_id is required to get a CurationTask")
+
+        trace.get_current_span().set_attributes(
+            {
+                "synapse.task_id": str(self.task_id),
+            }
+        )
+
+        task_result = await get_curation_task(
+            task_id=self.task_id, synapse_client=synapse_client
+        )
+        self.fill_from_dict(synapse_response=task_result)
+        self._set_last_persistent_instance()
+        return self
+
+    async def delete_async(self, *, synapse_client: Optional[Synapse] = None) -> None:
+        """
+        Deletes a CurationTask from Synapse.
+
+        Arguments:
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Raises:
+            ValueError: If the CurationTask object does not have a task_id.
+        """
+        if not self.task_id:
+            raise ValueError("task_id is required to delete a CurationTask")
+
+        trace.get_current_span().set_attributes(
+            {
+                "synapse.task_id": str(self.task_id),
+            }
+        )
+
+        await delete_curation_task(task_id=self.task_id, synapse_client=synapse_client)
+
+    async def store_async(
+        self, *, synapse_client: Optional[Synapse] = None
+    ) -> "CurationTask":
+        """
+        Creates a new CurationTask or updates an existing one on Synapse.
+
+        This method implements non-destructive updates. If a CurationTask with the same
+        project_id and data_type exists and this instance hasn't been retrieved from
+        Synapse before, it will merge the existing task data with the current instance
+        before updating.
+
+        Arguments:
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            CurationTask: The CurationTask object.
+
+        """
+        if not self.project_id:
+            raise ValueError("project_id is required")
+        if not self.data_type:
+            raise ValueError("data_type is required")
+
+        trace.get_current_span().set_attributes(
+            {
+                "synapse.data_type": self.data_type or "",
+                "synapse.project_id": self.project_id or "",
+                "synapse.task_id": str(self.task_id) if self.task_id else "",
+            }
+        )
+
+        if (
+            not self._last_persistent_instance
+            and not self.task_id
+            and (
+                existing_task_id := await _get_existing_curation_task_id(
+                    project_id=self.project_id,
+                    data_type=self.data_type,
+                    synapse_client=synapse_client,
+                )
+            )
+            and (
+                existing_task := await CurationTask(task_id=existing_task_id).get_async(
+                    synapse_client=synapse_client
+                )
+            )
+        ):
+            merge_dataclass_entities(source=existing_task, destination=self)
+
+        if self.task_id:
+            task_result = await update_curation_task(
+                task_id=self.task_id,
+                curation_task=self.to_synapse_request(),
+                synapse_client=synapse_client,
+            )
+            self.fill_from_dict(synapse_response=task_result)
+            self._set_last_persistent_instance()
+            return self
+        else:
+            if not self.project_id:
+                raise ValueError("project_id is required to create a CurationTask")
+            if not self.data_type:
+                raise ValueError("data_type is required to create a CurationTask")
+            if not self.instructions:
+                raise ValueError("instructions is required to create a CurationTask")
+            if not self.task_properties:
+                raise ValueError("task_properties is required to create a CurationTask")
+
+            task_result = await create_curation_task(
+                curation_task=self.to_synapse_request(),
+                synapse_client=synapse_client,
+            )
+            self.fill_from_dict(synapse_response=task_result)
+            self._set_last_persistent_instance()
+            return self
+
+    @classmethod
+    async def list_async(
+        cls,
+        project_id: str,
+        *,
+        synapse_client: Optional[Synapse] = None,
+    ) -> AsyncGenerator["CurationTask", None]:
+        """
+        Generator that yields CurationTasks for a project as they become available.
+
+        Arguments:
+            project_id: The synId of the project.
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Yields:
+            CurationTask objects as they are retrieved from the API.
+        """
+        trace.get_current_span().set_attributes(
+            {
+                "synapse.project_id": project_id,
+            }
+        )
+
+        async for task_dict in list_curation_tasks(
+            project_id=project_id, synapse_client=synapse_client
+        ):
+            task = cls().fill_from_dict(synapse_response=task_dict)
+            yield task
+
+
+@dataclass
+class CreateGridRequest(AsynchronousCommunicator):
+    """
+    Start a job to create a new Grid session.
+
+    Represents a [Synapse CreateGridRequest](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/grid/CreateGridRequest.html).
+
+    Attributes:
+        concrete_type: The concrete type for the request
+        record_set_id: When provided, the grid will be initialized using the CSV file
+            stored for the given record set id
+        initial_query: Initialize a grid session from an EntityView.
+            Mutually exclusive with record_set_id.
+        session_id: The session ID of the created grid (populated from response)
+    """
+
+    concrete_type: str = CREATE_GRID_REQUEST
+    """The concrete type for the request"""
+
+    record_set_id: Optional[str] = None
+    """When provided, the grid will be initialized using the CSV file stored for
+    the given record set id. The grid columns will match the header of the CSV.
+    Optional, if present the initialQuery cannot be included."""
+
+    initial_query: Optional[Query] = None
+    """Initialize a grid session from an EntityView.
+    Mutually exclusive with record_set_id."""
+
+    session_id: Optional[str] = None
+    """The session ID of the created grid (populated from response)"""
+
+    _grid_session_data: Optional[Dict[str, Any]] = field(default=None, compare=False)
+    """Internal storage of the full grid session data from the response for later use."""
+
+    def fill_from_dict(
+        self, synapse_response: Union[Dict[str, Any], Any]
+    ) -> "CreateGridRequest":
+        """
+        Converts a response from the REST API into this dataclass.
+
+        Arguments:
+            synapse_response: The response from the REST API.
+
+        Returns:
+            The CreateGridRequest object.
+        """
+        # Extract session ID from the response body
+        grid_session_data = synapse_response.get("gridSession", {})
+        self.session_id = grid_session_data.get("sessionId", None)
+
+        # Store the full grid session data for later use
+        self._grid_session_data = grid_session_data
+
+        return self
+
+    def fill_grid_session_from_response(self, grid_session: "Grid") -> "Grid":
+        """
+        Fills a GridSession object with data from the stored response.
+
+        Arguments:
+            grid_session: The GridSession object to populate.
+
+        Returns:
+            The populated GridSession object.
+        """
+        if not hasattr(self, "_grid_session_data"):
+            return grid_session
+
+        data = self._grid_session_data
+
+        grid_session.session_id = data.get("sessionId", None)
+        grid_session.started_by = data.get("startedBy", None)
+        grid_session.started_on = data.get("startedOn", None)
+        grid_session.etag = data.get("etag", None)
+        grid_session.modified_on = data.get("modifiedOn", None)
+        grid_session.last_replica_id_client = data.get("lastReplicaIdClient", None)
+        grid_session.last_replica_id_service = data.get("lastReplicaIdService", None)
+        grid_session.grid_json_schema_id = data.get("gridJsonSchema$Id", None)
+        grid_session.source_entity_id = data.get("sourceEntityId", None)
+
+        return grid_session
+
+    def to_synapse_request(self) -> Dict[str, Any]:
+        """
+        Converts this dataclass to a dictionary suitable for a Synapse REST API request.
+
+        Returns:
+            A dictionary representation of this object for API requests.
+        """
+        request_dict = {"concreteType": self.concrete_type}
+        request_dict["recordSetId"] = self.record_set_id
+        request_dict["initialQuery"] = (
+            self.initial_query.to_synapse_request() if self.initial_query else None
+        )
+        delete_none_keys(request_dict)
+        return request_dict
+
+
+@dataclass
+class GridRecordSetExportRequest(AsynchronousCommunicator):
+    """
+    A request to export a grid created from a record set back to the original record set.
+    A CSV file will be generated and set as a new version of the recordset.
+
+    Represents a [Synapse GridRecordSetExportRequest](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/grid/GridRecordSetExportRequest.html).
+
+    Attributes:
+        concrete_type: The concrete type for the request
+        session_id: The grid session ID
+        response_session_id: The session ID from the export response
+        response_record_set_id: The record set ID from the export response
+        record_set_version_number: The version number from the export response
+        validation_summary_statistics: Summary statistics from the export response
+    """
+
+    concrete_type: str = GRID_RECORD_SET_EXPORT_REQUEST
+    """The concrete type for the request"""
+
+    session_id: Optional[str] = None
+    """The grid session ID"""
+
+    response_session_id: Optional[str] = None
+    """The session ID from the export response"""
+
+    response_record_set_id: Optional[str] = None
+    """The record set ID from the export response"""
+
+    record_set_version_number: Optional[int] = None
+    """The version number from the export response"""
+
+    validation_summary_statistics: Optional[ValidationSummary] = None
+    """Summary statistics from the export response"""
+
+    def fill_from_dict(
+        self, synapse_response: Union[Dict[str, Any], Any]
+    ) -> "GridRecordSetExportRequest":
+        """
+        Converts a response from the REST API into this dataclass.
+
+        Arguments:
+            synapse_response: The response from the REST API.
+
+        Returns:
+            The GridRecordSetExportRequest object.
+        """
+        self.response_session_id = synapse_response.get("sessionId", None)
+        self.response_record_set_id = synapse_response.get("recordSetId", None)
+        self.record_set_version_number = synapse_response.get(
+            "recordSetVersionNumber", None
+        )
+
+        validation_stats_dict = synapse_response.get(
+            "validationSummaryStatistics", None
+        )
+        if validation_stats_dict:
+            self.validation_summary_statistics = ValidationSummary(
+                container_id=validation_stats_dict.get("containerId", None),
+                total_number_of_children=validation_stats_dict.get(
+                    "totalNumberOfChildren", None
+                ),
+                number_of_valid_children=validation_stats_dict.get(
+                    "numberOfValidChildren", None
+                ),
+                number_of_invalid_children=validation_stats_dict.get(
+                    "numberOfInvalidChildren", None
+                ),
+                number_of_unknown_children=validation_stats_dict.get(
+                    "numberOfUnknownChildren", None
+                ),
+                generated_on=validation_stats_dict.get("generatedOn", None),
+            )
+
+        return self
+
+    def to_synapse_request(self) -> Dict[str, Any]:
+        """
+        Converts this dataclass to a dictionary suitable for a Synapse REST API request.
+
+        Returns:
+            A dictionary representation of this object for API requests.
+        """
+        request_dict = {"concreteType": self.concrete_type}
+        if self.session_id is not None:
+            request_dict["sessionId"] = self.session_id
+        return request_dict
+
+
+@dataclass
+@async_to_sync
+class Grid:
+    """
+    A GridSession provides functionality to create and manage grid sessions in Synapse.
+    Grid sessions are used for curation workflows where data can be edited in a grid format
+    and then exported back to record sets.
+
+    Attributes:
+        record_set_id: The synId of the RecordSet to use for initializing the grid
+        initial_query: Initialize a grid session from an EntityView.
+            Mutually exclusive with record_set_id.
+        session_id: The unique sessionId that identifies the grid session
+        started_by: The user that started this session
+        started_on: The date-time when the session was started
+        etag: Changes when the session changes
+        modified_on: The date-time when the session was last changed
+        last_replica_id_client: The last replica ID issued to a client
+        last_replica_id_service: The last replica ID issued to a service
+        grid_json_schema_id: The $id of the JSON schema used for model validation
+        source_entity_id: The synId of the table/view/csv that this grid was cloned from
+        record_set_version_number: The version number of the exported record set
+        validation_summary_statistics: Summary statistics for validation results
+    """
+
+    record_set_id: Optional[str] = None
+    """The synId of the RecordSet to use for initializing the grid"""
+
+    initial_query: Optional[Query] = None
+    """Initialize a grid session from an EntityView.
+    Mutually exclusive with record_set_id."""
+
+    session_id: Optional[str] = None
+    """The unique sessionId that identifies the grid session"""
+
+    started_by: Optional[str] = None
+    """The user that started this session"""
+
+    started_on: Optional[str] = None
+    """The date-time when the session was started"""
+
+    etag: Optional[str] = None
+    """Changes when the session changes"""
+
+    modified_on: Optional[str] = None
+    """The date-time when the session was last changed"""
+
+    last_replica_id_client: Optional[int] = None
+    """The last replica ID issued to a client. Client replica IDs are incremented."""
+
+    last_replica_id_service: Optional[int] = None
+    """The last replica ID issued to a service. Service replica IDs are decremented."""
+
+    grid_json_schema_id: Optional[str] = None
+    """The $id of the JSON schema that will be used for model validation in this grid session"""
+
+    source_entity_id: Optional[str] = None
+    """The synId of the table/view/csv that this grid was cloned from"""
+
+    record_set_version_number: Optional[int] = None
+    """The version number of the exported record set"""
+
+    validation_summary_statistics: Optional[ValidationSummary] = None
+    """Summary statistics for validation results"""
+
+    async def create_async(self, *, synapse_client: Optional[Synapse] = None) -> "Grid":
+        """
+        Creates a new grid session from a record set.
+
+        Arguments:
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            GridSession: The GridSession object with populated session_id.
+
+        Raises:
+            ValueError: If record_set_id is not provided.
+        """
+        if not self.record_set_id and not self.initial_query:
+            raise ValueError(
+                "record_set_id or initial_query is required to create a GridSession"
+            )
+
+        trace.get_current_span().set_attributes(
+            {
+                "synapse.record_set_id": self.record_set_id or "",
+                "synapse.session_id": self.session_id or "",
+            }
+        )
+
+        # Create and send the grid creation request
+        create_request = CreateGridRequest(
+            record_set_id=self.record_set_id, initial_query=self.initial_query
+        )
+        result = await create_request.send_job_and_wait_async(
+            synapse_client=synapse_client
+        )
+
+        # Fill this GridSession with the grid session data from the async job response
+        result.fill_grid_session_from_response(self)
+
+        return self
+
+    async def export_to_record_set_async(
+        self, *, synapse_client: Optional[Synapse] = None
+    ) -> "Grid":
+        """
+        Exports the grid session data back to a record set. This will create a new version
+        of the original record set with the modified data from the grid session.
+
+        Arguments:
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            GridSession: The GridSession object with export information populated.
+
+        Raises:
+            ValueError: If session_id is not provided.
+        """
+        if not self.session_id:
+            raise ValueError("session_id is required to export a GridSession")
+
+        trace.get_current_span().set_attributes(
+            {
+                "synapse.session_id": self.session_id or "",
+            }
+        )
+
+        # Create and send the export request
+        export_request = GridRecordSetExportRequest(session_id=self.session_id)
+        result = await export_request.send_job_and_wait_async(
+            synapse_client=synapse_client
+        )
+
+        self.record_set_id = result.response_record_set_id
+        self.record_set_version_number = result.record_set_version_number
+        self.validation_summary_statistics = result.validation_summary_statistics
+
+        return self

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from opentelemetry import trace
 
-from synapseclient import File as SynapseFile
 from synapseclient import Synapse
 from synapseclient.api import get_from_entity_factory
 from synapseclient.core import utils
@@ -37,7 +36,7 @@ from synapseclient.models.services.storable_entity_components import (
 )
 
 if TYPE_CHECKING:
-    from synapseclient.models import Folder, Project
+    from synapseclient.models import Folder, Project, RecordSet
 
 
 @dataclass()
@@ -851,7 +850,7 @@ class File(FileSynchronousProtocol, AccessControllable, BaseJSONSchema):
             async with client._get_parallel_file_transfer_semaphore(
                 asyncio_event_loop=asyncio.get_running_loop()
             ):
-                await self._upload_file(synapse_client=client)
+                await _upload_file(entity_to_upload=self, synapse_client=client)
         elif self.data_file_handle_id:
             self.path = client.cache.get(file_handle_id=self.data_file_handle_id)
 
@@ -1238,165 +1237,145 @@ class File(FileSynchronousProtocol, AccessControllable, BaseJSONSchema):
         )
         return file_copy
 
-    async def _needs_upload(self, syn: Synapse) -> bool:
-        """
-        Determines if a file needs to be uploaded to Synapse. The following conditions
-        apply:
 
-        - The file exists and is an ExternalFileHandle and the url has changed
-        - The file exists and is a local file and the MD5 has changed
-        - The file is not present in Synapse
+async def _needs_upload(
+    syn: Synapse, entity_to_upload: Union["File", "RecordSet"]
+) -> bool:
+    """
+    Determines if a file needs to be uploaded to Synapse. The following conditions
+    apply:
 
-        If the file is already specifying a data_file_handle_id then it is assumed that
-        the file is already uploaded to Synapse. It does not need to be uploaded and
-        the only thing that will occur is the File metadata will be added to Synapse
-        outside of this upload process.
+    - The file exists and is an ExternalFileHandle and the url has changed
+    - The file exists and is a local file and the MD5 has changed
+    - The file is not present in Synapse
 
-        Arguments:
-            syn: If not passed in and caching was not disabled by
-                `Synapse.allow_client_caching(False)` this will use the last created
-                instance from the Synapse class constructor.
+    If the file is already specifying a data_file_handle_id then it is assumed that
+    the file is already uploaded to Synapse. It does not need to be uploaded and
+    the only thing that will occur is the File metadata will be added to Synapse
+    outside of this upload process.
 
-        Returns:
-            True if the file needs to be uploaded, otherwise False.
-        """
-        needs_upload = False
-        # Check if the file should be uploaded
-        if self._last_persistent_instance is not None:
-            if (
-                self.file_handle
-                and self.file_handle.concrete_type
-                == "org.sagebionetworks.repo.model.file.ExternalFileHandle"
-            ):
-                # switching away from ExternalFileHandle or the url was updated
-                needs_upload = self.synapse_store or (
-                    self.file_handle.external_url != self.external_url
-                )
-            else:
-                # Check if we need to upload a new version of an existing
-                # file. If the file referred to by entity['path'] has been
-                # modified, we want to upload the new version.
-                # If synapeStore is false then we must upload a ExternalFileHandle
-                needs_upload = (
-                    not self.synapse_store
-                    or not self.file_handle
-                    or not (
-                        exists_in_cache := syn.cache.contains(
-                            self.file_handle.id, self.path
-                        )
+    Arguments:
+        syn: If not passed in and caching was not disabled by
+            `Synapse.allow_client_caching(False)` this will use the last created
+            instance from the Synapse class constructor.
+
+    Returns:
+        True if the file needs to be uploaded, otherwise False.
+    """
+    needs_upload = False
+    # Check if the file should be uploaded
+    if entity_to_upload._last_persistent_instance is not None:
+        if (
+            entity_to_upload.file_handle
+            and entity_to_upload.file_handle.concrete_type
+            == "org.sagebionetworks.repo.model.file.ExternalFileHandle"
+        ):
+            # switching away from ExternalFileHandle or the url was updated
+            needs_upload = entity_to_upload.synapse_store or (
+                entity_to_upload.file_handle.external_url
+                != entity_to_upload.external_url
+            )
+        else:
+            # Check if we need to upload a new version of an existing
+            # file. If the file referred to by entity['path'] has been
+            # modified, we want to upload the new version.
+            # If synapeStore is false then we must upload a ExternalFileHandle
+            needs_upload = (
+                not entity_to_upload.synapse_store
+                or not entity_to_upload.file_handle
+                or not (
+                    exists_in_cache := syn.cache.contains(
+                        entity_to_upload.file_handle.id, entity_to_upload.path
                     )
                 )
-
-                md5_stored_in_synapse = (
-                    self.file_handle.content_md5 if self.file_handle else None
-                )
-
-                # Check if we got an MD5 checksum from Synapse and compare it to the local file
-                if (
-                    self.synapse_store
-                    and needs_upload
-                    and os.path.isfile(self.path)
-                    and md5_stored_in_synapse
-                ):
-                    await self._load_local_md5()
-                    if md5_stored_in_synapse == (
-                        local_file_md5_hex := self.content_md5
-                    ):
-                        needs_upload = False
-
-                    # If we had a cache miss, but already uploaded to Synapse we
-                    # can add the file to the cache.
-                    if (
-                        not exists_in_cache
-                        and self.file_handle
-                        and self.file_handle.id
-                        and local_file_md5_hex
-                    ):
-                        syn.cache.add(
-                            file_handle_id=self.file_handle.id,
-                            path=self.path,
-                            md5=local_file_md5_hex,
-                        )
-        elif self.data_file_handle_id is not None:
-            needs_upload = False
-        else:
-            needs_upload = True
-        return needs_upload
-
-    async def _upload_file(
-        self,
-        *,
-        synapse_client: Optional[Synapse] = None,
-    ) -> "File":
-        """The upload process for a file. This will upload the file to Synapse if it
-        needs to be uploaded. If the file does not need to be uploaded the file
-        metadata will be added to Synapse outside of this upload process.
-
-        Arguments:
-            synapse_client: If not passed in and caching was not disabled by
-                `Synapse.allow_client_caching(False)` this will use the last created
-                instance from the Synapse class constructor.
-
-        Returns:
-            The file object.
-        """
-        syn = Synapse.get_client(synapse_client=synapse_client)
-
-        needs_upload = await self._needs_upload(syn=syn)
-
-        if needs_upload:
-            parent_id_for_upload = self.parent_id
-
-            if not parent_id_for_upload:
-                raise SynapseMalformedEntityError(
-                    "Entities of type File must have a parentId."
-                )
-
-            updated_file_handle = await upload_file_handle(
-                syn=syn,
-                parent_entity_id=parent_id_for_upload,
-                path=(
-                    self.path
-                    if (self.synapse_store or self.external_url is None)
-                    else self.external_url
-                ),
-                synapse_store=self.synapse_store,
-                md5=self.content_md5,
-                file_size=self.content_size,
-                mimetype=self.content_type,
             )
 
-            self.file_handle = FileHandle().fill_from_dict(updated_file_handle)
-            self._fill_from_file_handle()
-
-        return self
-
-    def _convert_into_legacy_file(self) -> SynapseFile:
-        """Convert the file object into a SynapseFile object."""
-        return_data = SynapseFile(
-            id=self.id,
-            name=self.name,
-            description=self.description,
-            etag=self.etag,
-            createdOn=self.created_on,
-            modifiedOn=self.modified_on,
-            createdBy=self.created_by,
-            modifiedBy=self.modified_by,
-            parentId=self.parent_id,
-            versionNumber=self.version_number,
-            versionLabel=self.version_label,
-            versionComment=self.version_comment,
-            dataFileHandleId=self.data_file_handle_id,
-            path=self.path,
-            properties={
-                "isLatestVersion": self.is_latest_version,
-            },
-            _file_handle=(
-                self.file_handle._convert_into_legacy_file_handle()
-                if self.file_handle
+            md5_stored_in_synapse = (
+                entity_to_upload.file_handle.content_md5
+                if entity_to_upload.file_handle
                 else None
+            )
+
+            # Check if we got an MD5 checksum from Synapse and compare it to the local file
+            if (
+                entity_to_upload.synapse_store
+                and needs_upload
+                and os.path.isfile(entity_to_upload.path)
+                and md5_stored_in_synapse
+            ):
+                await entity_to_upload._load_local_md5()
+                if md5_stored_in_synapse == (
+                    local_file_md5_hex := entity_to_upload.content_md5
+                ):
+                    needs_upload = False
+
+                # If we had a cache miss, but already uploaded to Synapse we
+                # can add the file to the cache.
+                if (
+                    not exists_in_cache
+                    and entity_to_upload.file_handle
+                    and entity_to_upload.file_handle.id
+                    and local_file_md5_hex
+                ):
+                    syn.cache.add(
+                        file_handle_id=entity_to_upload.file_handle.id,
+                        path=entity_to_upload.path,
+                        md5=local_file_md5_hex,
+                    )
+    elif entity_to_upload.data_file_handle_id is not None:
+        needs_upload = False
+    else:
+        needs_upload = True
+    return needs_upload
+
+
+async def _upload_file(
+    entity_to_upload: Union["File", "RecordSet"],
+    *,
+    synapse_client: Optional[Synapse] = None,
+) -> "File":
+    """The upload process for a file. This will upload the file to Synapse if it
+    needs to be uploaded. If the file does not need to be uploaded the file
+    metadata will be added to Synapse outside of this upload process.
+
+    Arguments:
+        synapse_client: If not passed in and caching was not disabled by
+            `Synapse.allow_client_caching(False)` this will use the last created
+            instance from the Synapse class constructor.
+
+    Returns:
+        The file object.
+    """
+    syn = Synapse.get_client(synapse_client=synapse_client)
+
+    needs_upload = await _needs_upload(entity_to_upload, syn=syn)
+
+    if needs_upload:
+        parent_id_for_upload = entity_to_upload.parent_id
+
+        if not parent_id_for_upload:
+            raise SynapseMalformedEntityError(
+                "Entities of type File must have a parentId."
+            )
+
+        updated_file_handle = await upload_file_handle(
+            syn=syn,
+            parent_entity_id=parent_id_for_upload,
+            path=(
+                entity_to_upload.path
+                if (
+                    entity_to_upload.synapse_store
+                    or entity_to_upload.external_url is None
+                )
+                else entity_to_upload.external_url
             ),
-            annotations=self.annotations,
+            synapse_store=entity_to_upload.synapse_store,
+            md5=entity_to_upload.content_md5,
+            file_size=entity_to_upload.content_size,
+            mimetype=entity_to_upload.content_type,
         )
-        delete_none_keys(return_data)
-        return return_data
+
+        entity_to_upload.file_handle = FileHandle().fill_from_dict(updated_file_handle)
+        entity_to_upload._fill_from_file_handle()
+
+    return entity_to_upload

--- a/synapseclient/models/mixins/asynchronous_job.py
+++ b/synapseclient/models/mixins/asynchronous_job.py
@@ -12,8 +12,10 @@ from typing_extensions import Self
 from synapseclient import Synapse
 from synapseclient.core.constants.concrete_types import (
     AGENT_CHAT_REQUEST,
+    CREATE_GRID_REQUEST,
     CREATE_SCHEMA_REQUEST,
     GET_VALIDATION_SCHEMA_REQUEST,
+    GRID_RECORD_SET_EXPORT_REQUEST,
     QUERY_BUNDLE_REQUEST,
     QUERY_TABLE_CSV_REQUEST,
     TABLE_UPDATE_TRANSACTION_REQUEST,
@@ -26,6 +28,8 @@ from synapseclient.core.exceptions import (
 
 ASYNC_JOB_URIS = {
     AGENT_CHAT_REQUEST: "/agent/chat/async",
+    CREATE_GRID_REQUEST: "/grid/session/async",
+    GRID_RECORD_SET_EXPORT_REQUEST: "/grid/export/recordset/async",
     TABLE_UPDATE_TRANSACTION_REQUEST: "/entity/{entityId}/table/transaction/async",
     GET_VALIDATION_SCHEMA_REQUEST: "/schema/type/validation/async",
     CREATE_SCHEMA_REQUEST: "/schema/type/create/async",

--- a/synapseclient/models/recordset.py
+++ b/synapseclient/models/recordset.py
@@ -1,0 +1,1178 @@
+"""Script to work with Synapse files."""
+
+import asyncio
+import dataclasses
+import os
+from copy import deepcopy
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+from opentelemetry import trace
+
+from synapseclient import Synapse
+from synapseclient.api import get_from_entity_factory
+from synapseclient.core import utils
+from synapseclient.core.async_utils import async_to_sync
+from synapseclient.core.constants import concrete_types
+from synapseclient.core.exceptions import SynapseFileNotFoundError
+from synapseclient.core.utils import (
+    delete_none_keys,
+    guess_file_name,
+    merge_dataclass_entities,
+)
+from synapseclient.models import Activity, Annotations
+from synapseclient.models.mixins import AccessControllable, BaseJSONSchema
+from synapseclient.models.services.search import get_id
+from synapseclient.models.services.storable_entity import store_entity
+from synapseclient.models.services.storable_entity_components import (
+    store_entity_components,
+)
+
+if TYPE_CHECKING:
+    from synapseclient.models import CsvTableDescriptor, FileHandle, Folder, Project
+
+
+@dataclass()
+class ValidationSummary:
+    """Summary statistics for the JSON schema validation results for the children of
+    an Entity container (Project or Folder).
+
+    Attributes:
+        container_id: The ID of the container Entity.
+        total_number_of_children: The total number of children in the container.
+        number_of_valid_children: The total number of children that are valid according
+            to their bound JSON schema.
+        number_of_invalid_children: The total number of children that are invalid
+            according to their bound JSON schema.
+        number_of_unknown_children: The total number of children that do not have
+            validation results. This can occur when a child does not have a bound JSON
+            schema or when a child has not been validated yet.
+        generated_on: The date-time when the statistics were calculated.
+    """
+
+    container_id: Optional[str] = None
+    """The ID of the container Entity."""
+
+    total_number_of_children: Optional[int] = None
+    """The total number of children in the container."""
+
+    number_of_valid_children: Optional[int] = None
+    """The total number of children that are valid according to their bound JSON schema."""
+
+    number_of_invalid_children: Optional[int] = None
+    """The total number of children that are invalid according to their bound JSON schema."""
+
+    number_of_unknown_children: Optional[int] = None
+    """The total number of children that do not have validation results. This can occur
+    when a child does not have a bound JSON schema or when a child has not been
+    validated yet.
+    """
+    generated_on: Optional[str] = None
+    """The date-time when the statistics were calculated."""
+
+
+# TODO: Create Sync Protocol for all methods
+@dataclass()
+@async_to_sync
+class RecordSet(AccessControllable, BaseJSONSchema):
+    """A RecordSet within Synapse.
+
+    Attributes:
+        id: The unique immutable ID for this file. A new ID will be generated for new
+            Files. Once issued, this ID is guaranteed to never change or be re-issued.
+        name: The name of this entity. Must be 256 characters or less. Names may only
+            contain: letters, numbers, spaces, underscores, hyphens, periods, plus
+            signs, apostrophes, and parentheses. If not specified, the name will be
+            derived from the file name.
+        path: The path to the file on disk. Using shorthand `~` will be expanded to
+            the user's home directory.
+
+            This is used during a `get` operation to specify where to download the
+            file to. It should be pointing to a directory.
+
+            This is also used during a `store` operation to specify the file to
+            upload. It should be pointing to a file.
+        description: The description of this file. Must be 1000 characters or less.
+        parent_id: The ID of the Entity that is the parent of this Entity. Setting
+            this to a new value and storing it will move this File under the new
+            parent.
+        version_label: The version label for this entity. Updates to the entity will
+            increment the version number.
+        version_comment: The version comment for this entity.
+        data_file_handle_id: ID of the file handle associated with this entity. You
+            may define an existing data_file_handle_id to use the existing
+            data_file_handle_id. The creator of the file must also be the owner of
+            the data_file_handle_id to have permission to store the file.
+        external_url: The external URL of this file. If this is set AND
+            `synapse_store` is False, only a reference to this URL and the file
+            metadata will be stored in Synapse. The file itself will not be uploaded.
+            If this attribute is set it will override the `path`.
+        activity: The Activity model represents the main record of Provenance in
+            Synapse.  It is analygous to the Activity defined in the
+            [W3C Specification](https://www.w3.org/TR/prov-n/) on Provenance.
+            Activity cannot be removed during a store operation by setting it to None.
+            You must use: [synapseclient.models.Activity.delete_async][] or
+            [synapseclient.models.Activity.disassociate_from_entity_async][].
+        annotations: Additional metadata associated with the entity. The key is the
+            name of your desired annotations. The value is an object containing a list
+            of values (use empty list to represent no values for key) and the value
+            type associated with all values in the list. To remove all annotations
+            set this to an empty dict `{}`.
+        upsert_keys: One or more column names that define this upsert key for this
+            set. This key is used to determine if a new record should be treated as
+            an update or an insert.
+        csv_descriptor: The description of a CSV for upload or download.
+        validation_summary: Summary statistics for the JSON schema validation results
+            for the children of an Entity container (Project or Folder).
+        file_name_override: An optional replacement for the name of the uploaded
+            file. This is distinct from the entity name. If omitted the file will
+            retain its original name.
+        content_type: (New Upload Only) Used to manually specify Content-type header,
+            for example 'application/png' or 'application/json; charset=UTF-8'. If not
+            specified, the content type will be derived from the file extension.
+
+            This can be specified only during the initial store of this file. In order
+            to change this after the File has been created use
+            [synapseclient.models.File.change_metadata][].
+        content_size: (New Upload Only) The size of the file in bytes. This can be
+            specified only during the initial creation of the File. This is also only
+            applicable to files not uploaded to Synapse. ie: `synapse_store` is False.
+        content_md5: (Store only) The MD5 of the file is known. If not supplied this
+            will be computed in the client is possible. If supplied for a file entity
+            already stored in Synapse it will be calculated again to check if a new
+            upload needs to occur. This will not be filled in during a read for data.
+            It is only used during a store operation. To retrieve the md5 of the file
+            after read from synapse use the `.file_handle.content_md5` attribute.
+        create_or_update: (Store only) Indicates whether the method should
+            automatically perform an update if the file conflicts with an existing
+            Synapse object.
+        force_version: (Store only) Indicates whether the method should increment the
+            version of the object if something within the entity has changed. For
+            example updating the description or name. You may set this to False and
+            an update to the entity will not increment the version.
+
+            Updating the `version_label` attribute will also cause a version update
+            regardless of this flag.
+
+            An update to the MD5 of the file will force a version update regardless
+            of this flag.
+        is_restricted: (Store only) If set to true, an email will be sent to the
+            Synapse access control team to start the process of adding terms-of-use
+            or review board approval for this entity. You will be contacted with
+            regards to the specific data being restricted and the requirements of
+            access.
+
+            This may be used only by an administrator of the specified file.
+        merge_existing_annotations: (Store only) Works in conjunction with
+            `create_or_update` in that this is only evaluated if `create_or_update`
+            is True. If this entity exists in Synapse that has annotations that are
+            not present in a store operation, these annotations will be added to the
+            entity. If this is False any annotations that are not present within a
+            store operation will be removed from this entity. This allows one to
+            complete a destructive update of annotations on an entity.
+        associate_activity_to_new_version: (Store only) Works in conjunction with
+            `create_or_update` in that this is only evaluated if `create_or_update`
+            is True. When true an activity already attached to the current version of
+            this entity will be associated the new version during a store operation
+            if the version was updated. This is useful if you are updating the entity
+            and want to ensure that the activity is persisted onto the new version
+            the entity.
+
+            When this is False the activity will not be associated to the new version
+            of the entity during a store operation.
+
+            Regardless of this setting, if you have an Activity object on the entity
+            it will be persisted onto the new version. This is only used when you
+            don't have an Activity object on the entity.
+        synapse_store: (Store only) Whether the File should be uploaded or if false:
+            only the path should be stored when [synapseclient.models.File.store][]
+            is called.
+        download_file: (Get only) If True the file will be downloaded.
+        if_collision: (Get only) Determines how to handle file collisions. Defaults
+            to "keep.both". May be:
+
+            - `overwrite.local`
+            - `keep.local`
+            - `keep.both`
+        synapse_container_limit: (Get only) A Synanpse ID used to limit the search in
+            Synapse if file is specified as a local file. That is, if the file is
+            stored in multiple locations in Synapse only the ones in the specified
+            folder/project will be returned.
+        etag: (Read Only) Synapse employs an Optimistic Concurrency Control (OCC)
+            scheme to handle concurrent updates. Since the E-Tag changes every time
+            an entity is updated it is used to detect when a client's current
+            representation of an entity is out-of-date.
+        created_on: (Read Only) The date this entity was created.
+        modified_on: (Read Only) The date this entity was last modified.
+        created_by: (Read Only) The ID of the user that created this entity.
+        modified_by: (Read Only) The ID of the user that last modified this entity.
+        version_number: (Read Only) The version number issued to this version on the
+            object.
+        is_latest_version: (Read Only) If this is the latest version of the object.
+        file_handle: (Read Only) The file handle associated with this entity.
+    """
+
+    id: Optional[str] = None
+    """The unique immutable ID for this file. A new ID will be generated for new Files.
+    Once issued, this ID is guaranteed to never change or be re-issued."""
+
+    name: Optional[str] = None
+    """
+    The name of this entity. Must be 256 characters or less.
+    Names may only contain: letters, numbers, spaces, underscores, hyphens, periods,
+    plus signs, apostrophes, and parentheses. If not specified, the name will be
+    derived from the file name.
+    """
+
+    path: Optional[str] = field(default=None, compare=False)
+    """The path to the file on disk. Using shorthand `~` will be expanded to the user's
+    home directory.
+
+    This is used during a `get` operation to specify where to download the file to. It
+    should be pointing to a directory.
+
+    This is also used during a `store` operation to specify the file to upload. It
+    should be pointing to a file."""
+
+    description: Optional[str] = None
+    """The description of this file. Must be 1000 characters or less."""
+
+    parent_id: Optional[str] = None
+    """The ID of the Entity that is the parent of this Entity. Setting this to a new
+    value and storing it will move this File under the new parent."""
+
+    version_label: Optional[str] = None
+    """The version label for this entity. Updates to the entity will increment the
+    version number."""
+
+    version_comment: Optional[str] = None
+    """The version comment for this entity."""
+
+    data_file_handle_id: Optional[str] = None
+    """
+    ID of the file handle associated with this entity. You may define an existing
+    data_file_handle_id to use the existing data_file_handle_id. The creator of the
+    file must also be the owner of the data_file_handle_id to have permission to
+    store the file.
+    """
+
+    external_url: Optional[str] = field(default=None, compare=False)
+    """
+    The external URL of this file. If this is set AND `synapse_store` is False, only
+    a reference to this URL and the file metadata will be stored in Synapse. The file
+    itself will not be uploaded. If this attribute is set it will override the `path`.
+    """
+
+    activity: Optional[Activity] = field(default=None, compare=False)
+    """The Activity model represents the main record of Provenance in Synapse.  It is
+    analygous to the Activity defined in the
+    [W3C Specification](https://www.w3.org/TR/prov-n/) on Provenance. Activity cannot
+    be removed during a store operation by setting it to None. You must use:
+    [synapseclient.models.Activity.delete_async][] or
+    [synapseclient.models.Activity.disassociate_from_entity_async][].
+    """
+
+    annotations: Optional[
+        Dict[
+            str,
+            Union[
+                List[str],
+                List[bool],
+                List[float],
+                List[int],
+                List[date],
+                List[datetime],
+            ],
+        ]
+    ] = field(default_factory=dict, compare=False)
+    """Additional metadata associated with the folder. The key is the name of your
+    desired annotations. The value is an object containing a list of values
+    (use empty list to represent no values for key) and the value type associated with
+    all values in the list. To remove all annotations set this to an empty dict `{}`."""
+
+    upsert_keys: Optional[List[str]] = field(default_factory=list)
+    """One or more column names that define this upsert key for this set. This key is
+    used to determine if a new record should be treated as an update or an insert.
+    """
+
+    csv_descriptor: Optional["CsvTableDescriptor"] = field(default=None)
+    """The description of a CSV for upload or download."""
+
+    validation_summary: Optional[ValidationSummary] = field(default=None, compare=False)
+    """Summary statistics for the JSON schema validation results for the children of
+    an Entity container (Project or Folder)"""
+
+    file_name_override: Optional[str] = None
+    """An optional replacement for the name of the uploaded file. This is distinct from
+    the entity name. If omitted the file will retain its original name.
+    """
+
+    content_type: Optional[str] = None
+    """
+    (New Upload Only)
+    Used to manually specify Content-type header, for example 'application/png'
+    or 'application/json; charset=UTF-8'. If not specified, the content type will be
+    derived from the file extension.
+
+    This can be specified only during the initial store of this file. In order to change
+    this after the File has been created use
+    [synapseclient.models.File.change_metadata][].
+    """
+
+    content_size: Optional[int] = None
+    """
+    (New Upload Only)
+    The size of the file in bytes. This can be specified only during the initial
+    creation of the File. This is also only applicable to files not uploaded to Synapse.
+    ie: `synapse_store` is False.
+    """
+
+    content_md5: Optional[str] = field(default=None, compare=False)
+    """
+    (Store only)
+    The MD5 of the file is known. If not supplied this will be computed in the client
+    is possible. If supplied for a file entity already stored in Synapse it will be
+    calculated again to check if a new upload needs to occur. This will not be filled
+    in during a read for data. It is only used during a store operation. To retrieve
+    the md5 of the file after read from synapse use the `.file_handle.content_md5`
+    attribute.
+    """
+
+    create_or_update: bool = field(default=True, repr=False, compare=False)
+    """
+    (Store only)
+
+    Indicates whether the method should automatically perform an update if the file
+    conflicts with an existing Synapse object.
+    """
+
+    force_version: bool = field(default=True, repr=False, compare=False)
+    """
+    (Store only)
+
+    Indicates whether the method should increment the version of the object if something
+    within the entity has changed. For example updating the description or name.
+    You may set this to False and an update to the entity will not increment the
+    version.
+
+    Updating the `version_label` attribute will also cause a version update regardless
+    of this flag.
+
+    An update to the MD5 of the file will force a version update regardless of this
+    flag.
+    """
+
+    is_restricted: bool = field(default=False, repr=False)
+    """
+    (Store only)
+
+    If set to true, an email will be sent to the Synapse access control team to start
+    the process of adding terms-of-use or review board approval for this entity.
+    You will be contacted with regards to the specific data being restricted and the
+    requirements of access.
+
+    This may be used only by an administrator of the specified file.
+    """
+
+    merge_existing_annotations: bool = field(default=True, repr=False, compare=False)
+    """
+    (Store only)
+
+    Works in conjunction with `create_or_update` in that this is only evaluated if
+    `create_or_update` is True. If this entity exists in Synapse that has annotations
+    that are not present in a store operation, these annotations will be added to the
+    entity. If this is False any annotations that are not present within a store
+    operation will be removed from this entity. This allows one to complete a
+    destructive update of annotations on an entity.
+    """
+
+    associate_activity_to_new_version: bool = field(
+        default=False, repr=False, compare=False
+    )
+    """
+    (Store only)
+
+    Works in conjunction with `create_or_update` in that this is only evaluated if
+    `create_or_update` is True. When true an activity already attached to the current
+    version of this entity will be associated the new version during a store operation
+    if the version was updated. This is useful if you are updating the entity and want
+    to ensure that the activity is persisted onto the new version the entity.
+
+    When this is False the activity will not be associated to the new version of the
+    entity during a store operation.
+
+    Regardless of this setting, if you have an Activity object on the entity it will be
+    persisted onto the new version. This is only used when you don't have an Activity
+    object on the entity.
+    """
+
+    synapse_store: bool = field(default=True, repr=False)
+    """
+    (Store only)
+
+    Whether the File should be uploaded or if false: only the path should be stored when
+    [synapseclient.models.File.store][] is called.
+    """
+
+    download_file: bool = field(default=True, repr=False, compare=False)
+    """
+    (Get only)
+
+    If True the file will be downloaded."""
+
+    if_collision: str = field(default="keep.both", repr=False, compare=False)
+    """
+    (Get only)
+
+    Determines how to handle file collisions. Defaults to "keep.both".
+            May be
+
+            - `overwrite.local`
+            - `keep.local`
+            - `keep.both`
+    """
+
+    synapse_container_limit: Optional[str] = field(
+        default=None, repr=False, compare=False
+    )
+    """A Synanpse ID used to limit the search in Synapse if file is specified as a local
+    file. That is, if the file is stored in multiple locations in Synapse only the
+    ones in the specified folder/project will be returned."""
+
+    etag: Optional[str] = field(default=None, compare=False)
+    """
+    (Read Only)
+    Synapse employs an Optimistic Concurrency Control (OCC) scheme to handle
+    concurrent updates. Since the E-Tag changes every time an entity is updated it is
+    used to detect when a client's current representation of an entity is out-of-date.
+    """
+
+    created_on: Optional[str] = field(default=None, compare=False)
+    """(Read Only) The date this entity was created."""
+
+    modified_on: Optional[str] = field(default=None, compare=False)
+    """(Read Only) The date this entity was last modified."""
+
+    created_by: Optional[str] = field(default=None, compare=False)
+    """(Read Only) The ID of the user that created this entity."""
+
+    modified_by: Optional[str] = field(default=None, compare=False)
+    """(Read Only) The ID of the user that last modified this entity."""
+
+    version_number: Optional[int] = field(default=None, compare=False)
+    """(Read Only) The version number issued to this version on the object."""
+
+    is_latest_version: Optional[bool] = field(default=None, compare=False)
+    """(Read Only) If this is the latest version of the object."""
+
+    file_handle: Optional["FileHandle"] = field(default=None, compare=False)
+    """(Read Only) The file handle associated with this entity."""
+
+    _last_persistent_instance: Optional["RecordSet"] = field(
+        default=None, repr=False, compare=False
+    )
+    """The last persistent instance of this object. This is used to determine if the
+    object has been changed and needs to be updated in Synapse."""
+
+    @property
+    def has_changed(self) -> bool:
+        """
+        Determines if the object has been changed and needs to be updated in Synapse."""
+        return (
+            not self._last_persistent_instance or self._last_persistent_instance != self
+        )
+
+    def _set_last_persistent_instance(self) -> None:
+        """Stash the last time this object interacted with Synapse. This is used to
+        determine if the object has been changed and needs to be updated in Synapse."""
+        del self._last_persistent_instance
+        self._last_persistent_instance = dataclasses.replace(self)
+        self._last_persistent_instance.activity = (
+            dataclasses.replace(self.activity) if self.activity else None
+        )
+        self._last_persistent_instance.annotations = (
+            deepcopy(self.annotations) if self.annotations else {}
+        )
+
+    def _fill_from_file_handle(self) -> None:
+        """Fill the file object from the file handle."""
+        if self.file_handle:
+            self.data_file_handle_id = self.file_handle.id
+            self.content_type = self.file_handle.content_type
+            self.content_size = self.file_handle.content_size
+            self.external_url = self.file_handle.external_url
+
+    def fill_from_dict(
+        self,
+        entity: Dict[str, Union[bool, str, int]],
+        set_annotations: bool = True,
+    ) -> "RecordSet":
+        """
+        Converts a response from the REST API into this dataclass.
+
+        This method populates the RecordSet instance with data from a Synapse REST API
+        response or a dictionary containing RecordSet information. It handles the
+        conversion from Synapse API field names (camelCase) to Python attribute names
+        (snake_case) and processes nested objects appropriately.
+
+        Arguments:
+            synapse_file: The response from the REST API or a dictionary containing
+                RecordSet data. Can be either a Synapse_File object or a dictionary
+                with string keys and various value types.
+            set_annotations: Whether to set the annotations from the response.
+                If True, annotations will be populated from the API response.
+
+        Returns:
+            The RecordSet object with updated attributes from the API response.
+        """
+        self.id = entity.get("id", None)
+        self.name = entity.get("name", None)
+        self.description = entity.get("description", None)
+        self.etag = entity.get("etag", None)
+        self.created_on = entity.get("createdOn", None)
+        self.modified_on = entity.get("modifiedOn", None)
+        self.created_by = entity.get("createdBy", None)
+        self.modified_by = entity.get("modifiedBy", None)
+        self.parent_id = entity.get("parentId", None)
+        self.version_number = entity.get("versionNumber", None)
+        self.version_label = entity.get("versionLabel", None)
+        self.version_comment = entity.get("versionComment", None)
+        self.is_latest_version = entity.get("isLatestVersion", False)
+        self.data_file_handle_id = entity.get("dataFileHandleId", None)
+        self.path = entity.get("path", self.path)
+        self.file_name_override = entity.get("fileNameOverride", None)
+        csv_descriptor = entity.get("csvDescriptor", None)
+        if csv_descriptor:
+            from synapseclient.models import CsvTableDescriptor
+
+            self.csv_descriptor = CsvTableDescriptor().fill_from_dict(csv_descriptor)
+
+        validation_summary = entity.get("validationSummary", None)
+
+        if validation_summary:
+            self.validation_summary = ValidationSummary(
+                container_id=validation_summary.get("containerId", None),
+                total_number_of_children=validation_summary.get(
+                    "totalNumberOfChildren", None
+                ),
+                number_of_valid_children=validation_summary.get(
+                    "numberOfValidChildren", None
+                ),
+                number_of_invalid_children=validation_summary.get(
+                    "numberOfInvalidChildren", None
+                ),
+                number_of_unknown_children=validation_summary.get(
+                    "numberOfUnknownChildren", None
+                ),
+                generated_on=validation_summary.get("generatedOn", None),
+            )
+
+        self.upsert_keys = entity.get("upsertKey", [])
+
+        synapse_file_handle = entity.get("_file_handle", None)
+        if synapse_file_handle:
+            from synapseclient.models import FileHandle
+
+            file_handle = self.file_handle or FileHandle()
+            self.file_handle = file_handle.fill_from_dict(
+                synapse_instance=synapse_file_handle
+            )
+            self._fill_from_file_handle()
+
+        if set_annotations:
+            self.annotations = Annotations.from_dict(entity.get("annotations", {}))
+        return self
+
+    def _cannot_store(self) -> bool:
+        """
+        Determines based on guard conditions if a store operation can proceed.
+        """
+        return (
+            not (
+                self.id is not None
+                and (self.path is not None or self.data_file_handle_id is not None)
+            )
+            and not (self.path is not None and self.parent_id is not None)
+            and not (
+                self.parent_id is not None and self.data_file_handle_id is not None
+            )
+        )
+
+    async def _load_local_md5(self) -> None:
+        """
+        Load the MD5 hash of a local file if it exists and hasn't been loaded yet.
+
+        This method computes and sets the content_md5 attribute for local files
+        that exist on disk. It only performs the calculation if the content_md5
+        is not already set and the path points to an existing file.
+        """
+        if not self.content_md5 and self.path and os.path.isfile(self.path):
+            self.content_md5 = utils.md5_for_file_hex(filename=self.path)
+
+    async def _find_existing_entity(
+        self, *, synapse_client: Optional[Synapse] = None
+    ) -> Union["RecordSet", None]:
+        """
+        Determines if the RecordSet already exists in Synapse.
+
+        This method searches for an existing RecordSet in Synapse that matches the
+        current instance. If found, it returns the existing RecordSet object, otherwise
+        it returns None. This is used to determine if the RecordSet should be updated
+        or created during a store operation.
+
+        Arguments:
+            synapse_client: If not passed in and caching was not disabled, this will
+                use the last created instance from the Synapse class constructor.
+
+        Returns:
+            The existing RecordSet object if it exists in Synapse, None otherwise.
+        """
+
+        async def get_entity(existing_id: str) -> "RecordSet":
+            """Small wrapper to retrieve a file instance without raising an error if it
+            does not exist.
+
+            Arguments:
+                existing_id: The ID of the file to retrieve.
+
+            Returns:
+                The file object if it exists, otherwise None.
+            """
+            try:
+                entity_copy = RecordSet(
+                    id=existing_id,
+                    download_file=False,
+                    version_number=self.version_number,
+                    synapse_container_limit=self.synapse_container_limit,
+                    parent_id=self.parent_id,
+                )
+                return await entity_copy.get_async(
+                    synapse_client=synapse_client,
+                    include_activity=self.activity is not None
+                    or self.associate_activity_to_new_version,
+                )
+            except SynapseFileNotFoundError:
+                return None
+
+        if (
+            self.create_or_update
+            and not self._last_persistent_instance
+            and (
+                existing_entity_id := await get_id(
+                    entity=self,
+                    failure_strategy=None,
+                    synapse_client=synapse_client,
+                )
+            )
+            and (existing_file := await get_entity(existing_entity_id))
+        ):
+            return existing_file
+        return None
+
+    def _determine_fields_to_ignore_in_merge(self) -> List[str]:
+        """
+        Determine which fields should not be merged when merging two entities.
+
+        This method returns a list of field names that should be ignored during
+        entity merging operations. This allows for fine-tuned destructive updates
+        of an entity based on the current configuration settings.
+
+        The method has special handling for manifest uploads where specific fields
+        are provided in the manifest and should take precedence over existing
+        entity values.
+
+        Returns:
+            A list of field names that should not be merged from the existing entity.
+        """
+        fields_to_not_merge = []
+        if not self.merge_existing_annotations:
+            fields_to_not_merge.append("annotations")
+
+        if not self.associate_activity_to_new_version:
+            fields_to_not_merge.append("activity")
+
+        return fields_to_not_merge
+
+    def to_synapse_request(self) -> Dict[str, Any]:
+        """
+        Converts this dataclass to a dictionary suitable for a Synapse REST API request.
+
+        This method transforms the RecordSet object into a dictionary format that
+        matches the structure expected by the Synapse REST API. It handles the
+        conversion of Python snake_case attribute names to the camelCase format
+        used by the API, and ensures that nested objects are properly serialized.
+
+        Returns:
+            A dictionary representation of this object formatted for API requests.
+            None values are automatically removed from the dictionary.
+
+        Example: Converting a RecordSet for API submission
+            This method is used internally when storing or updating RecordSets:
+
+            ```python
+            from synapseclient.models import RecordSet
+
+            record_set = RecordSet(
+                name="My RecordSet",
+                description="A test record set",
+                parent_id="syn123456"
+            )
+            api_dict = record_set.to_synapse_request()
+            # api_dict contains properly formatted data for the REST API
+            ```
+        """
+
+        entity = {
+            "concreteType": concrete_types.RECORD_SET_ENTITY,
+            "name": self.name,
+            "description": self.description,
+            "id": self.id,
+            "etag": self.etag,
+            "createdOn": self.created_on,
+            "modifiedOn": self.modified_on,
+            "createdBy": self.created_by,
+            "modifiedBy": self.modified_by,
+            "parentId": self.parent_id,
+            "versionNumber": self.version_number,
+            "versionLabel": self.version_label,
+            "versionComment": self.version_comment,
+            "isLatestVersion": self.is_latest_version,
+            "dataFileHandleId": self.data_file_handle_id,
+            "upsertKey": self.upsert_keys,
+            "csvDescriptor": self.csv_descriptor.to_synapse_request()
+            if self.csv_descriptor
+            else None,
+            "validationSummary": {
+                "containerId": self.validation_summary.container_id,
+                "totalNumberOfChildren": self.validation_summary.total_number_of_children,
+                "numberOfValidChildren": self.validation_summary.number_of_valid_children,
+                "numberOfInvalidChildren": self.validation_summary.number_of_invalid_children,
+                "numberOfUnknownChildren": self.validation_summary.number_of_unknown_children,
+                "generatedOn": self.validation_summary.generated_on,
+            }
+            if self.validation_summary
+            else None,
+            "fileNameOverride": self.file_name_override,
+        }
+        delete_none_keys(entity)
+
+        return entity
+
+    async def store_async(
+        self,
+        parent: Optional[Union["Folder", "Project"]] = None,
+        *,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "RecordSet":
+        """
+        Store the RecordSet in Synapse.
+
+        This method uploads or updates a RecordSet in Synapse. It can handle both
+        creating new RecordSets and updating existing ones based on the
+        `create_or_update` flag. The method supports file uploads, metadata updates,
+        and merging with existing entities when appropriate.
+
+        Arguments:
+            parent: The parent Folder or Project for this RecordSet. If provided,
+                this will override the `parent_id` attribute.
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)`, this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            The RecordSet object with updated metadata from Synapse after the
+            store operation.
+
+        Raises:
+            ValueError: If the RecordSet does not have the required information
+                for storing. Must have either: (ID with path or data_file_handle_id),
+                or (path with parent_id), or (data_file_handle_id with parent_id).
+
+        Example: Storing a new RecordSet
+            Creating and storing a new RecordSet in Synapse:
+
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import RecordSet
+
+            async def main():
+                syn = Synapse()
+                syn.login()
+
+                record_set = RecordSet(
+                    name="My RecordSet",
+                    description="A dataset for analysis",
+                    parent_id="syn123456",
+                    path="/path/to/data.csv"
+                )
+                stored_record_set = await record_set.store_async()
+                print(f"Stored RecordSet with ID: {stored_record_set.id}")
+
+            asyncio.run(main())
+            ```
+
+            Updating an existing RecordSet:
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import RecordSet
+
+            async def main():
+                syn = Synapse()
+                syn.login()
+
+                record_set = await RecordSet(id="syn789012").get_async()
+                record_set.description = "Updated description"
+                updated_record_set = await record_set.store_async()
+
+            asyncio.run(main())
+            ```
+        """
+        self.parent_id = parent.id if parent else self.parent_id
+        if self._cannot_store():
+            raise ValueError(
+                "The file must have an (ID with a (path or `data_file_handle_id`)), or a "
+                "(path with a (`parent_id` or parent with an id)), or a "
+                "(data_file_handle_id with a (`parent_id` or parent with an id)) to store."
+            )
+        self.name = self.name or (guess_file_name(self.path) if self.path else None)
+        client = Synapse.get_client(synapse_client=synapse_client)
+
+        if existing_file := await self._find_existing_entity(synapse_client=client):
+            merge_dataclass_entities(
+                source=existing_file,
+                destination=self,
+                fields_to_ignore=self._determine_fields_to_ignore_in_merge(),
+            )
+
+        if self.id:
+            trace.get_current_span().set_attributes(
+                {
+                    "synapse.id": self.id,
+                }
+            )
+
+        if self.path:
+            self.path = os.path.expanduser(self.path)
+            async with client._get_parallel_file_transfer_semaphore(
+                asyncio_event_loop=asyncio.get_running_loop()
+            ):
+                from synapseclient.models.file import _upload_file
+
+                await _upload_file(entity_to_upload=self, synapse_client=client)
+        elif self.data_file_handle_id:
+            self.path = client.cache.get(file_handle_id=self.data_file_handle_id)
+
+        if self.has_changed:
+            entity = await store_entity(
+                resource=self, entity=self.to_synapse_request(), synapse_client=client
+            )
+
+            self.fill_from_dict(entity=entity, set_annotations=False)
+
+        re_read_required = await store_entity_components(
+            root_resource=self, synapse_client=client
+        )
+        if re_read_required:
+            before_download_file = self.download_file
+            self.download_file = False
+            await self.get_async(
+                synapse_client=client,
+            )
+            self.download_file = before_download_file
+
+        self._set_last_persistent_instance()
+
+        client.logger.debug(f"Stored File {self.name}, id: {self.id}: {self.path}")
+        # Clear the content_md5 so that it is recalculated if the file is updated
+        self.content_md5 = None
+        return self
+
+    async def change_metadata_async(
+        self,
+        name: Optional[str] = None,
+        download_as: Optional[str] = None,
+        content_type: Optional[str] = None,
+        *,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "RecordSet":
+        """
+        Change RecordSet Entity metadata for properties that are immutable after creation.
+
+        This method allows modification of certain RecordSet properties that cannot
+        be changed through the normal store method after the initial creation. This
+        includes the entity name, file download name, and content type.
+
+        Arguments:
+            name: Specify to change the name of the RecordSet as seen on Synapse.
+            download_as: Specify filename to change the filename of the associated
+                filehandle when downloaded.
+            content_type: Specify content type to change the content type of the
+                associated filehandle.
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)`, this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            The RecordSet object with updated metadata.
+
+        Raises:
+            ValueError: If the RecordSet does not have an ID to change metadata.
+
+        Example: Changing RecordSet metadata
+            Update various metadata properties without re-uploading:
+
+            ```python
+            import asyncio
+            import os
+            from synapseclient import Synapse
+            from synapseclient.models import RecordSet
+
+            async def main():
+                syn = Synapse()
+                syn.login()
+
+                record_set = await RecordSet(id="syn123", download_file=False).get_async()
+                print(os.path.basename(record_set.path))  # prints original filename
+
+                record_set = await record_set.change_metadata_async(
+                    name="my_new_name_recordset.csv",
+                    download_as="my_new_download_name.csv",
+                    content_type="text/csv"
+                )
+                print(os.path.basename(record_set.path))  # prints "my_new_download_name.csv"
+                print(record_set.name)  # prints "my_new_name_recordset.csv"
+
+            asyncio.run(main())
+            ```
+        """
+        if not self.id:
+            raise ValueError("The file must have an ID to change metadata.")
+        from synapseutils.copy_functions import changeFileMetaData
+
+        loop = asyncio.get_event_loop()
+
+        syn = Synapse.get_client(synapse_client=synapse_client)
+        entity = await loop.run_in_executor(
+            None,
+            lambda: changeFileMetaData(
+                syn=syn,
+                entity=self.id,
+                name=name,
+                downloadAs=download_as,
+                contentType=content_type,
+                forceVersion=self.force_version,
+            ),
+        )
+
+        self.fill_from_dict(entity=entity, set_annotations=True)
+        self._set_last_persistent_instance()
+        Synapse.get_client(synapse_client=synapse_client).logger.debug(
+            f"Change metadata for file {self.name}, id: {self.id}: {self.path}"
+        )
+        return self
+
+    async def get_async(
+        self,
+        include_activity: bool = False,
+        *,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "RecordSet":
+        """
+        Get the RecordSet from Synapse.
+
+        This method retrieves a RecordSet entity from Synapse. You may retrieve
+        a RecordSet by either its ID or path. If you specify both, the ID will
+        take precedence.
+
+        If you specify the path and the RecordSet is stored in multiple locations
+        in Synapse, only the first one found will be returned. The other matching
+        RecordSets will be printed to the console.
+
+        You may also specify a `version_number` to get a specific version of the
+        RecordSet.
+
+        Arguments:
+            include_activity: If True, the activity will be included in the RecordSet
+                if it exists.
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)`, this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            The RecordSet object with data populated from Synapse.
+
+        Raises:
+            ValueError: If the RecordSet does not have an ID or path to retrieve.
+
+        Example: Retrieving a RecordSet by ID
+            Get an existing RecordSet from Synapse:
+
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import RecordSet
+
+            async def main():
+                syn = Synapse()
+                syn.login()
+
+                record_set = await RecordSet(id="syn123").get_async()
+                print(f"RecordSet name: {record_set.name}")
+
+            asyncio.run(main())
+            ```
+
+            Downloading a RecordSet to a specific directory:
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import RecordSet
+
+            async def main():
+                syn = Synapse()
+                syn.login()
+
+                record_set = await RecordSet(
+                    id="syn123",
+                    path="/path/to/download/directory"
+                ).get_async()
+
+            asyncio.run(main())
+            ```
+
+            Including activity information:
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import RecordSet
+
+            async def main():
+                syn = Synapse()
+                syn.login()
+
+                record_set = await RecordSet(id="syn123").get_async(include_activity=True)
+                if record_set.activity:
+                    print(f"Activity: {record_set.activity.name}")
+
+            asyncio.run(main())
+            ```
+        """
+        if not self.id and not self.path:
+            raise ValueError("The file must have an ID or path to get.")
+        syn = Synapse.get_client(synapse_client=synapse_client)
+
+        await self._load_local_md5()
+
+        await get_from_entity_factory(
+            entity_to_update=self,
+            synapse_id_or_path=self.id or self.path,
+            version=self.version_number,
+            if_collision=self.if_collision,
+            limit_search=self.synapse_container_limit or self.parent_id,
+            download_file=self.download_file,
+            download_location=os.path.dirname(self.path)
+            if self.path and os.path.isfile(self.path)
+            else self.path,
+            md5=self.content_md5,
+            synapse_client=syn,
+        )
+
+        if (
+            self.data_file_handle_id
+            and (not self.path or (self.path and not os.path.isfile(self.path)))
+            and (cached_path := syn.cache.get(file_handle_id=self.data_file_handle_id))
+        ):
+            self.path = cached_path
+
+        if include_activity:
+            self.activity = await Activity.from_parent_async(
+                parent=self, synapse_client=synapse_client
+            )
+
+        self._set_last_persistent_instance()
+        Synapse.get_client(synapse_client=synapse_client).logger.debug(
+            f"Got file {self.name}, id: {self.id}, path: {self.path}"
+        )
+        return self
+
+    async def delete_async(
+        self,
+        version_only: Optional[bool] = False,
+        *,
+        synapse_client: Optional[Synapse] = None,
+    ) -> None:
+        """
+        Delete the RecordSet from Synapse using its ID.
+
+        This method removes a RecordSet entity from Synapse. You can choose to
+        delete either a specific version or the entire RecordSet including all
+        its versions.
+
+        Arguments:
+            version_only: If True, only the version specified in the `version_number`
+                attribute of the RecordSet will be deleted. If False, the entire
+                RecordSet including all versions will be deleted.
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)`, this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            None
+
+        Raises:
+            ValueError: If the RecordSet does not have an ID to delete.
+            ValueError: If the RecordSet does not have a version number to delete a
+                specific version, and `version_only` is True.
+
+        Example: Deleting a RecordSet
+            Delete an entire RecordSet and all its versions:
+
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import RecordSet
+
+            async def main():
+                syn = Synapse()
+                syn.login()
+
+                await RecordSet(id="syn123").delete_async()
+
+            asyncio.run(main())
+            ```
+
+            Delete only a specific version:
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import RecordSet
+
+            async def main():
+                syn = Synapse()
+                syn.login()
+
+                record_set = RecordSet(id="syn123", version_number=2)
+                await record_set.delete_async(version_only=True)
+
+            asyncio.run(main())
+            ```
+        """
+        if not self.id:
+            raise ValueError("The file must have an ID to delete.")
+        if version_only and not self.version_number:
+            raise ValueError("The file must have a version number to delete a version.")
+
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(
+            None,
+            lambda: Synapse.get_client(synapse_client=synapse_client).delete(
+                obj=self.id,
+                version=self.version_number if version_only else None,
+            ),
+        )
+        Synapse.get_client(synapse_client=synapse_client).logger.debug(
+            f"Deleted file {self.id}"
+        )

--- a/synapseclient/models/services/storable_entity_components.py
+++ b/synapseclient/models/services/storable_entity_components.py
@@ -8,12 +8,16 @@ from synapseclient.core.exceptions import SynapseError
 if TYPE_CHECKING:
     from synapseclient.models import (
         Dataset,
+        DatasetCollection,
         EntityView,
         File,
         Folder,
+        MaterializedView,
         Project,
+        RecordSet,
         SubmissionView,
         Table,
+        VirtualTable,
     )
 
 
@@ -50,7 +54,19 @@ async def wrap_coroutine(
 
 
 async def store_entity_components(
-    root_resource: Union["File", "Folder", "Project", "Table", "Dataset", "EntityView"],
+    root_resource: Union[
+        "File",
+        "Folder",
+        "Project",
+        "Table",
+        "Dataset",
+        "EntityView",
+        "RecordSet",
+        "SubmissionView",
+        "MaterializedView",
+        "VirtualTable",
+        "DatasetCollection",
+    ],
     failure_strategy: FailureStrategy = FailureStrategy.LOG_EXCEPTION,
     *,
     synapse_client: Optional[Synapse] = None,

--- a/synapseclient/models/table_components.py
+++ b/synapseclient/models/table_components.py
@@ -134,6 +134,17 @@ class CsvTableDescriptor:
         delete_none_keys(request)
         return request
 
+    def fill_from_dict(self, data: Dict[str, Any]) -> "Self":
+        """Converts a response from the REST API into this dataclass."""
+        self.separator = data.get("separator", self.separator)
+        self.quote_character = data.get("quoteCharacter", self.quote_character)
+        self.escape_character = data.get("escapeCharacter", self.escape_character)
+        self.line_end = data.get("lineEnd", self.line_end)
+        self.is_first_line_header = data.get(
+            "isFirstLineHeader", self.is_first_line_header
+        )
+        return self
+
 
 @dataclass
 class PartialRow:


### PR DESCRIPTION
Actually covers SYNPY-1653 and SYNPY-1655

# **Problem:**

- RecordSet and CurationTask are new concepts introduced to the Synapse Rest APIs and need to be implemented in Python.

# **Solution:**

- Implement these new concepts, new APIs, and some supporting classes

# **Testing:**

- [ ] Unit tests
- [ ] Integration tests

- Did manual testing during development, but needs more comprehensive testing
