### PR TITLE
Add actions read permission for Trivy scan job

### DIFF
--- a/.github/workflows/trivy_periodic_scan.yml
+++ b/.github/workflows/trivy_periodic_scan.yml
@@ -86,6 +86,7 @@ jobs:
       deployments: write
       security-events: write
       packages: write
+      actions: read # Required by docker_build.yml's nested trivy-scan job
 
   # Only create the git tag after the rebuilt image passes Trivy and is pushed
   create-tag:


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration by adding the `actions: read` permission. This is required for compatibility with the nested `trivy-scan` job in `docker_build.yml`.