### PR TITLE
[SYNPY-1375] Add Activity/Provenance tutorial

### DIFF
--- a/docs/tutorials/python/activity.md
+++ b/docs/tutorials/python/activity.md
@@ -22,7 +22,7 @@ In this tutorial you will:
 #### First retrieve the project, folder, and file we want to track provenance for
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/activity.py!lines=6-24}
+--8<-- "docs/tutorials/python/tutorial_scripts/activity.py:retrieve_project_folder_file"
 ```
 
 #### Create an Activity and attach it to the file
@@ -30,7 +30,7 @@ In this tutorial you will:
 An `Activity` captures what was **used** (input data and reference URLs) and **executed** (code and software) to produce a file. Here we record a QC pipeline run on the biospecimen data:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/activity.py!lines=26-53}
+--8<-- "docs/tutorials/python/tutorial_scripts/activity.py:create_activity"
 ```
 
 <details class="example">
@@ -47,7 +47,7 @@ Stored file: fileA.txt (version 1) with activity: Quality Control Analysis
 Each time you store an updated file, Synapse creates a new version. You can associate a distinct activity with each version to capture the full history of how the data evolved. Here we record a downstream analysis step that used the QC-passed data from version 1:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/activity.py!lines=55-88}
+--8<-- "docs/tutorials/python/tutorial_scripts/activity.py:add_activity_to_version"
 ```
 
 <details class="example">
@@ -64,7 +64,7 @@ Stored activity 'Downstream Analysis' on file fileA.txt (version 1)
 Use `Activity.from_parent()` to retrieve the provenance for any version of a file. Pass a `parent_version_number` to retrieve the activity for a specific older version:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/activity.py!lines=90-108}
+--8<-- "docs/tutorials/python/tutorial_scripts/activity.py:print_activities"
 ```
 
 <details class="example">
@@ -90,7 +90,7 @@ Activity on version 1:
 Deleting an activity disassociates it from the entity. Once the activity is no longer referenced by any entity, Synapse removes it entirely. If the same activity is shared across multiple entities you will need to call `Activity.delete()` on each of them:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/activity.py!lines=110-118}
+--8<-- "docs/tutorials/python/tutorial_scripts/activity.py:delete_activity"
 ```
 
 <details class="example">
@@ -109,7 +109,7 @@ Activity after deletion: None
   <summary>Click to show me</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/activity.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/activity.py"
 ```
 </details>
 

--- a/docs/tutorials/python/activity.md
+++ b/docs/tutorials/python/activity.md
@@ -4,7 +4,6 @@ Provenance is a concept describing the origin of something. In Synapse, it is us
 
 The model Synapse uses for provenance is based on the [W3C provenance spec](https://www.w3.org/TR/prov-n/) where items are derived from an activity which has components that were **used** and components that were **executed**. Think of the **used** items as input files and **executed** items as software or code. Both **used** and **executed** items can reside in Synapse or in URLs such as a link to a GitHub commit or a link to a specific version of a software tool.
 
-[Dive into Activity/Provenance further here](../../explanations/domain_models_of_synapse.md#activityprovenance)
 
 ## Tutorial Purpose
 In this tutorial you will:
@@ -15,7 +14,7 @@ In this tutorial you will:
 1. Delete an activity
 
 ## Prerequisites
-- In order to follow this tutorial you will need to have a [Project](./project.md) created with at least one [File](./file.md) stored in a Folder named `biospecimen_experiment_1`.
+- In order to follow this tutorial you will need to have a [Project](./project.md) created with a Folder named `biospecimen_experiment_1` containing at least one [File](./file.md). You will also need the Synapse ID of that file (e.g. `synNNNNN`).
 
 ## 1. Add a new Activity to your File
 
@@ -54,7 +53,7 @@ Each time you store an updated file, Synapse creates a new version. You can asso
   <summary>You'll notice the output looks like:</summary>
 
 ```
-Stored activity 'Downstream Analysis' on file fileA.txt (version 1)
+Stored activity 'Downstream Analysis' on file fileA.txt (version 2)
 ```
 </details>
 
@@ -87,7 +86,7 @@ Activity on version 1:
 
 ## 4. Delete an activity
 
-Deleting an activity disassociates it from the entity. Once the activity is no longer referenced by any entity, Synapse removes it entirely. If the same activity is shared across multiple entities you will need to call `Activity.delete()` on each of them:
+Deleting an activity is a two-step process: first call `disassociate_from_entity()` to remove the link between the activity and the file version, then call `delete()` to remove the activity record from Synapse entirely:
 
 ```python
 --8<-- "docs/tutorials/python/tutorial_scripts/activity.py:delete_activity"
@@ -97,7 +96,7 @@ Deleting an activity disassociates it from the entity. Once the activity is no l
   <summary>You'll notice the output looks like:</summary>
 
 ```
-Deleted activity from: fileA.txt (version 1)
+Deleted activity from: fileA.txt (version 2)
 Activity after deletion: None
 ```
 </details>

--- a/docs/tutorials/python/activity.md
+++ b/docs/tutorials/python/activity.md
@@ -18,7 +18,7 @@ In this tutorial you will:
 
 ## 1. Add a new Activity to your File
 
-#### First retrieve the project, folder, and file we want to track provenance for
+#### First retrieve the project, folder and a file is created within that folder to track provenance
 
 ```python
 --8<-- "docs/tutorials/python/tutorial_scripts/activity.py:retrieve_project_folder_file"

--- a/docs/tutorials/python/activity.md
+++ b/docs/tutorials/python/activity.md
@@ -1,9 +1,6 @@
 # Activity/Provenance
-[See the current available tutorial](../python_client.md#provenance)
 
-![Under Construction](../../assets/under_construction.png)
-
-Provenance is a concept describing the origin of something. In Synapse, it is used to describe the connections between the workflow steps used to create a particular file or set of results. Data analysis often involves multiple steps to go from a raw data file to a finished analysis. Synapse’s provenance tools allow users to keep track of each step involved in an analysis and share those steps with other users.
+Provenance is a concept describing the origin of something. In Synapse, it is used to describe the connections between the workflow steps used to create a particular file or set of results. Data analysis often involves multiple steps to go from a raw data file to a finished analysis. Synapse's provenance tools allow users to keep track of each step involved in an analysis and share those steps with other users.
 
 The model Synapse uses for provenance is based on the [W3C provenance spec](https://www.w3.org/TR/prov-n/) where items are derived from an activity which has components that were **used** and components that were **executed**. Think of the **used** items as input files and **executed** items as software or code. Both **used** and **executed** items can reside in Synapse or in URLs such as a link to a GitHub commit or a link to a specific version of a software tool.
 
@@ -18,4 +15,108 @@ In this tutorial you will:
 1. Delete an activity
 
 ## Prerequisites
-- In order to follow this tutorial you will need to have a [Project](./project.md) created with at least one [File](./file.md) with multiple [Versions](./versions.md).
+- In order to follow this tutorial you will need to have a [Project](./project.md) created with at least one [File](./file.md) stored in a Folder named `biospecimen_experiment_1`.
+
+## 1. Add a new Activity to your File
+
+#### First retrieve the project, folder, and file we want to track provenance for
+
+```python
+{!docs/tutorials/python/tutorial_scripts/activity.py!lines=6-24}
+```
+
+#### Create an Activity and attach it to the file
+
+An `Activity` captures what was **used** (input data and reference URLs) and **executed** (code and software) to produce a file. Here we record a QC pipeline run on the biospecimen data:
+
+```python
+{!docs/tutorials/python/tutorial_scripts/activity.py!lines=26-53}
+```
+
+<details class="example">
+  <summary>You'll notice the output looks like:</summary>
+
+```
+Stored file: fileA.txt (version 1) with activity: Quality Control Analysis
+```
+</details>
+
+
+## 2. Add a new Activity to a specific version of your File
+
+Each time you store an updated file, Synapse creates a new version. You can associate a distinct activity with each version to capture the full history of how the data evolved. Here we record a downstream analysis step that used the QC-passed data from version 1:
+
+```python
+{!docs/tutorials/python/tutorial_scripts/activity.py!lines=55-88}
+```
+
+<details class="example">
+  <summary>You'll notice the output looks like:</summary>
+
+```
+Stored activity 'Downstream Analysis' on file fileA.txt (version 1)
+```
+</details>
+
+
+## 3. Print stored activities on your File
+
+Use `Activity.from_parent()` to retrieve the provenance for any version of a file. Pass a `parent_version_number` to retrieve the activity for a specific older version:
+
+```python
+{!docs/tutorials/python/tutorial_scripts/activity.py!lines=90-108}
+```
+
+<details class="example">
+  <summary>You'll notice the output looks like:</summary>
+
+```
+Activity on latest version (v1):
+  Name: Downstream Analysis
+  Description: Downstream analysis of QC-passed biospecimen samples.
+  Used: UsedURL(name='Seurat v5.0.0', url='https://github.com/satijalab/seurat/releases/tag/v5.0.0')
+  Used: UsedEntity(target_id='syn12345678', target_version_number=1)
+  Executed: UsedURL(name='Downstream Analysis Script', url='https://github.com/Sage-Bionetworks/analysis-scripts/blob/v1.0/downstream_analysis.py')
+
+Activity on version 1:
+  Name: Quality Control Analysis
+  Description: Initial QC analysis of biospecimen data using the FastQC pipeline.
+```
+</details>
+
+
+## 4. Delete an activity
+
+Deleting an activity disassociates it from the entity. Once the activity is no longer referenced by any entity, Synapse removes it entirely. If the same activity is shared across multiple entities you will need to call `Activity.delete()` on each of them:
+
+```python
+{!docs/tutorials/python/tutorial_scripts/activity.py!lines=110-118}
+```
+
+<details class="example">
+  <summary>You'll notice the output looks like:</summary>
+
+```
+Deleted activity from: fileA.txt (version 1)
+Activity after deletion: None
+```
+</details>
+
+
+## Source code for this tutorial
+
+<details class="quote">
+  <summary>Click to show me</summary>
+
+```python
+{!docs/tutorials/python/tutorial_scripts/activity.py!}
+```
+</details>
+
+## References used in this tutorial
+
+- [Activity][synapseclient.models.Activity]
+- [UsedEntity][synapseclient.models.UsedEntity]
+- [UsedURL][synapseclient.models.UsedURL]
+- [File][file-reference-sync]
+- [syn.login][synapseclient.Synapse.login]

--- a/docs/tutorials/python/tutorial_scripts/activity.py
+++ b/docs/tutorials/python/tutorial_scripts/activity.py
@@ -13,10 +13,8 @@ from synapseclient.models import Activity, File, Folder, Project, UsedEntity, Us
 syn = synapseclient.login()
 
 # Set project and folder name that exists within the project
-PROJECT_NAME = "My uniquely named project about Alzheimer's Disease"
+PROJECT_NAME = "Dark Side Of The Moon"
 FOLDER_NAME = "biospecimen_experiment_1"
-# Set the file id that exists within the folder
-FILE_A_SYN_ID = "synNNNNN"
 
 # Retrieve the project and folder IDs
 my_project_id = Project(name=PROJECT_NAME).get().id
@@ -25,8 +23,17 @@ biospecimen_experiment_1_folder = Folder(
     name=FOLDER_NAME, parent_id=my_project_id
 ).get()
 
-# Retrieve an existing file from the project
-my_file = File(id=FILE_A_SYN_ID).get()
+with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as tmp:
+    tmp.write("First biospecimen data - post-QC analysis results")
+    tmp_path = tmp.name
+# Store a first version of the file in Synapse
+my_file = File(
+    path=tmp_path,
+    name="biospecimen_data.txt",
+    parent_id=biospecimen_experiment_1_folder.id,
+)
+my_file.store()
+
 # --8<-- [end:retrieve_project_folder_file]
 
 # --8<-- [start:create_activity]
@@ -71,9 +78,13 @@ with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as tmp:
     tmp.write("Updated biospecimen data - post-QC analysis results")
     tmp_path = tmp.name
 
-updated_file = File(path=tmp_path, id=my_file.id).store()
+updated_file = File(
+    path=tmp_path,
+    name="biospecimen_data.txt",
+    parent_id=biospecimen_experiment_1_folder.id,
+)
+updated_file.store()
 second_version_number = updated_file.version_number
-os.unlink(tmp_path)
 
 downstream_activity = Activity(
     name="Downstream Analysis",

--- a/docs/tutorials/python/tutorial_scripts/activity.py
+++ b/docs/tutorials/python/tutorial_scripts/activity.py
@@ -9,13 +9,14 @@ from synapseclient.models import Activity, File, Folder, Project, UsedEntity, Us
 
 syn = synapseclient.login()
 
+PROJECT_NAME = "My uniquely named project about Alzheimer's Disease"
+FOLDER_NAME = "biospecimen_experiment_1"
+
 # Retrieve the project and folder IDs
-my_project_id = (
-    Project(name="My uniquely named project about Alzheimer's Disease").get().id
-)
+my_project_id = Project(name=PROJECT_NAME).get().id
 
 biospecimen_experiment_1_folder = Folder(
-    name="biospecimen_experiment_1", parent_id=my_project_id
+    name=FOLDER_NAME, parent_id=my_project_id
 ).get()
 
 # Retrieve an existing file from the project
@@ -83,14 +84,7 @@ downstream_activity = Activity(
 )
 
 # Store the activity directly on the file using Activity.store()
-second_version_file = File(id=my_file.id).get()
-downstream_activity.store(parent=second_version_file)
-
-second_version_number = second_version_file.version_number
-print(
-    f"Stored activity '{downstream_activity.name}' on file "
-    f"{second_version_file.name} (version {second_version_number})"
-)
+downstream_activity.store(parent=my_file)
 # --8<-- [end:add_activity_to_version]
 
 # --8<-- [start:print_activities]

--- a/docs/tutorials/python/tutorial_scripts/activity.py
+++ b/docs/tutorials/python/tutorial_scripts/activity.py
@@ -3,6 +3,7 @@ Here is where you'll find the code for the Activity/Provenance tutorial.
 """
 
 # Step 1: Add a new Activity to your File
+# --8<-- [start:retrieve_project_folder_file]
 import synapseclient
 from synapseclient.models import Activity, File, Folder, Project, UsedEntity, UsedURL
 
@@ -22,7 +23,9 @@ my_file = File(
     name="fileA.txt",
     parent_id=biospecimen_experiment_1_folder.id,
 ).get()
+# --8<-- [end:retrieve_project_folder_file]
 
+# --8<-- [start:create_activity]
 # Create an Activity describing the analysis step that produced this file
 analysis_activity = Activity(
     name="Quality Control Analysis",
@@ -51,7 +54,9 @@ print(
     f"Stored file: {my_file.name} (version {first_version_number}) "
     f"with activity: {my_file.activity.name}"
 )
+# --8<-- [end:create_activity]
 
+# --8<-- [start:add_activity_to_version]
 # Step 2: Add a new Activity to a specific version of your File
 # Each time you store an updated file, Synapse creates a new version.
 # You can track a different activity for each version to capture the
@@ -86,7 +91,9 @@ print(
     f"Stored activity '{downstream_activity.name}' on file "
     f"{second_version_file.name} (version {second_version_number})"
 )
+# --8<-- [end:add_activity_to_version]
 
+# --8<-- [start:print_activities]
 # Step 3: Print stored activities on your File
 # Retrieve and print the activity on the latest version of the file
 current_activity = Activity.from_parent(parent=my_file)
@@ -106,7 +113,9 @@ first_activity = Activity.from_parent(
 print(f"\nActivity on version {first_version_number}:")
 print(f"  Name: {first_activity.name}")
 print(f"  Description: {first_activity.description}")
+# --8<-- [end:print_activities]
 
+# --8<-- [start:delete_activity]
 # Step 4: Delete an activity
 # Deleting an activity disassociates it from the entity and removes it from
 # Synapse once it is no longer referenced by any entity.
@@ -116,3 +125,4 @@ print(f"\nDeleted activity from: {my_file.name} (version {my_file.version_number
 # Verify the activity was removed
 deleted_activity = Activity.from_parent(parent=my_file)
 print(f"Activity after deletion: {deleted_activity}")
+# --8<-- [end:delete_activity]

--- a/docs/tutorials/python/tutorial_scripts/activity.py
+++ b/docs/tutorials/python/tutorial_scripts/activity.py
@@ -4,13 +4,19 @@ Here is where you'll find the code for the Activity/Provenance tutorial.
 
 # Step 1: Add a new Activity to your File
 # --8<-- [start:retrieve_project_folder_file]
+import os
+import tempfile
+
 import synapseclient
 from synapseclient.models import Activity, File, Folder, Project, UsedEntity, UsedURL
 
 syn = synapseclient.login()
 
+# Set project and folder name that exists within the project
 PROJECT_NAME = "My uniquely named project about Alzheimer's Disease"
 FOLDER_NAME = "biospecimen_experiment_1"
+# Set the file id that exists within the folder
+FILE_A_SYN_ID = "synNNNNN"
 
 # Retrieve the project and folder IDs
 my_project_id = Project(name=PROJECT_NAME).get().id
@@ -20,10 +26,7 @@ biospecimen_experiment_1_folder = Folder(
 ).get()
 
 # Retrieve an existing file from the project
-my_file = File(
-    name="fileA.txt",
-    parent_id=biospecimen_experiment_1_folder.id,
-).get()
+my_file = File(id=FILE_A_SYN_ID).get()
 # --8<-- [end:retrieve_project_folder_file]
 
 # --8<-- [start:create_activity]
@@ -62,6 +65,16 @@ print(
 # Each time you store an updated file, Synapse creates a new version.
 # You can track a different activity for each version to capture the
 # full history of what was done to produce each version of the file.
+
+# Create a dummy file and upload it as a new version
+with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as tmp:
+    tmp.write("Updated biospecimen data - post-QC analysis results")
+    tmp_path = tmp.name
+
+updated_file = File(path=tmp_path, id=my_file.id).store()
+second_version_number = updated_file.version_number
+os.unlink(tmp_path)
+
 downstream_activity = Activity(
     name="Downstream Analysis",
     description="Downstream analysis of QC-passed biospecimen samples.",
@@ -83,8 +96,12 @@ downstream_activity = Activity(
     ],
 )
 
-# Store the activity directly on the file using Activity.store()
-downstream_activity.store(parent=my_file)
+# Store the activity on the new version using Activity.store()
+downstream_activity.store(parent=updated_file)
+print(
+    f"Stored activity '{downstream_activity.name}' on file "
+    f"{updated_file.name} (version {second_version_number})"
+)
 # --8<-- [end:add_activity_to_version]
 
 # --8<-- [start:print_activities]
@@ -113,10 +130,16 @@ print(f"  Description: {first_activity.description}")
 # Step 4: Delete an activity
 # Deleting an activity disassociates it from the entity and removes it from
 # Synapse once it is no longer referenced by any entity.
-Activity.delete(parent=my_file)
-print(f"\nDeleted activity from: {my_file.name} (version {my_file.version_number})")
+
+current_activity.disassociate_from_entity(parent=updated_file)
+current_activity.delete(parent=updated_file)
+print(
+    f"\nDeleted activity from: {updated_file.name} (version {updated_file.version_number})"
+)
 
 # Verify the activity was removed
-deleted_activity = Activity.from_parent(parent=my_file)
+deleted_activity = Activity.from_parent(
+    parent=updated_file, parent_version_number=updated_file.version_number
+)
 print(f"Activity after deletion: {deleted_activity}")
 # --8<-- [end:delete_activity]

--- a/docs/tutorials/python/tutorial_scripts/activity.py
+++ b/docs/tutorials/python/tutorial_scripts/activity.py
@@ -1,0 +1,118 @@
+"""
+Here is where you'll find the code for the Activity/Provenance tutorial.
+"""
+
+# Step 1: Add a new Activity to your File
+import synapseclient
+from synapseclient.models import Activity, File, Folder, Project, UsedEntity, UsedURL
+
+syn = synapseclient.login()
+
+# Retrieve the project and folder IDs
+my_project_id = (
+    Project(name="My uniquely named project about Alzheimer's Disease").get().id
+)
+
+biospecimen_experiment_1_folder = Folder(
+    name="biospecimen_experiment_1", parent_id=my_project_id
+).get()
+
+# Retrieve an existing file from the project
+my_file = File(
+    name="fileA.txt",
+    parent_id=biospecimen_experiment_1_folder.id,
+).get()
+
+# Create an Activity describing the analysis step that produced this file
+analysis_activity = Activity(
+    name="Quality Control Analysis",
+    description="Initial QC analysis of biospecimen data using the FastQC pipeline.",
+    used=[
+        UsedURL(
+            name="FastQC v0.12.1",
+            url="https://github.com/s-andrews/FastQC/releases/tag/v0.12.1",
+        ),
+        UsedEntity(target_id=my_project_id),
+    ],
+    executed=[
+        UsedURL(
+            name="QC Analysis Script",
+            url="https://github.com/Sage-Bionetworks/analysis-scripts/blob/v1.0/qc_analysis.py",
+        ),
+    ],
+)
+
+# Attach the activity to the file and store it
+my_file.activity = analysis_activity
+my_file = my_file.store()
+
+first_version_number = my_file.version_number
+print(
+    f"Stored file: {my_file.name} (version {first_version_number}) "
+    f"with activity: {my_file.activity.name}"
+)
+
+# Step 2: Add a new Activity to a specific version of your File
+# Each time you store an updated file, Synapse creates a new version.
+# You can track a different activity for each version to capture the
+# full history of what was done to produce each version of the file.
+downstream_activity = Activity(
+    name="Downstream Analysis",
+    description="Downstream analysis of QC-passed biospecimen samples.",
+    used=[
+        UsedURL(
+            name="Seurat v5.0.0",
+            url="https://github.com/satijalab/seurat/releases/tag/v5.0.0",
+        ),
+        UsedEntity(
+            target_id=my_file.id,
+            target_version_number=first_version_number,
+        ),
+    ],
+    executed=[
+        UsedURL(
+            name="Downstream Analysis Script",
+            url="https://github.com/Sage-Bionetworks/analysis-scripts/blob/v1.0/downstream_analysis.py",
+        ),
+    ],
+)
+
+# Store the activity directly on the file using Activity.store()
+second_version_file = File(id=my_file.id).get()
+downstream_activity.store(parent=second_version_file)
+
+second_version_number = second_version_file.version_number
+print(
+    f"Stored activity '{downstream_activity.name}' on file "
+    f"{second_version_file.name} (version {second_version_number})"
+)
+
+# Step 3: Print stored activities on your File
+# Retrieve and print the activity on the latest version of the file
+current_activity = Activity.from_parent(parent=my_file)
+print(f"\nActivity on latest version (v{my_file.version_number}):")
+print(f"  Name: {current_activity.name}")
+print(f"  Description: {current_activity.description}")
+for item in current_activity.used:
+    print(f"  Used: {item}")
+for item in current_activity.executed:
+    print(f"  Executed: {item}")
+
+# Retrieve and print the activity for the first version
+first_activity = Activity.from_parent(
+    parent=my_file,
+    parent_version_number=first_version_number,
+)
+print(f"\nActivity on version {first_version_number}:")
+print(f"  Name: {first_activity.name}")
+print(f"  Description: {first_activity.description}")
+
+# Step 4: Delete an activity
+# Deleting an activity disassociates it from the entity and removes it from
+# Synapse once it is no longer referenced by any entity.
+Activity.delete(parent=my_file)
+print(f"\nDeleted activity from: {my_file.name} (version {my_file.version_number})")
+
+# Verify the activity was removed
+deleted_activity = Activity.from_parent(parent=my_file)
+print(f"Activity after deletion: {deleted_activity}")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -260,6 +260,9 @@ markdown_extensions:
 
   - markdown_include.include:
 
+  - pymdownx.snippets:
+      base_path: ["."]
+
   - toc:
       permalink: true
   - attr_list

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,7 @@ nav:
           - Submission: tutorials/python/submission.md
           - Annotation: tutorials/python/annotation.md
           # - Versions: tutorials/python/versions.md
-          # - Activity/Provenance: tutorials/python/activity.md
+          - Activity/Provenance: tutorials/python/activity.md
           - Entity View: tutorials/python/entityview.md
           - Table: tutorials/python/table.md
           # - Using a Table: tutorials/python/table_crud.md


### PR DESCRIPTION
# **Problem:**

- The `docs/tutorials/python/activity.md` page was a placeholder with no working tutorial content, only an "Under Construction" banner and a redirect to the legacy docs.
- Users had no OOP-style tutorial for working with Activity/Provenance using the new `synapseclient.models` API introduced in PR #1036.

# **Solution:**

- Replaced the placeholder `activity.md` with a full tutorial that walks through the four planned steps: add an activity to a file, add an activity to a specific file version, print stored activities, and delete an activity.
- Added `docs/tutorials/python/tutorial_scripts/activity.py` — a self-contained runnable script that backs the tutorial page, following the same pattern as all other tutorial scripts in the directory.
- The tutorial uses the `Activity`, `UsedEntity`, and `UsedURL` OOP models and demonstrates both `file.activity = ...; file.store()` and the direct `Activity.store(parent=...)` / `Activity.from_parent()` / `Activity.delete()` class methods.
- No changes to production code — documentation only.

# **Testing:**

- Pre-commit hooks (ruff, black, isort, bandit) all passed on commit.
- Manual review of line ranges in the `pymdownx.snippets` includes against the script to confirm each section renders the intended code.
- Full end-to-end execution against a real Synapse project is included as a checklist item for reviewers (requires a project with a file in `biospecimen_experiment_1`).

https://synapsepythonclient--1351.org.readthedocs.build/en/1351/