### PR TITLE
Add optional ARTIFACT_NAME_SUFFIX input to Trivy workflow and update artifact naming

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -65,6 +65,7 @@ jobs:
       IMAGE_NAME: rebuild-image:local
       TARFILE_NAME: ${{ needs.build.outputs.tarfile_artifact }}
       EXIT_CODE: 1
+      ARTIFACT_NAME_SUFFIX: -rebuild
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -24,6 +24,10 @@ on:
         required: false
         type: number
         default: 0
+      ARTIFACT_NAME_SUFFIX: # optional suffix to disambiguate artifact names when this workflow is called multiple times in the same run
+        required: false
+        type: string
+        default: ""
     outputs:
       trivy_conclusion:
         description: "The pass/fail status from Trivy"
@@ -84,7 +88,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: ${{ env.sarif_file_name }}
+          name: ${{ env.sarif_file_name }}${{ inputs.ARTIFACT_NAME_SUFFIX }}
           path: ${{ env.sarif_file_name }}
 
     outputs:


### PR DESCRIPTION
# **Problem:**

- Trivy periodic scanning was failing https://github.com/Sage-Bionetworks/synapsePythonClient/actions/runs/24257613164 due to name collisions.

# **Solution:**

- Include a naming suffix on rebuild

# **Testing:**

- Will test the build on branch
