### PR TITLE
Remove sorting functionality

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -552,12 +552,18 @@ jobs:
           exit 1
 
   # containerize the package and upload to the GHCR upon new release (whether pre-release or not)
-  ghcr-build-and-push-on-release:
+  # Step 1: Build the Docker image and save as tar for scanning
+  ghcr-build-on-release:
     needs: deploy
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      image-tags: ${{ steps.set-tags.outputs.tags }}
+      image-name: synapsepythonclient-release
+    env:
+      TARFILE_NAME: synapsepythonclient-release.tar
 
     steps:
       - name: Check out the repo
@@ -565,74 +571,167 @@ jobs:
       - name: Extract Release Version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
         shell: bash
+      - name: Set image tags
+        id: set-tags
+        shell: bash
+        run: |
+          if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
+            echo "tags=ghcr.io/sage-bionetworks/synapsepythonclient:${{ env.RELEASE_VERSION }}-prerelease" >> $GITHUB_OUTPUT
+          else
+            echo "tags=ghcr.io/sage-bionetworks/synapsepythonclient:latest,ghcr.io/sage-bionetworks/synapsepythonclient:${{ env.RELEASE_VERSION }}" >> $GITHUB_OUTPUT
+          fi
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          load: true
+          provenance: false
+          tags: synapsepythonclient-release:local
+          file: ./Dockerfile
+          platforms: linux/amd64
+          cache-from: type=registry,ref=ghcr.io/sage-bionetworks/synapsepythonclient:build-cache
+          cache-to: type=inline
+      - name: Save Docker image to tar
+        run: docker save synapsepythonclient-release:local -o ${{ env.TARFILE_NAME }}
+      - name: Upload tar artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.TARFILE_NAME }}
+          path: ${{ env.TARFILE_NAME }}
+          retention-days: 1
+
+  # Step 2: Scan the built image with Trivy before pushing
+  trivy-scan-release:
+    needs: [ghcr-build-on-release]
+    uses: ./.github/workflows/trivy.yml
+    with:
+      SOURCE_TYPE: tar
+      TARFILE_NAME: synapsepythonclient-release.tar
+      IMAGE_NAME: synapsepythonclient-release:local
+      EXIT_CODE: 1
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+  # Step 3: Push the image to GHCR only if Trivy scan passes
+  ghcr-push-on-release:
+    needs: [ghcr-build-on-release, trivy-scan-release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      TARFILE_NAME: synapsepythonclient-release.tar
+
+    steps:
+      - name: Download scanned tar
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.TARFILE_NAME }}
+          path: /tmp
+      - name: Load Docker image from tar
+        run: docker load -i /tmp/${{ env.TARFILE_NAME }}
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker image (official release)
-        id: docker_build
-        if: '!github.event.release.prerelease'
-        uses: docker/build-push-action@v3
-        with:
-          push: true
-          provenance: false
-          tags: ghcr.io/sage-bionetworks/synapsepythonclient:latest,ghcr.io/sage-bionetworks/synapsepythonclient:${{ env.RELEASE_VERSION }}
-          file: ./Dockerfile
-          platforms: linux/amd64
-          cache-from: type=registry,ref=ghcr.io/sage-bionetworks/synapsepythonclient:build-cache
-          cache-to: type=registry,mode=max,ref=ghcr.io/sage-bionetworks/synapsepythonclient:build-cache
-      - name: Build and push Docker image (pre-release)
-        id: docker_build_prerelease
-        if: 'github.event.release.prerelease'
-        uses: docker/build-push-action@v3
-        with:
-          push: true
-          provenance: false
-          tags: ghcr.io/sage-bionetworks/synapsepythonclient:${{ env.RELEASE_VERSION }}-prerelease
-          file: ./Dockerfile
-          platforms: linux/amd64
-          cache-from: type=registry,ref=ghcr.io/sage-bionetworks/synapsepythonclient:build-cache-prerelease
-          cache-to: type=registry,mode=max,ref=ghcr.io/sage-bionetworks/synapsepythonclient:build-cache-prerelease
-      - name: Output image digest (official release)
-        if: '!github.event.release.prerelease'
-        run: echo "The image digest for official release is ${{ steps.docker_build.outputs.digest }}"
-      - name: Output image digest (pre-release)
-        if: 'github.event.release.prerelease'
-        run: echo "The image digest for pre-release is ${{ steps.docker_build_prerelease.outputs.digest }}"
+      - name: Tag and push Docker image
+        shell: bash
+        run: |
+          IFS=',' read -ra TAGS <<< "${{ needs.ghcr-build-on-release.outputs.image-tags }}"
+          for TAG in "${TAGS[@]}"; do
+            docker tag synapsepythonclient-release:local "$TAG"
+            docker push "$TAG"
+          done
 
   # containerize the package and upload to the GHCR upon commit in develop
-  ghcr-build-and-push-on-develop:
+  # Step 1: Build the Docker image and save as tar for scanning
+  ghcr-build-on-develop:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/develop'
     permissions:
       contents: read
       packages: write
+    outputs:
+      image-tag: ghcr.io/sage-bionetworks/synapsepythonclient:develop-${{ github.sha }}
+      image-name: synapsepythonclient-develop
+    env:
+      TARFILE_NAME: synapsepythonclient-develop.tar
 
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          load: true
+          provenance: false
+          tags: synapsepythonclient-develop:local
+          file: ./Dockerfile
+          platforms: linux/amd64
+          cache-from: type=registry,ref=ghcr.io/sage-bionetworks/synapsepythonclient:build-cache
+          cache-to: type=inline
+      - name: Save Docker image to tar
+        run: docker save synapsepythonclient-develop:local -o ${{ env.TARFILE_NAME }}
+      - name: Upload tar artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.TARFILE_NAME }}
+          path: ${{ env.TARFILE_NAME }}
+          retention-days: 1
+
+  # Step 2: Scan the built image with Trivy before pushing
+  trivy-scan-develop:
+    needs: [ghcr-build-on-develop]
+    uses: ./.github/workflows/trivy.yml
+    with:
+      SOURCE_TYPE: tar
+      TARFILE_NAME: synapsepythonclient-develop.tar
+      IMAGE_NAME: synapsepythonclient-develop:local
+      EXIT_CODE: 1
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+  # Step 3: Push the image to GHCR only if Trivy scan passes
+  ghcr-push-on-develop:
+    needs: [ghcr-build-on-develop, trivy-scan-develop]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/develop'
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      TARFILE_NAME: synapsepythonclient-develop.tar
+
+    steps:
+      - name: Download scanned tar
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.TARFILE_NAME }}
+          path: /tmp
+      - name: Load Docker image from tar
+        run: docker load -i /tmp/${{ env.TARFILE_NAME }}
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker image for develop
-        id: docker_build
-        uses: docker/build-push-action@v5
-        with:
-          push: true
-          provenance: false
-          tags: ghcr.io/sage-bionetworks/synapsepythonclient:develop-${{ github.sha }}
-          file: ./Dockerfile
-          platforms: linux/amd64
-          cache-from: type=registry,ref=ghcr.io/sage-bionetworks/synapsepythonclient:build-cache
-          cache-to: type=inline
-      - name: Output image digest
-        run: echo "The image digest is ${{ steps.docker_build.outputs.digest }}"
+      - name: Tag and push Docker image
+        run: |
+          docker tag synapsepythonclient-develop:local "${{ needs.ghcr-build-on-develop.outputs.image-tag }}"
+          docker push "${{ needs.ghcr-build-on-develop.outputs.image-tag }}"

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -65,6 +65,7 @@ jobs:
       IMAGE_NAME: rebuild-image:local
       TARFILE_NAME: ${{ needs.build.outputs.tarfile_artifact }}
       EXIT_CODE: 1
+      ARTIFACT_NAME_SUFFIX: -rebuild
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,0 +1,103 @@
+---
+#
+# Reusable workflow to build, scan, and push a Docker image.
+# Called by the periodic scan workflow to rebuild images
+# when new vulnerabilities are found.
+#
+name: Build and publish a Docker image
+
+on:
+  workflow_call:
+    inputs:
+      REF_TO_CHECKOUT:
+        required: false
+        type: string
+        description: "Reference to checkout, e.g. a tag like v1.0.1. Defaults to the branch/tag of the current event."
+      IMAGE_REFERENCES:
+        required: true
+        type: string
+        description: "Comma-separated image references, e.g., ghcr.io/sage-bionetworks/synapsepythonclient:1.0.1"
+
+env:
+  TARFILE_NAME: image.tar
+  LOCAL_IMAGE_TAG: rebuild-image:local
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.REF_TO_CHECKOUT }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          load: true
+          tags: ${{ env.LOCAL_IMAGE_TAG }}
+          file: ./Dockerfile
+          platforms: linux/amd64
+
+      - name: Save Docker image to tar
+        run: docker save ${{ env.LOCAL_IMAGE_TAG }} -o ${{ env.TARFILE_NAME }}
+
+      - name: Upload tarball for use by Trivy job
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.TARFILE_NAME }}
+          path: ${{ env.TARFILE_NAME }}
+          retention-days: 1
+
+    outputs:
+      tarfile_artifact: ${{ env.TARFILE_NAME }}
+
+  trivy-scan:
+    needs: build
+    uses: "./.github/workflows/trivy.yml"
+    with:
+      SOURCE_TYPE: tar
+      IMAGE_NAME: rebuild-image:local
+      TARFILE_NAME: ${{ needs.build.outputs.tarfile_artifact }}
+      EXIT_CODE: 1
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+  push-image:
+    needs: [build, trivy-scan]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download tar artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build.outputs.tarfile_artifact }}
+          path: /tmp
+
+      - name: Load Docker image from tar
+        run: docker load -i /tmp/${{ needs.build.outputs.tarfile_artifact }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag and push Docker image
+        shell: bash
+        run: |
+          IFS=',' read -ra TAGS <<< "${{ inputs.IMAGE_REFERENCES }}"
+          for TAG in "${TAGS[@]}"; do
+            docker tag ${{ env.LOCAL_IMAGE_TAG }} "$TAG"
+            docker push "$TAG"
+          done

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -24,6 +24,10 @@ on:
         required: false
         type: number
         default: 0
+      ARTIFACT_NAME_SUFFIX: # optional suffix to disambiguate artifact names when this workflow is called multiple times in the same run
+        required: false
+        type: string
+        default: ""
     outputs:
       trivy_conclusion:
         description: "The pass/fail status from Trivy"
@@ -84,7 +88,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: ${{ env.sarif_file_name }}
+          name: ${{ env.sarif_file_name }}${{ inputs.ARTIFACT_NAME_SUFFIX }}
           path: ${{ env.sarif_file_name }}
 
     outputs:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,91 @@
+---
+#
+# This workflow runs Trivy on a Docker image
+# It can pull the image from a container registry
+# or download a tar file. The latter is used
+# to check a container image prior to publishing
+# to the registry.
+
+name: Run Trivy on a Docker image and push results to GitHub
+
+on:
+  workflow_call:
+    inputs:
+      SOURCE_TYPE: # 'tar' or 'image'
+        required: true
+        type: string
+      TARFILE_NAME: # only used if SOURCE_TYPE=='tar'
+        required: false
+        type: string
+      IMAGE_NAME:
+        required: true
+        type: string
+      EXIT_CODE: # return code for failed scan. 0 means OK. Non-zero will fail the build when there are findings.
+        required: false
+        type: number
+        default: 0
+    outputs:
+      trivy_conclusion:
+        description: "The pass/fail status from Trivy"
+        value: ${{ jobs.trivy.outputs.trivy_conclusion }}
+
+env:
+  sarif_file_name: trivy-results.sarif
+  # downloading the trivy-db from its default GitHub location fails because
+  # the site experiences too many downloads. The fix is to pull from this
+  # alternate location.
+  TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+  TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
+
+jobs:
+  trivy:
+    name: Trivy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download tar file
+        id: tar-download
+        uses: actions/download-artifact@v4
+        if: ${{ inputs.SOURCE_TYPE == 'tar' }}
+        with:
+          name: ${{ inputs.TARFILE_NAME }}
+          path: /tmp
+
+      - name: Load docker image from tar file
+        if: ${{ inputs.SOURCE_TYPE == 'tar' }}
+        run: docker load -i ${{ steps.tar-download.outputs.download-path }}/${{ inputs.TARFILE_NAME }}
+
+      - name: Run Trivy vulnerability scanner for any major issues
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        id: trivy
+        with:
+          image-ref: ${{ inputs.IMAGE_NAME }}
+          ignore-unfixed: true # skip vulnerabilities for which there is no fix
+          severity: 'CRITICAL,HIGH'
+          format: 'sarif'
+          limit-severities-for-sarif: true
+          output: ${{ env.sarif_file_name }}
+          exit-code: ${{ inputs.EXIT_CODE }}
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+        if: ${{ !cancelled() }}
+        with:
+          sarif_file: ${{ env.sarif_file_name }}
+          wait-for-processing: true
+
+      - name: Upload Trivy output
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: ${{ env.sarif_file_name }}
+          path: ${{ env.sarif_file_name }}
+
+    outputs:
+      trivy_conclusion: ${{ steps.trivy.conclusion }}

--- a/.github/workflows/trivy_periodic_scan.yml
+++ b/.github/workflows/trivy_periodic_scan.yml
@@ -1,0 +1,155 @@
+---
+#
+# This workflow scans the latest published container image
+# for new vulnerabilities daily, publishing findings to
+# the GitHub Security tab. If vulnerabilities are found,
+# it bumps the patch version and triggers a rebuild.
+#
+name: Trivy Periodic Image Scan
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # run daily
+  workflow_dispatch: {}
+
+jobs:
+  get-image-reference:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Convert repo name to lower case
+        id: to_lower_case
+        run: |
+          # While GitHub repos can be mixed case,
+          # Docker images can only be lower case
+          repo_name=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+          echo "repo_name=$repo_name" >> $GITHUB_OUTPUT
+      - name: Find current version
+        id: find_version
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: true # setting to 'true' means no new version is created
+    outputs:
+      image_repo: ghcr.io/${{ steps.to_lower_case.outputs.repo_name }}
+      image_tag: ${{ steps.find_version.outputs.previous_tag }}
+    permissions:
+      contents: read
+
+  periodic-scan:
+    needs: get-image-reference
+    uses: "./.github/workflows/trivy.yml"
+    with:
+      SOURCE_TYPE: image
+      IMAGE_NAME: ${{ needs.get-image-reference.outputs.image_repo }}:${{ needs.get-image-reference.outputs.image_tag }}
+      EXIT_CODE: 1
+    permissions:
+      contents: read
+      deployments: write
+      security-events: write
+
+  # If scan failed, compute next version (dry run) and attempt a rebuild.
+  # The tag is only created after a successful rebuild to prevent
+  # infinite bump loops when a CVE fix requires a major version upgrade
+  # that a simple rebuild cannot provide.
+  compute-next-version:
+    needs: periodic-scan
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() && needs.periodic-scan.outputs.trivy_conclusion == 'failure' }}
+    steps:
+      - name: Compute next version (dry run — no tag created)
+        id: tag_version
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: true
+      - name: Parse new version
+        id: parsed
+        uses: booxmedialtd/ws-action-parse-semver@7784200024d6b3fc01253e617ec0168daf603de3 # v1.4.7
+        with:
+          input_string: ${{ steps.tag_version.outputs.new_version }}
+    outputs:
+      new_tag: ${{ steps.tag_version.outputs.new_tag }}
+      new_version: ${{ steps.tag_version.outputs.new_version }}
+      new_major_minor: ${{ steps.parsed.outputs.major }}.${{ steps.parsed.outputs.minor }}
+    permissions:
+      contents: read
+
+  update-image:
+    needs: [get-image-reference, periodic-scan, compute-next-version]
+    if: ${{ !cancelled() && needs.periodic-scan.outputs.trivy_conclusion == 'failure' && needs.compute-next-version.result == 'success' }}
+    uses: "./.github/workflows/docker_build.yml"
+    with:
+      REF_TO_CHECKOUT: ${{ needs.get-image-reference.outputs.image_tag }}
+      IMAGE_REFERENCES: "${{ needs.get-image-reference.outputs.image_repo }}:${{ needs.compute-next-version.outputs.new_tag }},${{ needs.get-image-reference.outputs.image_repo }}:${{ needs.compute-next-version.outputs.new_major_minor }}"
+    permissions:
+      contents: read
+      deployments: write
+      security-events: write
+      packages: write
+
+  # Only create the git tag after the rebuilt image passes Trivy and is pushed
+  create-tag:
+    needs: [periodic-scan, update-image]
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() && needs.periodic-scan.outputs.trivy_conclusion == 'failure' && needs.update-image.result == 'success' }}
+    steps:
+      - name: Bump version and push tag
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+
+  # If the rebuild still has vulnerabilities, open a GitHub issue for manual triage
+  # instead of looping endlessly
+  alert-on-failure:
+    needs: [periodic-scan, update-image]
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() && needs.periodic-scan.outputs.trivy_conclusion == 'failure' && needs.update-image.result == 'failure' }}
+    permissions:
+      issues: write
+    steps:
+      - name: Check for existing open issue
+        id: check_issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'trivy,security',
+              per_page: 1
+            });
+            return issues.data.length > 0 ? 'true' : 'false';
+          result-encoding: string
+
+      - name: Create GitHub issue for unresolved vulnerabilities
+        if: steps.check_issue.outputs.result == 'false'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Trivy: unresolved container vulnerabilities after rebuild',
+              body: [
+                '## Summary',
+                '',
+                'The daily Trivy periodic scan found Critical/High vulnerabilities in the latest published Docker image.',
+                'An automated rebuild was attempted but the rebuilt image **still has vulnerabilities**,',
+                'indicating the fix requires a manual dependency update rather than a base image refresh.',
+                '',
+                '## Next steps',
+                '',
+                `- Review findings in the [Security tab](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/security/code-scanning)`,
+                '- Update the affected dependencies to a version that includes the fix',
+                '- Or add the CVE ID(s) to a `.trivyignore` file if the risk is accepted',
+                '',
+                '## Details',
+                '',
+                `- **Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                `- **Triggered at:** ${new Date().toISOString()}`,
+              ].join('\n'),
+              labels: ['trivy', 'security']
+            });

--- a/.github/workflows/trivy_periodic_scan.yml
+++ b/.github/workflows/trivy_periodic_scan.yml
@@ -86,6 +86,7 @@ jobs:
       deployments: write
       security-events: write
       packages: write
+      actions: read # Required by docker_build.yml's nested trivy-scan job
 
   # Only create the git tag after the rebuilt image passes Trivy and is pushed
   create-tag:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
         name: isort (python)
 
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 26.3.1
     hooks:
       - id: black
         language_version: python3

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e0442132198c73f3b5eaaee9f635609da7860eab9654c678da8100ff4bdc9b40"
+            "sha256": "1b0f62e133c9783da2ebfd109ba8a24a7ba1961c49743568cc139a02f98bf0ed"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -39,6 +39,40 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==1.0.1"
+        },
+        "black": {
+            "hashes": [
+                "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c",
+                "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7",
+                "sha256:28ef38aee69e4b12fda8dba75e21f9b4f979b490c8ac0baa7cb505369ac9e1ff",
+                "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b",
+                "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07",
+                "sha256:2d6bfaf7fd0993b420bed691f20f9492d53ce9a2bcccea4b797d34e947318a78",
+                "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f",
+                "sha256:474c27574d6d7037c1bc875a81d9be0a9a4f9ee95e62800dab3cfaadbf75acd5",
+                "sha256:5602bdb96d52d2d0672f24f6ffe5218795736dd34807fd0fd55ccd6bf206168b",
+                "sha256:5e9d0d86df21f2e1677cc4bd090cd0e446278bcbbe49bf3659c308c3e402843e",
+                "sha256:5ed0ca58586c8d9a487352a96b15272b7fa55d139fc8496b519e78023a8dab0a",
+                "sha256:6c54a4a82e291a1fee5137371ab488866b7c86a3305af4026bdd4dc78642e1ac",
+                "sha256:6e131579c243c98f35bce64a7e08e87fb2d610544754675d4a0e73a070a5aa3a",
+                "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54",
+                "sha256:86a8b5035fce64f5dcd1b794cf8ec4d31fe458cf6ce3986a30deb434df82a1d2",
+                "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f",
+                "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1",
+                "sha256:9a5e9f45e5d5e1c5b5c29b3bd4265dcc90e8b92cf4534520896ed77f791f4da5",
+                "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2",
+                "sha256:b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f",
+                "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1",
+                "sha256:bf9bf162ed91a26f1adba8efda0b573bc6924ec1408a52cc6f82cb73ec2b142c",
+                "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839",
+                "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983",
+                "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb",
+                "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56",
+                "sha256:f89f2ab047c76a9c03f78d0d66ca519e389519902fa27e7a91117ef7611c0568"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==26.3.1"
         },
         "certifi": {
             "hashes": [
@@ -167,6 +201,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==3.4.4"
         },
+        "click": {
+            "hashes": [
+                "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a",
+                "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==8.3.1"
+        },
         "deprecated": {
             "hashes": [
                 "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f",
@@ -222,6 +264,14 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==8.7.1"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505",
+                "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.1.0"
         },
         "nest-asyncio": {
             "hashes": [
@@ -335,6 +385,22 @@
             "markers": "python_version >= '3.8'",
             "version": "==26.0"
         },
+        "pathspec": {
+            "hashes": [
+                "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645",
+                "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.0.4"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934",
+                "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==4.9.4"
+        },
         "protobuf": {
             "hashes": [
                 "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c",
@@ -377,6 +443,54 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==7.2.2"
+        },
+        "pytokens": {
+            "hashes": [
+                "sha256:0fc71786e629cef478cbf29d7ea1923299181d0699dbe7c3c0f4a583811d9fc1",
+                "sha256:11edda0942da80ff58c4408407616a310adecae1ddd22eef8c692fe266fa5009",
+                "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083",
+                "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1",
+                "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de",
+                "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2",
+                "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a",
+                "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1",
+                "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5",
+                "sha256:30f51edd9bb7f85c748979384165601d028b84f7bd13fe14d3e065304093916a",
+                "sha256:34bcc734bd2f2d5fe3b34e7b3c0116bfb2397f2d9666139988e7a3eb5f7400e3",
+                "sha256:3ad72b851e781478366288743198101e5eb34a414f1d5627cdd585ca3b25f1db",
+                "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68",
+                "sha256:42f144f3aafa5d92bad964d471a581651e28b24434d184871bd02e3a0d956037",
+                "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321",
+                "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc",
+                "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7",
+                "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f",
+                "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918",
+                "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9",
+                "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c",
+                "sha256:682fa37ff4d8e95f7df6fe6fe6a431e8ed8e788023c6bcc0f0880a12eab80ad1",
+                "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1",
+                "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3",
+                "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b",
+                "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb",
+                "sha256:941d4343bf27b605e9213b26bfa1c4bf197c9c599a9627eb7305b0defcfe40c1",
+                "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a",
+                "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4",
+                "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa",
+                "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78",
+                "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe",
+                "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9",
+                "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d",
+                "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975",
+                "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440",
+                "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16",
+                "sha256:da5baeaf7116dced9c6bb76dc31ba04a2dc3695f3d9f74741d7910122b456edc",
+                "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d",
+                "sha256:dcafc12c30dbaf1e2af0490978352e0c4041a7cde31f4f81435c2a5e8b9cabb6",
+                "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6",
+                "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.4.1"
         },
         "requests": {
             "hashes": [
@@ -643,36 +757,36 @@
         },
         "black": {
             "hashes": [
-                "sha256:101540cb2a77c680f4f80e628ae98bd2bd8812fb9d72ade4f8995c5ff019e82c",
-                "sha256:1054e8e47ebd686e078c0bb0eaf31e6ce69c966058d122f2c0c950311f9f3ede",
-                "sha256:1de0f7d01cc894066a1153b738145b194414cc6eeaad8ef4397ac9abacf40f6b",
-                "sha256:2b807c240b64609cb0e80d2200a35b23c7df82259f80bef1b2c96eb422b4aac9",
-                "sha256:3cee1487a9e4c640dc7467aaa543d6c0097c391dc8ac74eb313f2fbf9d7a7cb5",
-                "sha256:53c62883b3f999f14e5d30b5a79bd437236658ad45b2f853906c7cbe79de00af",
-                "sha256:5e8e75dabb6eb83d064b0db46392b25cabb6e784ea624219736e8985a6b3675d",
-                "sha256:643d27fb5facc167c0b1b59d0315f2674a6e950341aed0fc05cf307d22bf4954",
-                "sha256:66912475200b67ef5a0ab665011964bf924745103f51977a78b4fb92a9fc1bf0",
-                "sha256:6eeca41e70b5f5c84f2f913af857cf2ce17410847e1d54642e658e078da6544f",
-                "sha256:6f3977a16e347f1b115662be07daa93137259c711e526402aa444d7a88fdc9d4",
-                "sha256:7ed300200918147c963c87700ccf9966dceaefbbb7277450a8d646fc5646bf24",
-                "sha256:91a68ae46bf07868963671e4d05611b179c2313301bd756a89ad4e3b3db2325b",
-                "sha256:9459ad0d6cd483eacad4c6566b0f8e42af5e8b583cee917d90ffaa3778420a0a",
-                "sha256:9dc8c71656a79ca49b8d3e2ce8103210c9481c57798b48deeb3a8bb02db5f115",
-                "sha256:a19915ec61f3a8746e8b10adbac4a577c6ba9851fa4a9e9fbfbcf319887a5791",
-                "sha256:b22b3810451abe359a964cc88121d57f7bce482b53a066de0f1584988ca36e79",
-                "sha256:ba1d768fbfb6930fc93b0ecc32a43d8861ded16f47a40f14afa9bb04ab93d304",
-                "sha256:be5e2fe860b9bd9edbf676d5b60a9282994c03fbbd40fe8f5e75d194f96064ca",
-                "sha256:c5b7713daea9bf943f79f8c3b46f361cc5229e0e604dcef6a8bb6d1c37d9df89",
-                "sha256:ca699710dece84e3ebf6e92ee15f5b8f72870ef984bf944a57a777a48357c168",
-                "sha256:d294ac3340eef9c9eb5d29288e96dc719ff269a88e27b396340459dd85da4c58",
-                "sha256:d62d14ca31c92adf561ebb2e5f2741bf8dea28aef6deb400d49cca011d186c68",
-                "sha256:dd39eef053e58e60204f2cdf059e2442e2eb08f15989eefe259870f89614c8b6",
-                "sha256:eb07665d9a907a1a645ee41a0df8a25ffac8ad9c26cdb557b7b88eeeeec934e0",
-                "sha256:f016baaadc423dc960cdddf9acae679e71ee02c4c341f78f3179d7e4819c095f",
-                "sha256:fb1dafbbaa3b1ee8b4550a84425aac8874e5f390200f5502cf3aee4a2acb2f14"
+                "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c",
+                "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7",
+                "sha256:28ef38aee69e4b12fda8dba75e21f9b4f979b490c8ac0baa7cb505369ac9e1ff",
+                "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b",
+                "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07",
+                "sha256:2d6bfaf7fd0993b420bed691f20f9492d53ce9a2bcccea4b797d34e947318a78",
+                "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f",
+                "sha256:474c27574d6d7037c1bc875a81d9be0a9a4f9ee95e62800dab3cfaadbf75acd5",
+                "sha256:5602bdb96d52d2d0672f24f6ffe5218795736dd34807fd0fd55ccd6bf206168b",
+                "sha256:5e9d0d86df21f2e1677cc4bd090cd0e446278bcbbe49bf3659c308c3e402843e",
+                "sha256:5ed0ca58586c8d9a487352a96b15272b7fa55d139fc8496b519e78023a8dab0a",
+                "sha256:6c54a4a82e291a1fee5137371ab488866b7c86a3305af4026bdd4dc78642e1ac",
+                "sha256:6e131579c243c98f35bce64a7e08e87fb2d610544754675d4a0e73a070a5aa3a",
+                "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54",
+                "sha256:86a8b5035fce64f5dcd1b794cf8ec4d31fe458cf6ce3986a30deb434df82a1d2",
+                "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f",
+                "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1",
+                "sha256:9a5e9f45e5d5e1c5b5c29b3bd4265dcc90e8b92cf4534520896ed77f791f4da5",
+                "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2",
+                "sha256:b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f",
+                "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1",
+                "sha256:bf9bf162ed91a26f1adba8efda0b573bc6924ec1408a52cc6f82cb73ec2b142c",
+                "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839",
+                "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983",
+                "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb",
+                "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56",
+                "sha256:f89f2ab047c76a9c03f78d0d66ca519e389519902fa27e7a91117ef7611c0568"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==26.1.0"
+            "version": "==26.3.1"
         },
         "boto3": {
             "hashes": [
@@ -1176,20 +1290,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==1.72.0"
-        },
-        "griffe": {
-            "hashes": [
-                "sha256:5418081135a391c3e6e757a7f3f156f1a1a746cc7b4023868ff7d5e2f9a980aa"
-            ],
-            "markers": "python_version >= '3.10'",
-            "version": "==2.0.0"
-        },
-        "griffecli": {
-            "hashes": [
-                "sha256:9f7cd9ee9b21d55e91689358978d2385ae65c22f307a63fb3269acf3f21e643d"
-            ],
-            "markers": "python_version >= '3.10'",
-            "version": "==2.0.0"
         },
         "griffelib": {
             "hashes": [
@@ -1799,11 +1899,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:9170634f126f8efdae22fb58ae8a0eaa86f38365bc57897a6c4f781d1f5875bd",
-                "sha256:9a33809944b9db043ad67ca0db94b14bf452cc6aeaac46a88ea55b26e2e9d291"
+                "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934",
+                "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==4.9.2"
+            "version": "==4.9.4"
         },
         "pluggy": {
             "hashes": [

--- a/docs/scripts/object_orientated_programming_poc/synapse_project.py
+++ b/docs/scripts/object_orientated_programming_poc/synapse_project.py
@@ -10,6 +10,7 @@ The following actions are shown in this script:
 
 All steps also include setting a number of annotations for the objects.
 """
+
 import os
 import uuid
 from datetime import datetime, timedelta, timezone

--- a/docs/tutorials/python/tutorial_scripts/upload_data_in_bulk.py
+++ b/docs/tutorials/python/tutorial_scripts/upload_data_in_bulk.py
@@ -66,9 +66,9 @@ row_index = df[
 
 # After finding the row we want to update let's go ahead and add a relationship to
 # another file in our manifest. This allows us to say "We used 'this' file in some way".
-df.loc[
-    row_index, "used"
-] = f"{DIRECTORY_FOR_MY_PROJECT}/single_cell_RNAseq_batch_1/SRR12345678_R1.fastq.gz"
+df.loc[row_index, "used"] = (
+    f"{DIRECTORY_FOR_MY_PROJECT}/single_cell_RNAseq_batch_1/SRR12345678_R1.fastq.gz"
+)
 
 # Let's also link to the pipeline that we ran in order to produce these results. In a
 # real scenario you may want to link to a specific run of the tool where the results
@@ -76,9 +76,9 @@ df.loc[
 df.loc[row_index, "executed"] = "https://nf-co.re/rnaseq/3.14.0"
 
 # Let's also add a description for this Activity/Provenance
-df.loc[
-    row_index, "activityDescription"
-] = "Experiment results created as a result of the linked data while running the pipeline."
+df.loc[row_index, "activityDescription"] = (
+    "Experiment results created as a result of the linked data while running the pipeline."
+)
 
 # Write the DataFrame back to the manifest file
 df.to_csv(PATH_TO_MANIFEST_FILE, sep="\t", index=False)

--- a/docs/tutorials/python/tutorial_scripts/wiki.py
+++ b/docs/tutorials/python/tutorial_scripts/wiki.py
@@ -12,6 +12,7 @@ This script shows how to:
 7. Delete wiki pages
 
 """
+
 import os
 
 from synapseclient import Synapse

--- a/docs/tutorials/python/wiki.md
+++ b/docs/tutorials/python/wiki.md
@@ -31,7 +31,7 @@ In this tutorial you will:
 ## 1. Create a Wiki page
 ### Initial setup
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=15-31}
+{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=16-31}
 ```
 A Wiki page requires an owner object, a title, and markdown. Here is an example to create a new root Wiki page for your project with plain text markdown:
 ```python

--- a/synapseclient/activity.py
+++ b/synapseclient/activity.py
@@ -223,9 +223,9 @@ class Activity(dict):
 
             resource = target
             if "concreteType" not in resource:
-                resource[
-                    "concreteType"
-                ] = "org.sagebionetworks.repo.model.provenance.UsedEntity"
+                resource["concreteType"] = (
+                    "org.sagebionetworks.repo.model.provenance.UsedEntity"
+                )
 
         # -- Used URL
         elif is_used_url(target):
@@ -234,9 +234,9 @@ class Activity(dict):
 
             resource = target
             if "concreteType" not in resource:
-                resource[
-                    "concreteType"
-                ] = "org.sagebionetworks.repo.model.provenance.UsedURL"
+                resource["concreteType"] = (
+                    "org.sagebionetworks.repo.model.provenance.UsedURL"
+                )
 
         # -- Synapse Entity
         elif is_synapse_entity(target):

--- a/synapseclient/api/docker_commit_services.py
+++ b/synapseclient/api/docker_commit_services.py
@@ -1,6 +1,7 @@
 """This module is responsible for exposing the services defined at:
 <https://rest-docs.synapse.org/rest/#org.sagebionetworks.repo.web.controller.DockerCommitController>
 """
+
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:

--- a/synapseclient/api/file_services.py
+++ b/synapseclient/api/file_services.py
@@ -269,7 +269,7 @@ async def post_external_filehandle(
         "contentSize": file_size,
     }
     if mimetype is None:
-        (mimetype, _) = mimetypes.guess_type(external_url, strict=False)
+        mimetype, _ = mimetypes.guess_type(external_url, strict=False)
     if mimetype is not None:
         file_handle["contentType"] = mimetype
     return await client.rest_post_async(

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -2,6 +2,7 @@
 The `Synapse` object encapsulates a connection to the Synapse service and is used for building projects, uploading and
 retrieving data, and recording provenance of data analysis.
 """
+
 import asyncio
 import collections
 import collections.abc
@@ -607,9 +608,7 @@ class Synapse(object):
         logger_name = (
             SILENT_LOGGER_NAME
             if self.silent
-            else DEBUG_LOGGER_NAME
-            if self.debug
-            else DEFAULT_LOGGER_NAME
+            else DEBUG_LOGGER_NAME if self.debug else DEFAULT_LOGGER_NAME
         )
         self.logger = logging.getLogger(logger_name)
         logging.getLogger("py.warnings").handlers = self.logger.handlers
@@ -2672,9 +2671,11 @@ class Synapse(object):
                 fileHandle = await upload_file_handle_async(
                     self,
                     parent_id_for_upload,
-                    local_state["path"]
-                    if (synapseStore or local_state_fh.get("externalURL") is None)
-                    else local_state_fh.get("externalURL"),
+                    (
+                        local_state["path"]
+                        if (synapseStore or local_state_fh.get("externalURL") is None)
+                        else local_state_fh.get("externalURL")
+                    ),
                     synapse_store=synapseStore,
                     md5=local_file_md5_hex or local_state_fh.get("contentMd5"),
                     file_size=local_state_fh.get("contentSize"),
@@ -3243,9 +3244,10 @@ class Synapse(object):
         dl_list_path = self.get_download_list_manifest()
         downloaded_files = []
         new_manifest_path = f"manifest_{time.time_ns()}.csv"
-        with open(dl_list_path) as manifest_f, open(
-            new_manifest_path, "w"
-        ) as write_obj:
+        with (
+            open(dl_list_path) as manifest_f,
+            open(new_manifest_path, "w") as write_obj,
+        ):
             reader = csv.DictReader(manifest_f)
             columns = reader.fieldnames
             columns.extend(["path", "error"])
@@ -4925,9 +4927,11 @@ class Synapse(object):
         if usedList is None:
             return None
         usedList = [
-            self.get(target, limitSearch=limitSearch)
-            if (os.path.isfile(target) if isinstance(target, str) else False)
-            else target
+            (
+                self.get(target, limitSearch=limitSearch)
+                if (os.path.isfile(target) if isinstance(target, str) else False)
+                else target
+            )
             for target in usedList
         ]
         return usedList
@@ -5468,7 +5472,7 @@ class Synapse(object):
             "contentSize": fileSize,
         }
         if mimetype is None:
-            (mimetype, enc) = mimetypes.guess_type(externalURL, strict=False)
+            mimetype, enc = mimetypes.guess_type(externalURL, strict=False)
         if mimetype is not None:
             fileHandle["contentType"] = mimetype
         return self.restPOST(
@@ -5893,16 +5897,16 @@ class Synapse(object):
         }
 
         if bucket_name:
-            storage_location_kwargs[
-                "concreteType"
-            ] = concrete_types.EXTERNAL_S3_STORAGE_LOCATION_SETTING
+            storage_location_kwargs["concreteType"] = (
+                concrete_types.EXTERNAL_S3_STORAGE_LOCATION_SETTING
+            )
             storage_location_kwargs["bucket"] = bucket_name
             if base_key:
                 storage_location_kwargs["baseKey"] = base_key
         else:
-            storage_location_kwargs[
-                "concreteType"
-            ] = concrete_types.SYNAPSE_S3_STORAGE_LOCATION_SETTING
+            storage_location_kwargs["concreteType"] = (
+                concrete_types.SYNAPSE_S3_STORAGE_LOCATION_SETTING
+            )
 
         storage_location_setting = self.restPOST(
             "/storageLocation", json.dumps(storage_location_kwargs)

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -479,13 +479,13 @@ async def download_by_file_handle(
 
     while retries > 0:
         try:
-            file_handle_result: Dict[
-                str, str
-            ] = await get_file_handle_for_download_async(
-                file_handle_id=file_handle_id,
-                synapse_id=synapse_id,
-                entity_type=entity_type,
-                synapse_client=syn,
+            file_handle_result: Dict[str, str] = (
+                await get_file_handle_for_download_async(
+                    file_handle_id=file_handle_id,
+                    synapse_id=synapse_id,
+                    entity_type=entity_type,
+                    synapse_client=syn,
+                )
             )
             file_handle = file_handle_result["fileHandle"]
             concrete_type = file_handle["concreteType"]

--- a/synapseclient/core/dozer.py
+++ b/synapseclient/core/dozer.py
@@ -5,6 +5,7 @@ Created on Sep 21, 2017
 
 sleep while checking registered _listeners
 """
+
 import time
 
 from opentelemetry import trace

--- a/synapseclient/core/models/custom_json.py
+++ b/synapseclient/core/models/custom_json.py
@@ -1,6 +1,7 @@
 """
 When imported, monkey-patches the 'json' module's encoder with a custom json encoding function.
 """
+
 import datetime
 import json
 

--- a/synapseclient/core/otel_config.py
+++ b/synapseclient/core/otel_config.py
@@ -1,4 +1,5 @@
 """OpenTelemetry configuration for Synapse Python Client."""
+
 import os
 import sys
 from typing import Any, Dict, List, Optional

--- a/synapseclient/core/transfer_bar.py
+++ b/synapseclient/core/transfer_bar.py
@@ -1,4 +1,5 @@
 """Logic used to handle progress bars for file uploads and downloads."""
+
 try:
     import threading as _threading
 except ImportError:

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -278,7 +278,7 @@ def id_of(obj: typing.Union[str, collections.abc.Mapping, numbers.Number]) -> st
 
 
 def validate_submission_id(
-    submission_id: typing.Union[str, int, collections.abc.Mapping]
+    submission_id: typing.Union[str, int, collections.abc.Mapping],
 ) -> str:
     """
     Ensures that a given submission ID is either an integer or a string that
@@ -462,7 +462,7 @@ def is_synapse_id_str(obj: str) -> typing.Union[str, None]:
 
 
 def get_synid_and_version(
-    obj: typing.Union[str, collections.abc.Mapping]
+    obj: typing.Union[str, collections.abc.Mapping],
 ) -> typing.Tuple[str, typing.Union[int, None]]:
     """Extract the Synapse ID and version number from input entity
 
@@ -698,7 +698,7 @@ def to_unix_epoch_time(dt: typing.Union[datetime.date, datetime.datetime, str]) 
 
 
 def to_unix_epoch_time_secs(
-    dt: typing.Union[datetime.date, datetime.datetime]
+    dt: typing.Union[datetime.date, datetime.datetime],
 ) -> float:
     """
     Convert either [datetime.date or datetime.datetime objects](http://docs.python.org/2/library/datetime.html) to UNIX time.

--- a/synapseclient/extensions/curator/record_based_metadata_task.py
+++ b/synapseclient/extensions/curator/record_based_metadata_task.py
@@ -5,6 +5,7 @@ CurationTask, and also create a Grid to bootstrap the ValidationStatistics.
 This module provides library functions for creating record-based metadata curation tasks
 in Synapse, including RecordSet creation, CurationTask setup, and Grid view initialization.
 """
+
 import tempfile
 from typing import Any, Dict, List, Optional, Tuple, Union
 

--- a/synapseclient/extensions/curator/schema_generation.py
+++ b/synapseclient/extensions/curator/schema_generation.py
@@ -343,18 +343,18 @@ def find_and_convert_ints(
     if (
         dataframe.size < large_manifest_cutoff_size
     ):  # If small manifest, iterate as normal for improved performance
-        ints = dataframe.map(  # type:ignore
+        ints = dataframe.map(  # type: ignore
             lambda cell: convert_ints(cell), na_action="ignore"
         ).fillna(False)
 
     else:  # parallelize iterations for large manifests
         pandarallel.initialize(verbose=1)
-        ints = dataframe.parallel_applymap(  # type:ignore
+        ints = dataframe.parallel_applymap(  # type: ignore
             lambda cell: convert_ints(cell), na_action="ignore"
         ).fillna(False)
 
     # Identify cells converted to integers
-    is_int = ints.map(is_integer)  # type:ignore
+    is_int = ints.map(is_integer)  # type: ignore
 
     assert isinstance(ints, DataFrame)
     assert isinstance(is_int, DataFrame)
@@ -2049,6 +2049,7 @@ class PropertyTemplate:
 @dataclass
 class ClassTemplate:
     "Class Template"
+
     magic_id: str = field(default="", metadata=config(field_name="@id"))
     magic_type: str = field(default="rdfs:Class", metadata=config(field_name="@type"))
     magic_comment: str = field(default="", metadata=config(field_name="rdfs:comment"))
@@ -3876,7 +3877,7 @@ def match_node_names_with_reserved_names(
 
 
 def create_reserve_name_error_messages(
-    reserved_names_found: list[Tuple[str, str]]
+    reserved_names_found: list[Tuple[str, str]],
 ) -> list[str]:
     """Creates the error messages when a reserved name is used
 
@@ -3943,7 +3944,7 @@ def get_missing_fields_from(
 
 
 def create_missing_fields_error_messages(
-    missing_fields: list[Tuple[str, str]]
+    missing_fields: list[Tuple[str, str]],
 ) -> list[str]:
     """Creates the error message for when a node is missing a required field
 
@@ -4119,7 +4120,7 @@ def export_schema(schema: dict, file_path: str, logger: Logger) -> None:
 
 
 def parsed_model_as_dataframe(
-    parsed_model: dict[str, dict[str, Any]]
+    parsed_model: dict[str, dict[str, Any]],
 ) -> DATA_FRAME_TYPE:
     """Convert parsed model dictionary to an unpacked pandas DataFrame.
     Args:
@@ -5168,7 +5169,7 @@ class JSONSchema:
 
     @staticmethod
     def _convert_conditional_properties_to_all_of(
-        conditional_dependencies: dict[tuple[str, str], list[str]]
+        conditional_dependencies: dict[tuple[str, str], list[str]],
     ) -> list[AllOf]:
         """
         Converts the conditional dependencies dict to a list of JSON Schema allOf conditions

--- a/synapseclient/extensions/curator/schema_generation.py
+++ b/synapseclient/extensions/curator/schema_generation.py
@@ -4114,7 +4114,7 @@ def export_schema(schema: dict, file_path: str, logger: Logger) -> None:
         if json_schema_dirname != "":
             os.makedirs(json_schema_dirname, exist_ok=True)
     with open(file_path, "w", encoding="utf-8") as json_file:
-        json.dump(schema, json_file, sort_keys=True, indent=4, ensure_ascii=False)
+        json.dump(schema, json_file, sort_keys=False, indent=4, ensure_ascii=False)
 
     logger.info(f"The Data Model was created and saved to '{file_path}' location.")
 
@@ -5522,7 +5522,7 @@ def get_json_schema_log_file_path(data_model_path: str, source_node: str) -> str
 def export_json(json_doc: Any, file_path: str, indent: Optional[int] = 4) -> None:
     """Export JSON doc to file"""
     with open(file_path, "w", encoding="utf8") as fle:
-        json.dump(json_doc, fle, sort_keys=True, indent=indent, ensure_ascii=False)
+        json.dump(json_doc, fle, sort_keys=False, indent=indent, ensure_ascii=False)
 
 
 def create_json_schema(  # pylint: disable=too-many-arguments

--- a/synapseclient/models/agent.py
+++ b/synapseclient/models/agent.py
@@ -199,9 +199,9 @@ class AgentSession(AgentSessionSynchronousProtocol):
     """The unique ID of the agent session.
     Can only be used by the user that created it."""
 
-    access_level: Optional[
-        AgentSessionAccessLevel
-    ] = AgentSessionAccessLevel.PUBLICLY_ACCESSIBLE
+    access_level: Optional[AgentSessionAccessLevel] = (
+        AgentSessionAccessLevel.PUBLICLY_ACCESSIBLE
+    )
     """The access level of the agent session.
         One of PUBLICLY_ACCESSIBLE, READ_YOUR_PRIVATE_DATA, or
         WRITE_YOUR_PRIVATE_DATA. Defaults to PUBLICLY_ACCESSIBLE.

--- a/synapseclient/models/annotations.py
+++ b/synapseclient/models/annotations.py
@@ -93,9 +93,7 @@ class Annotations(AnnotationsSynchronousProtocol):
         return self
 
     @classmethod
-    def from_dict(
-        cls, synapse_annotations: dict
-    ) -> Union[
+    def from_dict(cls, synapse_annotations: dict) -> Union[
         Dict[
             str,
             Union[

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -132,7 +132,7 @@ class RecordBasedMetadataTaskProperties:
 
 
 def _create_task_properties_from_dict(
-    properties_dict: Dict[str, Any]
+    properties_dict: Dict[str, Any],
 ) -> Union[FileBasedMetadataTaskProperties, RecordBasedMetadataTaskProperties]:
     """
     Factory method to create the appropriate FileBasedMetadataTaskProperties/RecordBasedMetadataTaskProperties

--- a/synapseclient/models/entityview.py
+++ b/synapseclient/models/entityview.py
@@ -790,15 +790,21 @@ class EntityView(
             "versionLabel": self.version_label,
             "versionComment": self.version_comment,
             "isLatestVersion": self.is_latest_version,
-            "columnIds": [
-                column.id for column in self._last_persistent_instance.columns.values()
-            ]
-            if self._last_persistent_instance and self._last_persistent_instance.columns
-            else [],
+            "columnIds": (
+                [
+                    column.id
+                    for column in self._last_persistent_instance.columns.values()
+                ]
+                if self._last_persistent_instance
+                and self._last_persistent_instance.columns
+                else []
+            ),
             "isSearchEnabled": self.is_search_enabled,
-            "viewTypeMask": self.view_type_mask.value
-            if isinstance(self.view_type_mask, ViewTypeMask)
-            else self.view_type_mask,
+            "viewTypeMask": (
+                self.view_type_mask.value
+                if isinstance(self.view_type_mask, ViewTypeMask)
+                else self.view_type_mask
+            ),
             "scopeIds": list(scopes_without_syn) if scopes_without_syn else None,
         }
         delete_none_keys(entity)

--- a/synapseclient/models/file.py
+++ b/synapseclient/models/file.py
@@ -1053,9 +1053,11 @@ class File(FileSynchronousProtocol, AccessControllable, BaseJSONSchema):
             if_collision=self.if_collision,
             limit_search=self.synapse_container_limit or self.parent_id,
             download_file=self.download_file,
-            download_location=os.path.dirname(self.path)
-            if self.path and os.path.isfile(self.path)
-            else self.path,
+            download_location=(
+                os.path.dirname(self.path)
+                if self.path and os.path.isfile(self.path)
+                else self.path
+            ),
             md5=self.content_md5,
             synapse_client=syn,
         )

--- a/synapseclient/models/link.py
+++ b/synapseclient/models/link.py
@@ -358,12 +358,14 @@ class Link(LinkSynchronousProtocol):
             "modifiedBy": self.modified_by,
             "parentId": self.parent_id,
             "concreteType": LINK_ENTITY,
-            "linksTo": {
-                "targetId": self.target_id,
-                "targetVersionNumber": self.target_version_number,
-            }
-            if self.target_id
-            else None,
+            "linksTo": (
+                {
+                    "targetId": self.target_id,
+                    "targetVersionNumber": self.target_version_number,
+                }
+                if self.target_id
+                else None
+            ),
             "linksToClassName": self.links_to_class_name,
         }
         if request_dict["linksTo"]:

--- a/synapseclient/models/mixins/table_components.py
+++ b/synapseclient/models/mixins/table_components.py
@@ -1844,10 +1844,10 @@ def _construct_partial_rows_for_upsert(
                 if (
                     isinstance(cell_value, list) and len(cell_value) > 0
                 ) or not cell_is_na:
-                    partial_change_values[
-                        column_id
-                    ] = _convert_pandas_row_to_python_types(
-                        cell=cell_value, column_type=column_type
+                    partial_change_values[column_id] = (
+                        _convert_pandas_row_to_python_types(
+                            cell=cell_value, column_type=column_type
+                        )
                     )
                 else:
                     partial_change_values[column_id] = None

--- a/synapseclient/models/protocols/docker_protocol.py
+++ b/synapseclient/models/protocols/docker_protocol.py
@@ -1,4 +1,5 @@
 """Protocol defining the synchronous interface for DockerRepository operations."""
+
 from typing import TYPE_CHECKING, Optional, Protocol
 
 from synapseclient import Synapse

--- a/synapseclient/models/recordset.py
+++ b/synapseclient/models/recordset.py
@@ -1031,19 +1031,23 @@ class RecordSet(RecordSetSynchronousProtocol, AccessControllable, BaseJSONSchema
             "isLatestVersion": self.is_latest_version,
             "dataFileHandleId": self.data_file_handle_id,
             "upsertKey": self.upsert_keys,
-            "csvDescriptor": self.csv_descriptor.to_synapse_request()
-            if self.csv_descriptor
-            else None,
-            "validationSummary": {
-                "containerId": self.validation_summary.container_id,
-                "totalNumberOfChildren": self.validation_summary.total_number_of_children,
-                "numberOfValidChildren": self.validation_summary.number_of_valid_children,
-                "numberOfInvalidChildren": self.validation_summary.number_of_invalid_children,
-                "numberOfUnknownChildren": self.validation_summary.number_of_unknown_children,
-                "generatedOn": self.validation_summary.generated_on,
-            }
-            if self.validation_summary
-            else None,
+            "csvDescriptor": (
+                self.csv_descriptor.to_synapse_request()
+                if self.csv_descriptor
+                else None
+            ),
+            "validationSummary": (
+                {
+                    "containerId": self.validation_summary.container_id,
+                    "totalNumberOfChildren": self.validation_summary.total_number_of_children,
+                    "numberOfValidChildren": self.validation_summary.number_of_valid_children,
+                    "numberOfInvalidChildren": self.validation_summary.number_of_invalid_children,
+                    "numberOfUnknownChildren": self.validation_summary.number_of_unknown_children,
+                    "generatedOn": self.validation_summary.generated_on,
+                }
+                if self.validation_summary
+                else None
+            ),
             "fileNameOverride": self.file_name_override,
         }
         delete_none_keys(entity)
@@ -1280,9 +1284,11 @@ class RecordSet(RecordSetSynchronousProtocol, AccessControllable, BaseJSONSchema
             if_collision=self.if_collision,
             limit_search=self.synapse_container_limit or self.parent_id,
             download_file=self.download_file,
-            download_location=os.path.dirname(self.path)
-            if self.path and os.path.isfile(self.path)
-            else self.path,
+            download_location=(
+                os.path.dirname(self.path)
+                if self.path and os.path.isfile(self.path)
+                else self.path
+            ),
             md5=self.content_md5,
             synapse_client=syn,
         )

--- a/synapseclient/models/schema_organization.py
+++ b/synapseclient/models/schema_organization.py
@@ -1228,7 +1228,7 @@ class JSONSchema(JSONSchemaProtocol):
 
     @staticmethod
     def _create_json_schema_version_from_response(
-        response: dict[str, Any]
+        response: dict[str, Any],
     ) -> JSONSchemaVersionInfo:
         """
         Creates a JSONSchemaVersionInfo object from a Synapse API response
@@ -1370,7 +1370,7 @@ class CreateSchemaRequest(AsynchronousCommunicator):
 
     @staticmethod
     def _create_json_schema_version_from_response(
-        response: dict[str, Any]
+        response: dict[str, Any],
     ) -> JSONSchemaVersionInfo:
         """
         Creates a JSONSchemaVersionInfo object from a Synapse API response

--- a/synapseutils/migrate_functions.py
+++ b/synapseutils/migrate_functions.py
@@ -348,8 +348,7 @@ def _ensure_schema(cursor):
     # our representation of migratable file handles is flat including both file entities
     # and table attached files, so not all columns are applicable to both. row id and col id
     # are only used by table attached files, for example.
-    cursor.execute(
-        """
+    cursor.execute("""
             create table if not exists migrations (
                 id text not null,
                 type integer not null,
@@ -368,8 +367,7 @@ def _ensure_schema(cursor):
 
                 primary key (id, type, row_id, col_id, version)
             )
-        """
-    )
+        """)
 
     # we get counts grouping on status
     cursor.execute("create index if not exists ix_status on migrations(status)")

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -1056,12 +1056,12 @@ async def readManifestFile_async(syn: Synapse, manifestFile: str) -> DATA_FRAME_
     df = pd.read_csv(manifestFile, sep="\t")
     if "synapseStore" not in df:
         df = df.assign(synapseStore=None)
-    df.loc[
-        df["path"].apply(is_url), "synapseStore"
-    ] = False  # override synapseStore values to False when path is a url
-    df.loc[
-        df["synapseStore"].isnull(), "synapseStore"
-    ] = True  # remaining unset values default to True
+    df.loc[df["path"].apply(is_url), "synapseStore"] = (
+        False  # override synapseStore values to False when path is a url
+    )
+    df.loc[df["synapseStore"].isnull(), "synapseStore"] = (
+        True  # remaining unset values default to True
+    )
     df.synapseStore = df.synapseStore.astype(bool)
     df = df.fillna("")
 
@@ -1335,9 +1335,9 @@ def _build_annotations_for_file(
         if annotation_value is None or annotation_value == "":
             continue
         if isinstance(annotation_value, str):
-            file_annotations[
-                annotation_key
-            ] = _convert_cell_in_manifest_to_python_types(cell=annotation_value)
+            file_annotations[annotation_key] = (
+                _convert_cell_in_manifest_to_python_types(cell=annotation_value)
+            )
         else:
             file_annotations[annotation_key] = annotation_value
     return file_annotations

--- a/tests/integration/synapseclient/core/test_external_storage.py
+++ b/tests/integration/synapseclient/core/test_external_storage.py
@@ -423,12 +423,15 @@ class TestExernalStorage:
         ) = await self._configure_storage_location(external_object_store=True)
 
         try:
-            with mock.patch(
-                "synapseclient.core.upload.upload_functions_async._get_aws_credentials",
-                return_value=get_aws_env()[1],
-            ), mock.patch(
-                "synapseclient.core.download.download_functions._get_aws_credentials",
-                return_value=get_aws_env()[1],
+            with (
+                mock.patch(
+                    "synapseclient.core.upload.upload_functions_async._get_aws_credentials",
+                    return_value=get_aws_env()[1],
+                ),
+                mock.patch(
+                    "synapseclient.core.download.download_functions._get_aws_credentials",
+                    return_value=get_aws_env()[1],
+                ),
             ):
                 # WHEN we save a file to that location
                 upload_file = utils.make_bogus_uuid_file()

--- a/tests/integration/synapseclient/core/upload/test_multipart_upload.py
+++ b/tests/integration/synapseclient/core/upload/test_multipart_upload.py
@@ -31,7 +31,7 @@ async def test_round_trip(syn: Synapse, project: Project, schedule_for_cleanup):
         # Download the file and compare it with the original
         junk = File(parent=project, dataFileHandleId=fhid)
         junk.properties.update(syn._createEntity(junk.properties))
-        (_, tmp_path) = tempfile.mkstemp()
+        _, tmp_path = tempfile.mkstemp()
         schedule_for_cleanup(tmp_path)
 
         junk["path"] = await download_by_file_handle(
@@ -107,7 +107,7 @@ async def test_randomly_failing_parts(
             # Download the file and compare it with the original
             junk = File(parent=project, dataFileHandleId=fhid)
             junk.properties.update(syn._createEntity(junk.properties))
-            (tmp_f, tmp_path) = tempfile.mkstemp()
+            tmp_f, tmp_path = tempfile.mkstemp()
             schedule_for_cleanup(tmp_path)
 
             junk["path"] = await download_by_file_handle(
@@ -181,7 +181,7 @@ async def test_multipart_upload_big_string(
     # Download the file and compare it with the original
     junk = File(parent=project, dataFileHandleId=fhid)
     junk.properties.update(syn._createEntity(junk.properties))
-    (_, tmp_path) = tempfile.mkstemp()
+    _, tmp_path = tempfile.mkstemp()
     schedule_for_cleanup(tmp_path)
 
     junk["path"] = await download_by_file_handle(

--- a/tests/integration/synapseclient/core/upload/test_multipart_upload_async.py
+++ b/tests/integration/synapseclient/core/upload/test_multipart_upload_async.py
@@ -41,7 +41,7 @@ async def test_round_trip(
             parent_id=project_model.id, data_file_handle_id=file_handle_id
         ).store_async(synapse_client=syn)
 
-        (_, tmp_path) = tempfile.mkstemp()
+        _, tmp_path = tempfile.mkstemp()
         schedule_for_cleanup(tmp_path)
 
         # AND I download the file from Synapse
@@ -128,7 +128,7 @@ async def test_randomly_failing_parts(
                 parent_id=project_model.id, data_file_handle_id=file_handle_id
             ).store_async(synapse_client=syn)
 
-            (_, tmp_path) = tempfile.mkstemp()
+            _, tmp_path = tempfile.mkstemp()
             schedule_for_cleanup(tmp_path)
 
             # AND I download the file from Synapse
@@ -215,7 +215,7 @@ async def test_multipart_upload_big_string(
         parent_id=project_model.id, data_file_handle_id=file_handle_id
     ).store_async(synapse_client=syn)
 
-    (_, tmp_path) = tempfile.mkstemp()
+    _, tmp_path = tempfile.mkstemp()
     schedule_for_cleanup(tmp_path)
 
     # AND I download the file from Synapse

--- a/tests/integration/synapseclient/extensions/curator/test_schema_management.py
+++ b/tests/integration/synapseclient/extensions/curator/test_schema_management.py
@@ -1,4 +1,5 @@
 """Integration tests for schema management wrapper functions (register and bind)"""
+
 import json
 import os
 import tempfile

--- a/tests/integration/synapseclient/integration_test.py
+++ b/tests/integration/synapseclient/integration_test.py
@@ -360,17 +360,13 @@ def test_provenance(syn, project, schedule_for_cleanup):
     # Create a File Entity of Code
     fd, path = tempfile.mkstemp(suffix=".py")
     with os.fdopen(fd, "w") as f:
-        f.write(
-            utils.normalize_lines(
-                """
+        f.write(utils.normalize_lines("""
             ## Chris's fabulous random data generator
             ############################################################
             import random
             random.seed(12345)
             data = [random.gauss(mu=0.0, sigma=1.0) for i in range(100)]
-            """
-            )
-        )
+            """))
     schedule_for_cleanup(path)
     code_entity = syn.store(File(path, parent=project["id"]))
 

--- a/tests/integration/synapseclient/models/async/test_form_async.py
+++ b/tests/integration/synapseclient/models/async/test_form_async.py
@@ -1,6 +1,7 @@
 """
 Integration tests for the synapseclient.models.Form class.
 """
+
 import tempfile
 import uuid
 from typing import Callable

--- a/tests/integration/synapseclient/models/async/test_schema_organization_async.py
+++ b/tests/integration/synapseclient/models/async/test_schema_organization_async.py
@@ -1,4 +1,5 @@
 """Integration tests for SchemaOrganization and JSONSchema classes"""
+
 import asyncio
 import uuid
 from typing import Any, Optional

--- a/tests/integration/synapseclient/models/async/test_submission_bundle_async.py
+++ b/tests/integration/synapseclient/models/async/test_submission_bundle_async.py
@@ -184,7 +184,9 @@ class TestSubmissionBundleRetrievalAsync:
         # WHEN I attempt to get submission bundles with an invalid status
         with pytest.raises(SynapseHTTPError) as exc_info:
             bundles = []
-            async for bundle in SubmissionBundle.get_evaluation_submission_bundles_async(
+            async for (
+                bundle
+            ) in SubmissionBundle.get_evaluation_submission_bundles_async(
                 evaluation_id=test_evaluation.id,
                 status="NONEXISTENT_STATUS",
                 synapse_client=self.syn,
@@ -233,7 +235,9 @@ class TestSubmissionBundleRetrievalAsync:
         # WHEN I try to get submission bundles for a non-existent evaluation
         with pytest.raises(SynapseHTTPError) as exc_info:
             bundles = []
-            async for bundle in SubmissionBundle.get_evaluation_submission_bundles_async(
+            async for (
+                bundle
+            ) in SubmissionBundle.get_evaluation_submission_bundles_async(
                 evaluation_id="syn999999999999",
                 synapse_client=self.syn,
             ):

--- a/tests/integration/synapseclient/operations/async/test_delete_operations_async.py
+++ b/tests/integration/synapseclient/operations/async/test_delete_operations_async.py
@@ -1,4 +1,5 @@
 """Integration tests for delete operations async."""
+
 import uuid
 from typing import Callable
 

--- a/tests/integration/synapseclient/operations/async/test_utility_operations_async.py
+++ b/tests/integration/synapseclient/operations/async/test_utility_operations_async.py
@@ -1,4 +1,5 @@
 """Integration tests for utility operations asynchronous."""
+
 import uuid
 from typing import Callable
 

--- a/tests/integration/synapseclient/test_command_line_client.py
+++ b/tests/integration/synapseclient/test_command_line_client.py
@@ -1,4 +1,5 @@
 """Integration tests for the CLI."""
+
 import filecmp
 import json
 import logging
@@ -932,11 +933,14 @@ def test_login(test_state):
     alt_syn = Synapse(cache_client=False)
     username = "username"
     auth_token = "my_auth_token"
-    with patch.object(alt_syn, "login") as mock_login, patch.object(
-        alt_syn,
-        "getUserProfile",
-        return_value={"userName": "test_user", "ownerId": "ownerId"},
-    ) as mock_get_user_profile:
+    with (
+        patch.object(alt_syn, "login") as mock_login,
+        patch.object(
+            alt_syn,
+            "getUserProfile",
+            return_value={"userName": "test_user", "ownerId": "ownerId"},
+        ) as mock_get_user_profile,
+    ):
         run(
             test_state,
             "synapse" "--skip-checks",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Coroutine
 
 
 def spy_for_async_function(
-    original_func: Callable[..., Any]
+    original_func: Callable[..., Any],
 ) -> Callable[..., Coroutine[Any, Any, Any]]:
     """This function is used to create a spy for async functions."""
 

--- a/tests/unit/synapseclient/api/unit_test_entity_services.py
+++ b/tests/unit/synapseclient/api/unit_test_entity_services.py
@@ -1,4 +1,5 @@
 """Unit tests for entity_services utility functions."""
+
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/unit/synapseclient/api/unit_test_web_services.py
+++ b/tests/unit/synapseclient/api/unit_test_web_services.py
@@ -1,4 +1,5 @@
 """Unit tests for web_services functions."""
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import synapseclient.api.web_services as web_services

--- a/tests/unit/synapseclient/core/credentials/unit_test_cred_provider.py
+++ b/tests/unit/synapseclient/core/credentials/unit_test_cred_provider.py
@@ -117,11 +117,14 @@ class TestSynapseCredentialProvider(object):
 
     def test_get_synapse_credentials(self) -> None:
         auth_info = ("username", "auth_token")
-        with patch.object(
-            self.provider, "_get_auth_info", return_value=auth_info
-        ) as mock_get_auth_info, patch.object(
-            self.provider, "_create_synapse_credential"
-        ) as mock_create_synapse_credentials:
+        with (
+            patch.object(
+                self.provider, "_get_auth_info", return_value=auth_info
+            ) as mock_get_auth_info,
+            patch.object(
+                self.provider, "_create_synapse_credential"
+            ) as mock_create_synapse_credentials,
+        ):
             self.provider.get_synapse_credentials(self.syn, self.user_login_args)
 
             mock_get_auth_info.assert_called_once_with(

--- a/tests/unit/synapseclient/core/download/unit_test_download_async.py
+++ b/tests/unit/synapseclient/core/download/unit_test_download_async.py
@@ -32,11 +32,14 @@ class TestPresignedUrlProvider:
             expiration_utc=utc_now + datetime.timedelta(seconds=6),
         )
 
-        with mock.patch.object(
-            PresignedUrlProvider, "_get_pre_signed_info", return_value=info
-        ) as mock_get_presigned_info, mock.patch.object(
-            download_async, "datetime", wraps=datetime
-        ) as mock_datetime:
+        with (
+            mock.patch.object(
+                PresignedUrlProvider, "_get_pre_signed_info", return_value=info
+            ) as mock_get_presigned_info,
+            mock.patch.object(
+                download_async, "datetime", wraps=datetime
+            ) as mock_datetime,
+        ):
             mock_datetime.datetime.now.return_value = utc_now
 
             presigned_url_provider = PresignedUrlProvider(
@@ -64,16 +67,19 @@ class TestPresignedUrlProvider:
             expiration_utc=unexpired_date,
         )
 
-        with mock.patch.object(
-            PresignedUrlProvider,
-            "_get_pre_signed_info",
-            side_effect=[unexpired_info],
-        ) as mock_get_presigned_info, mock.patch(
-            "synapseclient.core.download.download_async.get_file_handle_for_download",
-            return_value={
-                "fileHandle": {"fileName": "myFile.txt"},
-                "preSignedURL": f"https://synapse.org?X-Amz-Date={unexpired_date.strftime('%Y%m%dT%H%M%SZ')}&X-Amz-Expires=5&X-Amz-Signature=123456",
-            },
+        with (
+            mock.patch.object(
+                PresignedUrlProvider,
+                "_get_pre_signed_info",
+                side_effect=[unexpired_info],
+            ) as mock_get_presigned_info,
+            mock.patch(
+                "synapseclient.core.download.download_async.get_file_handle_for_download",
+                return_value={
+                    "fileHandle": {"fileName": "myFile.txt"},
+                    "preSignedURL": f"https://synapse.org?X-Amz-Date={unexpired_date.strftime('%Y%m%dT%H%M%SZ')}&X-Amz-Expires=5&X-Amz-Signature=123456",
+                },
+            ),
         ):
             presigned_url_provider = PresignedUrlProvider(
                 self.mock_synapse_client, request=self.download_request
@@ -89,17 +95,20 @@ class TestPresignedUrlProvider:
         fake_url = "https://synapse.org/foo.txt"
         fake_file_name = "foo.txt"
 
-        with mock.patch.object(
-            download_async,
-            "_pre_signed_url_expiration_time",
-            return_value=fake_exp_time,
-        ) as mock_pre_signed_url_expiration_time, mock.patch(
-            "synapseclient.core.download.download_async.get_file_handle_for_download",
-            return_value={
-                "fileHandle": {"fileName": "myFile.txt"},
-                "preSignedURL": f"https://synapse.org?X-Amz-Date={fake_exp_time.strftime('%Y%m%dT%H%M%SZ')}&X-Amz-Expires=5&X-Amz-Signature=123456",
-            },
-        ) as mock_file_handle_download:
+        with (
+            mock.patch.object(
+                download_async,
+                "_pre_signed_url_expiration_time",
+                return_value=fake_exp_time,
+            ) as mock_pre_signed_url_expiration_time,
+            mock.patch(
+                "synapseclient.core.download.download_async.get_file_handle_for_download",
+                return_value={
+                    "fileHandle": {"fileName": "myFile.txt"},
+                    "preSignedURL": f"https://synapse.org?X-Amz-Date={fake_exp_time.strftime('%Y%m%dT%H%M%SZ')}&X-Amz-Expires=5&X-Amz-Signature=123456",
+                },
+            ) as mock_file_handle_download,
+        ):
             fake_file_handle_response = {
                 "fileHandle": {"fileName": fake_file_name},
                 "preSignedURL": fake_url,

--- a/tests/unit/synapseclient/core/multithread_download/unit_test_download_threads.py
+++ b/tests/unit/synapseclient/core/multithread_download/unit_test_download_threads.py
@@ -37,11 +37,14 @@ class TestPresignedUrlProvider(object):
             expiration_utc=utc_now + datetime.timedelta(seconds=6),
         )
 
-        with mock.patch.object(
-            PresignedUrlProvider, "_get_pre_signed_info", return_value=info
-        ) as mock_get_presigned_info, mock.patch.object(
-            download_threads, "datetime", wraps=datetime
-        ) as mock_datetime:
+        with (
+            mock.patch.object(
+                PresignedUrlProvider, "_get_pre_signed_info", return_value=info
+            ) as mock_get_presigned_info,
+            mock.patch.object(
+                download_threads, "datetime", wraps=datetime
+            ) as mock_datetime,
+        ):
             mock_datetime.datetime.utcnow.return_value = utc_now
 
             presigned_url_provider = PresignedUrlProvider(
@@ -68,13 +71,14 @@ class TestPresignedUrlProvider(object):
             expiration_utc=utc_now + datetime.timedelta(seconds=6),
         )
 
-        with mock.patch.object(
-            PresignedUrlProvider,
-            "_get_pre_signed_info",
-            side_effect=[expired_info, unexpired_info],
-        ) as mock_get_presigned_info, mock.patch.object(
-            download_threads, "datetime"
-        ) as mock_datetime:
+        with (
+            mock.patch.object(
+                PresignedUrlProvider,
+                "_get_pre_signed_info",
+                side_effect=[expired_info, unexpired_info],
+            ) as mock_get_presigned_info,
+            mock.patch.object(download_threads, "datetime") as mock_datetime,
+        ):
             mock_datetime.datetime.utcnow.return_value = utc_now
 
             presigned_url_provider = PresignedUrlProvider(
@@ -235,25 +239,29 @@ class MultithreadedDownloaderTests(TestCase):
         file_size = int(1.5 * (2**20))
         request = DownloadRequest(file_handle_id, object_id, None, path)
 
-        with mock.patch.object(
-            download_threads, "PresignedUrlProvider"
-        ) as mock_url_provider_init, mock.patch.object(
-            download_threads, "TransferStatus"
-        ) as mock_transfer_status_init, mock.patch.object(
-            download_threads, "_get_file_size"
-        ) as mock_get_file_size, mock.patch.object(
-            download_threads, "_generate_chunk_ranges"
-        ) as mock_generate_chunk_ranges, mock.patch.object(
-            _MultithreadedDownloader, "_prep_file"
-        ) as mock_prep_file, mock.patch.object(
-            _MultithreadedDownloader, "_submit_chunks"
-        ) as mock_submit_chunks, mock.patch.object(
-            _MultithreadedDownloader, "_write_chunks"
-        ) as mock_write_chunks, mock.patch(
-            "concurrent.futures.wait"
-        ) as mock_futures_wait, mock.patch.object(
-            _MultithreadedDownloader, "_check_for_errors"
-        ) as mock_check_for_errors:
+        with (
+            mock.patch.object(
+                download_threads, "PresignedUrlProvider"
+            ) as mock_url_provider_init,
+            mock.patch.object(
+                download_threads, "TransferStatus"
+            ) as mock_transfer_status_init,
+            mock.patch.object(download_threads, "_get_file_size") as mock_get_file_size,
+            mock.patch.object(
+                download_threads, "_generate_chunk_ranges"
+            ) as mock_generate_chunk_ranges,
+            mock.patch.object(_MultithreadedDownloader, "_prep_file") as mock_prep_file,
+            mock.patch.object(
+                _MultithreadedDownloader, "_submit_chunks"
+            ) as mock_submit_chunks,
+            mock.patch.object(
+                _MultithreadedDownloader, "_write_chunks"
+            ) as mock_write_chunks,
+            mock.patch("concurrent.futures.wait") as mock_futures_wait,
+            mock.patch.object(
+                _MultithreadedDownloader, "_check_for_errors"
+            ) as mock_check_for_errors,
+        ):
             mock_url_info = mock.create_autospec(PresignedUrlInfo, url=url)
             mock_url_provider = mock.create_autospec(PresignedUrlProvider)
             mock_url_provider.get_info.return_value = mock_url_info
@@ -340,25 +348,25 @@ class MultithreadedDownloaderTests(TestCase):
         file_size = int(1.5 * (2**20))
         request = DownloadRequest(file_handle_id, entity_id, None, path)
 
-        with mock.patch.object(
-            download_threads, "PresignedUrlProvider"
-        ) as mock_url_provider_init, mock.patch.object(
-            download_threads, "TransferStatus"
-        ) as mock_transfer_status_init, mock.patch.object(
-            download_threads, "_get_file_size"
-        ) as mock_get_file_size, mock.patch.object(
-            download_threads, "_generate_chunk_ranges"
-        ) as mock_generate_chunk_ranges, mock.patch.object(
-            download_threads, "os"
-        ) as mock_os, mock.patch.object(
-            _MultithreadedDownloader, "_prep_file"
-        ), mock.patch.object(
-            _MultithreadedDownloader, "_submit_chunks"
-        ) as mock_submit_chunks, mock.patch.object(
-            _MultithreadedDownloader, "_write_chunks"
-        ), mock.patch(
-            "concurrent.futures.wait"
-        ) as mock_futures_wait:
+        with (
+            mock.patch.object(
+                download_threads, "PresignedUrlProvider"
+            ) as mock_url_provider_init,
+            mock.patch.object(
+                download_threads, "TransferStatus"
+            ) as mock_transfer_status_init,
+            mock.patch.object(download_threads, "_get_file_size") as mock_get_file_size,
+            mock.patch.object(
+                download_threads, "_generate_chunk_ranges"
+            ) as mock_generate_chunk_ranges,
+            mock.patch.object(download_threads, "os") as mock_os,
+            mock.patch.object(_MultithreadedDownloader, "_prep_file"),
+            mock.patch.object(
+                _MultithreadedDownloader, "_submit_chunks"
+            ) as mock_submit_chunks,
+            mock.patch.object(_MultithreadedDownloader, "_write_chunks"),
+            mock.patch("concurrent.futures.wait") as mock_futures_wait,
+        ):
             mock_url_info = mock.create_autospec(PresignedUrlInfo, url=url)
             mock_url_provider = mock.create_autospec(PresignedUrlProvider)
             mock_url_provider.get_info.return_value = mock_url_info
@@ -412,11 +420,14 @@ class MultithreadedDownloaderTests(TestCase):
         request = DownloadRequest(file_handle_id, entity_id, None, path)
 
         # AND A mocked session
-        with mock.patch.object(
-            download_threads, "_get_new_session"
-        ) as mock_get_new_session, mock.patch.object(
-            download_threads, "PresignedUrlProvider"
-        ) as mock_url_provider_init:
+        with (
+            mock.patch.object(
+                download_threads, "_get_new_session"
+            ) as mock_get_new_session,
+            mock.patch.object(
+                download_threads, "PresignedUrlProvider"
+            ) as mock_url_provider_init,
+        ):
             mock_url_info = mock.create_autospec(PresignedUrlInfo, url=url)
             mock_url_provider = mock.create_autospec(PresignedUrlProvider)
             mock_url_provider.get_info.return_value = mock_url_info

--- a/tests/unit/synapseclient/core/unit_test_Cache.py
+++ b/tests/unit/synapseclient/core/unit_test_Cache.py
@@ -121,11 +121,10 @@ def test_subsecond_timestamps():
 
     my_cache.add(file_handle_id=1234, path=path)
 
-    with patch.object(
-        cache, "_get_modified_time"
-    ) as _get_modified_time_mock, patch.object(
-        cache.Cache, "_read_cache_map"
-    ) as _read_cache_map_mock:
+    with (
+        patch.object(cache, "_get_modified_time") as _get_modified_time_mock,
+        patch.object(cache.Cache, "_read_cache_map") as _read_cache_map_mock,
+    ):
         # this should be a match, 'cause we round microseconds to milliseconds
         _read_cache_map_mock.return_value = {path: "2015-05-05T21:34:55.001Z"}
         _get_modified_time_mock.return_value = 1430861695.001111

--- a/tests/unit/synapseclient/core/unit_test_doze.py
+++ b/tests/unit/synapseclient/core/unit_test_doze.py
@@ -3,6 +3,7 @@ Created on Sep 21, 2017
 
 @author: bhoff
 """
+
 import synapseclient.core.dozer as doze
 
 

--- a/tests/unit/synapseclient/core/unit_test_remote_storage_file_wrappers.py
+++ b/tests/unit/synapseclient/core/unit_test_remote_storage_file_wrappers.py
@@ -33,13 +33,13 @@ class TestS3ClientWrapper:
         endpoint_url = "http://foo.s3.amazon.com"
         show_progress = kwargs.pop("show_progress", True)
 
-        with mock.patch(
-            "boto3.session.Session"
-        ) as mock_boto_session, mock.patch.object(
-            S3ClientWrapper, "_create_progress_callback_func"
-        ) as mock_create_progress_callback, mock.patch(
-            "boto3.s3.transfer.TransferConfig"
-        ) as mock_TransferConfig:
+        with (
+            mock.patch("boto3.session.Session") as mock_boto_session,
+            mock.patch.object(
+                S3ClientWrapper, "_create_progress_callback_func"
+            ) as mock_create_progress_callback,
+            mock.patch("boto3.s3.transfer.TransferConfig") as mock_TransferConfig,
+        ):
             # Create a mock object for s3.Object with content_length set to an integer
             mock_s3_object = mock.Mock(content_length=1234)
             # Make resource().Object return the mock object
@@ -162,15 +162,14 @@ class TestS3ClientWrapper:
         upload_file_path = "/tmp/upload_file"
         endpoint_url = "http://foo.s3.amazon.com"
 
-        with mock.patch(
-            "boto3.session.Session"
-        ) as mock_boto_session, mock.patch.object(
-            S3ClientWrapper, "_create_progress_callback_func"
-        ) as mock_create_progress_callback, mock.patch(
-            "boto3.s3.transfer.TransferConfig"
-        ) as mock_TransferConfig, mock.patch.object(
-            remote_file_storage_wrappers, "os"
-        ) as mock_os:
+        with (
+            mock.patch("boto3.session.Session") as mock_boto_session,
+            mock.patch.object(
+                S3ClientWrapper, "_create_progress_callback_func"
+            ) as mock_create_progress_callback,
+            mock.patch("boto3.s3.transfer.TransferConfig") as mock_TransferConfig,
+            mock.patch.object(remote_file_storage_wrappers, "os") as mock_os,
+        ):
             mock_os.stat.return_value = mock.Mock(st_size=1234)
             returned_upload_path = S3ClientWrapper.upload_file(
                 bucket_name, endpoint_url, remote_file_key, upload_file_path, **kwargs

--- a/tests/unit/synapseclient/core/unit_test_sts_transfer.py
+++ b/tests/unit/synapseclient/core/unit_test_sts_transfer.py
@@ -75,12 +75,14 @@ class TestGetStsCredentials:
                 )
             ),
             _getDefaultUploadDestination=mock.Mock(
-                return_value=upload_destination
-                if upload_destination is not None
-                else {
-                    "bucket": "bucket1",
-                    "baseKey": "key1",
-                }
+                return_value=(
+                    upload_destination
+                    if upload_destination is not None
+                    else {
+                        "bucket": "bucket1",
+                        "baseKey": "key1",
+                    }
+                )
             ),
         )
 

--- a/tests/unit/synapseclient/core/unit_test_version_check.py
+++ b/tests/unit/synapseclient/core/unit_test_version_check.py
@@ -1,6 +1,5 @@
 """Unit tests for version check functions"""
 
-
 from unittest.mock import patch
 
 import pytest

--- a/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
+++ b/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
@@ -307,14 +307,11 @@ class TestUploadAttempt:
 
         md5_hex = md5_fn(chunk, None)
 
-        with mock.patch.object(
-            multipart_upload, "get_file_chunk"
-        ) as chunk_fn, mock.patch.object(
-            upload, "_get_thread_session"
-        ) as get_session, mock.patch.object(
-            upload, "_refresh_pre_signed_part_urls"
-        ) as refresh_urls, mock.patch.object(
-            syn, "restPUT"
+        with (
+            mock.patch.object(multipart_upload, "get_file_chunk") as chunk_fn,
+            mock.patch.object(upload, "_get_thread_session") as get_session,
+            mock.patch.object(upload, "_refresh_pre_signed_part_urls") as refresh_urls,
+            mock.patch.object(syn, "restPUT"),
         ):
             get_session.return_value = mock_session
             chunk_fn.return_value = chunk
@@ -440,13 +437,11 @@ class TestUploadAttempt:
         upload._pre_signed_part_urls = {part_number: (pre_signed_url_1, signed_headers)}
         mock_session = mock.Mock()
 
-        with mock.patch.object(
-            multipart_upload, "get_file_chunk"
-        ) as chunk_fn, mock.patch.object(
-            upload, "_get_thread_session"
-        ) as get_session, mock.patch.object(
-            upload, "_refresh_pre_signed_part_urls"
-        ) as refresh_urls:
+        with (
+            mock.patch.object(multipart_upload, "get_file_chunk") as chunk_fn,
+            mock.patch.object(upload, "_get_thread_session") as get_session,
+            mock.patch.object(upload, "_refresh_pre_signed_part_urls") as refresh_urls,
+        ):
             get_session.return_value = mock_session
             chunk_fn.return_value = chunk
             refresh_urls.side_effect = [
@@ -490,17 +485,17 @@ class TestUploadAttempt:
             future.set_result((i, upload._part_size))
             futures.append(future)
 
-        with mock.patch.object(
-            upload, "_create_synapse_upload"
-        ) as create_synapse_upload, mock.patch.object(
-            upload, "_fetch_pre_signed_part_urls"
-        ) as fetch_pre_signed_urls, mock.patch.object(
-            pool_provider, "get_executor"
-        ) as get_executor, mock.patch.object(
-            upload, "_get_thread_session"
-        ) as get_session, mock.patch.object(
-            syn, "restPUT"
-        ) as restPUT:
+        with (
+            mock.patch.object(
+                upload, "_create_synapse_upload"
+            ) as create_synapse_upload,
+            mock.patch.object(
+                upload, "_fetch_pre_signed_part_urls"
+            ) as fetch_pre_signed_urls,
+            mock.patch.object(pool_provider, "get_executor") as get_executor,
+            mock.patch.object(upload, "_get_thread_session") as get_session,
+            mock.patch.object(syn, "restPUT") as restPUT,
+        ):
             mock_session = mock.Mock()
             get_session.return_value = mock_session
 
@@ -539,13 +534,15 @@ class TestUploadAttempt:
         future = Future()
         future.set_exception(part_exception())
 
-        with mock.patch.object(
-            upload, "_create_synapse_upload"
-        ) as create_synapse_upload, mock.patch.object(
-            upload, "_fetch_pre_signed_part_urls"
-        ) as fetch_pre_signed_urls, mock.patch.object(
-            pool_provider, "get_executor"
-        ) as get_executor:
+        with (
+            mock.patch.object(
+                upload, "_create_synapse_upload"
+            ) as create_synapse_upload,
+            mock.patch.object(
+                upload, "_fetch_pre_signed_part_urls"
+            ) as fetch_pre_signed_urls,
+            mock.patch.object(pool_provider, "get_executor") as get_executor,
+        ):
             create_synapse_upload.return_value = upload_status
             fetch_pre_signed_urls.return_value = pre_signed_urls
 
@@ -585,13 +582,15 @@ class TestUploadAttempt:
             "state": "COMPLETED",
         }
 
-        with mock.patch.object(
-            upload, "_create_synapse_upload"
-        ) as create_synapse_upload, mock.patch.object(
-            upload, "_fetch_pre_signed_part_urls"
-        ) as fetch_pre_signed_urls, mock.patch.object(
-            pool_provider, "get_executor"
-        ) as get_executor:
+        with (
+            mock.patch.object(
+                upload, "_create_synapse_upload"
+            ) as create_synapse_upload,
+            mock.patch.object(
+                upload, "_fetch_pre_signed_part_urls"
+            ) as fetch_pre_signed_urls,
+            mock.patch.object(pool_provider, "get_executor") as get_executor,
+        ):
             create_synapse_upload.return_value = upload_status_response
 
             upload_result = upload()
@@ -622,15 +621,16 @@ class TestUploadAttempt:
             "state": "COMPLETED",
         }
 
-        with mock.patch.object(
-            upload, "_create_synapse_upload"
-        ) as create_synapse_upload, mock.patch.object(
-            upload, "_fetch_pre_signed_part_urls"
-        ) as fetch_pre_signed_urls, mock.patch.object(
-            pool_provider, "get_executor"
-        ) as get_executor, mock.patch.object(
-            upload._syn, "restPUT"
-        ) as restPUT:
+        with (
+            mock.patch.object(
+                upload, "_create_synapse_upload"
+            ) as create_synapse_upload,
+            mock.patch.object(
+                upload, "_fetch_pre_signed_part_urls"
+            ) as fetch_pre_signed_urls,
+            mock.patch.object(pool_provider, "get_executor") as get_executor,
+            mock.patch.object(upload._syn, "restPUT") as restPUT,
+        ):
             create_synapse_upload.return_value = create_status_response
             restPUT.return_value = complete_status_response
 
@@ -664,17 +664,19 @@ class TestMultipartUpload:
         md5_hex = "abc123"
         storage_location_id = 5432
 
-        with mock.patch("os.path.exists") as os_path_exists, mock.patch(
-            "os.path.isdir"
-        ) as os_path_is_dir, mock.patch(
-            "os.path.getsize"
-        ) as os_path_getsize, mock.patch.object(
-            multipart_upload,
-            "md5_for_file",
-        ) as md5_for_file, mock.patch.object(
-            multipart_upload,
-            "_multipart_upload",
-        ) as mock_multipart_upload:
+        with (
+            mock.patch("os.path.exists") as os_path_exists,
+            mock.patch("os.path.isdir") as os_path_is_dir,
+            mock.patch("os.path.getsize") as os_path_getsize,
+            mock.patch.object(
+                multipart_upload,
+                "md5_for_file",
+            ) as md5_for_file,
+            mock.patch.object(
+                multipart_upload,
+                "_multipart_upload",
+            ) as mock_multipart_upload,
+        ):
             os_path_getsize.return_value = file_size
             md5_for_file.return_value.hexdigest.return_value = md5_hex
 

--- a/tests/unit/synapseclient/extensions/test_schema_management.py
+++ b/tests/unit/synapseclient/extensions/test_schema_management.py
@@ -33,9 +33,11 @@ async def test_register_jsonschema_async(mock_synapse_client, mock_jsonschema):
 
     m_open = mock_open(read_data=json.dumps(schema_content))
 
-    with patch("builtins.open", m_open), patch(
-        "synapseclient.Synapse.get_client", return_value=mock_synapse_client
-    ), patch("json.load", return_value=schema_content):
+    with (
+        patch("builtins.open", m_open),
+        patch("synapseclient.Synapse.get_client", return_value=mock_synapse_client),
+        patch("json.load", return_value=schema_content),
+    ):
         result = await register_jsonschema_async(
             schema_path=schema_path,
             organization_name=org_name,
@@ -71,9 +73,11 @@ async def test_register_jsonschema_async_fix_schema_name(
 
     m_open = mock_open(read_data=json.dumps(schema_content))
 
-    with patch("builtins.open", m_open), patch(
-        "synapseclient.Synapse.get_client", return_value=mock_synapse_client
-    ), patch("json.load", return_value=schema_content):
+    with (
+        patch("builtins.open", m_open),
+        patch("synapseclient.Synapse.get_client", return_value=mock_synapse_client),
+        patch("json.load", return_value=schema_content),
+    ):
         result = await register_jsonschema_async(
             schema_path=schema_path,
             organization_name=org_name,

--- a/tests/unit/synapseclient/extensions/unit_test_create_json_schema.py
+++ b/tests/unit/synapseclient/extensions/unit_test_create_json_schema.py
@@ -999,9 +999,10 @@ def test_create_json_schema_with_class_label(
         use_display_labels=False,
         logger=logger,
     )
-    with open(expected_path, encoding="utf-8") as file1, open(
-        test_path, encoding="utf-8"
-    ) as file2:
+    with (
+        open(expected_path, encoding="utf-8") as file1,
+        open(test_path, encoding="utf-8") as file2,
+    ):
         expected_json = json.load(file1)
         test_json = json.load(file2)
     assert expected_json == test_json
@@ -1029,9 +1030,10 @@ def test_create_json_schema_with_display_names(
         schema_path=test_path,
         logger=logger,
     )
-    with open(expected_path, encoding="utf-8") as file1, open(
-        test_path, encoding="utf-8"
-    ) as file2:
+    with (
+        open(expected_path, encoding="utf-8") as file1,
+        open(test_path, encoding="utf-8") as file2,
+    ):
         expected_json = json.load(file1)
         test_json = json.load(file2)
     assert expected_json == test_json
@@ -1074,9 +1076,10 @@ def test_create_json_schema_with_class_label_using_jsonld(
         use_display_labels=False,
         logger=logger,
     )
-    with open(expected_path, encoding="utf-8") as file1, open(
-        test_path, encoding="utf-8"
-    ) as file2:
+    with (
+        open(expected_path, encoding="utf-8") as file1,
+        open(test_path, encoding="utf-8") as file2,
+    ):
         expected_json = json.load(file1)
         test_json = json.load(file2)
     assert expected_json == test_json

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -381,14 +381,17 @@ class TestCurationTask:
             return
             yield  # pragma: no cover
 
-        with patch(
-            "synapseclient.models.curation.list_curation_tasks",
-            return_value=empty_list_gen(),
-        ), patch(
-            "synapseclient.models.curation.create_curation_task",
-            new_callable=AsyncMock,
-            return_value=_get_file_based_task_api_response(),
-        ) as mock_create:
+        with (
+            patch(
+                "synapseclient.models.curation.list_curation_tasks",
+                return_value=empty_list_gen(),
+            ),
+            patch(
+                "synapseclient.models.curation.create_curation_task",
+                new_callable=AsyncMock,
+                return_value=_get_file_based_task_api_response(),
+            ) as mock_create,
+        ):
             result = await task.store_async(synapse_client=self.syn)
 
             # THEN the create API should be called
@@ -446,18 +449,22 @@ class TestCurationTask:
             yield existing_response
 
         # WHEN I call store_async
-        with patch(
-            "synapseclient.models.curation.list_curation_tasks",
-            return_value=mock_list(),
-        ), patch(
-            "synapseclient.models.curation.get_curation_task",
-            new_callable=AsyncMock,
-            return_value=existing_response,
-        ), patch(
-            "synapseclient.models.curation.update_curation_task",
-            new_callable=AsyncMock,
-            return_value=existing_response,
-        ) as mock_update:
+        with (
+            patch(
+                "synapseclient.models.curation.list_curation_tasks",
+                return_value=mock_list(),
+            ),
+            patch(
+                "synapseclient.models.curation.get_curation_task",
+                new_callable=AsyncMock,
+                return_value=existing_response,
+            ),
+            patch(
+                "synapseclient.models.curation.update_curation_task",
+                new_callable=AsyncMock,
+                return_value=existing_response,
+            ) as mock_update,
+        ):
             result = await task.store_async(synapse_client=self.syn)
 
             # THEN it should have merged the existing task and done an update
@@ -664,15 +671,18 @@ class TestGrid:
 
         # WHEN I call create_async with attach_to_previous_session=True and no
         # existing sessions
-        with patch.object(
-            Grid,
-            "list_async",
-            return_value=mock_list_async(),
-        ), patch.object(
-            CreateGridRequest,
-            "send_job_and_wait_async",
-            new_callable=AsyncMock,
-            return_value=mock_create_request,
+        with (
+            patch.object(
+                Grid,
+                "list_async",
+                return_value=mock_list_async(),
+            ),
+            patch.object(
+                CreateGridRequest,
+                "send_job_and_wait_async",
+                new_callable=AsyncMock,
+                return_value=mock_create_request,
+            ),
         ):
             result = await grid.create_async(
                 attach_to_previous_session=True, synapse_client=self.syn

--- a/tests/unit/synapseclient/models/async/unit_test_docker_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_docker_async.py
@@ -197,15 +197,18 @@ class TestDockerRepository:
             # Separately set annotations to match real implementation
             entity_to_update.annotations = Annotations.from_dict(test_annotation)
 
-        with patch(
-            "synapseclient.models.docker.get_entity_id_by_repository_name",
-            new_callable=AsyncMock,
-            side_effect=mock_get_entity_id_by_repository_name,
-        ) as mocked_get_id, patch(
-            "synapseclient.models.docker.get_from_entity_factory",
-            new_callable=AsyncMock,
-            side_effect=mock_get_from_entity_factory,
-        ) as mocked_get_from_factory:
+        with (
+            patch(
+                "synapseclient.models.docker.get_entity_id_by_repository_name",
+                new_callable=AsyncMock,
+                side_effect=mock_get_entity_id_by_repository_name,
+            ) as mocked_get_id,
+            patch(
+                "synapseclient.models.docker.get_from_entity_factory",
+                new_callable=AsyncMock,
+                side_effect=mock_get_from_entity_factory,
+            ) as mocked_get_from_factory,
+        ):
             result = await docker.get_async(synapse_client=self.syn)
 
             # Verify repository name lookup was called

--- a/tests/unit/synapseclient/models/async/unit_test_evaluation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_evaluation_async.py
@@ -517,15 +517,18 @@ class TestEvaluationAsync:
         )
 
         # WHEN I call update_acl_async with a principal_id and access_type
-        with patch(
-            "synapseclient.api.evaluation_services.get_evaluation_acl",
-            new_callable=AsyncMock,
-            return_value=current_acl,
-        ) as mock_get_acl, patch(
-            "synapseclient.api.evaluation_services.update_evaluation_acl",
-            new_callable=AsyncMock,
-            return_value=updated_acl,
-        ) as mock_update_acl:
+        with (
+            patch(
+                "synapseclient.api.evaluation_services.get_evaluation_acl",
+                new_callable=AsyncMock,
+                return_value=current_acl,
+            ) as mock_get_acl,
+            patch(
+                "synapseclient.api.evaluation_services.update_evaluation_acl",
+                new_callable=AsyncMock,
+                return_value=updated_acl,
+            ) as mock_update_acl,
+        ):
             result = await evaluation.update_acl_async(
                 principal_id=PRINCIPAL_ID,
                 access_type=["READ", "SUBMIT"],
@@ -599,15 +602,18 @@ class TestEvaluationAsync:
         )
 
         # WHEN I call update_acl_async with a NEW principal_id
-        with patch(
-            "synapseclient.api.evaluation_services.get_evaluation_acl",
-            new_callable=AsyncMock,
-            return_value=current_acl,
-        ), patch(
-            "synapseclient.api.evaluation_services.update_evaluation_acl",
-            new_callable=AsyncMock,
-            return_value=expected_updated_acl,
-        ) as mock_update_acl:
+        with (
+            patch(
+                "synapseclient.api.evaluation_services.get_evaluation_acl",
+                new_callable=AsyncMock,
+                return_value=current_acl,
+            ),
+            patch(
+                "synapseclient.api.evaluation_services.update_evaluation_acl",
+                new_callable=AsyncMock,
+                return_value=expected_updated_acl,
+            ) as mock_update_acl,
+        ):
             result = await evaluation.update_acl_async(
                 principal_id=TEAM_PRINCIPAL_ID,
                 access_type=["READ", "SUBMIT"],
@@ -640,15 +646,18 @@ class TestEvaluationAsync:
         expected_updated_acl["resourceAccess"][0]["accessType"] = ["READ"]
 
         # WHEN I call update_acl_async to update the existing principal's permissions
-        with patch(
-            "synapseclient.api.evaluation_services.get_evaluation_acl",
-            new_callable=AsyncMock,
-            return_value=current_acl,
-        ), patch(
-            "synapseclient.api.evaluation_services.update_evaluation_acl",
-            new_callable=AsyncMock,
-            return_value=expected_updated_acl,
-        ) as mock_update_acl:
+        with (
+            patch(
+                "synapseclient.api.evaluation_services.get_evaluation_acl",
+                new_callable=AsyncMock,
+                return_value=current_acl,
+            ),
+            patch(
+                "synapseclient.api.evaluation_services.update_evaluation_acl",
+                new_callable=AsyncMock,
+                return_value=expected_updated_acl,
+            ) as mock_update_acl,
+        ):
             result = await evaluation.update_acl_async(
                 principal_id=OWNER_ID,
                 access_type=["READ"],
@@ -685,15 +694,18 @@ class TestEvaluationAsync:
         expected_updated_acl["resourceAccess"] = []
 
         # WHEN I call update_acl_async with an empty access_type list
-        with patch(
-            "synapseclient.api.evaluation_services.get_evaluation_acl",
-            new_callable=AsyncMock,
-            return_value=current_acl,
-        ), patch(
-            "synapseclient.api.evaluation_services.update_evaluation_acl",
-            new_callable=AsyncMock,
-            return_value=expected_updated_acl,
-        ) as mock_update_acl:
+        with (
+            patch(
+                "synapseclient.api.evaluation_services.get_evaluation_acl",
+                new_callable=AsyncMock,
+                return_value=current_acl,
+            ),
+            patch(
+                "synapseclient.api.evaluation_services.update_evaluation_acl",
+                new_callable=AsyncMock,
+                return_value=expected_updated_acl,
+            ) as mock_update_acl,
+        ):
             result = await evaluation.update_acl_async(
                 principal_id=OWNER_ID,
                 access_type=[],
@@ -758,15 +770,18 @@ class TestEvaluationAsync:
         current_acl = self.get_example_acl_response()
 
         # WHEN I call update_acl_async with lowercase access_type values
-        with patch(
-            "synapseclient.api.evaluation_services.get_evaluation_acl",
-            new_callable=AsyncMock,
-            return_value=current_acl,
-        ), patch(
-            "synapseclient.api.evaluation_services.update_evaluation_acl",
-            new_callable=AsyncMock,
-            return_value=current_acl,
-        ) as mock_update_acl:
+        with (
+            patch(
+                "synapseclient.api.evaluation_services.get_evaluation_acl",
+                new_callable=AsyncMock,
+                return_value=current_acl,
+            ),
+            patch(
+                "synapseclient.api.evaluation_services.update_evaluation_acl",
+                new_callable=AsyncMock,
+                return_value=current_acl,
+            ) as mock_update_acl,
+        ):
             await evaluation.update_acl_async(
                 principal_id=TEAM_PRINCIPAL_ID,
                 access_type=["read", "submit"],

--- a/tests/unit/synapseclient/models/async/unit_test_file_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_file_async.py
@@ -1,4 +1,5 @@
 """Unit tests for the File model"""
+
 import os
 from typing import Dict, Union
 from unittest.mock import AsyncMock, patch
@@ -186,19 +187,23 @@ class TestFile:
         file = File(id=SYN_123, path=PATH, description=MODIFIED_DESCRIPTION)
 
         # WHEN I store the example file
-        with patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_rest_api_file_output()),
-        ) as mocked_get_entity_bundle, patch(
-            "synapseclient.models.file.upload_file_handle",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_file_handle()),
-        ) as mocked_file_handle_upload, patch(
-            "synapseclient.models.file.store_entity",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_file_output()),
-        ) as mocked_store_entity:
+        with (
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_rest_api_file_output()),
+            ) as mocked_get_entity_bundle,
+            patch(
+                "synapseclient.models.file.upload_file_handle",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_file_handle()),
+            ) as mocked_file_handle_upload,
+            patch(
+                "synapseclient.models.file.store_entity",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_file_output()),
+            ) as mocked_store_entity,
+        ):
             result = await file.store_async(synapse_client=self.syn)
 
             # THEN we should call the method with this data
@@ -265,19 +270,23 @@ class TestFile:
         )
 
         # WHEN I store the example file
-        with patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_rest_api_file_output(path=None)),
-        ) as mocked_get_entity_bundle, patch(
-            "synapseclient.models.file.upload_file_handle",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_file_handle()),
-        ) as mocked_file_handle_upload, patch(
-            "synapseclient.models.file.store_entity",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_file_output()),
-        ) as mocked_store_entity:
+        with (
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_rest_api_file_output(path=None)),
+            ) as mocked_get_entity_bundle,
+            patch(
+                "synapseclient.models.file.upload_file_handle",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_file_handle()),
+            ) as mocked_file_handle_upload,
+            patch(
+                "synapseclient.models.file.store_entity",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_file_output()),
+            ) as mocked_store_entity,
+        ):
             result = await file.store_async(synapse_client=self.syn)
 
             # THEN we should call the method with this data
@@ -339,23 +348,28 @@ class TestFile:
         )
 
         # WHEN I store the example file
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=None,
-        ) as mocked_get_call, patch(
-            "synapseclient.models.file.get_id",
-            new_callable=AsyncMock,
-            return_value=None,
-        ), patch(
-            "synapseclient.models.file.upload_file_handle",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_file_handle()),
-        ) as mocked_file_handle_upload, patch(
-            "synapseclient.models.file.store_entity",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_file_output(path=bogus_file)),
-        ) as mocked_store_entity:
+        with (
+            patch.object(
+                self.syn,
+                "get",
+                return_value=None,
+            ) as mocked_get_call,
+            patch(
+                "synapseclient.models.file.get_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "synapseclient.models.file.upload_file_handle",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_file_handle()),
+            ) as mocked_file_handle_upload,
+            patch(
+                "synapseclient.models.file.store_entity",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_file_output(path=bogus_file)),
+            ) as mocked_store_entity,
+        ):
             result = await file.store_async(
                 parent=Project(id=ACTUAL_PARENT_ID), synapse_client=self.syn
             )
@@ -427,23 +441,28 @@ class TestFile:
         )
 
         # WHEN I store the example file
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=None,
-        ) as mocked_get_call, patch(
-            "synapseclient.models.file.get_id",
-            new_callable=AsyncMock,
-            return_value=None,
-        ), patch(
-            "synapseclient.models.file.upload_file_handle",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_file_handle()),
-        ) as mocked_file_handle_upload, patch(
-            "synapseclient.models.file.store_entity",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_file_output(path=bogus_file)),
-        ) as mocked_store_entity:
+        with (
+            patch.object(
+                self.syn,
+                "get",
+                return_value=None,
+            ) as mocked_get_call,
+            patch(
+                "synapseclient.models.file.get_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "synapseclient.models.file.upload_file_handle",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_file_handle()),
+            ) as mocked_file_handle_upload,
+            patch(
+                "synapseclient.models.file.store_entity",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_file_output(path=bogus_file)),
+            ) as mocked_store_entity,
+        ):
             result = await file.store_async(
                 parent=Project(id=ACTUAL_PARENT_ID), synapse_client=self.syn
             )
@@ -522,30 +541,37 @@ class TestFile:
         )
 
         # WHEN I store the example file
-        with patch.object(
-            self.syn,
-            "get",
-            return_value=None,
-        ) as mocked_get_call, patch(
-            "synapseclient.models.file.get_id",
-            new_callable=AsyncMock,
-            return_value=None,
-        ), patch(
-            "synapseclient.models.file.upload_file_handle",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_file_handle()),
-        ) as mocked_file_handle_upload, patch(
-            "synapseclient.models.file.store_entity",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_file_output(path=bogus_file)),
-        ) as mocked_store_entity, patch(
-            "synapseclient.models.file.store_entity_components",
-            return_value=True,
-        ) as mocked_store_entity_components, patch.object(
-            file,
-            "get_async",
-            return_value=file,
-        ) as mocked_get:
+        with (
+            patch.object(
+                self.syn,
+                "get",
+                return_value=None,
+            ) as mocked_get_call,
+            patch(
+                "synapseclient.models.file.get_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "synapseclient.models.file.upload_file_handle",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_file_handle()),
+            ) as mocked_file_handle_upload,
+            patch(
+                "synapseclient.models.file.store_entity",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_file_output(path=bogus_file)),
+            ) as mocked_store_entity,
+            patch(
+                "synapseclient.models.file.store_entity_components",
+                return_value=True,
+            ) as mocked_store_entity_components,
+            patch.object(
+                file,
+                "get_async",
+                return_value=file,
+            ) as mocked_get,
+        ):
             result = await file.store_async(synapse_client=self.syn)
 
             # THEN we should not call the get method when just the path is supplied.
@@ -795,16 +821,18 @@ class TestFile:
         file = File(path=PATH, description=MODIFIED_DESCRIPTION)
 
         # WHEN I get the example file
-        with patch(
-            "synapseclient.api.entity_factory._search_for_file_by_md5",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_rest_api_file_output()),
-        ) as mocked_search_for_file, patch.object(
-            file,
-            "_load_local_md5",
-            return_value=(None),
-        ), patch(
-            "os.path.isfile", return_value=True
+        with (
+            patch(
+                "synapseclient.api.entity_factory._search_for_file_by_md5",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_rest_api_file_output()),
+            ) as mocked_search_for_file,
+            patch.object(
+                file,
+                "_load_local_md5",
+                return_value=(None),
+            ),
+            patch("os.path.isfile", return_value=True),
         ):
             result = await file.get_async(synapse_client=self.syn)
 
@@ -857,15 +885,17 @@ class TestFile:
         path = PATH
 
         # WHEN I get the example file
-        with patch(
-            "synapseclient.api.entity_factory._search_for_file_by_md5",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_rest_api_file_output()),
-        ) as mocked_search_for_file, patch(
-            "synapseclient.models.file.File._load_local_md5",
-            return_value=(None),
-        ), patch(
-            "os.path.isfile", return_value=True
+        with (
+            patch(
+                "synapseclient.api.entity_factory._search_for_file_by_md5",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_rest_api_file_output()),
+            ) as mocked_search_for_file,
+            patch(
+                "synapseclient.models.file.File._load_local_md5",
+                return_value=(None),
+            ),
+            patch("os.path.isfile", return_value=True),
         ):
             result = await File.from_path_async(path=path, synapse_client=self.syn)
 

--- a/tests/unit/synapseclient/models/async/unit_test_folder_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_folder_async.py
@@ -1,4 +1,5 @@
 """Tests for the Folder class."""
+
 import uuid
 from typing import Dict
 from unittest.mock import AsyncMock, patch
@@ -89,22 +90,25 @@ class TestFolder:
         folder.description = description
 
         # WHEN I call `store` with the Folder object
-        with patch(
-            "synapseclient.models.services.storable_entity.put_entity",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_folder_output()),
-        ) as mocked_client_call, patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-            new_callable=AsyncMock,
-            return_value=(
-                {
-                    "entity": {
-                        "concreteType": concrete_types.FOLDER_ENTITY,
-                        "id": folder.id,
+        with (
+            patch(
+                "synapseclient.models.services.storable_entity.put_entity",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_folder_output()),
+            ) as mocked_client_call,
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+                new_callable=AsyncMock,
+                return_value=(
+                    {
+                        "entity": {
+                            "concreteType": concrete_types.FOLDER_ENTITY,
+                            "id": folder.id,
+                        }
                     }
-                }
-            ),
-        ) as mocked_get:
+                ),
+            ) as mocked_get,
+        ):
             result = await folder.store_async(synapse_client=self.syn)
 
             # THEN we should call the method with this data
@@ -142,21 +146,24 @@ class TestFolder:
         )
 
         # WHEN I call `store` with the Folder object
-        with patch.object(
-            self.syn,
-            "store",
-        ) as mocked_store, patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-            new_callable=AsyncMock,
-            return_value=(
-                {
-                    "entity": {
-                        "concreteType": concrete_types.FOLDER_ENTITY,
-                        "id": folder.id,
+        with (
+            patch.object(
+                self.syn,
+                "store",
+            ) as mocked_store,
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+                new_callable=AsyncMock,
+                return_value=(
+                    {
+                        "entity": {
+                            "concreteType": concrete_types.FOLDER_ENTITY,
+                            "id": folder.id,
+                        }
                     }
-                }
-            ),
-        ) as mocked_get:
+                ),
+            ) as mocked_get,
+        ):
             result = await folder.store_async(synapse_client=self.syn)
 
             # THEN we should not call store because there are no changes
@@ -195,16 +202,19 @@ class TestFolder:
             assert folder.id == SYN_123
 
         # WHEN I call `store` with the Folder object
-        with patch.object(
-            self.syn,
-            "store",
-        ) as mocked_store, patch.object(
-            self.syn,
-            "get",
-            return_value=Synapse_Folder(
-                id=folder.id,
-            ),
-        ) as mocked_get:
+        with (
+            patch.object(
+                self.syn,
+                "store",
+            ) as mocked_store,
+            patch.object(
+                self.syn,
+                "get",
+                return_value=Synapse_Folder(
+                    id=folder.id,
+                ),
+            ) as mocked_get,
+        ):
             result = await folder.store_async(synapse_client=self.syn)
 
             # THEN we should not call store because there are no changes
@@ -247,14 +257,17 @@ class TestFolder:
         folder.description = description
 
         # WHEN I call `store` with the Folder object
-        with patch(
-            "synapseclient.models.services.storable_entity.put_entity",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_folder_output()),
-        ) as mocked_store, patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-            new_callable=AsyncMock,
-        ) as mocked_get:
+        with (
+            patch(
+                "synapseclient.models.services.storable_entity.put_entity",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_folder_output()),
+            ) as mocked_store,
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+                new_callable=AsyncMock,
+            ) as mocked_get,
+        ):
             result = await folder.store_async(synapse_client=self.syn)
 
             # THEN we should  call store because there are changes
@@ -303,25 +316,29 @@ class TestFolder:
         folder.description = description
 
         # WHEN I call `store` with the Folder object
-        with patch(
-            "synapseclient.models.folder.store_entity_components",
-            return_value=(None),
-        ) as mocked_store_entity_components, patch(
-            "synapseclient.models.services.storable_entity.put_entity",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_folder_output()),
-        ) as mocked_client_call, patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-            new_callable=AsyncMock,
-            return_value=(
-                {
-                    "entity": {
-                        "concreteType": concrete_types.FOLDER_ENTITY,
-                        "id": folder.id,
+        with (
+            patch(
+                "synapseclient.models.folder.store_entity_components",
+                return_value=(None),
+            ) as mocked_store_entity_components,
+            patch(
+                "synapseclient.models.services.storable_entity.put_entity",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_folder_output()),
+            ) as mocked_client_call,
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+                new_callable=AsyncMock,
+                return_value=(
+                    {
+                        "entity": {
+                            "concreteType": concrete_types.FOLDER_ENTITY,
+                            "id": folder.id,
+                        }
                     }
-                }
-            ),
-        ) as mocked_get:
+                ),
+            ) as mocked_get,
+        ):
             result = await folder.store_async(synapse_client=self.syn)
 
             # THEN we should call the method with this data
@@ -371,26 +388,30 @@ class TestFolder:
         folder.description = description
 
         # WHEN I call `store` with the Folder object
-        with patch(
-            "synapseclient.models.services.storable_entity.put_entity",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_folder_output()),
-        ) as mocked_client_call, patch.object(
-            self.syn,
-            "findEntityId",
-            return_value=SYN_123,
-        ) as mocked_get, patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-            new_callable=AsyncMock,
-            return_value=(
-                {
-                    "entity": {
-                        "concreteType": concrete_types.FOLDER_ENTITY,
-                        "id": folder.id,
+        with (
+            patch(
+                "synapseclient.models.services.storable_entity.put_entity",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_folder_output()),
+            ) as mocked_client_call,
+            patch.object(
+                self.syn,
+                "findEntityId",
+                return_value=SYN_123,
+            ) as mocked_get,
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+                new_callable=AsyncMock,
+                return_value=(
+                    {
+                        "entity": {
+                            "concreteType": concrete_types.FOLDER_ENTITY,
+                            "id": folder.id,
+                        }
                     }
-                }
-            ),
-        ) as mocked_get:
+                ),
+            ) as mocked_get,
+        ):
             result = await folder.store_async(synapse_client=self.syn)
 
             # THEN we should call the method with this data
@@ -436,26 +457,30 @@ class TestFolder:
         folder.description = description
 
         # WHEN I call `store` with the Folder object
-        with patch(
-            "synapseclient.models.services.storable_entity.put_entity",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_folder_output()),
-        ) as mocked_client_call, patch.object(
-            self.syn,
-            "findEntityId",
-            return_value=SYN_123,
-        ) as mocked_get, patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-            new_callable=AsyncMock,
-            return_value=(
-                {
-                    "entity": {
-                        "concreteType": concrete_types.FOLDER_ENTITY,
-                        "id": folder.id,
+        with (
+            patch(
+                "synapseclient.models.services.storable_entity.put_entity",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_folder_output()),
+            ) as mocked_client_call,
+            patch.object(
+                self.syn,
+                "findEntityId",
+                return_value=SYN_123,
+            ) as mocked_get,
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+                new_callable=AsyncMock,
+                return_value=(
+                    {
+                        "entity": {
+                            "concreteType": concrete_types.FOLDER_ENTITY,
+                            "id": folder.id,
+                        }
                     }
-                }
-            ),
-        ) as mocked_get:
+                ),
+            ) as mocked_get,
+        ):
             result = await folder.store_async(
                 parent=Folder(id=PARENT_ID), synapse_client=self.syn
             )
@@ -572,15 +597,18 @@ class TestFolder:
         )
 
         # WHEN I call `get` with the Folder object
-        with patch.object(
-            self.syn,
-            "findEntityId",
-            return_value=(SYN_123),
-        ) as mocked_client_search, patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-            new_callable=AsyncMock,
-            return_value=self.get_example_rest_api_folder_output(),
-        ) as mocked_client_call:
+        with (
+            patch.object(
+                self.syn,
+                "findEntityId",
+                return_value=(SYN_123),
+            ) as mocked_client_search,
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+                new_callable=AsyncMock,
+                return_value=self.get_example_rest_api_folder_output(),
+            ) as mocked_client_call,
+        ):
             result = await folder.get_async(synapse_client=self.syn)
 
             # THEN we should call the method with this data
@@ -675,16 +703,20 @@ class TestFolder:
         }
 
         # WHEN I call `copy` with the Folder object
-        with patch(
-            "synapseclient.models.folder.copy",
-            return_value=(copy_mapping),
-        ) as mocked_copy, patch(
-            "synapseclient.models.folder.Folder.get_async",
-            return_value=(returned_folder),
-        ) as mocked_get, patch(
-            "synapseclient.models.folder.Folder.sync_from_synapse_async",
-            return_value=(returned_folder),
-        ) as mocked_sync:
+        with (
+            patch(
+                "synapseclient.models.folder.copy",
+                return_value=(copy_mapping),
+            ) as mocked_copy,
+            patch(
+                "synapseclient.models.folder.Folder.get_async",
+                return_value=(returned_folder),
+            ) as mocked_get,
+            patch(
+                "synapseclient.models.folder.Folder.sync_from_synapse_async",
+                return_value=(returned_folder),
+            ) as mocked_sync,
+        ):
             result = await folder.copy_async(
                 parent_id="destination_id", synapse_client=self.syn
             )
@@ -754,16 +786,20 @@ class TestFolder:
             for child in children:
                 yield child
 
-        with patch(
-            "synapseclient.models.mixins.storable_container.get_children",
-            side_effect=mock_get_children,
-        ) as mocked_children_call, patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-            new_callable=AsyncMock,
-            return_value=self.get_example_rest_api_folder_output(),
-        ) as mocked_folder_get, patch(
-            "synapseclient.models.file.File.get_async",
-            return_value=(File(id=SYN_456, name="example_file_1")),
+        with (
+            patch(
+                "synapseclient.models.mixins.storable_container.get_children",
+                side_effect=mock_get_children,
+            ) as mocked_children_call,
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+                new_callable=AsyncMock,
+                return_value=self.get_example_rest_api_folder_output(),
+            ) as mocked_folder_get,
+            patch(
+                "synapseclient.models.file.File.get_async",
+                return_value=(File(id=SYN_456, name="example_file_1")),
+            ),
         ):
             result = await folder.sync_from_synapse_async(synapse_client=self.syn)
 

--- a/tests/unit/synapseclient/models/async/unit_test_form_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_form_async.py
@@ -287,16 +287,20 @@ class TestFormData:
         form_data = FormData(form_data_id="67890", data_file_handle_id="54321")
 
         # WHEN downloading the form data
-        with patch(
-            "synapseclient.core.download.download_functions.download_by_file_handle",
-            new_callable=AsyncMock,
-        ) as mock_download_file_handle, patch.object(syn, "cache") as mock_cache, patch(
-            "synapseclient.core.download.download_functions.ensure_download_location_is_directory",
-        ) as mock_ensure_dir:
+        with (
+            patch(
+                "synapseclient.core.download.download_functions.download_by_file_handle",
+                new_callable=AsyncMock,
+            ) as mock_download_file_handle,
+            patch.object(syn, "cache") as mock_cache,
+            patch(
+                "synapseclient.core.download.download_functions.ensure_download_location_is_directory",
+            ) as mock_ensure_dir,
+        ):
             mock_cache.get.side_effect = "/tmp/foo"
-            mock_ensure_dir.return_value = (
-                mock_cache.get_cache_dir.return_value
-            ) = "/tmp/download"
+            mock_ensure_dir.return_value = mock_cache.get_cache_dir.return_value = (
+                "/tmp/download"
+            )
             mock_file_name = f"SYNAPSE_FORM_{form_data.data_file_handle_id}.csv"
 
             await form_data.download_async(

--- a/tests/unit/synapseclient/models/async/unit_test_link_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_link_async.py
@@ -225,18 +225,22 @@ class TestLink:
         link = Link(id=LINK_ID)
 
         # WHEN we call get_async with follow_link=True (default)
-        with patch(
-            "synapseclient.models.link.get_id",
-            new_callable=AsyncMock,
-            return_value=LINK_ID,
-        ) as mocked_get_id, patch(
-            "synapseclient.models.link.get_from_entity_factory",
-            new_callable=AsyncMock,
-        ) as mocked_get_entity_factory, patch(
-            "synapseclient.operations.factory_operations.get_async",
-            new_callable=AsyncMock,
-            return_value="followed_entity",
-        ) as mocked_factory_get_async:
+        with (
+            patch(
+                "synapseclient.models.link.get_id",
+                new_callable=AsyncMock,
+                return_value=LINK_ID,
+            ) as mocked_get_id,
+            patch(
+                "synapseclient.models.link.get_from_entity_factory",
+                new_callable=AsyncMock,
+            ) as mocked_get_entity_factory,
+            patch(
+                "synapseclient.operations.factory_operations.get_async",
+                new_callable=AsyncMock,
+                return_value="followed_entity",
+            ) as mocked_factory_get_async,
+        ):
             # Set up get_from_entity_factory to populate the link
             async def fill_link(synapse_id_or_path, entity_to_update, synapse_client):
                 entity_to_update.fill_from_dict(self.get_example_rest_api_response())
@@ -271,14 +275,17 @@ class TestLink:
         link = Link(id=LINK_ID)
 
         # WHEN we call get_async with follow_link=False
-        with patch(
-            "synapseclient.models.link.get_id",
-            new_callable=AsyncMock,
-            return_value=LINK_ID,
-        ) as mocked_get_id, patch(
-            "synapseclient.models.link.get_from_entity_factory",
-            new_callable=AsyncMock,
-        ) as mocked_get_entity_factory:
+        with (
+            patch(
+                "synapseclient.models.link.get_id",
+                new_callable=AsyncMock,
+                return_value=LINK_ID,
+            ) as mocked_get_id,
+            patch(
+                "synapseclient.models.link.get_from_entity_factory",
+                new_callable=AsyncMock,
+            ) as mocked_get_entity_factory,
+        ):
 
             async def fill_link(synapse_id_or_path, entity_to_update, synapse_client):
                 entity_to_update.fill_from_dict(self.get_example_rest_api_response())
@@ -309,14 +316,17 @@ class TestLink:
         link = Link(name=LINK_NAME, parent_id=PARENT_ID)
 
         # WHEN we call get_async
-        with patch(
-            "synapseclient.models.link.get_id",
-            new_callable=AsyncMock,
-            return_value=LINK_ID,
-        ) as mocked_get_id, patch(
-            "synapseclient.models.link.get_from_entity_factory",
-            new_callable=AsyncMock,
-        ) as mocked_get_entity_factory:
+        with (
+            patch(
+                "synapseclient.models.link.get_id",
+                new_callable=AsyncMock,
+                return_value=LINK_ID,
+            ) as mocked_get_id,
+            patch(
+                "synapseclient.models.link.get_from_entity_factory",
+                new_callable=AsyncMock,
+            ) as mocked_get_entity_factory,
+        ):
 
             async def fill_link(synapse_id_or_path, entity_to_update, synapse_client):
                 entity_to_update.fill_from_dict(self.get_example_rest_api_response())
@@ -340,14 +350,17 @@ class TestLink:
         parent = Folder(id=PARENT_ID)
 
         # WHEN we call get_async with the parent
-        with patch(
-            "synapseclient.models.link.get_id",
-            new_callable=AsyncMock,
-            return_value=LINK_ID,
-        ), patch(
-            "synapseclient.models.link.get_from_entity_factory",
-            new_callable=AsyncMock,
-        ) as mocked_get_entity_factory:
+        with (
+            patch(
+                "synapseclient.models.link.get_id",
+                new_callable=AsyncMock,
+                return_value=LINK_ID,
+            ),
+            patch(
+                "synapseclient.models.link.get_from_entity_factory",
+                new_callable=AsyncMock,
+            ) as mocked_get_entity_factory,
+        ):
 
             async def fill_link(synapse_id_or_path, entity_to_update, synapse_client):
                 entity_to_update.fill_from_dict(self.get_example_rest_api_response())
@@ -369,14 +382,17 @@ class TestLink:
         parent = Project(id=PARENT_ID)
 
         # WHEN we call get_async with the parent
-        with patch(
-            "synapseclient.models.link.get_id",
-            new_callable=AsyncMock,
-            return_value=LINK_ID,
-        ), patch(
-            "synapseclient.models.link.get_from_entity_factory",
-            new_callable=AsyncMock,
-        ) as mocked_get_entity_factory:
+        with (
+            patch(
+                "synapseclient.models.link.get_id",
+                new_callable=AsyncMock,
+                return_value=LINK_ID,
+            ),
+            patch(
+                "synapseclient.models.link.get_from_entity_factory",
+                new_callable=AsyncMock,
+            ) as mocked_get_entity_factory,
+        ):
 
             async def fill_link(synapse_id_or_path, entity_to_update, synapse_client):
                 entity_to_update.fill_from_dict(self.get_example_rest_api_response())
@@ -424,18 +440,22 @@ class TestLink:
         mock_file_options = object()
 
         # WHEN we call get_async with follow_link=True and file_options
-        with patch(
-            "synapseclient.models.link.get_id",
-            new_callable=AsyncMock,
-            return_value=LINK_ID,
-        ), patch(
-            "synapseclient.models.link.get_from_entity_factory",
-            new_callable=AsyncMock,
-        ) as mocked_get_entity_factory, patch(
-            "synapseclient.operations.factory_operations.get_async",
-            new_callable=AsyncMock,
-            return_value="followed_file_entity",
-        ) as mocked_factory_get_async:
+        with (
+            patch(
+                "synapseclient.models.link.get_id",
+                new_callable=AsyncMock,
+                return_value=LINK_ID,
+            ),
+            patch(
+                "synapseclient.models.link.get_from_entity_factory",
+                new_callable=AsyncMock,
+            ) as mocked_get_entity_factory,
+            patch(
+                "synapseclient.operations.factory_operations.get_async",
+                new_callable=AsyncMock,
+                return_value="followed_file_entity",
+            ) as mocked_factory_get_async,
+        ):
 
             async def fill_link(synapse_id_or_path, entity_to_update, synapse_client):
                 entity_to_update.fill_from_dict(self.get_example_rest_api_response())
@@ -464,14 +484,17 @@ class TestLink:
         link = Link(id=LINK_ID)
 
         # WHEN we call get_async with follow_link=False
-        with patch(
-            "synapseclient.models.link.get_id",
-            new_callable=AsyncMock,
-            return_value=LINK_ID,
-        ), patch(
-            "synapseclient.models.link.get_from_entity_factory",
-            new_callable=AsyncMock,
-        ) as mocked_get_entity_factory:
+        with (
+            patch(
+                "synapseclient.models.link.get_id",
+                new_callable=AsyncMock,
+                return_value=LINK_ID,
+            ),
+            patch(
+                "synapseclient.models.link.get_from_entity_factory",
+                new_callable=AsyncMock,
+            ) as mocked_get_entity_factory,
+        ):
 
             async def fill_link(synapse_id_or_path, entity_to_update, synapse_client):
                 entity_to_update.fill_from_dict(self.get_example_rest_api_response())
@@ -498,19 +521,23 @@ class TestLink:
         )
 
         # WHEN we call store_async
-        with patch(
-            "synapseclient.models.link.get_id",
-            new_callable=AsyncMock,
-            return_value=None,
-        ), patch(
-            "synapseclient.models.link.store_entity",
-            new_callable=AsyncMock,
-            return_value=self.get_example_rest_api_response(),
-        ) as mocked_store_entity, patch(
-            "synapseclient.models.link.store_entity_components",
-            new_callable=AsyncMock,
-            return_value=False,
-        ) as mocked_store_components:
+        with (
+            patch(
+                "synapseclient.models.link.get_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "synapseclient.models.link.store_entity",
+                new_callable=AsyncMock,
+                return_value=self.get_example_rest_api_response(),
+            ) as mocked_store_entity,
+            patch(
+                "synapseclient.models.link.store_entity_components",
+                new_callable=AsyncMock,
+                return_value=False,
+            ) as mocked_store_components,
+        ):
             result = await link.store_async(synapse_client=self.syn)
 
             # THEN store_entity should have been called
@@ -550,21 +577,26 @@ class TestLink:
         )
 
         # WHEN we call store_async
-        with patch(
-            "synapseclient.models.link.get_id",
-            new_callable=AsyncMock,
-            return_value=LINK_ID,
-        ), patch(
-            "synapseclient.models.link.get_from_entity_factory",
-            new_callable=AsyncMock,
-        ) as mocked_get_entity_factory, patch(
-            "synapseclient.models.link.store_entity",
-            new_callable=AsyncMock,
-            return_value=self.get_example_rest_api_response(),
-        ) as mocked_store_entity, patch(
-            "synapseclient.models.link.store_entity_components",
-            new_callable=AsyncMock,
-            return_value=False,
+        with (
+            patch(
+                "synapseclient.models.link.get_id",
+                new_callable=AsyncMock,
+                return_value=LINK_ID,
+            ),
+            patch(
+                "synapseclient.models.link.get_from_entity_factory",
+                new_callable=AsyncMock,
+            ) as mocked_get_entity_factory,
+            patch(
+                "synapseclient.models.link.store_entity",
+                new_callable=AsyncMock,
+                return_value=self.get_example_rest_api_response(),
+            ) as mocked_store_entity,
+            patch(
+                "synapseclient.models.link.store_entity_components",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
         ):
             # Set up get_from_entity_factory to populate the link copy in
             # _find_existing_entity
@@ -593,18 +625,22 @@ class TestLink:
         parent = Folder(id=PARENT_ID)
 
         # WHEN we call store_async with the parent argument
-        with patch(
-            "synapseclient.models.link.get_id",
-            new_callable=AsyncMock,
-            return_value=None,
-        ), patch(
-            "synapseclient.models.link.store_entity",
-            new_callable=AsyncMock,
-            return_value=self.get_example_rest_api_response(),
-        ) as mocked_store_entity, patch(
-            "synapseclient.models.link.store_entity_components",
-            new_callable=AsyncMock,
-            return_value=False,
+        with (
+            patch(
+                "synapseclient.models.link.get_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "synapseclient.models.link.store_entity",
+                new_callable=AsyncMock,
+                return_value=self.get_example_rest_api_response(),
+            ) as mocked_store_entity,
+            patch(
+                "synapseclient.models.link.store_entity_components",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
         ):
             result = await link.store_async(parent=parent, synapse_client=self.syn)
 
@@ -627,18 +663,22 @@ class TestLink:
         parent = Project(id=PARENT_ID)
 
         # WHEN we call store_async with the parent argument
-        with patch(
-            "synapseclient.models.link.get_id",
-            new_callable=AsyncMock,
-            return_value=None,
-        ), patch(
-            "synapseclient.models.link.store_entity",
-            new_callable=AsyncMock,
-            return_value=self.get_example_rest_api_response(),
-        ), patch(
-            "synapseclient.models.link.store_entity_components",
-            new_callable=AsyncMock,
-            return_value=False,
+        with (
+            patch(
+                "synapseclient.models.link.get_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "synapseclient.models.link.store_entity",
+                new_callable=AsyncMock,
+                return_value=self.get_example_rest_api_response(),
+            ),
+            patch(
+                "synapseclient.models.link.store_entity_components",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
         ):
             result = await link.store_async(parent=parent, synapse_client=self.syn)
 
@@ -677,21 +717,26 @@ class TestLink:
         link = Link(id=LINK_ID)
 
         # WHEN we call store_async, it should NOT raise ValueError
-        with patch(
-            "synapseclient.models.link.get_id",
-            new_callable=AsyncMock,
-            return_value=LINK_ID,
-        ), patch(
-            "synapseclient.models.link.get_from_entity_factory",
-            new_callable=AsyncMock,
-        ) as mocked_get_entity_factory, patch(
-            "synapseclient.models.link.store_entity",
-            new_callable=AsyncMock,
-            return_value=self.get_example_rest_api_response(),
-        ), patch(
-            "synapseclient.models.link.store_entity_components",
-            new_callable=AsyncMock,
-            return_value=False,
+        with (
+            patch(
+                "synapseclient.models.link.get_id",
+                new_callable=AsyncMock,
+                return_value=LINK_ID,
+            ),
+            patch(
+                "synapseclient.models.link.get_from_entity_factory",
+                new_callable=AsyncMock,
+            ) as mocked_get_entity_factory,
+            patch(
+                "synapseclient.models.link.store_entity",
+                new_callable=AsyncMock,
+                return_value=self.get_example_rest_api_response(),
+            ),
+            patch(
+                "synapseclient.models.link.store_entity_components",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
         ):
 
             async def fill_link(synapse_id_or_path, entity_to_update, synapse_client):
@@ -713,14 +758,17 @@ class TestLink:
         )
 
         # AND get_async has been called (which sets _last_persistent_instance)
-        with patch(
-            "synapseclient.models.link.get_id",
-            new_callable=AsyncMock,
-            return_value=LINK_ID,
-        ), patch(
-            "synapseclient.models.link.get_from_entity_factory",
-            new_callable=AsyncMock,
-        ) as mocked_get_entity_factory:
+        with (
+            patch(
+                "synapseclient.models.link.get_id",
+                new_callable=AsyncMock,
+                return_value=LINK_ID,
+            ),
+            patch(
+                "synapseclient.models.link.get_from_entity_factory",
+                new_callable=AsyncMock,
+            ) as mocked_get_entity_factory,
+        ):
 
             async def fill_link(synapse_id_or_path, entity_to_update, synapse_client):
                 entity_to_update.fill_from_dict(self.get_example_rest_api_response())
@@ -729,13 +777,16 @@ class TestLink:
             await link.get_async(follow_link=False, synapse_client=self.syn)
 
         # WHEN we call store_async without making changes
-        with patch(
-            "synapseclient.models.link.store_entity",
-            new_callable=AsyncMock,
-        ) as mocked_store_entity, patch(
-            "synapseclient.models.link.store_entity_components",
-            new_callable=AsyncMock,
-            return_value=False,
+        with (
+            patch(
+                "synapseclient.models.link.store_entity",
+                new_callable=AsyncMock,
+            ) as mocked_store_entity,
+            patch(
+                "synapseclient.models.link.store_entity_components",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
         ):
             result = await link.store_async(synapse_client=self.syn)
 
@@ -749,14 +800,17 @@ class TestLink:
         # GIVEN a Link that was previously retrieved from Synapse
         link = Link(id=LINK_ID)
 
-        with patch(
-            "synapseclient.models.link.get_id",
-            new_callable=AsyncMock,
-            return_value=LINK_ID,
-        ), patch(
-            "synapseclient.models.link.get_from_entity_factory",
-            new_callable=AsyncMock,
-        ) as mocked_get_entity_factory:
+        with (
+            patch(
+                "synapseclient.models.link.get_id",
+                new_callable=AsyncMock,
+                return_value=LINK_ID,
+            ),
+            patch(
+                "synapseclient.models.link.get_from_entity_factory",
+                new_callable=AsyncMock,
+            ) as mocked_get_entity_factory,
+        ):
 
             async def fill_link(synapse_id_or_path, entity_to_update, synapse_client):
                 entity_to_update.fill_from_dict(self.get_example_rest_api_response())
@@ -771,14 +825,17 @@ class TestLink:
         updated_response = self.get_example_rest_api_response()
         updated_response["description"] = "New description"
 
-        with patch(
-            "synapseclient.models.link.store_entity",
-            new_callable=AsyncMock,
-            return_value=updated_response,
-        ) as mocked_store_entity, patch(
-            "synapseclient.models.link.store_entity_components",
-            new_callable=AsyncMock,
-            return_value=False,
+        with (
+            patch(
+                "synapseclient.models.link.store_entity",
+                new_callable=AsyncMock,
+                return_value=updated_response,
+            ) as mocked_store_entity,
+            patch(
+                "synapseclient.models.link.store_entity_components",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
         ):
             result = await link.store_async(synapse_client=self.syn)
 
@@ -797,23 +854,28 @@ class TestLink:
         )
 
         # WHEN we call store_async and store_entity_components returns True
-        with patch(
-            "synapseclient.models.link.get_id",
-            new_callable=AsyncMock,
-            return_value=None,
-        ), patch(
-            "synapseclient.models.link.store_entity",
-            new_callable=AsyncMock,
-            return_value=self.get_example_rest_api_response(),
-        ), patch(
-            "synapseclient.models.link.store_entity_components",
-            new_callable=AsyncMock,
-            return_value=True,
-        ), patch.object(
-            link,
-            "get_async",
-            new_callable=AsyncMock,
-        ) as mocked_get_async:
+        with (
+            patch(
+                "synapseclient.models.link.get_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "synapseclient.models.link.store_entity",
+                new_callable=AsyncMock,
+                return_value=self.get_example_rest_api_response(),
+            ),
+            patch(
+                "synapseclient.models.link.store_entity_components",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                link,
+                "get_async",
+                new_callable=AsyncMock,
+            ) as mocked_get_async,
+        ):
             result = await link.store_async(synapse_client=self.syn)
 
             # THEN get_async should have been called for a re-read
@@ -830,23 +892,28 @@ class TestLink:
         )
 
         # WHEN we call store_async and store_entity_components returns False
-        with patch(
-            "synapseclient.models.link.get_id",
-            new_callable=AsyncMock,
-            return_value=None,
-        ), patch(
-            "synapseclient.models.link.store_entity",
-            new_callable=AsyncMock,
-            return_value=self.get_example_rest_api_response(),
-        ), patch(
-            "synapseclient.models.link.store_entity_components",
-            new_callable=AsyncMock,
-            return_value=False,
-        ), patch.object(
-            link,
-            "get_async",
-            new_callable=AsyncMock,
-        ) as mocked_get_async:
+        with (
+            patch(
+                "synapseclient.models.link.get_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "synapseclient.models.link.store_entity",
+                new_callable=AsyncMock,
+                return_value=self.get_example_rest_api_response(),
+            ),
+            patch(
+                "synapseclient.models.link.store_entity_components",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                link,
+                "get_async",
+                new_callable=AsyncMock,
+            ) as mocked_get_async,
+        ):
             result = await link.store_async(synapse_client=self.syn)
 
             # THEN get_async should NOT have been called for a re-read
@@ -864,14 +931,17 @@ class TestLink:
         )
 
         # WHEN we call _find_existing_entity and an entity is found
-        with patch(
-            "synapseclient.models.link.get_id",
-            new_callable=AsyncMock,
-            return_value=LINK_ID,
-        ), patch(
-            "synapseclient.models.link.get_from_entity_factory",
-            new_callable=AsyncMock,
-        ) as mocked_get_entity_factory:
+        with (
+            patch(
+                "synapseclient.models.link.get_id",
+                new_callable=AsyncMock,
+                return_value=LINK_ID,
+            ),
+            patch(
+                "synapseclient.models.link.get_from_entity_factory",
+                new_callable=AsyncMock,
+            ) as mocked_get_entity_factory,
+        ):
 
             async def fill_link(synapse_id_or_path, entity_to_update, synapse_client):
                 entity_to_update.fill_from_dict(self.get_example_rest_api_response())

--- a/tests/unit/synapseclient/models/async/unit_test_project_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_project_async.py
@@ -1,4 +1,5 @@
 """Tests for the synapseclient.models.Project class."""
+
 import uuid
 from typing import Dict
 from unittest.mock import AsyncMock, patch
@@ -88,22 +89,25 @@ class TestProject:
         project.description = description
 
         # WHEN I call `store` with the Project object
-        with patch(
-            "synapseclient.models.services.storable_entity.put_entity",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_project_output()),
-        ) as mocked_client_call, patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-            new_callable=AsyncMock,
-            return_value=(
-                {
-                    "entity": {
-                        "concreteType": concrete_types.PROJECT_ENTITY,
-                        "id": project.id,
+        with (
+            patch(
+                "synapseclient.models.services.storable_entity.put_entity",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_project_output()),
+            ) as mocked_client_call,
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+                new_callable=AsyncMock,
+                return_value=(
+                    {
+                        "entity": {
+                            "concreteType": concrete_types.PROJECT_ENTITY,
+                            "id": project.id,
+                        }
                     }
-                }
-            ),
-        ) as mocked_get:
+                ),
+            ) as mocked_get,
+        ):
             result = await project.store_async(synapse_client=self.syn)
 
             # THEN we should call the method with this data
@@ -141,21 +145,24 @@ class TestProject:
         )
 
         # WHEN I call `store` with the Project object
-        with patch.object(
-            self.syn,
-            "store",
-        ) as mocked_store, patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-            new_callable=AsyncMock,
-            return_value=(
-                {
-                    "entity": {
-                        "concreteType": concrete_types.PROJECT_ENTITY,
-                        "id": project.id,
+        with (
+            patch.object(
+                self.syn,
+                "store",
+            ) as mocked_store,
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+                new_callable=AsyncMock,
+                return_value=(
+                    {
+                        "entity": {
+                            "concreteType": concrete_types.PROJECT_ENTITY,
+                            "id": project.id,
+                        }
                     }
-                }
-            ),
-        ) as mocked_get:
+                ),
+            ) as mocked_get,
+        ):
             result = await project.store_async(synapse_client=self.syn)
 
             # THEN we should not call store because there are no changes
@@ -194,21 +201,24 @@ class TestProject:
             assert project.id == PROJECT_ID
 
         # WHEN I call `store` with the Project object
-        with patch.object(
-            self.syn,
-            "store",
-        ) as mocked_store, patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-            new_callable=AsyncMock,
-            return_value=(
-                {
-                    "entity": {
-                        "concreteType": concrete_types.PROJECT_ENTITY,
-                        "id": project.id,
+        with (
+            patch.object(
+                self.syn,
+                "store",
+            ) as mocked_store,
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+                new_callable=AsyncMock,
+                return_value=(
+                    {
+                        "entity": {
+                            "concreteType": concrete_types.PROJECT_ENTITY,
+                            "id": project.id,
+                        }
                     }
-                }
-            ),
-        ) as mocked_get:
+                ),
+            ) as mocked_get,
+        ):
             result = await project.store_async(synapse_client=self.syn)
 
             # THEN we should not call store because there are no changes
@@ -251,13 +261,16 @@ class TestProject:
         project.description = description
 
         # WHEN I call `store` with the Project object
-        with patch(
-            "synapseclient.models.services.storable_entity.put_entity",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_project_output()),
-        ) as mocked_store, patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-        ) as mocked_get:
+        with (
+            patch(
+                "synapseclient.models.services.storable_entity.put_entity",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_project_output()),
+            ) as mocked_store,
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            ) as mocked_get,
+        ):
             result = await project.store_async(synapse_client=self.syn)
 
             # THEN we should  call store because there are changes
@@ -306,25 +319,29 @@ class TestProject:
         project.description = description
 
         # WHEN I call `store` with the Project object
-        with patch(
-            "synapseclient.models.project.store_entity_components",
-            return_value=(None),
-        ) as mocked_store_entity_components, patch(
-            "synapseclient.models.services.storable_entity.put_entity",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_project_output()),
-        ) as mocked_client_call, patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-            new_callable=AsyncMock,
-            return_value=(
-                {
-                    "entity": {
-                        "concreteType": concrete_types.PROJECT_ENTITY,
-                        "id": project.id,
+        with (
+            patch(
+                "synapseclient.models.project.store_entity_components",
+                return_value=(None),
+            ) as mocked_store_entity_components,
+            patch(
+                "synapseclient.models.services.storable_entity.put_entity",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_project_output()),
+            ) as mocked_client_call,
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+                new_callable=AsyncMock,
+                return_value=(
+                    {
+                        "entity": {
+                            "concreteType": concrete_types.PROJECT_ENTITY,
+                            "id": project.id,
+                        }
                     }
-                }
-            ),
-        ) as mocked_get:
+                ),
+            ) as mocked_get,
+        ):
             result = await project.store_async(synapse_client=self.syn)
 
             # THEN we should call the method with this data
@@ -374,26 +391,30 @@ class TestProject:
         project.description = description
 
         # WHEN I call `store` with the Project object
-        with patch(
-            "synapseclient.models.services.storable_entity.put_entity",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_synapse_project_output()),
-        ) as mocked_client_call, patch.object(
-            self.syn,
-            "findEntityId",
-            return_value=PROJECT_ID,
-        ) as mocked_get, patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-            new_callable=AsyncMock,
-            return_value=(
-                {
-                    "entity": {
-                        "concreteType": concrete_types.PROJECT_ENTITY,
-                        "id": project.id,
+        with (
+            patch(
+                "synapseclient.models.services.storable_entity.put_entity",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_synapse_project_output()),
+            ) as mocked_client_call,
+            patch.object(
+                self.syn,
+                "findEntityId",
+                return_value=PROJECT_ID,
+            ) as mocked_get,
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+                new_callable=AsyncMock,
+                return_value=(
+                    {
+                        "entity": {
+                            "concreteType": concrete_types.PROJECT_ENTITY,
+                            "id": project.id,
+                        }
                     }
-                }
-            ),
-        ) as mocked_get:
+                ),
+            ) as mocked_get,
+        ):
             result = await project.store_async(synapse_client=self.syn)
 
             # THEN we should call the method with this data
@@ -476,15 +497,18 @@ class TestProject:
         )
 
         # WHEN I call `get` with the Project object
-        with patch.object(
-            self.syn,
-            "findEntityId",
-            return_value=(PROJECT_ID),
-        ) as mocked_client_search, patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_rest_api_project_output()),
-        ) as mocked_client_call:
+        with (
+            patch.object(
+                self.syn,
+                "findEntityId",
+                return_value=(PROJECT_ID),
+            ) as mocked_client_search,
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_rest_api_project_output()),
+            ) as mocked_client_call,
+        ):
             result = await project.get_async(synapse_client=self.syn)
 
             # THEN we should call the method with this data
@@ -579,16 +603,20 @@ class TestProject:
         }
 
         # WHEN I call `copy` with the Project object
-        with patch(
-            "synapseclient.models.project.copy",
-            return_value=(copy_mapping),
-        ) as mocked_copy, patch(
-            "synapseclient.models.project.Project.get_async",
-            return_value=(returned_project),
-        ) as mocked_get, patch(
-            "synapseclient.models.project.Project.sync_from_synapse_async",
-            return_value=(returned_project),
-        ) as mocked_sync:
+        with (
+            patch(
+                "synapseclient.models.project.copy",
+                return_value=(copy_mapping),
+            ) as mocked_copy,
+            patch(
+                "synapseclient.models.project.Project.get_async",
+                return_value=(returned_project),
+            ) as mocked_get,
+            patch(
+                "synapseclient.models.project.Project.sync_from_synapse_async",
+                return_value=(returned_project),
+            ) as mocked_sync,
+        ):
             result = await project.copy_async(
                 destination_id="destination_id", synapse_client=self.syn
             )
@@ -661,16 +689,20 @@ class TestProject:
             for child in children:
                 yield child
 
-        with patch(
-            "synapseclient.models.mixins.storable_container.get_children",
-            side_effect=mock_get_children,
-        ) as mocked_children_call, patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-            new_callable=AsyncMock,
-            return_value=(self.get_example_rest_api_project_output()),
-        ) as mocked_project_get, patch(
-            "synapseclient.models.file.File.get_async",
-            return_value=(File(id="syn456", name="example_file_1")),
+        with (
+            patch(
+                "synapseclient.models.mixins.storable_container.get_children",
+                side_effect=mock_get_children,
+            ) as mocked_children_call,
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+                new_callable=AsyncMock,
+                return_value=(self.get_example_rest_api_project_output()),
+            ) as mocked_project_get,
+            patch(
+                "synapseclient.models.file.File.get_async",
+                return_value=(File(id="syn456", name="example_file_1")),
+            ),
         ):
             result = await project.sync_from_synapse_async(synapse_client=self.syn)
 

--- a/tests/unit/synapseclient/models/async/unit_test_recordset_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_recordset_async.py
@@ -297,24 +297,30 @@ class TestRecordSet:
         self.syn._get_parallel_file_transfer_semaphore = mock_semaphore_ctx
 
         # WHEN I call store_async
-        with patch(
-            "synapseclient.models.recordset.get_id",
-            new_callable=AsyncMock,
-            return_value=None,
-        ), patch(
-            "synapseclient.models.file._upload_file",
-            new_callable=AsyncMock,
-        ) as mock_upload, patch(
-            "synapseclient.models.recordset.store_entity",
-            new_callable=AsyncMock,
-            return_value=entity_response,
-        ) as mock_store_entity, patch(
-            "synapseclient.models.recordset.store_entity_components",
-            new_callable=AsyncMock,
-            return_value=False,
-        ), patch(
-            "os.path.expanduser",
-            return_value=PATH,
+        with (
+            patch(
+                "synapseclient.models.recordset.get_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "synapseclient.models.file._upload_file",
+                new_callable=AsyncMock,
+            ) as mock_upload,
+            patch(
+                "synapseclient.models.recordset.store_entity",
+                new_callable=AsyncMock,
+                return_value=entity_response,
+            ) as mock_store_entity,
+            patch(
+                "synapseclient.models.recordset.store_entity_components",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "os.path.expanduser",
+                return_value=PATH,
+            ),
         ):
             result = await record_set.store_async(synapse_client=self.syn)
 
@@ -343,18 +349,22 @@ class TestRecordSet:
         self.syn.cache.get.return_value = None
 
         # WHEN I call store_async
-        with patch(
-            "synapseclient.models.recordset.get_id",
-            new_callable=AsyncMock,
-            return_value=None,
-        ), patch(
-            "synapseclient.models.recordset.store_entity",
-            new_callable=AsyncMock,
-            return_value=entity_response,
-        ) as mock_store_entity, patch(
-            "synapseclient.models.recordset.store_entity_components",
-            new_callable=AsyncMock,
-            return_value=False,
+        with (
+            patch(
+                "synapseclient.models.recordset.get_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "synapseclient.models.recordset.store_entity",
+                new_callable=AsyncMock,
+                return_value=entity_response,
+            ) as mock_store_entity,
+            patch(
+                "synapseclient.models.recordset.store_entity_components",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
         ):
             result = await record_set.store_async(synapse_client=self.syn)
 
@@ -388,24 +398,30 @@ class TestRecordSet:
         self.syn._get_parallel_file_transfer_semaphore = mock_semaphore_ctx
 
         # WHEN I call store_async with a parent object
-        with patch(
-            "synapseclient.models.recordset.get_id",
-            new_callable=AsyncMock,
-            return_value=None,
-        ), patch(
-            "synapseclient.models.file._upload_file",
-            new_callable=AsyncMock,
-        ), patch(
-            "synapseclient.models.recordset.store_entity",
-            new_callable=AsyncMock,
-            return_value=entity_response,
-        ), patch(
-            "synapseclient.models.recordset.store_entity_components",
-            new_callable=AsyncMock,
-            return_value=False,
-        ), patch(
-            "os.path.expanduser",
-            return_value=PATH,
+        with (
+            patch(
+                "synapseclient.models.recordset.get_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "synapseclient.models.file._upload_file",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "synapseclient.models.recordset.store_entity",
+                new_callable=AsyncMock,
+                return_value=entity_response,
+            ),
+            patch(
+                "synapseclient.models.recordset.store_entity_components",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "os.path.expanduser",
+                return_value=PATH,
+            ),
         ):
             result = await record_set.store_async(
                 parent=parent, synapse_client=self.syn
@@ -449,28 +465,35 @@ class TestRecordSet:
         self.syn._get_parallel_file_transfer_semaphore = mock_semaphore_ctx
 
         # WHEN I call store_async and an existing entity is found
-        with patch(
-            "synapseclient.models.recordset.get_id",
-            new_callable=AsyncMock,
-            return_value=SYN_123,
-        ), patch(
-            "synapseclient.api.entity_factory.get_entity_id_bundle2",
-            new_callable=AsyncMock,
-            return_value={"entity": existing_entity_response, "fileHandles": []},
-        ), patch(
-            "synapseclient.models.file._upload_file",
-            new_callable=AsyncMock,
-        ), patch(
-            "synapseclient.models.recordset.store_entity",
-            new_callable=AsyncMock,
-            return_value=updated_entity_response,
-        ), patch(
-            "synapseclient.models.recordset.store_entity_components",
-            new_callable=AsyncMock,
-            return_value=False,
-        ), patch(
-            "os.path.expanduser",
-            return_value=PATH,
+        with (
+            patch(
+                "synapseclient.models.recordset.get_id",
+                new_callable=AsyncMock,
+                return_value=SYN_123,
+            ),
+            patch(
+                "synapseclient.api.entity_factory.get_entity_id_bundle2",
+                new_callable=AsyncMock,
+                return_value={"entity": existing_entity_response, "fileHandles": []},
+            ),
+            patch(
+                "synapseclient.models.file._upload_file",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "synapseclient.models.recordset.store_entity",
+                new_callable=AsyncMock,
+                return_value=updated_entity_response,
+            ),
+            patch(
+                "synapseclient.models.recordset.store_entity_components",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "os.path.expanduser",
+                return_value=PATH,
+            ),
         ):
             result = await record_set.store_async(synapse_client=self.syn)
 
@@ -491,24 +514,29 @@ class TestRecordSet:
         self.syn.cache.get.return_value = None
 
         # WHEN I call store_async and store_entity_components returns True
-        with patch(
-            "synapseclient.models.recordset.get_id",
-            new_callable=AsyncMock,
-            return_value=None,
-        ), patch(
-            "synapseclient.models.recordset.store_entity",
-            new_callable=AsyncMock,
-            return_value=entity_response,
-        ), patch(
-            "synapseclient.models.recordset.store_entity_components",
-            new_callable=AsyncMock,
-            return_value=True,
-        ), patch.object(
-            RecordSet,
-            "get_async",
-            new_callable=AsyncMock,
-            return_value=record_set,
-        ) as mock_get:
+        with (
+            patch(
+                "synapseclient.models.recordset.get_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "synapseclient.models.recordset.store_entity",
+                new_callable=AsyncMock,
+                return_value=entity_response,
+            ),
+            patch(
+                "synapseclient.models.recordset.store_entity_components",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                RecordSet,
+                "get_async",
+                new_callable=AsyncMock,
+                return_value=record_set,
+            ) as mock_get,
+        ):
             result = await record_set.store_async(synapse_client=self.syn)
 
             # THEN get_async should be called again to re-read the entity
@@ -551,12 +579,15 @@ class TestRecordSet:
         entity_response = _get_record_set_entity_response()
 
         # WHEN I call get_async
-        with patch(
-            "synapseclient.models.recordset.get_from_entity_factory",
-            new_callable=AsyncMock,
-        ) as mock_factory, patch(
-            "os.path.isfile",
-            return_value=False,
+        with (
+            patch(
+                "synapseclient.models.recordset.get_from_entity_factory",
+                new_callable=AsyncMock,
+            ) as mock_factory,
+            patch(
+                "os.path.isfile",
+                return_value=False,
+            ),
         ):
 
             async def side_effect(**kwargs):
@@ -596,14 +627,17 @@ class TestRecordSet:
         )
 
         # WHEN I call get_async with include_activity=True
-        with patch(
-            "synapseclient.models.recordset.get_from_entity_factory",
-            new_callable=AsyncMock,
-        ) as mock_factory, patch(
-            "synapseclient.models.Activity.from_parent_async",
-            new_callable=AsyncMock,
-            return_value=activity_response,
-        ) as mock_from_parent:
+        with (
+            patch(
+                "synapseclient.models.recordset.get_from_entity_factory",
+                new_callable=AsyncMock,
+            ) as mock_factory,
+            patch(
+                "synapseclient.models.Activity.from_parent_async",
+                new_callable=AsyncMock,
+                return_value=activity_response,
+            ) as mock_from_parent,
+        ):
 
             async def side_effect(**kwargs):
                 entity_to_update = kwargs["entity_to_update"]
@@ -726,16 +760,20 @@ class TestRecordSet:
         self.syn.cache.get_cache_dir.return_value = "/syn_cache_dir"
 
         # WHEN I call get_detailed_validation_results_async
-        with patch(
-            "synapseclient.models.recordset.test_import_pandas",
-        ), patch(
-            "synapseclient.models.recordset.download_by_file_handle",
-            new_callable=AsyncMock,
-            return_value="/cached/validation_results.csv",
-        ) as mock_download, patch(
-            "pandas.read_csv",
-            return_value=mock_df,
-        ) as mock_read_csv:
+        with (
+            patch(
+                "synapseclient.models.recordset.test_import_pandas",
+            ),
+            patch(
+                "synapseclient.models.recordset.download_by_file_handle",
+                new_callable=AsyncMock,
+                return_value="/cached/validation_results.csv",
+            ) as mock_download,
+            patch(
+                "pandas.read_csv",
+                return_value=mock_df,
+            ) as mock_read_csv,
+        ):
             result = await record_set.get_detailed_validation_results_async(
                 synapse_client=self.syn
             )
@@ -754,10 +792,13 @@ class TestRecordSet:
         record_set = RecordSet(id=SYN_123)
 
         # WHEN I call get_detailed_validation_results_async
-        with patch(
-            "synapseclient.models.recordset.test_import_pandas",
-        ), patch(
-            "pandas.read_csv",
+        with (
+            patch(
+                "synapseclient.models.recordset.test_import_pandas",
+            ),
+            patch(
+                "pandas.read_csv",
+            ),
         ):
             result = await record_set.get_detailed_validation_results_async(
                 synapse_client=self.syn
@@ -782,18 +823,23 @@ class TestRecordSet:
         self.syn.cache.get_cache_dir.return_value = "/syn_cache_dir"
 
         # WHEN I call get_detailed_validation_results_async with a download_location
-        with patch(
-            "synapseclient.models.recordset.test_import_pandas",
-        ), patch(
-            "synapseclient.models.recordset.ensure_download_location_is_directory",
-            return_value=download_location,
-        ), patch(
-            "synapseclient.models.recordset.download_by_file_handle",
-            new_callable=AsyncMock,
-            return_value=f"{download_location}/SYNAPSE_RECORDSET_VALIDATION_{VALIDATION_FILE_HANDLE_ID}.csv",
-        ) as mock_download, patch(
-            "pandas.read_csv",
-            return_value=mock_df,
+        with (
+            patch(
+                "synapseclient.models.recordset.test_import_pandas",
+            ),
+            patch(
+                "synapseclient.models.recordset.ensure_download_location_is_directory",
+                return_value=download_location,
+            ),
+            patch(
+                "synapseclient.models.recordset.download_by_file_handle",
+                new_callable=AsyncMock,
+                return_value=f"{download_location}/SYNAPSE_RECORDSET_VALIDATION_{VALIDATION_FILE_HANDLE_ID}.csv",
+            ) as mock_download,
+            patch(
+                "pandas.read_csv",
+                return_value=mock_df,
+            ),
         ):
             result = await record_set.get_detailed_validation_results_async(
                 download_location=download_location, synapse_client=self.syn

--- a/tests/unit/synapseclient/models/async/unit_test_schema_organization_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_schema_organization_async.py
@@ -253,15 +253,18 @@ class TestSchemaOrganization:
         org = SchemaOrganization(name=ORG_NAME)
 
         # WHEN I call delete_async
-        with patch(
-            "synapseclient.models.schema_organization.get_organization",
-            new_callable=AsyncMock,
-            return_value=_get_organization_response(),
-        ) as mock_get, patch(
-            "synapseclient.models.schema_organization.delete_organization",
-            new_callable=AsyncMock,
-            return_value=None,
-        ) as mock_delete:
+        with (
+            patch(
+                "synapseclient.models.schema_organization.get_organization",
+                new_callable=AsyncMock,
+                return_value=_get_organization_response(),
+            ) as mock_get,
+            patch(
+                "synapseclient.models.schema_organization.delete_organization",
+                new_callable=AsyncMock,
+                return_value=None,
+            ) as mock_delete,
+        ):
             await org.delete_async(synapse_client=self.syn)
 
             # THEN get should be called first to obtain the id
@@ -341,15 +344,18 @@ class TestSchemaOrganization:
         acl_response = _get_acl_response()
 
         # WHEN I call get_acl_async (id will be fetched first)
-        with patch(
-            "synapseclient.models.schema_organization.get_organization",
-            new_callable=AsyncMock,
-            return_value=_get_organization_response(),
-        ) as mock_get, patch(
-            "synapseclient.models.schema_organization.get_organization_acl",
-            new_callable=AsyncMock,
-            return_value=acl_response,
-        ) as mock_get_acl:
+        with (
+            patch(
+                "synapseclient.models.schema_organization.get_organization",
+                new_callable=AsyncMock,
+                return_value=_get_organization_response(),
+            ) as mock_get,
+            patch(
+                "synapseclient.models.schema_organization.get_organization_acl",
+                new_callable=AsyncMock,
+                return_value=acl_response,
+            ) as mock_get_acl,
+        ):
             result = await org.get_acl_async(synapse_client=self.syn)
 
             # THEN get should be called first to obtain the id
@@ -365,15 +371,18 @@ class TestSchemaOrganization:
         acl_response = _get_acl_response()
 
         # WHEN I call update_acl_async with a new principal
-        with patch(
-            "synapseclient.models.schema_organization.get_organization_acl",
-            new_callable=AsyncMock,
-            return_value=acl_response,
-        ), patch(
-            "synapseclient.models.schema_organization.update_organization_acl",
-            new_callable=AsyncMock,
-            return_value=None,
-        ) as mock_update:
+        with (
+            patch(
+                "synapseclient.models.schema_organization.get_organization_acl",
+                new_callable=AsyncMock,
+                return_value=acl_response,
+            ),
+            patch(
+                "synapseclient.models.schema_organization.update_organization_acl",
+                new_callable=AsyncMock,
+                return_value=None,
+            ) as mock_update,
+        ):
             await org.update_acl_async(
                 principal_id=PRINCIPAL_ID_2,
                 access_type=["READ"],
@@ -404,15 +413,18 @@ class TestSchemaOrganization:
         acl_response = _get_acl_response()
 
         # WHEN I call update_acl_async for an existing principal with new permissions
-        with patch(
-            "synapseclient.models.schema_organization.get_organization_acl",
-            new_callable=AsyncMock,
-            return_value=acl_response,
-        ), patch(
-            "synapseclient.models.schema_organization.update_organization_acl",
-            new_callable=AsyncMock,
-            return_value=None,
-        ) as mock_update:
+        with (
+            patch(
+                "synapseclient.models.schema_organization.get_organization_acl",
+                new_callable=AsyncMock,
+                return_value=acl_response,
+            ),
+            patch(
+                "synapseclient.models.schema_organization.update_organization_acl",
+                new_callable=AsyncMock,
+                return_value=None,
+            ) as mock_update,
+        ):
             await org.update_acl_async(
                 principal_id=PRINCIPAL_ID_1,
                 access_type=["READ", "CREATE", "DELETE"],
@@ -681,13 +693,16 @@ class TestJSONSchema:
             yield schema_response
 
         # WHEN I call get_async (org exists and schema is found)
-        with patch(
-            "synapseclient.models.schema_organization.get_organization",
-            new_callable=AsyncMock,
-            return_value=_get_organization_response(),
-        ), patch(
-            "synapseclient.models.schema_organization.list_json_schemas",
-            return_value=mock_list(),
+        with (
+            patch(
+                "synapseclient.models.schema_organization.get_organization",
+                new_callable=AsyncMock,
+                return_value=_get_organization_response(),
+            ),
+            patch(
+                "synapseclient.models.schema_organization.list_json_schemas",
+                return_value=mock_list(),
+            ),
         ):
             result = await schema.get_async(synapse_client=self.syn)
 
@@ -709,13 +724,16 @@ class TestJSONSchema:
             yield other_schema_response
 
         # WHEN I call get_async
-        with patch(
-            "synapseclient.models.schema_organization.get_organization",
-            new_callable=AsyncMock,
-            return_value=_get_organization_response(),
-        ), patch(
-            "synapseclient.models.schema_organization.list_json_schemas",
-            return_value=mock_list(),
+        with (
+            patch(
+                "synapseclient.models.schema_organization.get_organization",
+                new_callable=AsyncMock,
+                return_value=_get_organization_response(),
+            ),
+            patch(
+                "synapseclient.models.schema_organization.list_json_schemas",
+                return_value=mock_list(),
+            ),
         ):
             # THEN it should raise ValueError
             with pytest.raises(ValueError, match="does not contain a schema with name"):

--- a/tests/unit/synapseclient/models/async/unit_test_submission_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_submission_async.py
@@ -1,4 +1,5 @@
 """Async unit tests for the synapseclient.models.Submission class."""
+
 import uuid
 from typing import Dict, List, Union
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -200,15 +201,18 @@ class TestSubmissionAsync:
         submission = Submission(entity_id=ENTITY_ID, evaluation_id=EVALUATION_ID)
 
         # WHEN I call _fetch_latest_entity with mocked Docker repository responses
-        with patch(
-            "synapseclient.api.entity_services.get_entity",
-            new_callable=AsyncMock,
-            return_value=self.get_example_docker_entity_response(),
-        ) as mock_get_entity, patch(
-            "synapseclient.api.docker_commit_services.get_docker_tag",
-            new_callable=AsyncMock,
-            return_value=self.get_example_docker_tag_response(),
-        ) as mock_get_docker_tag:
+        with (
+            patch(
+                "synapseclient.api.entity_services.get_entity",
+                new_callable=AsyncMock,
+                return_value=self.get_example_docker_entity_response(),
+            ) as mock_get_entity,
+            patch(
+                "synapseclient.api.docker_commit_services.get_docker_tag",
+                new_callable=AsyncMock,
+                return_value=self.get_example_docker_tag_response(),
+            ) as mock_get_docker_tag,
+        ):
             entity_info = await submission._fetch_latest_entity(synapse_client=self.syn)
 
             # THEN it should return the entity information with latest docker tag info
@@ -234,15 +238,18 @@ class TestSubmissionAsync:
         submission = Submission(entity_id=ENTITY_ID, evaluation_id=EVALUATION_ID)
 
         # WHEN I call _fetch_latest_entity with empty docker tag results
-        with patch(
-            "synapseclient.api.entity_services.get_entity",
-            new_callable=AsyncMock,
-            return_value=self.get_example_docker_entity_response(),
-        ) as mock_get_entity, patch(
-            "synapseclient.api.docker_commit_services.get_docker_tag",
-            new_callable=AsyncMock,
-            return_value={"totalNumberOfResults": 0, "results": []},
-        ) as mock_get_docker_tag:
+        with (
+            patch(
+                "synapseclient.api.entity_services.get_entity",
+                new_callable=AsyncMock,
+                return_value=self.get_example_docker_entity_response(),
+            ) as mock_get_entity,
+            patch(
+                "synapseclient.api.docker_commit_services.get_docker_tag",
+                new_callable=AsyncMock,
+                return_value={"totalNumberOfResults": 0, "results": []},
+            ) as mock_get_docker_tag,
+        ):
             entity_info = await submission._fetch_latest_entity(synapse_client=self.syn)
 
             # THEN it should return the entity information without docker tag info
@@ -268,15 +275,18 @@ class TestSubmissionAsync:
         submission = Submission(entity_id=ENTITY_ID, evaluation_id=EVALUATION_ID)
 
         # WHEN I call _fetch_latest_entity with multiple docker tags with different dates
-        with patch(
-            "synapseclient.api.entity_services.get_entity",
-            new_callable=AsyncMock,
-            return_value=self.get_example_docker_entity_response(),
-        ) as mock_get_entity, patch(
-            "synapseclient.api.docker_commit_services.get_docker_tag",
-            new_callable=AsyncMock,
-            return_value=self.get_complex_docker_tag_response(),
-        ) as mock_get_docker_tag:
+        with (
+            patch(
+                "synapseclient.api.entity_services.get_entity",
+                new_callable=AsyncMock,
+                return_value=self.get_example_docker_entity_response(),
+            ) as mock_get_entity,
+            patch(
+                "synapseclient.api.docker_commit_services.get_docker_tag",
+                new_callable=AsyncMock,
+                return_value=self.get_complex_docker_tag_response(),
+            ) as mock_get_docker_tag,
+        ):
             entity_info = await submission._fetch_latest_entity(synapse_client=self.syn)
 
             # THEN it should select the tag with the latest createdOn timestamp (v3.0)
@@ -302,16 +312,19 @@ class TestSubmissionAsync:
         )
 
         # WHEN I call store_async with mocked dependencies
-        with patch.object(
-            submission,
-            "_fetch_latest_entity",
-            new_callable=AsyncMock,
-            return_value=self.get_example_entity_response(),
-        ) as mock_fetch_entity, patch(
-            "synapseclient.api.evaluation_services.create_submission",
-            new_callable=AsyncMock,
-            return_value=self.get_example_submission_response(),
-        ) as mock_create_submission:
+        with (
+            patch.object(
+                submission,
+                "_fetch_latest_entity",
+                new_callable=AsyncMock,
+                return_value=self.get_example_entity_response(),
+            ) as mock_fetch_entity,
+            patch(
+                "synapseclient.api.evaluation_services.create_submission",
+                new_callable=AsyncMock,
+                return_value=self.get_example_submission_response(),
+            ) as mock_create_submission,
+        ):
             stored_submission = await submission.store_async(synapse_client=self.syn)
 
             # THEN it should fetch entity information, create the submission, and fill the object
@@ -342,16 +355,19 @@ class TestSubmissionAsync:
             }
         )
 
-        with patch.object(
-            submission,
-            "_fetch_latest_entity",
-            new_callable=AsyncMock,
-            return_value=docker_entity_with_tag,
-        ) as mock_fetch_entity, patch(
-            "synapseclient.api.evaluation_services.create_submission",
-            new_callable=AsyncMock,
-            return_value=self.get_example_submission_response(),
-        ) as mock_create_submission:
+        with (
+            patch.object(
+                submission,
+                "_fetch_latest_entity",
+                new_callable=AsyncMock,
+                return_value=docker_entity_with_tag,
+            ) as mock_fetch_entity,
+            patch(
+                "synapseclient.api.evaluation_services.create_submission",
+                new_callable=AsyncMock,
+                return_value=self.get_example_submission_response(),
+            ) as mock_create_submission,
+        ):
             stored_submission = await submission.store_async(synapse_client=self.syn)
 
             # THEN it should handle Docker repository specific logic
@@ -375,16 +391,19 @@ class TestSubmissionAsync:
         )
 
         # WHEN I call store_async with mocked dependencies
-        with patch.object(
-            submission,
-            "_fetch_latest_entity",
-            new_callable=AsyncMock,
-            return_value=self.get_example_entity_response(),
-        ) as mock_fetch_entity, patch(
-            "synapseclient.api.evaluation_services.create_submission",
-            new_callable=AsyncMock,
-            return_value=self.get_example_submission_response(),
-        ) as mock_create_submission:
+        with (
+            patch.object(
+                submission,
+                "_fetch_latest_entity",
+                new_callable=AsyncMock,
+                return_value=self.get_example_entity_response(),
+            ) as mock_fetch_entity,
+            patch(
+                "synapseclient.api.evaluation_services.create_submission",
+                new_callable=AsyncMock,
+                return_value=self.get_example_submission_response(),
+            ) as mock_create_submission,
+        ):
             stored_submission = await submission.store_async(synapse_client=self.syn)
 
             # THEN it should preserve team information in the stored submission
@@ -426,12 +445,15 @@ class TestSubmissionAsync:
         submission = Submission(id=SUBMISSION_ID)
 
         # WHEN I call delete_async with mocked dependencies
-        with patch(
-            "synapseclient.api.evaluation_services.delete_submission",
-            new_callable=AsyncMock,
-        ) as mock_delete_submission, patch(
-            "synapseclient.Synapse.get_client",
-            return_value=self.syn,
+        with (
+            patch(
+                "synapseclient.api.evaluation_services.delete_submission",
+                new_callable=AsyncMock,
+            ) as mock_delete_submission,
+            patch(
+                "synapseclient.Synapse.get_client",
+                return_value=self.syn,
+            ),
         ):
             # Mock the logger
             self.syn.logger = MagicMock()
@@ -453,13 +475,16 @@ class TestSubmissionAsync:
         submission = Submission(id=SUBMISSION_ID)
 
         # WHEN I call cancel_async with mocked dependencies
-        with patch(
-            "synapseclient.api.evaluation_services.cancel_submission",
-            new_callable=AsyncMock,
-            return_value=self.get_example_submission_response(),
-        ) as mock_cancel_submission, patch(
-            "synapseclient.Synapse.get_client",
-            return_value=self.syn,
+        with (
+            patch(
+                "synapseclient.api.evaluation_services.cancel_submission",
+                new_callable=AsyncMock,
+                return_value=self.get_example_submission_response(),
+            ) as mock_cancel_submission,
+            patch(
+                "synapseclient.Synapse.get_client",
+                return_value=self.syn,
+            ),
         ):
             # Mock the logger
             self.syn.logger = MagicMock()

--- a/tests/unit/synapseclient/models/async/unit_test_submission_bundle_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_submission_bundle_async.py
@@ -246,7 +246,9 @@ class TestSubmissionBundle:
             mock_get_bundles.side_effect = mock_async_gen
 
             result = []
-            async for bundle in SubmissionBundle.get_evaluation_submission_bundles_async(
+            async for (
+                bundle
+            ) in SubmissionBundle.get_evaluation_submission_bundles_async(
                 evaluation_id=EVALUATION_ID,
                 status="RECEIVED",
                 synapse_client=self.syn,
@@ -296,7 +298,9 @@ class TestSubmissionBundle:
             mock_get_bundles.side_effect = mock_async_gen
 
             result = []
-            async for bundle in SubmissionBundle.get_evaluation_submission_bundles_async(
+            async for (
+                bundle
+            ) in SubmissionBundle.get_evaluation_submission_bundles_async(
                 evaluation_id=EVALUATION_ID,
                 synapse_client=self.syn,
             ):

--- a/tests/unit/synapseclient/models/async/unit_test_wiki_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_wiki_async.py
@@ -1,4 +1,5 @@
 """Tests for the synapseclient.models.wiki classes."""
+
 import copy
 import os
 from typing import Any, AsyncGenerator, Dict, List
@@ -96,12 +97,15 @@ class TestWikiOrderHint:
 
         # WHEN I call `store_async`
         # THEN it should raise ValueError
-        with patch(
-            "synapseclient.models.wiki.put_wiki_order_hint",
-            new_callable=AsyncMock,
-            return_value=self.api_response,
-        ) as mocked_put, pytest.raises(
-            ValueError, match="Must provide owner_id to store wiki order hint."
+        with (
+            patch(
+                "synapseclient.models.wiki.put_wiki_order_hint",
+                new_callable=AsyncMock,
+                return_value=self.api_response,
+            ) as mocked_put,
+            pytest.raises(
+                ValueError, match="Must provide owner_id to store wiki order hint."
+            ),
         ):
             await order_hint.store_async(synapse_client=self.syn)
             # THEN the API should not be called
@@ -130,10 +134,11 @@ class TestWikiOrderHint:
         self.order_hint.owner_id = None
         # WHEN I call `get_async`
         # THEN it should raise ValueError
-        with patch(
-            "synapseclient.models.wiki.get_wiki_order_hint"
-        ) as mocked_get, pytest.raises(
-            ValueError, match="Must provide owner_id to get wiki order hint."
+        with (
+            patch("synapseclient.models.wiki.get_wiki_order_hint") as mocked_get,
+            pytest.raises(
+                ValueError, match="Must provide owner_id to get wiki order hint."
+            ),
         ):
             await self.order_hint.get_async(synapse_client=self.syn)
             # THEN the API should not be called
@@ -236,10 +241,11 @@ class TestWikiHistorySnapshot:
 
     async def test_get_async_missing_owner_id(self) -> None:
         # WHEN I call `get_async`
-        with patch(
-            "synapseclient.models.wiki.get_wiki_history"
-        ) as mocked_get, pytest.raises(
-            ValueError, match="Must provide owner_id to get wiki history."
+        with (
+            patch("synapseclient.models.wiki.get_wiki_history") as mocked_get,
+            pytest.raises(
+                ValueError, match="Must provide owner_id to get wiki history."
+            ),
         ):
             async for _ in WikiHistorySnapshot.get_async(
                 owner_id=None,
@@ -252,10 +258,9 @@ class TestWikiHistorySnapshot:
 
     async def test_get_async_missing_id(self) -> None:
         # WHEN I call `get_async`
-        with patch(
-            "synapseclient.models.wiki.get_wiki_history"
-        ) as mocked_get, pytest.raises(
-            ValueError, match="Must provide id to get wiki history."
+        with (
+            patch("synapseclient.models.wiki.get_wiki_history") as mocked_get,
+            pytest.raises(ValueError, match="Must provide id to get wiki history."),
         ):
             async for _ in WikiHistorySnapshot.get_async(
                 owner_id="syn123",
@@ -343,10 +348,11 @@ class TestWikiHeader:
     async def test_get_async_missing_owner_id(self) -> None:
         # WHEN I call `get_async`
         # THEN it should raise ValueError
-        with patch(
-            "synapseclient.models.wiki.get_wiki_header_tree"
-        ) as mocked_get, pytest.raises(
-            ValueError, match="Must provide owner_id to get wiki header tree."
+        with (
+            patch("synapseclient.models.wiki.get_wiki_header_tree") as mocked_get,
+            pytest.raises(
+                ValueError, match="Must provide owner_id to get wiki header tree."
+            ),
         ):
             async for _ in WikiHeader.get_async(owner_id=None, synapse_client=self.syn):
                 pass
@@ -419,9 +425,11 @@ class TestWikiPage:
         self.syn.cache.cache_root_dir = "temp_cache_dir"
 
         # WHEN I call `_to_gzip_file` with a markdown string
-        with patch("builtins.open") as mock_open_file, patch(
-            "gzip.open"
-        ) as mock_gzip_open, patch("os.path.exists", return_value=True):
+        with (
+            patch("builtins.open") as mock_open_file,
+            patch("gzip.open") as mock_gzip_open,
+            patch("os.path.exists", return_value=True),
+        ):
             file_path = self.wiki_page._to_gzip_file(self.wiki_page.markdown, self.syn)
 
         # THEN the content should be written to a gzipped file
@@ -446,9 +454,11 @@ class TestWikiPage:
         )
 
     def test_to_gzip_file_with_gzipped_file(self) -> None:
-        with patch("os.path.isfile"), patch("gzip.open") as mock_gzip_open, patch(
-            "builtins.open"
-        ) as mock_open_file:
+        with (
+            patch("os.path.isfile"),
+            patch("gzip.open") as mock_gzip_open,
+            patch("builtins.open") as mock_open_file,
+        ):
             self.syn.cache.cache_root_dir = "temp_cache_dir"
             markdown_file_path = "wiki_markdown_Test Wiki Page.md.gz"
 
@@ -462,10 +472,13 @@ class TestWikiPage:
         self.syn.cache.cache_root_dir = "temp_cache_dir"
 
         # WHEN I call `_to_gzip_file` with a file path
-        with patch("os.path.isfile", return_value=True), patch(
-            "builtins.open", new=mock_open(read_data=b"test content")
-        ) as mock_open_file, patch("gzip.open") as mock_gzip_open, patch(
-            "os.path.exists", return_value=True
+        with (
+            patch("os.path.isfile", return_value=True),
+            patch(
+                "builtins.open", new=mock_open(read_data=b"test content")
+            ) as mock_open_file,
+            patch("gzip.open") as mock_gzip_open,
+            patch("os.path.exists", return_value=True),
         ):
             test_file_path = os.path.join("file_path", "test.txt")
             file_path = self.wiki_page._to_gzip_file(test_file_path, self.syn)
@@ -501,9 +514,11 @@ class TestWikiPage:
         markdown_content_bytes = markdown_content.encode("utf-8")
 
         # WHEN I call `_unzip_gzipped_file` with a binary file
-        with patch("gzip.open") as mock_gzip_open, patch(
-            "builtins.open"
-        ) as mock_open_file, patch("pprint.pp") as mock_pprint:
+        with (
+            patch("gzip.open") as mock_gzip_open,
+            patch("builtins.open") as mock_open_file,
+            patch("pprint.pp") as mock_pprint,
+        ):
             mock_gzip_open.return_value.__enter__.return_value.read.return_value = (
                 markdown_content_bytes
             )
@@ -529,9 +544,11 @@ class TestWikiPage:
         binary_content = b"\x00\x01\x02\x03\xff\xfe\xfd"
 
         # WHEN I call `_unzip_gzipped_file` with a binary file
-        with patch("gzip.open") as mock_gzip_open, patch(
-            "builtins.open"
-        ) as mock_open_file, patch("pprint.pp") as mock_pprint:
+        with (
+            patch("gzip.open") as mock_gzip_open,
+            patch("builtins.open") as mock_open_file,
+            patch("pprint.pp") as mock_pprint,
+        ):
             mock_gzip_open.return_value.__enter__.return_value.read.return_value = (
                 binary_content
             )
@@ -556,11 +573,11 @@ class TestWikiPage:
         text_content_bytes = text_content.encode("utf-8")
 
         # WHEN I call `_unzip_gzipped_file` with a text file
-        with patch("gzip.open") as mock_gzip_open, patch(
-            "builtins.open"
-        ) as mock_open_file, patch(
-            "synapseclient.models.wiki.pprint.pp"
-        ) as mock_pprint:
+        with (
+            patch("gzip.open") as mock_gzip_open,
+            patch("builtins.open") as mock_open_file,
+            patch("synapseclient.models.wiki.pprint.pp") as mock_pprint,
+        ):
             mock_gzip_open.return_value.__enter__.return_value.read.return_value = (
                 text_content_bytes
             )
@@ -650,21 +667,20 @@ class TestWikiPage:
             WikiPage._should_gzip_file(123)
 
     async def test_get_markdown_file_handle_success_with_markdown(self) -> WikiPage:
-        with patch(
-            "synapseclient.models.wiki.WikiPage._to_gzip_file",
-            return_value=("test.txt.gz"),
-        ) as mock_to_gzip_file, patch(
-            "synapseclient.models.wiki.upload_file_handle",
-            return_value={"id": "handle1"},
-        ) as mock_upload, patch.object(
-            self.syn.logger, "info"
-        ) as mock_logger_info, patch.object(
-            self.syn.logger, "debug"
-        ) as mock_logger_debug, patch(
-            "os.path.exists", return_value=True
-        ), patch(
-            "os.remove"
-        ) as mock_remove:
+        with (
+            patch(
+                "synapseclient.models.wiki.WikiPage._to_gzip_file",
+                return_value=("test.txt.gz"),
+            ) as mock_to_gzip_file,
+            patch(
+                "synapseclient.models.wiki.upload_file_handle",
+                return_value={"id": "handle1"},
+            ) as mock_upload,
+            patch.object(self.syn.logger, "info") as mock_logger_info,
+            patch.object(self.syn.logger, "debug") as mock_logger_debug,
+            patch("os.path.exists", return_value=True),
+            patch("os.remove") as mock_remove,
+        ):
             # WHEN I call `_get_markdown_file_handle`
             results = await self.wiki_page._get_markdown_file_handle(
                 synapse_client=self.syn
@@ -721,21 +737,20 @@ class TestWikiPage:
             {"id": "handle2"},
         ]
 
-        with patch(
-            "synapseclient.models.wiki.WikiPage._to_gzip_file",
-            side_effect=mock_to_gzip_file_responses,
-        ) as mock_to_gzip_file, patch(
-            "synapseclient.models.wiki.upload_file_handle",
-            side_effect=mock_upload_responses,
-        ) as mock_upload, patch.object(
-            self.syn.logger, "info"
-        ) as mock_logger_info, patch.object(
-            self.syn.logger, "debug"
-        ) as mock_logger_debug, patch(
-            "os.path.exists", return_value=True
-        ), patch(
-            "os.remove"
-        ) as mock_remove:
+        with (
+            patch(
+                "synapseclient.models.wiki.WikiPage._to_gzip_file",
+                side_effect=mock_to_gzip_file_responses,
+            ) as mock_to_gzip_file,
+            patch(
+                "synapseclient.models.wiki.upload_file_handle",
+                side_effect=mock_upload_responses,
+            ) as mock_upload,
+            patch.object(self.syn.logger, "info") as mock_logger_info,
+            patch.object(self.syn.logger, "debug") as mock_logger_debug,
+            patch("os.path.exists", return_value=True),
+            patch("os.remove") as mock_remove,
+        ):
             # WHEN I call `_get_attachment_file_handles`
             results = await self.wiki_page._get_attachment_file_handles(
                 synapse_client=self.syn
@@ -817,21 +832,20 @@ class TestWikiPage:
             owner_id="syn123",
         )
 
-        with patch(
-            "synapseclient.models.wiki.WikiPage._to_gzip_file",
-            return_value=("/tmp/cache/test_1.txt.gz"),
-        ) as mock_to_gzip_file, patch(
-            "synapseclient.models.wiki.upload_file_handle",
-            return_value={"id": "handle1"},
-        ) as mock_upload, patch.object(
-            self.syn.logger, "info"
-        ) as mock_logger_info, patch.object(
-            self.syn.logger, "debug"
-        ) as mock_logger_debug, patch(
-            "os.path.exists", return_value=True
-        ), patch(
-            "os.remove"
-        ) as mock_remove:
+        with (
+            patch(
+                "synapseclient.models.wiki.WikiPage._to_gzip_file",
+                return_value=("/tmp/cache/test_1.txt.gz"),
+            ) as mock_to_gzip_file,
+            patch(
+                "synapseclient.models.wiki.upload_file_handle",
+                return_value={"id": "handle1"},
+            ) as mock_upload,
+            patch.object(self.syn.logger, "info") as mock_logger_info,
+            patch.object(self.syn.logger, "debug") as mock_logger_debug,
+            patch("os.path.exists", return_value=True),
+            patch("os.remove") as mock_remove,
+        ):
             # WHEN I call `_get_attachment_file_handles`
             results = await wiki_page._get_attachment_file_handles(
                 synapse_client=self.syn
@@ -874,21 +888,20 @@ class TestWikiPage:
             owner_id="syn123",
         )
 
-        with patch(
-            "synapseclient.models.wiki.WikiPage._to_gzip_file",
-            return_value=("/tmp/cache/test_1.txt.gz"),
-        ), patch(
-            "synapseclient.models.wiki.upload_file_handle",
-            return_value={"id": "handle1"},
-        ), patch(
-            "os.path.exists", return_value=False
-        ), patch.object(
-            self.syn.logger, "info"
-        ) as mock_logger_info, patch.object(
-            self.syn.logger, "debug"
-        ) as mock_logger_debug, patch(
-            "os.remove"
-        ) as mock_remove:
+        with (
+            patch(
+                "synapseclient.models.wiki.WikiPage._to_gzip_file",
+                return_value=("/tmp/cache/test_1.txt.gz"),
+            ),
+            patch(
+                "synapseclient.models.wiki.upload_file_handle",
+                return_value={"id": "handle1"},
+            ),
+            patch("os.path.exists", return_value=False),
+            patch.object(self.syn.logger, "info") as mock_logger_info,
+            patch.object(self.syn.logger, "debug") as mock_logger_debug,
+            patch("os.remove") as mock_remove,
+        ):
             # WHEN I call `_get_attachment_file_handles`
             results = await wiki_page._get_attachment_file_handles(
                 synapse_client=self.syn
@@ -913,19 +926,19 @@ class TestWikiPage:
             owner_id="syn123",
         )
 
-        with patch(
-            "synapseclient.models.wiki.WikiPage._to_gzip_file",
-            return_value=("/tmp/cache/test_1.txt.gz"),
-        ), patch(
-            "synapseclient.models.wiki.upload_file_handle",
-            side_effect=Exception("Upload failed"),
-        ), patch(
-            "os.path.exists", return_value=True
-        ), patch.object(
-            self.syn.logger, "debug"
-        ) as mock_logger_debug, patch(
-            "os.remove"
-        ) as mock_remove:
+        with (
+            patch(
+                "synapseclient.models.wiki.WikiPage._to_gzip_file",
+                return_value=("/tmp/cache/test_1.txt.gz"),
+            ),
+            patch(
+                "synapseclient.models.wiki.upload_file_handle",
+                side_effect=Exception("Upload failed"),
+            ),
+            patch("os.path.exists", return_value=True),
+            patch.object(self.syn.logger, "debug") as mock_logger_debug,
+            patch("os.remove") as mock_remove,
+        ):
             # WHEN I call `_get_attachment_file_handles`
             # THEN it should raise the exception
             with pytest.raises(Exception, match="Upload failed"):
@@ -1074,20 +1087,25 @@ class TestWikiPage:
         ]
 
         # AND mock responses
-        with patch(
-            "synapseclient.models.wiki.WikiPage._determine_wiki_action",
-            return_value="create_root_wiki_page",
-        ), patch(
-            "synapseclient.models.wiki.WikiPage._get_markdown_file_handle",
-            return_value=mock_wiki_with_markdown,
-        ), patch(
-            "synapseclient.models.wiki.WikiPage._get_attachment_file_handles",
-            return_value=mock_wiki_with_attachments,
-        ), patch(
-            "synapseclient.models.wiki.post_wiki_page", return_value=post_api_response
-        ) as mock_post_wiki, patch.object(
-            self.syn.logger, "info"
-        ) as mock_logger:
+        with (
+            patch(
+                "synapseclient.models.wiki.WikiPage._determine_wiki_action",
+                return_value="create_root_wiki_page",
+            ),
+            patch(
+                "synapseclient.models.wiki.WikiPage._get_markdown_file_handle",
+                return_value=mock_wiki_with_markdown,
+            ),
+            patch(
+                "synapseclient.models.wiki.WikiPage._get_attachment_file_handles",
+                return_value=mock_wiki_with_attachments,
+            ),
+            patch(
+                "synapseclient.models.wiki.post_wiki_page",
+                return_value=post_api_response,
+            ) as mock_post_wiki,
+            patch.object(self.syn.logger, "info") as mock_logger,
+        ):
             # WHEN I call `store_async`
 
             results = await new_wiki_page.store_async(synapse_client=self.syn)
@@ -1161,24 +1179,29 @@ class TestWikiPage:
         ]
 
         # AND mock responses
-        with patch(
-            "synapseclient.models.wiki.WikiPage._determine_wiki_action",
-            return_value="update_existing_wiki_page",
-        ), patch(
-            "synapseclient.models.wiki.WikiPage._get_markdown_file_handle",
-            return_value=mock_wiki_with_markdown,
-        ), patch(
-            "synapseclient.models.wiki.WikiPage._get_attachment_file_handles",
-            return_value=mock_wiki_with_attachments,
-        ), patch(
-            "synapseclient.models.wiki.get_wiki_page",
-            return_value=mock_get_wiki_response,
-        ) as mock_get_wiki, patch(
-            "synapseclient.models.wiki.put_wiki_page",
-            return_value=mock_put_wiki_response,
-        ) as mock_put_wiki, patch.object(
-            self.syn.logger, "info"
-        ) as mock_logger:
+        with (
+            patch(
+                "synapseclient.models.wiki.WikiPage._determine_wiki_action",
+                return_value="update_existing_wiki_page",
+            ),
+            patch(
+                "synapseclient.models.wiki.WikiPage._get_markdown_file_handle",
+                return_value=mock_wiki_with_markdown,
+            ),
+            patch(
+                "synapseclient.models.wiki.WikiPage._get_attachment_file_handles",
+                return_value=mock_wiki_with_attachments,
+            ),
+            patch(
+                "synapseclient.models.wiki.get_wiki_page",
+                return_value=mock_get_wiki_response,
+            ) as mock_get_wiki,
+            patch(
+                "synapseclient.models.wiki.put_wiki_page",
+                return_value=mock_put_wiki_response,
+            ) as mock_put_wiki,
+            patch.object(self.syn.logger, "info") as mock_logger,
+        ):
             # WHEN I call `store_async`
             results = await new_wiki_page.store_async(synapse_client=self.syn)
             # THEN the existing wiki should be retrieved
@@ -1244,20 +1267,25 @@ class TestWikiPage:
         ]
 
         # AND mock responses
-        with patch(
-            "synapseclient.models.wiki.WikiPage._determine_wiki_action",
-            return_value="create_sub_wiki_page",
-        ), patch(
-            "synapseclient.models.wiki.WikiPage._get_markdown_file_handle",
-            return_value=mock_wiki_with_markdown,
-        ), patch(
-            "synapseclient.models.wiki.WikiPage._get_attachment_file_handles",
-            return_value=mock_wiki_with_attachments,
-        ), patch(
-            "synapseclient.models.wiki.post_wiki_page", return_value=post_api_response
-        ) as mock_post_wiki, patch.object(
-            self.syn.logger, "info"
-        ) as mock_logger:
+        with (
+            patch(
+                "synapseclient.models.wiki.WikiPage._determine_wiki_action",
+                return_value="create_sub_wiki_page",
+            ),
+            patch(
+                "synapseclient.models.wiki.WikiPage._get_markdown_file_handle",
+                return_value=mock_wiki_with_markdown,
+            ),
+            patch(
+                "synapseclient.models.wiki.WikiPage._get_attachment_file_handles",
+                return_value=mock_wiki_with_attachments,
+            ),
+            patch(
+                "synapseclient.models.wiki.post_wiki_page",
+                return_value=post_api_response,
+            ) as mock_post_wiki,
+            patch.object(self.syn.logger, "info") as mock_logger,
+        ):
             # WHEN I call `store_async`
             results = await self.wiki_page.store_async(synapse_client=self.syn)
 
@@ -1313,9 +1341,10 @@ class TestWikiPage:
     ) -> None:
         # WHEN I call `restore_async`
         # THEN it should raise ValueError
-        with patch(
-            "synapseclient.models.wiki.put_wiki_version"
-        ) as mocked_put, pytest.raises(ValueError, match=expected_error):
+        with (
+            patch("synapseclient.models.wiki.put_wiki_version") as mocked_put,
+            pytest.raises(ValueError, match=expected_error),
+        ):
             await wiki_page.restore_async(synapse_client=self.syn)
             # THEN the API should not be called
             mocked_put.assert_not_called()
@@ -1389,12 +1418,16 @@ class TestWikiPage:
             for item in values:
                 yield item
 
-        with patch(
-            "synapseclient.models.wiki.get_wiki_header_tree",
-            return_value=mock_async_generator(mock_responses),
-        ) as mock_get_header_tree, patch(
-            "synapseclient.models.wiki.get_wiki_page", return_value=self.api_response
-        ) as mock_get_wiki:
+        with (
+            patch(
+                "synapseclient.models.wiki.get_wiki_header_tree",
+                return_value=mock_async_generator(mock_responses),
+            ) as mock_get_header_tree,
+            patch(
+                "synapseclient.models.wiki.get_wiki_page",
+                return_value=self.api_response,
+            ) as mock_get_wiki,
+        ):
             # WHEN I call `get_async`
             results = await wiki.get_async(synapse_client=self.syn)
 
@@ -1468,9 +1501,10 @@ class TestWikiPage:
     ) -> None:
         # WHEN I call `delete_async`
         # THEN it should raise ValueError
-        with patch(
-            "synapseclient.models.wiki.delete_wiki_page"
-        ) as mocked_delete, pytest.raises(ValueError, match=expected_error):
+        with (
+            patch("synapseclient.models.wiki.delete_wiki_page") as mocked_delete,
+            pytest.raises(ValueError, match=expected_error),
+        ):
             await wiki_page.delete_async(synapse_client=self.syn)
             # THEN the API should not be called
             mocked_delete.assert_not_called()
@@ -1504,9 +1538,10 @@ class TestWikiPage:
     ) -> None:
         # WHEN I call `get_attachment_handles_async`
         # THEN it should raise ValueError
-        with patch(
-            "synapseclient.models.wiki.get_attachment_handles"
-        ) as mocked_get, pytest.raises(ValueError, match=expected_error):
+        with (
+            patch("synapseclient.models.wiki.get_attachment_handles") as mocked_get,
+            pytest.raises(ValueError, match=expected_error),
+        ):
             await wiki_page.get_attachment_handles_async(synapse_client=self.syn)
             # THEN the API should not be called
             mocked_get.assert_not_called()
@@ -1558,9 +1593,10 @@ class TestWikiPage:
     ) -> None:
         # WHEN I call `get_attachment_async`
         # THEN it should raise ValueError
-        with patch(
-            "synapseclient.models.wiki.get_attachment_url"
-        ) as mocked_get, pytest.raises(ValueError, match=expected_error):
+        with (
+            patch("synapseclient.models.wiki.get_attachment_url") as mocked_get,
+            pytest.raises(ValueError, match=expected_error),
+        ):
             await wiki_page.get_attachment_async(
                 file_name=file_name,
                 synapse_client=self.syn,
@@ -1581,30 +1617,34 @@ class TestWikiPage:
             ]
         }
 
-        with patch(
-            "synapseclient.models.wiki.get_attachment_url",
-            return_value=mock_attachment_url,
-        ) as mock_get_url, patch(
-            "synapseclient.models.wiki.get_attachment_handles",
-            return_value=mock_filehandle_dict,
-        ) as mock_get_handles, patch(
-            "synapseclient.models.wiki.download_from_url",
-            return_value="/tmp/download/test.txt.gz",
-        ) as mock_download_from_url, patch(
-            "synapseclient.models.wiki.download_from_url_multi_threaded",
-            return_value="/tmp/download/test.txt.gz",
-        ) as mock_download_from_url_multi_threaded, patch(
-            "synapseclient.models.wiki._pre_signed_url_expiration_time",
-            return_value="2030-01-01T00:00:00.000Z",
-        ) as mock_expiration_time, patch.object(
-            self.syn.logger, "info"
-        ) as mock_logger_info, patch(
-            "os.remove"
-        ) as mock_remove, patch(
-            "synapseclient.models.wiki.WikiPage.unzip_gzipped_file"
-        ) as mock_unzip_gzipped_file, patch.object(
-            self.syn.logger, "debug"
-        ) as mock_logger_debug:
+        with (
+            patch(
+                "synapseclient.models.wiki.get_attachment_url",
+                return_value=mock_attachment_url,
+            ) as mock_get_url,
+            patch(
+                "synapseclient.models.wiki.get_attachment_handles",
+                return_value=mock_filehandle_dict,
+            ) as mock_get_handles,
+            patch(
+                "synapseclient.models.wiki.download_from_url",
+                return_value="/tmp/download/test.txt.gz",
+            ) as mock_download_from_url,
+            patch(
+                "synapseclient.models.wiki.download_from_url_multi_threaded",
+                return_value="/tmp/download/test.txt.gz",
+            ) as mock_download_from_url_multi_threaded,
+            patch(
+                "synapseclient.models.wiki._pre_signed_url_expiration_time",
+                return_value="2030-01-01T00:00:00.000Z",
+            ) as mock_expiration_time,
+            patch.object(self.syn.logger, "info") as mock_logger_info,
+            patch("os.remove") as mock_remove,
+            patch(
+                "synapseclient.models.wiki.WikiPage.unzip_gzipped_file"
+            ) as mock_unzip_gzipped_file,
+            patch.object(self.syn.logger, "debug") as mock_logger_debug,
+        ):
             # WHEN I call `get_attachment_async` with download_file=True
             result = await self.wiki_page.get_attachment_async(
                 file_name="test.txt",
@@ -1698,12 +1738,15 @@ class TestWikiPage:
         # AND a mock attachment URL
         mock_attachment_url = "https://example.com/attachment.txt"
 
-        with patch(
-            "synapseclient.models.wiki.get_attachment_url",
-            return_value=mock_attachment_url,
-        ) as mock_get_url, patch(
-            "synapseclient.models.wiki.get_attachment_handles"
-        ) as mock_get_handles:
+        with (
+            patch(
+                "synapseclient.models.wiki.get_attachment_url",
+                return_value=mock_attachment_url,
+            ) as mock_get_url,
+            patch(
+                "synapseclient.models.wiki.get_attachment_handles"
+            ) as mock_get_handles,
+        ):
             # WHEN I call `get_attachment_async` with download_file=True but no download_location
             # THEN it should raise ValueError
             with pytest.raises(
@@ -1753,9 +1796,10 @@ class TestWikiPage:
     ) -> None:
         # WHEN I call `get_attachment_preview_url_async`
         # THEN it should raise ValueError
-        with patch(
-            "synapseclient.models.wiki.get_attachment_preview_url"
-        ) as mocked_get, pytest.raises(ValueError, match=expected_error):
+        with (
+            patch("synapseclient.models.wiki.get_attachment_preview_url") as mocked_get,
+            pytest.raises(ValueError, match=expected_error),
+        ):
             await wiki_page.get_attachment_preview_async(
                 file_name=file_name,
                 synapse_client=self.syn,
@@ -1778,24 +1822,29 @@ class TestWikiPage:
             ]
         }
 
-        with patch(
-            "synapseclient.models.wiki.get_attachment_preview_url",
-            return_value=mock_attachment_url,
-        ) as mock_get_url, patch(
-            "synapseclient.models.wiki.get_attachment_handles",
-            return_value=mock_filehandle_dict,
-        ) as mock_get_handles, patch(
-            "synapseclient.models.wiki.download_from_url",
-            return_value="/tmp/download/test.txt.gz",
-        ) as mock_download_from_url, patch(
-            "synapseclient.models.wiki.download_from_url_multi_threaded",
-            return_value="/tmp/download/test.txt.gz",
-        ) as mock_download_from_url_multi_threaded, patch(
-            "synapseclient.models.wiki._pre_signed_url_expiration_time",
-            return_value="2030-01-01T00:00:00.000Z",
-        ) as mock_expiration_time, patch.object(
-            self.syn.logger, "info"
-        ) as mock_logger_info:
+        with (
+            patch(
+                "synapseclient.models.wiki.get_attachment_preview_url",
+                return_value=mock_attachment_url,
+            ) as mock_get_url,
+            patch(
+                "synapseclient.models.wiki.get_attachment_handles",
+                return_value=mock_filehandle_dict,
+            ) as mock_get_handles,
+            patch(
+                "synapseclient.models.wiki.download_from_url",
+                return_value="/tmp/download/test.txt.gz",
+            ) as mock_download_from_url,
+            patch(
+                "synapseclient.models.wiki.download_from_url_multi_threaded",
+                return_value="/tmp/download/test.txt.gz",
+            ) as mock_download_from_url_multi_threaded,
+            patch(
+                "synapseclient.models.wiki._pre_signed_url_expiration_time",
+                return_value="2030-01-01T00:00:00.000Z",
+            ) as mock_expiration_time,
+            patch.object(self.syn.logger, "info") as mock_logger_info,
+        ):
             # WHEN I call `get_attachment_async` with download_file=True
             result = await self.wiki_page.get_attachment_preview_async(
                 file_name="test.txt",
@@ -1883,12 +1932,15 @@ class TestWikiPage:
         # AND a mock attachment URL
         mock_attachment_url = "https://example.com/attachment.txt"
 
-        with patch(
-            "synapseclient.models.wiki.get_attachment_preview_url",
-            return_value=mock_attachment_url,
-        ) as mock_get_url, patch(
-            "synapseclient.models.wiki.get_attachment_handles"
-        ) as mock_get_handles:
+        with (
+            patch(
+                "synapseclient.models.wiki.get_attachment_preview_url",
+                return_value=mock_attachment_url,
+            ) as mock_get_url,
+            patch(
+                "synapseclient.models.wiki.get_attachment_handles"
+            ) as mock_get_handles,
+        ):
             # WHEN I call `get_attachment_async` with download_file=True but no download_location
             # THEN it should raise ValueError
             with pytest.raises(
@@ -1930,9 +1982,10 @@ class TestWikiPage:
     ) -> None:
         # WHEN I call `get_markdown_async`
         # THEN it should raise ValueError
-        with patch(
-            "synapseclient.models.wiki.get_markdown_url"
-        ) as mocked_get, pytest.raises(ValueError, match=expected_error):
+        with (
+            patch("synapseclient.models.wiki.get_markdown_url") as mocked_get,
+            pytest.raises(ValueError, match=expected_error),
+        ):
             await wiki_page.get_markdown_file_async(synapse_client=self.syn)
             # THEN the API should not be called
             mocked_get.assert_not_called()
@@ -1941,21 +1994,22 @@ class TestWikiPage:
         # Mock responses
         mock_markdown_url = "https://example.com/markdown.md.gz"
 
-        with patch(
-            "synapseclient.models.wiki.get_markdown_url",
-            return_value=mock_markdown_url,
-        ) as mock_get_url, patch(
-            "synapseclient.models.wiki.download_from_url",
-            return_value="/tmp/download/markdown.md.gz",
-        ) as mock_download_from_url, patch(
-            "synapseclient.models.wiki.WikiPage.unzip_gzipped_file"
-        ) as mock_unzip_gzipped_file, patch.object(
-            self.syn.logger, "info"
-        ) as mock_logger_info, patch.object(
-            self.syn.logger, "debug"
-        ) as mock_logger_debug, patch(
-            "os.remove"
-        ) as mock_remove:
+        with (
+            patch(
+                "synapseclient.models.wiki.get_markdown_url",
+                return_value=mock_markdown_url,
+            ) as mock_get_url,
+            patch(
+                "synapseclient.models.wiki.download_from_url",
+                return_value="/tmp/download/markdown.md.gz",
+            ) as mock_download_from_url,
+            patch(
+                "synapseclient.models.wiki.WikiPage.unzip_gzipped_file"
+            ) as mock_unzip_gzipped_file,
+            patch.object(self.syn.logger, "info") as mock_logger_info,
+            patch.object(self.syn.logger, "debug") as mock_logger_debug,
+            patch("os.remove") as mock_remove,
+        ):
             # WHEN I call `get_markdown_async` with download_file=True
             result = await self.wiki_page.get_markdown_file_async(
                 download_file=True,
@@ -2025,12 +2079,15 @@ class TestWikiPage:
         # AND a mock markdown URL
         mock_markdown_url = "https://example.com/markdown.md"
 
-        with patch(
-            "synapseclient.models.wiki.get_markdown_url",
-            return_value=mock_markdown_url,
-        ) as mock_get_url, patch(
-            "synapseclient.models.wiki.get_attachment_handles"
-        ) as mock_get_handles:
+        with (
+            patch(
+                "synapseclient.models.wiki.get_markdown_url",
+                return_value=mock_markdown_url,
+            ) as mock_get_url,
+            patch(
+                "synapseclient.models.wiki.get_attachment_handles"
+            ) as mock_get_handles,
+        ):
             # WHEN I call `get_markdown_async` with download_file=True but no download_location
             # THEN it should raise ValueError
             with pytest.raises(

--- a/tests/unit/synapseclient/models/synchronous/unit_test_docker.py
+++ b/tests/unit/synapseclient/models/synchronous/unit_test_docker.py
@@ -197,15 +197,18 @@ class TestDockerRepository:
             # Separately set annotations to match real implementation
             entity_to_update.annotations = Annotations.from_dict(test_annotation)
 
-        with patch(
-            "synapseclient.models.docker.get_entity_id_by_repository_name",
-            new_callable=AsyncMock,
-            side_effect=mock_get_entity_id_by_repository_name,
-        ) as mocked_get_id, patch(
-            "synapseclient.models.docker.get_from_entity_factory",
-            new_callable=AsyncMock,
-            side_effect=mock_get_from_entity_factory,
-        ) as mocked_get_from_factory:
+        with (
+            patch(
+                "synapseclient.models.docker.get_entity_id_by_repository_name",
+                new_callable=AsyncMock,
+                side_effect=mock_get_entity_id_by_repository_name,
+            ) as mocked_get_id,
+            patch(
+                "synapseclient.models.docker.get_from_entity_factory",
+                new_callable=AsyncMock,
+                side_effect=mock_get_from_entity_factory,
+            ) as mocked_get_from_factory,
+        ):
             result = docker.get(synapse_client=self.syn)
 
             # Verify repository name lookup was called

--- a/tests/unit/synapseclient/models/unit_test_entityview.py
+++ b/tests/unit/synapseclient/models/unit_test_entityview.py
@@ -1,4 +1,5 @@
 """Tests for the EntityView class."""
+
 import pytest
 
 from synapseclient import Synapse

--- a/tests/unit/synapseclient/operations/unit_test_utility_operations.py
+++ b/tests/unit/synapseclient/operations/unit_test_utility_operations.py
@@ -1,4 +1,5 @@
 """Unit tests for utility_operations wrapper functions."""
+
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/unit/synapseclient/services/unit_test_json_schema.py
+++ b/tests/unit/synapseclient/services/unit_test_json_schema.py
@@ -1,4 +1,5 @@
 """TODO: Add more tests"""
+
 import pytest
 
 from synapseclient.services import json_schema

--- a/tests/unit/synapseclient/unit_test_Entity.py
+++ b/tests/unit/synapseclient/unit_test_Entity.py
@@ -236,7 +236,7 @@ def test_split_entity_namespaces():
         "foo": 1234,
         "parentId": "syn1234",
     }
-    (properties, annotations, local_state) = split_entity_namespaces(e)
+    properties, annotations, local_state = split_entity_namespaces(e)
 
     assert set(properties.keys()) == {"concreteType", "name", "parentId"}
     assert properties["name"] == "Henry"
@@ -255,7 +255,7 @@ def test_split_entity_namespaces():
         "files": ["foo.xyz"],
         "path": "/foo/bar/bat/foo.xyz",
     }
-    (properties, annotations, local_state) = split_entity_namespaces(e)
+    properties, annotations, local_state = split_entity_namespaces(e)
 
     assert set(properties.keys()) == {
         "concreteType",

--- a/tests/unit/synapseclient/unit_test_client.py
+++ b/tests/unit/synapseclient/unit_test_client.py
@@ -1,4 +1,5 @@
 """Unit tests for the Synapse client"""
+
 import asyncio
 import configparser
 import datetime
@@ -344,12 +345,15 @@ class TestDownloadFileHandle:
             (disk_space_error, 1),
             (ValueError("foo"), retries),
         ]:
-            with patch(
-                GET_FILE_HANDLE_FOR_DOWNLOAD,
-                new_callable=AsyncMock,
-            ) as mock_get_file_handle_download, patch(
-                DOWNLOAD_FROM_URL,
-            ) as mock_download_from_URL:
+            with (
+                patch(
+                    GET_FILE_HANDLE_FOR_DOWNLOAD,
+                    new_callable=AsyncMock,
+                ) as mock_get_file_handle_download,
+                patch(
+                    DOWNLOAD_FROM_URL,
+                ) as mock_download_from_URL,
+            ):
                 mock_get_file_handle_download.return_value = {
                     "fileHandle": {
                         "id": file_handle_id,
@@ -413,10 +417,13 @@ class TestDownloadFileHandle:
         expected_download_path = FOO_KEY
         mock_s3_client_wrapper.download_file.return_value = expected_download_path
 
-        with patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-        ) as mock_get_file_handle_download, patch.object(self.syn, "cache") as cache:
+        with (
+            patch(
+                GET_FILE_HANDLE_FOR_DOWNLOAD,
+                new_callable=AsyncMock,
+            ) as mock_get_file_handle_download,
+            patch.object(self.syn, "cache") as cache,
+        ):
             mock_get_file_handle_download.return_value = {
                 "fileHandle": {
                     "id": file_handle_id,
@@ -468,19 +475,20 @@ class TestDownloadFileHandle:
         destination = "/tmp"
         expected_destination = os.path.abspath(destination)
 
-        with patch(
-            GET_FILE_HANDLE_FOR_DOWNLOAD,
-            new_callable=AsyncMock,
-        ) as mock_get_file_handle_download, patch.object(
-            self.syn, "cache"
-        ), patch.object(
-            urllib_request, "urlretrieve"
-        ) as mock_url_retrieve, patch.object(
-            utils, "md5_for_file"
-        ) as mock_md5_for_file, patch.object(
-            os, "makedirs"
-        ), patch.object(
-            sts_transfer, "is_storage_location_sts_enabled_async", return_value=False
+        with (
+            patch(
+                GET_FILE_HANDLE_FOR_DOWNLOAD,
+                new_callable=AsyncMock,
+            ) as mock_get_file_handle_download,
+            patch.object(self.syn, "cache"),
+            patch.object(urllib_request, "urlretrieve") as mock_url_retrieve,
+            patch.object(utils, "md5_for_file") as mock_md5_for_file,
+            patch.object(os, "makedirs"),
+            patch.object(
+                sts_transfer,
+                "is_storage_location_sts_enabled_async",
+                return_value=False,
+            ),
         ):
             mock_get_file_handle_download.return_value = {
                 "fileHandle": {
@@ -837,12 +845,14 @@ class TestSubmit:
             "contributors": self.contributors,
             "submitterAlias": self.team["name"],
         }
-        with patch.object(
-            self.syn, "get_async", return_value=docker_entity
-        ) as patch_syn_get, patch.object(
-            self.syn, "_get_docker_digest", return_value=docker_digest
-        ) as patch_get_digest, patch.object(
-            self.syn, "_submit", return_value=expected_submission
+        with (
+            patch.object(
+                self.syn, "get_async", return_value=docker_entity
+            ) as patch_syn_get,
+            patch.object(
+                self.syn, "_get_docker_digest", return_value=docker_digest
+            ) as patch_get_digest,
+            patch.object(self.syn, "_submit", return_value=expected_submission),
         ):
             submission = self.syn.submit("9090", patch_syn_get, name="George")
             patch_get_digest.assert_called_once_with(docker_entity, "latest")
@@ -973,13 +983,14 @@ def test_send_message(syn: Synapse) -> None:
         "Through caverns measureless to man\n"
         "Down to a sunless sea.\n"
     )
-    with patch(
-        "synapseclient.client.multipart_upload_string_async",
-        new_callable=AsyncMock,
-        return_value="7365905",
-    ) as mock_upload_string, patch(
-        "synapseclient.client.Synapse.restPOST"
-    ) as post_mock:
+    with (
+        patch(
+            "synapseclient.client.multipart_upload_string_async",
+            new_callable=AsyncMock,
+            return_value="7365905",
+        ) as mock_upload_string,
+        patch("synapseclient.client.Synapse.restPOST") as post_mock,
+    ):
         syn.sendMessage(
             userIds=[1421212], messageSubject="Xanadu", messageBody=messageBody
         )
@@ -1023,15 +1034,17 @@ class TestPrivateUploadExternallyStoringProjects:
         max_threads = 8
 
         # method under test
-        with patch.object(
-            upload_functions,
-            "multipart_upload_file",
-            return_value=expected_file_handle_id,
-        ) as mocked_multipart_upload, patch.object(
-            self.syn.cache, "add"
-        ) as mocked_cache_add, patch.object(
-            self.syn, "_get_file_handle_as_creator"
-        ) as mocked_get_file_handle:
+        with (
+            patch.object(
+                upload_functions,
+                "multipart_upload_file",
+                return_value=expected_file_handle_id,
+            ) as mocked_multipart_upload,
+            patch.object(self.syn.cache, "add") as mocked_cache_add,
+            patch.object(
+                self.syn, "_get_file_handle_as_creator"
+            ) as mocked_get_file_handle,
+        ):
             upload_functions.upload_file_handle(
                 syn=self.syn,
                 parent_entity=test_file["parentId"],
@@ -1429,9 +1442,10 @@ def test_move(syn: Synapse) -> None:
     entity = Folder(name="folder", parent="syn456")
     moved_entity = entity
     moved_entity.parentId = "syn789"
-    with patch.object(syn, "get", return_value=entity) as syn_get_patch, patch.object(
-        syn, "store", return_value=moved_entity
-    ) as syn_store_patch:
+    with (
+        patch.object(syn, "get", return_value=entity) as syn_get_patch,
+        patch.object(syn, "store", return_value=moved_entity) as syn_store_patch,
+    ):
         assert moved_entity == syn.move("syn123", "syn789")
         syn_get_patch.assert_called_once_with("syn123", downloadFile=False)
         syn_store_patch.assert_called_once_with(moved_entity, forceVersion=False)
@@ -1482,9 +1496,11 @@ def test_set_permissions_default_permissions(syn: Synapse) -> None:
             {"accessType": ["READ", "DOWNLOAD"], "principalId": principalId}
         ]
     }
-    with patch.object(syn, "_getBenefactor", return_value=entity), patch.object(
-        syn, "_getACL", return_value=acl
-    ), patch.object(syn, "_storeACL", return_value=update_acl) as patch_store_acl:
+    with (
+        patch.object(syn, "_getBenefactor", return_value=entity),
+        patch.object(syn, "_getACL", return_value=acl),
+        patch.object(syn, "_storeACL", return_value=update_acl) as patch_store_acl,
+    ):
         assert update_acl == syn.setPermissions(entity, principalId)
         patch_store_acl.assert_called_once_with(entity, update_acl)
 
@@ -1678,11 +1694,11 @@ class TestCreateS3StorageLocation:
     def _create_storage_location_test(
         self, expected_post_body, *args, **kwargs
     ) -> None:
-        with patch.object(self.syn, "restPOST") as mock_post, patch.object(
-            self.syn, "setStorageLocation"
-        ) as mock_set_storage_location, patch.object(
-            self.syn, "store_async"
-        ) as syn_store:
+        with (
+            patch.object(self.syn, "restPOST") as mock_post,
+            patch.object(self.syn, "setStorageLocation") as mock_set_storage_location,
+            patch.object(self.syn, "store_async") as syn_store,
+        ):
             mock_post.return_value = {"storageLocationId": 456}
             mock_set_storage_location.return_value = {"id": "foo"}
 
@@ -1754,19 +1770,16 @@ class TestCreateExternalS3FileHandle:
         self.syn = syn
 
     def _s3_file_handle_test(self, **kwargs) -> None:
-        with patch.object(
-            self.syn, "_getDefaultUploadDestination"
-        ) as mock_get_upload_dest, patch.object(
-            os, "path"
-        ) as mock_os_path, patch.object(
-            os, "stat"
-        ) as mock_os_stat, patch.object(
-            utils, "md5_for_file"
-        ) as mock_md5, patch(
-            "mimetypes.guess_type"
-        ) as mock_guess_mimetype, patch.object(
-            self.syn, "restPOST"
-        ) as mock_post:
+        with (
+            patch.object(
+                self.syn, "_getDefaultUploadDestination"
+            ) as mock_get_upload_dest,
+            patch.object(os, "path") as mock_os_path,
+            patch.object(os, "stat") as mock_os_stat,
+            patch.object(utils, "md5_for_file") as mock_md5,
+            patch("mimetypes.guess_type") as mock_guess_mimetype,
+            patch.object(self.syn, "restPOST") as mock_post,
+        ):
             bucket_name = "foo_bucket"
             s3_file_key = "/foo/bar/baz"
             file_path = "/tmp/foo"
@@ -1925,13 +1938,17 @@ class TestMembershipInvitation:
             "inviteeEmail": self.email,
             "inviteeId": None,
         }
-        with patch.object(
-            self.syn, "get_team_open_invitations", return_value=[]
-        ) as patch_get_invites, patch.object(
-            self.syn, "getUserProfile", return_value=self.profile
-        ) as patch_get_profile, patch.object(
-            self.syn, "send_membership_invitation", return_value=self.response
-        ) as patch_invitation:
+        with (
+            patch.object(
+                self.syn, "get_team_open_invitations", return_value=[]
+            ) as patch_get_invites,
+            patch.object(
+                self.syn, "getUserProfile", return_value=self.profile
+            ) as patch_get_profile,
+            patch.object(
+                self.syn, "send_membership_invitation", return_value=self.response
+            ) as patch_invitation,
+        ):
             invite = self.syn.invite_to_team(
                 self.team, inviteeEmail=self.email, message=self.message
             )
@@ -1944,15 +1961,20 @@ class TestMembershipInvitation:
         """Invite user to team via their Synapse userid"""
         self.member_status["isMember"] = False
         invite_body = {"inviteeId": self.userid, "inviteeEmail": None, "message": None}
-        with patch.object(
-            self.syn, "get_membership_status", return_value=self.member_status
-        ) as patch_getmem, patch.object(
-            self.syn, "get_team_open_invitations", return_value=[]
-        ) as patch_get_invites, patch.object(
-            self.syn, "getUserProfile", return_value=self.profile
-        ) as patch_get_profile, patch.object(
-            self.syn, "send_membership_invitation", return_value=self.response
-        ) as patch_invitation:
+        with (
+            patch.object(
+                self.syn, "get_membership_status", return_value=self.member_status
+            ) as patch_getmem,
+            patch.object(
+                self.syn, "get_team_open_invitations", return_value=[]
+            ) as patch_get_invites,
+            patch.object(
+                self.syn, "getUserProfile", return_value=self.profile
+            ) as patch_get_profile,
+            patch.object(
+                self.syn, "send_membership_invitation", return_value=self.response
+            ) as patch_invitation,
+        ):
             invite = self.syn.invite_to_team(self.team, user=self.userid)
             patch_getmem.assert_called_once_with(self.userid, self.team.id)
             patch_get_profile.assert_called_once_with(self.userid)
@@ -1964,15 +1986,20 @@ class TestMembershipInvitation:
         """Invite user to team via their Synapse username"""
         self.member_status["isMember"] = False
         invite_body = {"inviteeId": self.userid, "inviteeEmail": None, "message": None}
-        with patch.object(
-            self.syn, "get_membership_status", return_value=self.member_status
-        ) as patch_getmem, patch.object(
-            self.syn, "get_team_open_invitations", return_value=[]
-        ) as patch_get_invites, patch.object(
-            self.syn, "getUserProfile", return_value=self.profile
-        ) as patch_get_profile, patch.object(
-            self.syn, "send_membership_invitation", return_value=self.response
-        ) as patch_invitation:
+        with (
+            patch.object(
+                self.syn, "get_membership_status", return_value=self.member_status
+            ) as patch_getmem,
+            patch.object(
+                self.syn, "get_team_open_invitations", return_value=[]
+            ) as patch_get_invites,
+            patch.object(
+                self.syn, "getUserProfile", return_value=self.profile
+            ) as patch_get_profile,
+            patch.object(
+                self.syn, "send_membership_invitation", return_value=self.response
+            ) as patch_invitation,
+        ):
             invite = self.syn.invite_to_team(self.team, user=self.username)
             patch_getmem.assert_called_once_with(self.userid, self.team.id)
             patch_get_profile.assert_called_once_with(self.username)
@@ -1982,15 +2009,20 @@ class TestMembershipInvitation:
 
     def test_invite_to_team__ismember(self) -> None:
         """None returned when user is already a member"""
-        with patch.object(
-            self.syn, "get_membership_status", return_value=self.member_status
-        ) as patch_getmem, patch.object(
-            self.syn, "get_team_open_invitations", return_value=[]
-        ) as patch_get_invites, patch.object(
-            self.syn, "getUserProfile", return_value=self.profile
-        ) as patch_get_profile, patch.object(
-            self.syn, "send_membership_invitation", return_value=self.response
-        ) as patch_invitation:
+        with (
+            patch.object(
+                self.syn, "get_membership_status", return_value=self.member_status
+            ) as patch_getmem,
+            patch.object(
+                self.syn, "get_team_open_invitations", return_value=[]
+            ) as patch_get_invites,
+            patch.object(
+                self.syn, "getUserProfile", return_value=self.profile
+            ) as patch_get_profile,
+            patch.object(
+                self.syn, "send_membership_invitation", return_value=self.response
+            ) as patch_invitation,
+        ):
             invite = self.syn.invite_to_team(self.team, user=self.userid)
             patch_getmem.assert_called_once_with(self.userid, self.team.id)
             patch_get_profile.assert_called_once_with(self.userid)
@@ -2002,17 +2034,21 @@ class TestMembershipInvitation:
         """None returned when user already has an invitation"""
         self.member_status["isMember"] = False
         invite_body = {"inviteeId": self.userid}
-        with patch.object(
-            self.syn, "get_membership_status", return_value=self.member_status
-        ) as patch_getmem, patch.object(
-            self.syn, "get_team_open_invitations", return_value=[invite_body]
-        ) as patch_get_invites, patch.object(
-            self.syn, "getUserProfile", return_value=self.profile
-        ) as patch_get_profile, patch.object(
-            self.syn, "_delete_membership_invitation"
-        ) as patch_delete, patch.object(
-            self.syn, "send_membership_invitation", return_value=self.response
-        ) as patch_invitation:
+        with (
+            patch.object(
+                self.syn, "get_membership_status", return_value=self.member_status
+            ) as patch_getmem,
+            patch.object(
+                self.syn, "get_team_open_invitations", return_value=[invite_body]
+            ) as patch_get_invites,
+            patch.object(
+                self.syn, "getUserProfile", return_value=self.profile
+            ) as patch_get_profile,
+            patch.object(self.syn, "_delete_membership_invitation") as patch_delete,
+            patch.object(
+                self.syn, "send_membership_invitation", return_value=self.response
+            ) as patch_invitation,
+        ):
             invite = self.syn.invite_to_team(self.team, user=self.userid)
             patch_getmem.assert_called_once_with(self.userid, self.team.id)
             patch_get_profile.assert_called_once_with(self.userid)
@@ -2024,13 +2060,15 @@ class TestMembershipInvitation:
     def test_invite_to_team__email_openinvite(self) -> None:
         """None returned when email already has an invitation"""
         invite_body = {"inviteeEmail": self.email}
-        with patch.object(
-            self.syn, "get_team_open_invitations", return_value=[invite_body]
-        ) as patch_get_invites, patch.object(
-            self.syn, "_delete_membership_invitation"
-        ) as patch_delete, patch.object(
-            self.syn, "send_membership_invitation", return_value=self.response
-        ) as patch_invitation:
+        with (
+            patch.object(
+                self.syn, "get_team_open_invitations", return_value=[invite_body]
+            ) as patch_get_invites,
+            patch.object(self.syn, "_delete_membership_invitation") as patch_delete,
+            patch.object(
+                self.syn, "send_membership_invitation", return_value=self.response
+            ) as patch_invitation,
+        ):
             invite = self.syn.invite_to_team(self.team, inviteeEmail=self.email)
             patch_get_invites.assert_called_once_with(self.team.id)
             patch_invitation.assert_not_called()
@@ -2041,13 +2079,15 @@ class TestMembershipInvitation:
     def test_invite_to_team__none_matching_invitation(self) -> None:
         """Invitation sent when no matching open invitations"""
         invite_body = {"inviteeEmail": self.email + "foo"}
-        with patch.object(
-            self.syn, "get_team_open_invitations", return_value=[invite_body]
-        ) as patch_get_invites, patch.object(
-            self.syn, "_delete_membership_invitation"
-        ) as patch_delete, patch.object(
-            self.syn, "send_membership_invitation", return_value=self.response
-        ) as patch_invitation:
+        with (
+            patch.object(
+                self.syn, "get_team_open_invitations", return_value=[invite_body]
+            ) as patch_get_invites,
+            patch.object(self.syn, "_delete_membership_invitation") as patch_delete,
+            patch.object(
+                self.syn, "send_membership_invitation", return_value=self.response
+            ) as patch_invitation,
+        ):
             invite = self.syn.invite_to_team(self.team, inviteeEmail=self.email)
             patch_get_invites.assert_called_once_with(self.team.id)
             patch_delete.assert_not_called()
@@ -2058,13 +2098,15 @@ class TestMembershipInvitation:
         """Invitation sent when force the invite, make sure open invitation
         is deleted"""
         open_invitations = {"inviteeEmail": self.email, "id": "9938"}
-        with patch.object(
-            self.syn, "get_team_open_invitations", return_value=[open_invitations]
-        ) as patch_get_invites, patch.object(
-            self.syn, "_delete_membership_invitation"
-        ) as patch_delete, patch.object(
-            self.syn, "send_membership_invitation", return_value=self.response
-        ) as patch_invitation:
+        with (
+            patch.object(
+                self.syn, "get_team_open_invitations", return_value=[open_invitations]
+            ) as patch_get_invites,
+            patch.object(self.syn, "_delete_membership_invitation") as patch_delete,
+            patch.object(
+                self.syn, "send_membership_invitation", return_value=self.response
+            ) as patch_invitation,
+        ):
             invite = self.syn.invite_to_team(
                 self.team, inviteeEmail=self.email, force=True
             )
@@ -2293,15 +2335,16 @@ class TestRestCalls:
         kwargs = {"stream": True}
 
         requests_session = requests_session or self.syn._requests_session
-        with patch.object(
-            self.syn, "_build_uri_and_headers"
-        ) as mock_build_uri_and_headers, patch.object(
-            self.syn, "_build_retry_policy"
-        ) as mock_build_retry_policy, patch.object(
-            self.syn, "_handle_synapse_http_error"
-        ) as mock_handle_synapse_http_error, patch.object(
-            requests_session, method
-        ) as mock_requests_call:
+        with (
+            patch.object(
+                self.syn, "_build_uri_and_headers"
+            ) as mock_build_uri_and_headers,
+            patch.object(self.syn, "_build_retry_policy") as mock_build_retry_policy,
+            patch.object(
+                self.syn, "_handle_synapse_http_error"
+            ) as mock_handle_synapse_http_error,
+            patch.object(requests_session, method) as mock_requests_call,
+        ):
             mock_build_uri_and_headers.return_value = (uri, headers)
             mock_build_retry_policy.return_value = retryPolicy
 
@@ -2547,22 +2590,18 @@ def test_store_needs_upload_false_file_handle_id_not_in_local_state(
         ],
         "annotations": {"id": synapse_id, "etag": etag, "annotations": {}},
     }
-    with patch.object(
-        syn, "_getEntityBundle", return_value=returned_bundle
-    ), patch.object(
-        synapseclient.client,
-        "upload_file_handle_async",
-        return_value=returned_file_handle,
-    ), patch.object(
-        syn.cache, "contains", return_value=True
-    ), patch.object(
-        syn, "_updateEntity"
-    ), patch.object(
-        syn, "set_annotations"
-    ), patch.object(
-        Entity, "create"
-    ), patch.object(
-        syn, "get"
+    with (
+        patch.object(syn, "_getEntityBundle", return_value=returned_bundle),
+        patch.object(
+            synapseclient.client,
+            "upload_file_handle_async",
+            return_value=returned_file_handle,
+        ),
+        patch.object(syn.cache, "contains", return_value=True),
+        patch.object(syn, "_updateEntity"),
+        patch.object(syn, "set_annotations"),
+        patch.object(Entity, "create"),
+        patch.object(syn, "get"),
     ):
         f = File("/fake_file.txt", parent=parent_id)
         syn.store(f)
@@ -2627,22 +2666,20 @@ def test_store_existing_processed_as_update(syn: Synapse) -> None:
         "baz": [4],
     }
 
-    with patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle, patch.object(
-        synapseclient.client,
-        "upload_file_handle_async",
-        return_value=returned_file_handle,
-    ), patch.object(syn.cache, "contains", return_value=True), patch.object(
-        syn, "_createEntity"
-    ) as mock_createEntity, patch.object(
-        syn, "_updateEntity"
-    ) as mock_updateEntity, patch.object(
-        syn, "findEntityId"
-    ) as mock_findEntityId, patch.object(
-        syn, "set_annotations"
-    ) as mock_set_annotations, patch.object(
-        Entity, "create"
-    ), patch.object(
-        syn, "get"
+    with (
+        patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle,
+        patch.object(
+            synapseclient.client,
+            "upload_file_handle_async",
+            return_value=returned_file_handle,
+        ),
+        patch.object(syn.cache, "contains", return_value=True),
+        patch.object(syn, "_createEntity") as mock_createEntity,
+        patch.object(syn, "_updateEntity") as mock_updateEntity,
+        patch.object(syn, "findEntityId") as mock_findEntityId,
+        patch.object(syn, "set_annotations") as mock_set_annotations,
+        patch.object(Entity, "create"),
+        patch.object(syn, "get"),
     ):
         mock_get_entity_bundle.return_value = returned_bundle
 
@@ -2723,23 +2760,21 @@ def test_store__409_processed_as_update(syn: Synapse) -> None:
         "baz": [4],
     }
 
-    with patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle, patch.object(
-        synapseclient.client,
-        "upload_file_handle_async",
-        new_callable=AsyncMock,
-        return_value=returned_file_handle,
-    ), patch.object(syn.cache, "contains", return_value=True), patch.object(
-        syn, "_createEntity"
-    ) as mock_createEntity, patch.object(
-        syn, "_updateEntity"
-    ) as mock_updateEntity, patch.object(
-        syn, "findEntityId"
-    ) as mock_findEntityId, patch.object(
-        syn, "set_annotations"
-    ) as mock_set_annotations, patch.object(
-        Entity, "create"
-    ), patch.object(
-        syn, "get_async"
+    with (
+        patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle,
+        patch.object(
+            synapseclient.client,
+            "upload_file_handle_async",
+            new_callable=AsyncMock,
+            return_value=returned_file_handle,
+        ),
+        patch.object(syn.cache, "contains", return_value=True),
+        patch.object(syn, "_createEntity") as mock_createEntity,
+        patch.object(syn, "_updateEntity") as mock_updateEntity,
+        patch.object(syn, "findEntityId") as mock_findEntityId,
+        patch.object(syn, "set_annotations") as mock_set_annotations,
+        patch.object(Entity, "create"),
+        patch.object(syn, "get_async"),
     ):
         mock_get_entity_bundle.side_effect = [None, returned_bundle]
         mock_createEntity.side_effect = SynapseHTTPError(
@@ -2804,22 +2839,20 @@ def test_store__no_need_to_update_annotation(syn: Synapse) -> None:
         },
     }
 
-    with patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle, patch.object(
-        synapseclient.client,
-        "upload_file_handle_async",
-        return_value=returned_file_handle,
-    ), patch.object(syn.cache, "contains", return_value=True), patch.object(
-        syn, "_createEntity"
-    ), patch.object(
-        syn, "_updateEntity"
-    ), patch.object(
-        syn, "findEntityId"
-    ), patch.object(
-        syn, "set_annotations"
-    ) as mock_set_annotations, patch.object(
-        Entity, "create"
-    ), patch.object(
-        syn, "get"
+    with (
+        patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle,
+        patch.object(
+            synapseclient.client,
+            "upload_file_handle_async",
+            return_value=returned_file_handle,
+        ),
+        patch.object(syn.cache, "contains", return_value=True),
+        patch.object(syn, "_createEntity"),
+        patch.object(syn, "_updateEntity"),
+        patch.object(syn, "findEntityId"),
+        patch.object(syn, "set_annotations") as mock_set_annotations,
+        patch.object(Entity, "create"),
+        patch.object(syn, "get"),
     ):
         mock_get_entity_bundle.return_value = returned_bundle
 
@@ -2875,22 +2908,20 @@ def test_store__update_version_comment(syn: Synapse) -> None:
         "versionComment": "12345",
     }
 
-    with patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle, patch.object(
-        synapseclient.client,
-        "upload_file_handle_async",
-        return_value=returned_file_handle,
-    ), patch.object(syn.cache, "contains", return_value=True), patch.object(
-        syn, "_createEntity"
-    ) as mock_createEntity, patch.object(
-        syn, "_updateEntity"
-    ) as mock_updateEntity, patch.object(
-        syn, "findEntityId"
-    ) as mock_findEntityId, patch.object(
-        syn, "set_annotations"
-    ) as mock_set_annotations, patch.object(
-        Entity, "create"
-    ), patch.object(
-        syn, "get"
+    with (
+        patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle,
+        patch.object(
+            synapseclient.client,
+            "upload_file_handle_async",
+            return_value=returned_file_handle,
+        ),
+        patch.object(syn.cache, "contains", return_value=True),
+        patch.object(syn, "_createEntity") as mock_createEntity,
+        patch.object(syn, "_updateEntity") as mock_updateEntity,
+        patch.object(syn, "findEntityId") as mock_findEntityId,
+        patch.object(syn, "set_annotations") as mock_set_annotations,
+        patch.object(Entity, "create"),
+        patch.object(syn, "get"),
     ):
         mock_get_entity_bundle.return_value = returned_bundle
 
@@ -2984,16 +3015,17 @@ def test_store__existing_no_update(syn: Synapse) -> None:
         "annotations": {},
     }
 
-    with patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle, patch.object(
-        synapseclient.client,
-        "upload_file_handle_async",
-        return_value=returned_file_handle,
-    ), patch.object(syn.cache, "contains", return_value=True), patch.object(
-        syn, "_createEntity"
-    ) as mock_createEntity, patch.object(
-        syn, "_updateEntity"
-    ) as mock_updatentity, patch.object(
-        syn, "get"
+    with (
+        patch.object(syn, "_getEntityBundle") as mock_get_entity_bundle,
+        patch.object(
+            synapseclient.client,
+            "upload_file_handle_async",
+            return_value=returned_file_handle,
+        ),
+        patch.object(syn.cache, "contains", return_value=True),
+        patch.object(syn, "_createEntity") as mock_createEntity,
+        patch.object(syn, "_updateEntity") as mock_updatentity,
+        patch.object(syn, "get"),
     ):
         mock_get_entity_bundle.return_value = returned_bundle
         mock_createEntity.side_effect = SynapseHTTPError(
@@ -3049,9 +3081,10 @@ def test_get_submission_with_annotations(syn: Synapse) -> None:
         "entityBundleJSON": json.dumps(entity_bundle_json),
     }
 
-    with patch.object(syn, "restGET") as restGET, patch.object(
-        syn, "_getWithEntityBundle_async"
-    ) as get_entity:
+    with (
+        patch.object(syn, "restGET") as restGET,
+        patch.object(syn, "_getWithEntityBundle_async") as get_entity,
+    ):
         restGET.return_value = submission
         response = syn.getSubmission(submission_id)
 
@@ -3096,9 +3129,10 @@ def run_get_submission_test(
         "entityBundleJSON": json.dumps({}),
     }
 
-    with patch.object(syn, "restGET") as restGET, patch.object(
-        syn, "_getWithEntityBundle_async"
-    ) as get_entity:
+    with (
+        patch.object(syn, "restGET") as restGET,
+        patch.object(syn, "_getWithEntityBundle_async") as get_entity,
+    ):
         restGET.return_value = submission
 
         if should_warn:
@@ -3170,12 +3204,11 @@ def test_get_submission_and_submission_status_interchangeability(
     }
 
     # Let's mock all the API calls made within these two methods
-    with patch.object(syn, "restGET") as restGET, patch.object(
-        Submission, "getURI"
-    ) as get_submission_uri, patch.object(
-        SubmissionStatus, "getURI"
-    ) as get_status_uri, patch.object(
-        syn, "_getWithEntityBundle_async"
+    with (
+        patch.object(syn, "restGET") as restGET,
+        patch.object(Submission, "getURI") as get_submission_uri,
+        patch.object(SubmissionStatus, "getURI") as get_status_uri,
+        patch.object(syn, "_getWithEntityBundle_async"),
     ):
         get_submission_uri.return_value = (
             f"/evaluation/submission/{expected_submission_id}"
@@ -3248,9 +3281,10 @@ class TestTableSnapshot:
             "description": activity["description"],
             "id": 123,
         }
-        with patch.object(
-            syn, "restPOST", return_value=snapshot
-        ) as restpost, patch.object(syn, "_saveActivity") as mock__saveActivity:
+        with (
+            patch.object(syn, "restPOST", return_value=snapshot) as restpost,
+            patch.object(syn, "_saveActivity") as mock__saveActivity,
+        ):
             mock__saveActivity.return_value = mock_dict
             syn._create_table_snapshot(
                 "syn1234", comment="foo", label="new_label", activity=activity
@@ -3311,11 +3345,14 @@ class TestTableSnapshot:
         """Create Table snapshot"""
         table = Mock(Schema)
         snapshot_version = 3
-        with patch.object(syn, "get", return_value=table) as get, patch.object(
-            syn,
-            "_create_table_snapshot",
-            return_value={"snapshotVersionNumber": snapshot_version},
-        ) as create:
+        with (
+            patch.object(syn, "get", return_value=table) as get,
+            patch.object(
+                syn,
+                "_create_table_snapshot",
+                return_value={"snapshotVersionNumber": snapshot_version},
+            ) as create,
+        ):
             result = syn.create_snapshot_version(
                 "syn1234", comment="foo", label="new_label", activity=2, wait=True
             )
@@ -3335,11 +3372,14 @@ class TestTableSnapshot:
         views = [Mock(EntityViewSchema), Mock(SubmissionViewSchema)]
         for view in views:
             snapshot_version = 3
-            with patch.object(syn, "get", return_value=view) as get, patch.object(
-                syn,
-                "_async_table_update",
-                return_value={"snapshotVersionNumber": snapshot_version},
-            ) as update:
+            with (
+                patch.object(syn, "get", return_value=view) as get,
+                patch.object(
+                    syn,
+                    "_async_table_update",
+                    return_value={"snapshotVersionNumber": snapshot_version},
+                ) as update,
+            ):
                 result = syn.create_snapshot_version(
                     "syn1234",
                     comment="foo",
@@ -3358,9 +3398,12 @@ class TestTableSnapshot:
                 )
                 assert snapshot_version == result
 
-            with patch.object(syn, "get", return_value=view) as get, patch.object(
-                syn, "_async_table_update", return_value={"token": 5}
-            ) as update:
+            with (
+                patch.object(syn, "get", return_value=view) as get,
+                patch.object(
+                    syn, "_async_table_update", return_value={"token": 5}
+                ) as update,
+            ):
                 result = syn.create_snapshot_version(
                     "syn1234", comment="foo", label="new_label", activity=2, wait=False
                 )
@@ -3378,9 +3421,12 @@ class TestTableSnapshot:
     def test_create_snapshot_version_raiseerror(self, syn: Synapse) -> None:
         """Raise error if entity view or table not passed in"""
         wrong_type = Mock()
-        with patch.object(syn, "get", return_value=wrong_type), pytest.raises(
-            ValueError,
-            match="This function only accepts Synapse ids of Tables or Views",
+        with (
+            patch.object(syn, "get", return_value=wrong_type),
+            pytest.raises(
+                ValueError,
+                match="This function only accepts Synapse ids of Tables or Views",
+            ),
         ):
             syn.create_snapshot_version("syn1234")
 
@@ -3525,14 +3571,15 @@ class TestTableQuery:
         expanduser = os.path.expanduser
         expandvars = os.path.expandvars
         os_join = os.path.join
-        with patch.object(syn, "_waitForAsync") as mock_wait_for_async, patch.object(
-            syn, "cache"
-        ) as mock_cache, patch(
-            "synapseclient.client.download_by_file_handle",
-            new_callable=AsyncMock,
-        ) as mock_download_file_handle, patch.object(
-            client, "os"
-        ) as mock_os:
+        with (
+            patch.object(syn, "_waitForAsync") as mock_wait_for_async,
+            patch.object(syn, "cache") as mock_cache,
+            patch(
+                "synapseclient.client.download_by_file_handle",
+                new_callable=AsyncMock,
+            ) as mock_download_file_handle,
+            patch.object(client, "os") as mock_os,
+        ):
             mock_download_result = {"resultsFileHandleId": file_handle_id}
             mock_wait_for_async.return_value = mock_download_result
             mock_cache.get.return_value = None
@@ -3642,11 +3689,14 @@ def test__get_certified_passing_record(userid, syn: Synapse) -> None:
 
 @pytest.mark.parametrize("response", [True, False])
 def test_is_certified(response, syn: Synapse) -> None:
-    with patch.object(
-        syn, "getUserProfile", return_value={"ownerId": "foobar"}
-    ) as patch_get_user, patch.object(
-        syn, "_get_certified_passing_record", return_value={"passed": response}
-    ) as patch_get_cert:
+    with (
+        patch.object(
+            syn, "getUserProfile", return_value={"ownerId": "foobar"}
+        ) as patch_get_user,
+        patch.object(
+            syn, "_get_certified_passing_record", return_value={"passed": response}
+        ) as patch_get_cert,
+    ):
         is_certified = syn.is_certified("test")
         patch_get_user.assert_called_once_with("test")
         patch_get_cert.assert_called_once_with("foobar")
@@ -3658,13 +3708,16 @@ def test_is_certified__no_quiz_results(syn: Synapse) -> None:
     In this case the back end returns a 404 rather than a result."""
     response = MagicMock(requests.Response)
     response.status_code = 404
-    with patch.object(
-        syn, "getUserProfile", return_value={"ownerId": "foobar"}
-    ) as patch_get_user, patch.object(
-        syn,
-        "_get_certified_passing_record",
-        side_effect=SynapseHTTPError(response=response),
-    ) as patch_get_cert:
+    with (
+        patch.object(
+            syn, "getUserProfile", return_value={"ownerId": "foobar"}
+        ) as patch_get_user,
+        patch.object(
+            syn,
+            "_get_certified_passing_record",
+            side_effect=SynapseHTTPError(response=response),
+        ) as patch_get_cert,
+    ):
         is_certified = syn.is_certified("test")
     patch_get_user.assert_called_once_with("test")
     patch_get_cert.assert_called_once_with("foobar")
@@ -3776,41 +3829,46 @@ class TestPermissionsOnProject:
 
     def test_get_permissions_with_defined_set_for_access(self) -> None:
         # GIVEN the API calls are mocked
-        with patch.object(
-            self.syn,
-            "_getUserbyPrincipalIdOrName",
-            # AND a user with id of 456
-            return_value=456,
-        ), patch.object(
-            self.syn,
-            "_getACL",
-            return_value={
-                "resourceAccess": [
-                    {
-                        "principalId": 456,
-                        # AND the permissions are given to the user
-                        "accessType": [
-                            "READ",
-                            "DELETE",
-                            "CHANGE_SETTINGS",
-                            "UPDATE",
-                            "CHANGE_PERMISSIONS",
-                            "CREATE",
-                            "MODERATE",
-                            "DOWNLOAD",
-                        ],
-                    }
-                ]
-            },
-        ), patch.object(
-            self.syn,
-            "_find_teams_for_principal",
-            # AND the user is a part of no teams
-            return_value=[],
-        ), patch.object(
-            self.syn,
-            "_get_user_bundle",
-            return_value=None,
+        with (
+            patch.object(
+                self.syn,
+                "_getUserbyPrincipalIdOrName",
+                # AND a user with id of 456
+                return_value=456,
+            ),
+            patch.object(
+                self.syn,
+                "_getACL",
+                return_value={
+                    "resourceAccess": [
+                        {
+                            "principalId": 456,
+                            # AND the permissions are given to the user
+                            "accessType": [
+                                "READ",
+                                "DELETE",
+                                "CHANGE_SETTINGS",
+                                "UPDATE",
+                                "CHANGE_PERMISSIONS",
+                                "CREATE",
+                                "MODERATE",
+                                "DOWNLOAD",
+                            ],
+                        }
+                    ]
+                },
+            ),
+            patch.object(
+                self.syn,
+                "_find_teams_for_principal",
+                # AND the user is a part of no teams
+                return_value=[],
+            ),
+            patch.object(
+                self.syn,
+                "_get_user_bundle",
+                return_value=None,
+            ),
         ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")
@@ -3830,41 +3888,46 @@ class TestPermissionsOnProject:
 
     def test_get_permissions_with_no_permissions_for_user(self) -> None:
         # GIVEN the API calls are mocked
-        with patch.object(
-            self.syn,
-            "_getUserbyPrincipalIdOrName",
-            # AND a user with id of 456
-            return_value=456,
-        ), patch.object(
-            self.syn,
-            "_getACL",
-            return_value={
-                "resourceAccess": [
-                    {
-                        # AND the permissions are given to an unknown user
-                        "principalId": 99999,
-                        "accessType": [
-                            "READ",
-                            "DELETE",
-                            "CHANGE_SETTINGS",
-                            "UPDATE",
-                            "CHANGE_PERMISSIONS",
-                            "CREATE",
-                            "MODERATE",
-                            "DOWNLOAD",
-                        ],
-                    }
-                ]
-            },
-        ), patch.object(
-            self.syn,
-            "_find_teams_for_principal",
-            # AND the user is a part of no teams
-            return_value=[],
-        ), patch.object(
-            self.syn,
-            "_get_user_bundle",
-            return_value=None,
+        with (
+            patch.object(
+                self.syn,
+                "_getUserbyPrincipalIdOrName",
+                # AND a user with id of 456
+                return_value=456,
+            ),
+            patch.object(
+                self.syn,
+                "_getACL",
+                return_value={
+                    "resourceAccess": [
+                        {
+                            # AND the permissions are given to an unknown user
+                            "principalId": 99999,
+                            "accessType": [
+                                "READ",
+                                "DELETE",
+                                "CHANGE_SETTINGS",
+                                "UPDATE",
+                                "CHANGE_PERMISSIONS",
+                                "CREATE",
+                                "MODERATE",
+                                "DOWNLOAD",
+                            ],
+                        }
+                    ]
+                },
+            ),
+            patch.object(
+                self.syn,
+                "_find_teams_for_principal",
+                # AND the user is a part of no teams
+                return_value=[],
+            ),
+            patch.object(
+                self.syn,
+                "_get_user_bundle",
+                return_value=None,
+            ),
         ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")
@@ -3875,41 +3938,46 @@ class TestPermissionsOnProject:
 
     def test_get_permissions_with_permissions_given_through_single_team(self) -> None:
         # GIVEN the API calls are mocked
-        with patch.object(
-            self.syn,
-            "_getUserbyPrincipalIdOrName",
-            # AND a user with id of 456
-            return_value=456,
-        ), patch.object(
-            self.syn,
-            "_getACL",
-            return_value={
-                "resourceAccess": [
-                    {
-                        # AND the permissions are given to a team
-                        "principalId": 999,
-                        "accessType": [
-                            "READ",
-                            "DELETE",
-                            "CHANGE_SETTINGS",
-                            "UPDATE",
-                            "CHANGE_PERMISSIONS",
-                            "CREATE",
-                            "MODERATE",
-                            "DOWNLOAD",
-                        ],
-                    }
-                ]
-            },
-        ), patch.object(
-            self.syn,
-            "_find_teams_for_principal",
-            # AND the user is assigned to a team
-            return_value=[Team(id=999)],
-        ), patch.object(
-            self.syn,
-            "_get_user_bundle",
-            return_value=None,
+        with (
+            patch.object(
+                self.syn,
+                "_getUserbyPrincipalIdOrName",
+                # AND a user with id of 456
+                return_value=456,
+            ),
+            patch.object(
+                self.syn,
+                "_getACL",
+                return_value={
+                    "resourceAccess": [
+                        {
+                            # AND the permissions are given to a team
+                            "principalId": 999,
+                            "accessType": [
+                                "READ",
+                                "DELETE",
+                                "CHANGE_SETTINGS",
+                                "UPDATE",
+                                "CHANGE_PERMISSIONS",
+                                "CREATE",
+                                "MODERATE",
+                                "DOWNLOAD",
+                            ],
+                        }
+                    ]
+                },
+            ),
+            patch.object(
+                self.syn,
+                "_find_teams_for_principal",
+                # AND the user is assigned to a team
+                return_value=[Team(id=999)],
+            ),
+            patch.object(
+                self.syn,
+                "_get_user_bundle",
+                return_value=None,
+            ),
         ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")
@@ -3931,49 +3999,54 @@ class TestPermissionsOnProject:
         self,
     ) -> None:
         # GIVEN the API calls are mocked
-        with patch.object(
-            self.syn,
-            "_getUserbyPrincipalIdOrName",
-            # AND a user with id of 456
-            return_value=456,
-        ), patch.object(
-            self.syn,
-            "_getACL",
-            return_value={
-                "resourceAccess": [
-                    # AND the permissions are spread across a set of 2 teams
-                    {
-                        "principalId": 888,
-                        "accessType": [
-                            "READ",
-                            "DELETE",
-                            "CHANGE_SETTINGS",
-                            "UPDATE",
-                            "CHANGE_PERMISSIONS",
-                        ],
-                    },
-                    {
-                        "principalId": 999,
-                        "accessType": [
-                            "READ",
-                            "UPDATE",
-                            "CHANGE_PERMISSIONS",
-                            "CREATE",
-                            "MODERATE",
-                            "DOWNLOAD",
-                        ],
-                    },
-                ]
-            },
-        ), patch.object(
-            self.syn,
-            "_find_teams_for_principal",
-            # AND the user is assigned to both of the teams
-            return_value=[Team(id=888), Team(id=999)],
-        ), patch.object(
-            self.syn,
-            "_get_user_bundle",
-            return_value=None,
+        with (
+            patch.object(
+                self.syn,
+                "_getUserbyPrincipalIdOrName",
+                # AND a user with id of 456
+                return_value=456,
+            ),
+            patch.object(
+                self.syn,
+                "_getACL",
+                return_value={
+                    "resourceAccess": [
+                        # AND the permissions are spread across a set of 2 teams
+                        {
+                            "principalId": 888,
+                            "accessType": [
+                                "READ",
+                                "DELETE",
+                                "CHANGE_SETTINGS",
+                                "UPDATE",
+                                "CHANGE_PERMISSIONS",
+                            ],
+                        },
+                        {
+                            "principalId": 999,
+                            "accessType": [
+                                "READ",
+                                "UPDATE",
+                                "CHANGE_PERMISSIONS",
+                                "CREATE",
+                                "MODERATE",
+                                "DOWNLOAD",
+                            ],
+                        },
+                    ]
+                },
+            ),
+            patch.object(
+                self.syn,
+                "_find_teams_for_principal",
+                # AND the user is assigned to both of the teams
+                return_value=[Team(id=888), Team(id=999)],
+            ),
+            patch.object(
+                self.syn,
+                "_get_user_bundle",
+                return_value=None,
+            ),
         ):
             # WHEN I get the permissions for the user on the entity
             permissions = self.syn.getPermissions("123", "456")

--- a/tests/unit/synapseclient/unit_test_commandline.py
+++ b/tests/unit/synapseclient/unit_test_commandline.py
@@ -1,6 +1,4 @@
-"""Test the Synapse command line client.
-
-"""
+"""Test the Synapse command line client."""
 
 import os
 import shutil

--- a/tests/unit/synapseclient/unit_test_get_permissions.py
+++ b/tests/unit/synapseclient/unit_test_get_permissions.py
@@ -1,6 +1,7 @@
 """
 Unit test for synapseclient.client.get_permissions
 """
+
 from typing import Dict
 from unittest.mock import patch
 

--- a/tests/unit/synapseclient/unit_test_tables.py
+++ b/tests/unit/synapseclient/unit_test_tables.py
@@ -1,4 +1,5 @@
 """Unit test for synapseclient.table"""
+
 import csv
 import io
 import json
@@ -259,9 +260,10 @@ def test_csv_to_pandas_df_no_kwargs():
         {"col1": [1, 2, 3], "col2": ["a", "b", "c"], "col3": [True, False, True]}
     )
 
-    with patch.object(
-        pd, "read_csv", return_value=expected_df
-    ) as mock_read_csv, patch.object(os, "linesep", "\r\n"):
+    with (
+        patch.object(pd, "read_csv", return_value=expected_df) as mock_read_csv,
+        patch.object(os, "linesep", "\r\n"),
+    ):
         # WHEN I call _csv_to_pandas_df with default parameters
         df = _csv_to_pandas_df(
             filepath="dummy_path.csv",
@@ -297,9 +299,10 @@ def test_csv_to_pandas_df_with_kwargs() -> None:
     # GIVEN a pandas DataFrame (CSV file stand-in)
     expected_df = pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
 
-    with patch.object(
-        pd, "read_csv", return_value=expected_df
-    ) as mock_read_csv, patch.object(os, "linesep", "\r\n"):
+    with (
+        patch.object(pd, "read_csv", return_value=expected_df) as mock_read_csv,
+        patch.object(os, "linesep", "\r\n"),
+    ):
         # WHEN I call _csv_to_pandas_df with custom keyword arguments
         kwargs = {"escapechar": "\\", "keep_default_na": False}
         df = _csv_to_pandas_df(
@@ -339,9 +342,12 @@ def test_csv_to_pandas_df_calls_convert_date_cols():
         {"col1": [1, 2, 3], "date_col": ["2021-01-01", "2021-01-02", "2021-01-03"]}
     )
 
-    with patch.object(pd, "read_csv", return_value=expected_df), patch.object(
-        synapseclient.table, "_convert_df_date_cols_to_datetime"
-    ) as mock_convert_dates:
+    with (
+        patch.object(pd, "read_csv", return_value=expected_df),
+        patch.object(
+            synapseclient.table, "_convert_df_date_cols_to_datetime"
+        ) as mock_convert_dates,
+    ):
         # WHEN I call _csv_to_pandas_df with date_columns specified
         _csv_to_pandas_df(
             filepath="dummy_path.csv",
@@ -372,11 +378,13 @@ def test_csv_to_pandas_df_handles_list_columns():
         {"col1": [1, 2, 3], "list_col": [[1, 2, 3], [4, 5, 6], [7, 8, 9]]}
     )
 
-    with patch.object(pd, "read_csv", return_value=initial_df), patch.object(
-        synapseclient.table, "_convert_df_date_cols_to_datetime"
-    ), patch.object(
-        pd.Series, "apply", return_value=expected_final_df["list_col"]
-    ) as mock_apply:
+    with (
+        patch.object(pd, "read_csv", return_value=initial_df),
+        patch.object(synapseclient.table, "_convert_df_date_cols_to_datetime"),
+        patch.object(
+            pd.Series, "apply", return_value=expected_final_df["list_col"]
+        ) as mock_apply,
+    ):
         # WHEN I call _csv_to_pandas_df with list_columns specified
         result_df = synapseclient.table._csv_to_pandas_df(
             filepath="dummy_path.csv",
@@ -415,11 +423,14 @@ def test_csv_to_pandas_df_handles_row_id_and_version():
         {"col1": ["a", "b", "c"], "col2": [10, 20, 30]}, index=["1_1", "2_1", "3_2"]
     )  # Index format: ROW_ID_ROW_VERSION
 
-    with patch.object(pd, "read_csv", return_value=initial_df), patch.object(
-        synapseclient.table,
-        "row_labels_from_id_and_version",
-        return_value=["1_1", "2_1", "3_2"],
-    ) as mock_row_labels:
+    with (
+        patch.object(pd, "read_csv", return_value=initial_df),
+        patch.object(
+            synapseclient.table,
+            "row_labels_from_id_and_version",
+            return_value=["1_1", "2_1", "3_2"],
+        ) as mock_row_labels,
+    ):
         # WHEN I call _csv_to_pandas_df with rowIdAndVersionInIndex=True
         result_df = synapseclient.table._csv_to_pandas_df(
             filepath="dummy_path.csv",
@@ -1173,22 +1184,25 @@ def test_downloadTableColumns(syn: Synapse, download_location: str) -> None:
         3: zip_entry_file_paths[1],
     }
 
-    with patch.object(syn, "cache") as mock_cache, patch.object(
-        syn, "_waitForAsync"
-    ) as mock_async, patch(
-        "synapseclient.client.ensure_download_location_is_directory"
-    ) as mock_ensure_dir, patch(
-        "synapseclient.client.download_by_file_handle"
-    ) as mock_download_file_handle, patch.object(
-        client, "zipfile"
-    ), patch.object(
-        client, "extract_zip_file_to_directory"
-    ) as mock_extract_zip_file_to_directory:
+    with (
+        patch.object(syn, "cache") as mock_cache,
+        patch.object(syn, "_waitForAsync") as mock_async,
+        patch(
+            "synapseclient.client.ensure_download_location_is_directory"
+        ) as mock_ensure_dir,
+        patch(
+            "synapseclient.client.download_by_file_handle"
+        ) as mock_download_file_handle,
+        patch.object(client, "zipfile"),
+        patch.object(
+            client, "extract_zip_file_to_directory"
+        ) as mock_extract_zip_file_to_directory,
+    ):
         mock_cache.get.side_effect = cached_paths
         mock_async.return_value = mock_async_response
-        mock_ensure_dir.return_value = (
-            mock_cache.get_cache_dir.return_value
-        ) = "/tmp/download"
+        mock_ensure_dir.return_value = mock_cache.get_cache_dir.return_value = (
+            "/tmp/download"
+        )
         mock_download_file_handle.return_value = zip_file_path
         mock_extract_zip_file_to_directory.side_effect = zip_entry_file_paths
 
@@ -1245,12 +1259,10 @@ def test_SubmissionViewSchema__default_params() -> None:
 
 
 def test_SubmissionViewSchema__before_synapse_store(syn: Synapse) -> None:
-    with patch.object(
-        syn, "_get_default_view_columns"
-    ) as mocked_get_default, patch.object(
-        syn, "_get_annotation_view_columns"
-    ) as mocked_get_annotations, patch.object(
-        SchemaBase, "_before_synapse_store"
+    with (
+        patch.object(syn, "_get_default_view_columns") as mocked_get_default,
+        patch.object(syn, "_get_annotation_view_columns") as mocked_get_annotations,
+        patch.object(SchemaBase, "_before_synapse_store"),
     ):
         submission_view = SubmissionViewSchema(scopes=["123"], parent="idk")
         submission_view._before_synapse_store(syn)
@@ -1265,12 +1277,10 @@ def test_SubmissionViewSchema__before_synapse_store(syn: Synapse) -> None:
 def test_EntityViewSchema__before_synapse_store(syn: Synapse) -> None:
     syn = Synapse(debug=True, skip_checks=True, cache_client=False)
 
-    with patch.object(
-        syn, "_get_default_view_columns"
-    ) as mocked_get_default, patch.object(
-        syn, "_get_annotation_view_columns"
-    ) as mocked_get_annotations, patch.object(
-        SchemaBase, "_before_synapse_store"
+    with (
+        patch.object(syn, "_get_default_view_columns") as mocked_get_default,
+        patch.object(syn, "_get_annotation_view_columns") as mocked_get_annotations,
+        patch.object(SchemaBase, "_before_synapse_store"),
     ):
         submission_view = EntityViewSchema(scopes=["syn123"], parent="idk")
         submission_view._before_synapse_store(syn)
@@ -1385,12 +1395,12 @@ def test_EntityViewSchema__ignore_annotation_column_names(syn: Synapse) -> None:
         Column(name="long2", columnType="INTEGER"),
     ]
 
-    with patch.object(
-        syn, "_get_annotation_view_columns", return_value=mocked_annotation_result1
-    ) as mocked_get_annotations, patch.object(
-        syn, "getColumns"
-    ) as mocked_get_columns, patch.object(
-        SchemaBase, "_before_synapse_store"
+    with (
+        patch.object(
+            syn, "_get_annotation_view_columns", return_value=mocked_annotation_result1
+        ) as mocked_get_annotations,
+        patch.object(syn, "getColumns") as mocked_get_columns,
+        patch.object(SchemaBase, "_before_synapse_store"),
     ):
         entity_view._before_synapse_store(syn)
 
@@ -1500,8 +1510,9 @@ def test_rowset_asDataFrame__with_ROW_ETAG_column(syn: Synapse) -> None:
         },
     }
 
-    with patch.object(syn, "_queryTable", return_value=query_result), patch.object(
-        syn, "_queryTableNext", return_value=query_result_next_page
+    with (
+        patch.object(syn, "_queryTable", return_value=query_result),
+        patch.object(syn, "_queryTableNext", return_value=query_result_next_page),
     ):
         table = syn.tableQuery("select something from syn123", resultsAs="rowset")
         dataframe = table.asDataFrame()
@@ -1539,14 +1550,17 @@ def test_build_table__with_pandas_DataFrame() -> None:
 
 def test_build_table__with_csv() -> None:
     string_io = StringIOContextManager("a,b\n" "1,c\n" "2,d\n" "3,e")
-    with patch.object(
-        synapseclient.table,
-        "as_table_columns",
-        return_value=[
-            Column(name="a", columnType="INTEGER"),
-            Column(name="b", columnType="STRING"),
-        ],
-    ), patch.object(io, "open", return_value=string_io):
+    with (
+        patch.object(
+            synapseclient.table,
+            "as_table_columns",
+            return_value=[
+                Column(name="a", columnType="INTEGER"),
+                Column(name="b", columnType="STRING"),
+            ],
+        ),
+        patch.object(io, "open", return_value=string_io),
+    ):
         table = build_table("test", "syn123", "some_file_name")
         for col, row in enumerate(table):
             assert row[0] == (col + 1)

--- a/tests/unit/synapseutils/unit_test_synapseutils_copy.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_copy.py
@@ -15,8 +15,9 @@ from synapseutils.copy_functions import (
 
 def test_copyWiki_empty_Wiki(syn):
     entity = {"id": "syn123"}
-    with patch.object(syn, "getWikiHeaders", return_value=None), patch.object(
-        syn, "get", return_value=entity
+    with (
+        patch.object(syn, "getWikiHeaders", return_value=None),
+        patch.object(syn, "get", return_value=entity),
     ):
         synapseutils.copyWiki(syn, "syn123", "syn456", updateLinks=False)
 
@@ -35,10 +36,11 @@ def test_copyWiki_input_validation(syn):
         call({"id": "syn123"}, "8689"),
         call({"id": "syn123"}, "8690"),
     ]
-    with patch.object(syn, "getWikiHeaders", return_value=to_copy), patch.object(
-        syn, "get", return_value=entity
-    ), patch.object(syn, "getWiki", return_value=wiki) as mock_getWiki, patch.object(
-        syn, "store", return_value=wiki
+    with (
+        patch.object(syn, "getWikiHeaders", return_value=to_copy),
+        patch.object(syn, "get", return_value=entity),
+        patch.object(syn, "getWiki", return_value=wiki) as mock_getWiki,
+        patch.object(syn, "store", return_value=wiki),
     ):
         synapseutils.copyWiki(
             syn,
@@ -362,13 +364,12 @@ class TestProtectedBatchIteratorGenerator:
 
 @pytest.mark.parametrize("forceVersionToggle", [True, False])
 def test_change_file_metadata(syn, forceVersionToggle):
-    with patch.object(syn, "get") as get_mock, patch.object(
-        syn, "_getFileHandleDownload"
-    ) as fh_mock, patch(
-        "synapseutils.copy_functions.copyFileHandles"
-    ) as copy_mock, patch.object(
-        syn, "store"
-    ) as store_mock:
+    with (
+        patch.object(syn, "get") as get_mock,
+        patch.object(syn, "_getFileHandleDownload") as fh_mock,
+        patch("synapseutils.copy_functions.copyFileHandles") as copy_mock,
+        patch.object(syn, "store") as store_mock,
+    ):
         copy_result = {"failureCode": None, "newFileHandle": {"id": 123}}
         copy_mock.return_value = [copy_result]
         synapseutils.changeFileMetaData(syn, "syn123", forceVersion=forceVersionToggle)
@@ -402,11 +403,12 @@ class TestCopyPermissions:
     def test_dont_copy_read_permissions(self):
         """Entities with READ permissions not copied"""
         permissions = {"canDownload": False}
-        with patch.object(
-            self.syn, "get", return_value=self.file_ent
-        ) as patch_syn_get, patch.object(
-            self.syn, "restGET", return_value=permissions
-        ) as patch_rest_get:
+        with (
+            patch.object(self.syn, "get", return_value=self.file_ent) as patch_syn_get,
+            patch.object(
+                self.syn, "restGET", return_value=permissions
+            ) as patch_rest_get,
+        ):
             copied_file = synapseutils.copy(
                 self.syn,
                 self.file_ent,
@@ -441,11 +443,12 @@ class TestCopyAccessRestriction:
         # TEST: Entity with access requirement not copied
         access_requirements = {"results": ["fee", "fi"]}
         permissions = {"canDownload": True}
-        with patch.object(
-            self.syn, "get", return_value=self.file_ent
-        ) as patch_syn_get, patch.object(
-            self.syn, "restGET", side_effects=[permissions, access_requirements]
-        ) as patch_rest_get:
+        with (
+            patch.object(self.syn, "get", return_value=self.file_ent) as patch_syn_get,
+            patch.object(
+                self.syn, "restGET", side_effects=[permissions, access_requirements]
+            ) as patch_rest_get,
+        ):
             copied_file = synapseutils.copy(
                 self.syn,
                 self.file_ent,
@@ -483,15 +486,16 @@ class TestCopy:
         """Docker repositories and EntityViews aren't copied"""
         access_requirements = {"results": []}
         permissions = {"canDownload": True}
-        with patch.object(
-            self.syn, "get", return_value=self.project_entity
-        ) as patch_syn_get, patch.object(
-            self.syn, "restGET", side_effect=[permissions, access_requirements]
-        ) as patch_rest_get, patch.object(
-            self.syn, "getChildren"
-        ) as patch_get_children, patch.object(
-            self.syn, "store"
-        ) as patch_store:
+        with (
+            patch.object(
+                self.syn, "get", return_value=self.project_entity
+            ) as patch_syn_get,
+            patch.object(
+                self.syn, "restGET", side_effect=[permissions, access_requirements]
+            ) as patch_rest_get,
+            patch.object(self.syn, "getChildren") as patch_get_children,
+            patch.object(self.syn, "store") as patch_store,
+        ):
             copied_project = synapseutils.copy(
                 self.syn,
                 self.project_entity,

--- a/tests/unit/synapseutils/unit_test_synapseutils_describe.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_describe.py
@@ -154,11 +154,16 @@ class TestDescribe:
 
     def test_describe(self):
         syn = Mock()
-        with patch.object(
-            describe_functions, "_open_entity_as_df", return_value=self.df_mixed
-        ) as mock_open_entity, patch.object(
-            describe_functions, "_describe_wrapper", return_value=self.expected_results
-        ) as mock_describe:
+        with (
+            patch.object(
+                describe_functions, "_open_entity_as_df", return_value=self.df_mixed
+            ) as mock_open_entity,
+            patch.object(
+                describe_functions,
+                "_describe_wrapper",
+                return_value=self.expected_results,
+            ) as mock_describe,
+        ):
             result = describe_functions.describe(syn=syn, entity="syn1234")
             mock_open_entity.assert_called_once_with(syn=syn, entity="syn1234")
             mock_describe.assert_called_once_with(self.df_mixed, syn=syn)
@@ -167,9 +172,10 @@ class TestDescribe:
     def test_describe_none(self):
         """Test if data type is not supported"""
         syn = Mock()
-        with patch.object(
-            describe_functions, "_open_entity_as_df", return_value=None
-        ), patch.object(describe_functions, "_describe_wrapper") as mock_describe:
+        with (
+            patch.object(describe_functions, "_open_entity_as_df", return_value=None),
+            patch.object(describe_functions, "_describe_wrapper") as mock_describe,
+        ):
             result = describe_functions.describe(syn=syn, entity="syn1234")
             mock_describe.assert_not_called()
             assert result is None

--- a/tests/unit/synapseutils/unit_test_synapseutils_migrate.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_migrate.py
@@ -275,9 +275,10 @@ class TestIndex:
     @pytest.fixture(scope="function")
     def conn(self):
         # temp file context manager doesn't work on windows so we manually remove in fixture
-        with tempfile.NamedTemporaryFile(delete=False) as tmpfile, sqlite3.connect(
-            tmpfile.name
-        ) as conn:
+        with (
+            tempfile.NamedTemporaryFile(delete=False) as tmpfile,
+            sqlite3.connect(tmpfile.name) as conn,
+        ):
             yield conn
 
     def test_check_indexed(self, conn):
@@ -330,8 +331,7 @@ class TestIndex:
             file_version_strategy,
         )
 
-        row = cursor.execute(
-            """
+        row = cursor.execute("""
                 select
                     id,
                     parent_id,
@@ -341,8 +341,7 @@ class TestIndex:
                     file_size,
                     status
                 from migrations
-            """
-        ).fetchone()
+            """).fetchone()
 
         row_dict = _get_row_dict(cursor, row, True)
 
@@ -436,8 +435,7 @@ class TestIndex:
             "all",
         )
 
-        result = cursor.execute(
-            """
+        result = cursor.execute("""
                 select
                     id,
                     parent_id,
@@ -447,8 +445,7 @@ class TestIndex:
                     file_size,
                     status
                 from migrations
-            """
-        ).fetchall()
+            """).fetchall()
 
         result_iter = iter(result)
         row_0 = next(result_iter)
@@ -578,8 +575,7 @@ class TestIndex:
             [from_storage_location_id, "543"],
         )
 
-        result = cursor.execute(
-            """
+        result = cursor.execute("""
                 select
                     id,
                     parent_id,
@@ -589,8 +585,7 @@ class TestIndex:
                     from_file_handle_id,
                     status
                 from migrations
-            """
-        ).fetchall()
+            """).fetchall()
 
         row_iter = iter(result)
         row_0_dict = _get_row_dict(cursor, next(row_iter), True)
@@ -724,16 +719,14 @@ class TestIndex:
 
         assert mock_index_entity.call_args_list == expected_calls
 
-        row = cursor.execute(
-            """
+        row = cursor.execute("""
                 select
                     id,
                     type,
                     parent_id,
                     status
                 from migrations
-            """
-        ).fetchone()
+            """).fetchone()
 
         row_dict = _get_row_dict(cursor, row, True)
         assert row_dict["id"] == project_id
@@ -800,16 +793,14 @@ class TestIndex:
 
         assert mock_index_entity.call_args_list == expected_calls
 
-        row = cursor.execute(
-            """
+        row = cursor.execute("""
                 select
                     id,
                     type,
                     parent_id,
                     status
                 from migrations
-            """
-        ).fetchone()
+            """).fetchone()
 
         row_dict = _get_row_dict(cursor, row, True)
         assert row_dict["id"] == folder_id
@@ -1047,16 +1038,14 @@ class TestIndex:
             file_version_strategy,
         )
 
-        row = cursor.execute(
-            """
+        row = cursor.execute("""
                 select
                     id,
                     type,
                     status,
                     exception
                 from migrations
-            """
-        ).fetchone()
+            """).fetchone()
 
         row_dict = _get_row_dict(cursor, row, True)
         assert row_dict["id"] == entity_id
@@ -1288,9 +1277,10 @@ class TestMigrate:
     @pytest.fixture(scope="function")
     def conn(self):
         # temp file context manager doesn't work on windows so we manually remove in fixture
-        with tempfile.NamedTemporaryFile(delete=False) as tmpfile, sqlite3.connect(
-            tmpfile.name
-        ) as conn:
+        with (
+            tempfile.NamedTemporaryFile(delete=False) as tmpfile,
+            sqlite3.connect(tmpfile.name) as conn,
+        ):
             yield conn
 
     @pytest.fixture(scope="function")
@@ -1547,19 +1537,21 @@ class TestMigrate:
                 migration_values,
             )
 
-        with mock.patch.object(syn, "get") as mock_syn_get, mock.patch.object(
-            syn, "store"
-        ) as mock_syn_store, mock.patch.object(
-            syn, "_getFileHandleDownload"
-        ) as mock_get_file_handle_download, mock.patch.object(
-            syn, "restGET"
-        ) as mock_syn_rest_get, mock.patch.object(
-            syn, "create_snapshot_version"
-        ) as mock_create_snapshot_version, mock.patch.object(
-            syn, "tableQuery"
-        ) as mock_syn_table_query, mock.patch.object(
-            synapseutils.migrate_functions, "multipart_copy"
-        ) as mock_multipart_copy:
+        with (
+            mock.patch.object(syn, "get") as mock_syn_get,
+            mock.patch.object(syn, "store") as mock_syn_store,
+            mock.patch.object(
+                syn, "_getFileHandleDownload"
+            ) as mock_get_file_handle_download,
+            mock.patch.object(syn, "restGET") as mock_syn_rest_get,
+            mock.patch.object(
+                syn, "create_snapshot_version"
+            ) as mock_create_snapshot_version,
+            mock.patch.object(syn, "tableQuery") as mock_syn_table_query,
+            mock.patch.object(
+                synapseutils.migrate_functions, "multipart_copy"
+            ) as mock_multipart_copy,
+        ):
             mock_syn_get.side_effect = mock_syn_get_side_effect
             mock_syn_store.side_effect = mock_syn_store_side_effect
             mock_get_file_handle_download.side_effect = (
@@ -1693,9 +1685,10 @@ def test_migrate__shared_file_handles(mocker, syn):
         ),
     ]
 
-    with tempfile.NamedTemporaryFile(delete=False) as tmpfile, sqlite3.connect(
-        tmpfile.name
-    ) as conn:
+    with (
+        tempfile.NamedTemporaryFile(delete=False) as tmpfile,
+        sqlite3.connect(tmpfile.name) as conn,
+    ):
         cursor = conn.cursor()
         _ensure_schema(cursor)
 
@@ -2101,8 +2094,7 @@ def test_get_table_file_handle_rows__no_file_columns(mocker, syn):
 
 
 def _verify_schema(cursor):
-    results = cursor.execute(
-        """
+    results = cursor.execute("""
             SELECT
               m.name as table_name,
               p.name as column_name
@@ -2113,8 +2105,7 @@ def _verify_schema(cursor):
             ORDER BY
               m.name,
               p.cid
-        """
-    )
+        """)
 
     expected_table_columns = {
         "migration_settings": {
@@ -2148,9 +2139,10 @@ def _verify_schema(cursor):
 def test_ensure_schema():
     """Verify _ensure_schema bootstraps the necessary schema"""
 
-    with tempfile.NamedTemporaryFile(delete=False) as db_file, sqlite3.connect(
-        db_file.name
-    ) as conn:
+    with (
+        tempfile.NamedTemporaryFile(delete=False) as db_file,
+        sqlite3.connect(db_file.name) as conn,
+    ):
         cursor = conn.cursor()
         _ensure_schema(cursor)
         _verify_schema(cursor)
@@ -2177,9 +2169,10 @@ def test_verify_storage_location_ownership():
 def test__verify_index_settings__retrieve_index_settings():
     """Verify the behavior saving index settings and re-retreiving them."""
 
-    with tempfile.NamedTemporaryFile(delete=False) as db_file, sqlite3.connect(
-        db_file.name
-    ) as conn:
+    with (
+        tempfile.NamedTemporaryFile(delete=False) as db_file,
+        sqlite3.connect(db_file.name) as conn,
+    ):
         db_path = db_file.name
         cursor = conn.cursor()
         _ensure_schema(cursor)
@@ -2302,9 +2295,10 @@ def test__verify_index_settings__invalid_table_schema():
     version of the function.
     """
 
-    with tempfile.NamedTemporaryFile(delete=False) as db_file, sqlite3.connect(
-        db_file.name
-    ) as conn:
+    with (
+        tempfile.NamedTemporaryFile(delete=False) as db_file,
+        sqlite3.connect(db_file.name) as conn,
+    ):
         db_path = db_file.name
         cursor = conn.cursor()
         cursor.execute("create table migration_settings (foo text)")

--- a/tests/unit/synapseutils/unit_test_synapseutils_monitor.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_monitor.py
@@ -8,9 +8,12 @@ def test_notifyMe__successful_call(syn):
     subject = "some message subject"
     owner_id = "12434"
     user_profile = {"ownerId": owner_id}
-    with patch.object(syn, "sendMessage") as mocked_send_message, patch.object(
-        syn, "getUserProfile", return_value=user_profile
-    ) as mocked_get_user_profile:
+    with (
+        patch.object(syn, "sendMessage") as mocked_send_message,
+        patch.object(
+            syn, "getUserProfile", return_value=user_profile
+        ) as mocked_get_user_profile,
+    ):
         mocked_func = MagicMock()
 
         @notifyMe(syn, messageSubject=subject)
@@ -30,8 +33,9 @@ def test_notifyMe__exception_thrown_and_retry_fail(syn):
     subject = "some message subject"
     owner_id = "12434"
     user_profile = {"ownerId": owner_id}
-    with patch.object(syn, "sendMessage") as mocked_send_message, patch.object(
-        syn, "getUserProfile", return_value=user_profile
+    with (
+        patch.object(syn, "sendMessage") as mocked_send_message,
+        patch.object(syn, "getUserProfile", return_value=user_profile),
     ):
         mocked_func = MagicMock(
             side_effect=[Exception("first time fails"), "second time is Fine"]

--- a/tests/unit/synapseutils/unit_test_synapseutils_sync.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_sync.py
@@ -1,4 +1,5 @@
 """Unit tests for the Sync utility functions"""
+
 import csv
 import datetime
 import math
@@ -165,9 +166,11 @@ def test_read_manifest_sync_order_with_home_directory(syn: Synapse) -> None:
     # mock syn.get() to return a project because the final check is making sure parent is a container
     # mock isfile() to always return true to avoid having to create files in the home directory
     # side effect mocks values for: manfiest file, file1.txt, file2.txt, isfile(project.id) check in syn.get()
-    with patch.object(syn, "get_async", return_value=Project()), patch.object(
-        os.path, "isfile", side_effect=[True, True, True, False]
-    ), patch.object(sync, "_check_size_each_file", return_value=Mock()):
+    with (
+        patch.object(syn, "get_async", return_value=Project()),
+        patch.object(os.path, "isfile", side_effect=[True, True, True, False]),
+        patch.object(sync, "_check_size_each_file", return_value=Mock()),
+    ):
         manifest_dataframe = synapseutils.sync.readManifestFile(syn, manifest)
         expected_order = pd.Series(
             [
@@ -194,10 +197,10 @@ def test_read_manifest_file_synapse_store_values_not_set(syn: Synapse) -> None:
     }
 
     manifest = StringIO(header + row1 + row2)
-    with patch.object(syn, "get_async", return_value=Project()), patch.object(
-        os.path, "isfile", return_value=True
-    ), patch.object(
-        sync, "_check_size_each_file", return_value=Mock()
+    with (
+        patch.object(syn, "get_async", return_value=Project()),
+        patch.object(os.path, "isfile", return_value=True),
+        patch.object(sync, "_check_size_each_file", return_value=Mock()),
     ):  # side effect mocks values for: file1.txt
         manifest_dataframe = synapseutils.sync.readManifestFile(syn, manifest)
         actual_synapseStore = manifest_dataframe.set_index("path")[
@@ -233,10 +236,10 @@ def test_read_manifest_file_synapse_store_values_are_set(syn: Synapse) -> None:
     }
 
     manifest = StringIO(header + row1 + row2 + row3 + row4 + row5 + row6)
-    with patch.object(syn, "get_async", return_value=Project()), patch.object(
-        sync, "_check_size_each_file", return_value=Mock()
-    ), patch.object(
-        os.path, "isfile", return_value=True
+    with (
+        patch.object(syn, "get_async", return_value=Project()),
+        patch.object(sync, "_check_size_each_file", return_value=Mock()),
+        patch.object(os.path, "isfile", return_value=True),
     ):  # mocks values for: file1.txt, file3.txt, file5.txt
         manifest_dataframe = synapseutils.sync.readManifestFile(syn, manifest)
 
@@ -248,12 +251,14 @@ def test_read_manifest_file_synapse_store_values_are_set(syn: Synapse) -> None:
 
 def test_sync_from_synapse_non_file_entity(syn: Synapse) -> None:
     table_schema = "syn12345"
-    with patch.object(syn, "getChildren", return_value=[]), patch.object(
-        syn, "get", return_value=Schema(name="asssdfa", parent=PARENT_ID)
-    ), patch(
-        "synapseutils.sync.get_entity",
-        new_callable=AsyncMock,
-        return_value={"concreteType": concrete_types.TABLE_ENTITY},
+    with (
+        patch.object(syn, "getChildren", return_value=[]),
+        patch.object(syn, "get", return_value=Schema(name="asssdfa", parent=PARENT_ID)),
+        patch(
+            "synapseutils.sync.get_entity",
+            new_callable=AsyncMock,
+            return_value={"concreteType": concrete_types.TABLE_ENTITY},
+        ),
     ):
         pytest.raises(ValueError, synapseutils.syncFromSynapse, syn, table_schema)
 
@@ -263,17 +268,21 @@ def test_sync_from_synapse_empty_folder(syn: Synapse) -> None:
         for child in []:
             yield child
 
-    with patch(
-        "synapseclient.models.mixins.storable_container.get_children",
-        side_effect=mock_get_children,
-    ), patch(
-        "synapseutils.sync.get_entity",
-        new_callable=AsyncMock,
-        return_value=(mock_folder_dict()),
-    ), patch(
-        "synapseclient.api.entity_factory.get_entity_id_bundle2",
-        new_callable=AsyncMock,
-        return_value=(mocked_folder_rest_api_dict()),
+    with (
+        patch(
+            "synapseclient.models.mixins.storable_container.get_children",
+            side_effect=mock_get_children,
+        ),
+        patch(
+            "synapseutils.sync.get_entity",
+            new_callable=AsyncMock,
+            return_value=(mock_folder_dict()),
+        ),
+        patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(mocked_folder_rest_api_dict()),
+        ),
     ):
         assert list() == synapseutils.syncFromSynapse(syn=syn, entity=SYN_123)
 
@@ -285,14 +294,18 @@ def test_sync_from_synapse_file_entity(syn: Synapse) -> None:
         id=SYN_123,
         properties={"isLatestVersion": True},
     )
-    with patch.object(syn, "getChildren") as patch_syn_get_children, patch(
-        "synapseutils.sync.get_entity",
-        new_callable=AsyncMock,
-        return_value=(mock_file_dict()),
-    ), patch(
-        "synapseclient.api.entity_factory.get_entity_id_bundle2",
-        new_callable=AsyncMock,
-        return_value=(mocked_file_rest_api_dict()),
+    with (
+        patch.object(syn, "getChildren") as patch_syn_get_children,
+        patch(
+            "synapseutils.sync.get_entity",
+            new_callable=AsyncMock,
+            return_value=(mock_file_dict()),
+        ),
+        patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            return_value=(mocked_file_rest_api_dict()),
+        ),
     ):
         result = synapseutils.syncFromSynapse(syn, file)
         assert [file] == result
@@ -312,17 +325,21 @@ def test_sync_from_synapse_folder_contains_one_file(syn: Synapse) -> None:
         for child in [mocked_file_child()]:
             yield child
 
-    with patch(
-        "synapseclient.models.mixins.storable_container.get_children",
-        side_effect=mock_get_children,
-    ), patch(
-        "synapseutils.sync.get_entity",
-        new_callable=AsyncMock,
-        side_effect=[mock_folder_dict(), mock_file_dict()],
-    ), patch(
-        "synapseclient.api.entity_factory.get_entity_id_bundle2",
-        new_callable=AsyncMock,
-        side_effect=[mocked_folder_rest_api_dict(), mocked_file_rest_api_dict()],
+    with (
+        patch(
+            "synapseclient.models.mixins.storable_container.get_children",
+            side_effect=mock_get_children,
+        ),
+        patch(
+            "synapseutils.sync.get_entity",
+            new_callable=AsyncMock,
+            side_effect=[mock_folder_dict(), mock_file_dict()],
+        ),
+        patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            side_effect=[mocked_folder_rest_api_dict(), mocked_file_rest_api_dict()],
+        ),
     ):
         result = synapseutils.syncFromSynapse(syn, folder)
         assert [file] == result
@@ -353,25 +370,32 @@ def test_sync_from_synapse_project_contains_empty_folder(syn: Synapse) -> None:
             yield child
         call_count += 1
 
-    with patch(
-        "synapseclient.models.mixins.storable_container.get_children",
-        side_effect=mock_get_children,
-    ) as patch_syn_get_children, patch(
-        "synapseutils.sync.get_entity",
-        new_callable=AsyncMock,
-        side_effect=[mock_project_dict(), mock_folder_dict(), mock_file_dict()],
-    ), patch(
-        "synapseclient.api.entity_factory.get_entity_id_bundle2",
-        new_callable=AsyncMock,
-        side_effect=[
-            mocked_project_rest_api_dict(),
-            mocked_folder_rest_api_dict(),
-            mocked_file_rest_api_dict(),
-        ],
-    ), patch(
-        "synapseclient.models.file.get_from_entity_factory",
-        wraps=spy_for_async_function(synapseclient.models.file.get_from_entity_factory),
-    ) as patch_get_file_entity:
+    with (
+        patch(
+            "synapseclient.models.mixins.storable_container.get_children",
+            side_effect=mock_get_children,
+        ) as patch_syn_get_children,
+        patch(
+            "synapseutils.sync.get_entity",
+            new_callable=AsyncMock,
+            side_effect=[mock_project_dict(), mock_folder_dict(), mock_file_dict()],
+        ),
+        patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            side_effect=[
+                mocked_project_rest_api_dict(),
+                mocked_folder_rest_api_dict(),
+                mocked_file_rest_api_dict(),
+            ],
+        ),
+        patch(
+            "synapseclient.models.file.get_from_entity_factory",
+            wraps=spy_for_async_function(
+                synapseclient.models.file.get_from_entity_factory
+            ),
+        ) as patch_get_file_entity,
+    ):
         result = synapseutils.syncFromSynapse(syn=syn, entity=project)
         assert [file] == result
         assert patch_syn_get_children.call_count == 2
@@ -420,25 +444,32 @@ def test_sync_from_synapse_download_file_is_false(syn: Synapse) -> None:
             yield child
         call_count += 1
 
-    with patch(
-        "synapseclient.models.mixins.storable_container.get_children",
-        side_effect=mock_get_children,
-    ) as patch_syn_get_children, patch(
-        "synapseutils.sync.get_entity",
-        new_callable=AsyncMock,
-        side_effect=[mock_project_dict(), mock_folder_dict(), mock_file_dict()],
-    ), patch(
-        "synapseclient.api.entity_factory.get_entity_id_bundle2",
-        new_callable=AsyncMock,
-        side_effect=[
-            mocked_project_rest_api_dict(),
-            mocked_file_rest_api_dict(),
-            mocked_folder_rest_api_dict(),
-        ],
-    ), patch(
-        "synapseclient.models.file.get_from_entity_factory",
-        wraps=spy_for_async_function(synapseclient.models.file.get_from_entity_factory),
-    ) as patch_get_file_entity:
+    with (
+        patch(
+            "synapseclient.models.mixins.storable_container.get_children",
+            side_effect=mock_get_children,
+        ) as patch_syn_get_children,
+        patch(
+            "synapseutils.sync.get_entity",
+            new_callable=AsyncMock,
+            side_effect=[mock_project_dict(), mock_folder_dict(), mock_file_dict()],
+        ),
+        patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            side_effect=[
+                mocked_project_rest_api_dict(),
+                mocked_file_rest_api_dict(),
+                mocked_folder_rest_api_dict(),
+            ],
+        ),
+        patch(
+            "synapseclient.models.file.get_from_entity_factory",
+            wraps=spy_for_async_function(
+                synapseclient.models.file.get_from_entity_factory
+            ),
+        ) as patch_get_file_entity,
+    ):
         result = synapseutils.syncFromSynapse(
             syn=syn, entity=project, downloadFile=False
         )
@@ -520,38 +551,47 @@ def test_sync_from_synapse_manifest_is_all(
             yield child
         call_count += 1
 
-    with patch(
-        "synapseclient.models.mixins.storable_container.get_children",
-        side_effect=mock_get_children,
-    ) as patch_syn_get_children, patch(
-        "synapseutils.sync.get_entity",
-        new_callable=AsyncMock,
-        side_effect=[
-            mock_project_dict(),
-            mock_file_dict(syn_id=SYN_123),
-            mock_folder_dict(),
-            mock_file_dict(syn_id=SYN_789),
-        ],
-    ), patch(
-        "synapseclient.api.entity_factory.get_entity_id_bundle2",
-        new_callable=AsyncMock,
-        side_effect=[
-            mocked_project_rest_api_dict(),
-            mocked_file_rest_api_dict(syn_id=SYN_123),
-            mocked_folder_rest_api_dict(),
-            mocked_file_rest_api_dict(syn_id=SYN_789),
-        ],
-    ), patch(
-        "synapseclient.models.file.get_from_entity_factory",
-        wraps=spy_for_async_function(synapseclient.models.file.get_from_entity_factory),
-    ) as patch_get_file_entity, patch(
-        "synapseclient.models.activity.Activity.from_parent_async",
-        new_callable=AsyncMock,
-        side_effect=lambda parent, **kwargs: provenance.get(parent.id),
-    ) as patch_activity_from_parent, patch(
-        "synapseutils.sync.generate_manifest",
-        wraps=spy_for_function(synapseutils.sync.generate_manifest),
-    ) as generate_manifest_spy:
+    with (
+        patch(
+            "synapseclient.models.mixins.storable_container.get_children",
+            side_effect=mock_get_children,
+        ) as patch_syn_get_children,
+        patch(
+            "synapseutils.sync.get_entity",
+            new_callable=AsyncMock,
+            side_effect=[
+                mock_project_dict(),
+                mock_file_dict(syn_id=SYN_123),
+                mock_folder_dict(),
+                mock_file_dict(syn_id=SYN_789),
+            ],
+        ),
+        patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            side_effect=[
+                mocked_project_rest_api_dict(),
+                mocked_file_rest_api_dict(syn_id=SYN_123),
+                mocked_folder_rest_api_dict(),
+                mocked_file_rest_api_dict(syn_id=SYN_789),
+            ],
+        ),
+        patch(
+            "synapseclient.models.file.get_from_entity_factory",
+            wraps=spy_for_async_function(
+                synapseclient.models.file.get_from_entity_factory
+            ),
+        ) as patch_get_file_entity,
+        patch(
+            "synapseclient.models.activity.Activity.from_parent_async",
+            new_callable=AsyncMock,
+            side_effect=lambda parent, **kwargs: provenance.get(parent.id),
+        ) as patch_activity_from_parent,
+        patch(
+            "synapseutils.sync.generate_manifest",
+            wraps=spy_for_function(synapseutils.sync.generate_manifest),
+        ) as generate_manifest_spy,
+    ):
         result = synapseutils.syncFromSynapse(
             syn=syn, entity=project, path=temp_directory_path, manifest="all"
         )
@@ -712,38 +752,47 @@ def test_sync_from_synapse_manifest_is_root(
             yield child
         call_count += 1
 
-    with patch(
-        "synapseclient.models.mixins.storable_container.get_children",
-        side_effect=mock_get_children,
-    ) as patch_syn_get_children, patch(
-        "synapseutils.sync.get_entity",
-        new_callable=AsyncMock,
-        side_effect=[
-            mock_project_dict(),
-            mock_file_dict(syn_id=SYN_123),
-            mock_folder_dict(),
-            mock_file_dict(syn_id=SYN_789),
-        ],
-    ), patch(
-        "synapseclient.api.entity_factory.get_entity_id_bundle2",
-        new_callable=AsyncMock,
-        side_effect=[
-            mocked_project_rest_api_dict(),
-            mocked_file_rest_api_dict(syn_id=SYN_123),
-            mocked_folder_rest_api_dict(),
-            mocked_file_rest_api_dict(syn_id=SYN_789),
-        ],
-    ), patch(
-        "synapseclient.models.file.get_from_entity_factory",
-        wraps=spy_for_async_function(synapseclient.models.file.get_from_entity_factory),
-    ) as patch_get_file_entity, patch(
-        "synapseclient.models.activity.Activity.from_parent_async",
-        new_callable=AsyncMock,
-        side_effect=lambda parent, **kwargs: provenance.get(parent.id),
-    ) as patch_activity_from_parent, patch(
-        "synapseutils.sync.generate_manifest",
-        wraps=spy_for_function(synapseutils.sync.generate_manifest),
-    ) as generate_manifest_spy:
+    with (
+        patch(
+            "synapseclient.models.mixins.storable_container.get_children",
+            side_effect=mock_get_children,
+        ) as patch_syn_get_children,
+        patch(
+            "synapseutils.sync.get_entity",
+            new_callable=AsyncMock,
+            side_effect=[
+                mock_project_dict(),
+                mock_file_dict(syn_id=SYN_123),
+                mock_folder_dict(),
+                mock_file_dict(syn_id=SYN_789),
+            ],
+        ),
+        patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            side_effect=[
+                mocked_project_rest_api_dict(),
+                mocked_file_rest_api_dict(syn_id=SYN_123),
+                mocked_folder_rest_api_dict(),
+                mocked_file_rest_api_dict(syn_id=SYN_789),
+            ],
+        ),
+        patch(
+            "synapseclient.models.file.get_from_entity_factory",
+            wraps=spy_for_async_function(
+                synapseclient.models.file.get_from_entity_factory
+            ),
+        ) as patch_get_file_entity,
+        patch(
+            "synapseclient.models.activity.Activity.from_parent_async",
+            new_callable=AsyncMock,
+            side_effect=lambda parent, **kwargs: provenance.get(parent.id),
+        ) as patch_activity_from_parent,
+        patch(
+            "synapseutils.sync.generate_manifest",
+            wraps=spy_for_function(synapseutils.sync.generate_manifest),
+        ) as generate_manifest_spy,
+    ):
         result = synapseutils.syncFromSynapse(
             syn=syn, entity=project, path=temp_directory_path, manifest="root"
         )
@@ -875,35 +924,43 @@ def test_sync_from_synapse_manifest_is_suppress(
             yield child
         call_count += 1
 
-    with patch(
-        "synapseclient.models.mixins.storable_container.get_children",
-        side_effect=mock_get_children,
-    ) as patch_syn_get_children, patch(
-        "synapseutils.sync.get_entity",
-        new_callable=AsyncMock,
-        side_effect=[
-            mock_project_dict(),
-            mock_file_dict(syn_id=SYN_123),
-            mock_folder_dict(),
-            mock_file_dict(syn_id=SYN_789),
-        ],
-    ), patch(
-        "synapseclient.api.entity_factory.get_entity_id_bundle2",
-        new_callable=AsyncMock,
-        side_effect=[
-            mocked_project_rest_api_dict(),
-            mocked_file_rest_api_dict(syn_id=SYN_123),
-            mocked_folder_rest_api_dict(),
-            mocked_file_rest_api_dict(syn_id=SYN_789),
-        ],
-    ), patch(
-        "synapseclient.models.file.get_from_entity_factory",
-        wraps=spy_for_async_function(synapseclient.models.file.get_from_entity_factory),
-    ) as patch_get_file_entity, patch(
-        "synapseclient.models.activity.Activity.from_parent_async",
-        new_callable=AsyncMock,
-        return_value=None,
-    ) as patch_activity_from_parent:
+    with (
+        patch(
+            "synapseclient.models.mixins.storable_container.get_children",
+            side_effect=mock_get_children,
+        ) as patch_syn_get_children,
+        patch(
+            "synapseutils.sync.get_entity",
+            new_callable=AsyncMock,
+            side_effect=[
+                mock_project_dict(),
+                mock_file_dict(syn_id=SYN_123),
+                mock_folder_dict(),
+                mock_file_dict(syn_id=SYN_789),
+            ],
+        ),
+        patch(
+            "synapseclient.api.entity_factory.get_entity_id_bundle2",
+            new_callable=AsyncMock,
+            side_effect=[
+                mocked_project_rest_api_dict(),
+                mocked_file_rest_api_dict(syn_id=SYN_123),
+                mocked_folder_rest_api_dict(),
+                mocked_file_rest_api_dict(syn_id=SYN_789),
+            ],
+        ),
+        patch(
+            "synapseclient.models.file.get_from_entity_factory",
+            wraps=spy_for_async_function(
+                synapseclient.models.file.get_from_entity_factory
+            ),
+        ) as patch_get_file_entity,
+        patch(
+            "synapseclient.models.activity.Activity.from_parent_async",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as patch_activity_from_parent,
+    ):
         result = synapseutils.syncFromSynapse(
             syn=syn, entity=project, path="./", manifest="suppress"
         )
@@ -1086,10 +1143,9 @@ async def test_manifest_upload(syn: Synapse) -> None:
         mocked_uploaders.append(mock_uploader)
         return mock_uploader
 
-    with patch.object(
-        synapseutils.sync, "_SyncUploadItem"
-    ) as upload_item_init, patch.object(
-        synapseutils.sync, "_SyncUploader", new=mock_uploader_constructor
+    with (
+        patch.object(synapseutils.sync, "_SyncUploadItem") as upload_item_init,
+        patch.object(synapseutils.sync, "_SyncUploader", new=mock_uploader_constructor),
     ):
         await synapseutils.sync._manifest_upload(syn, df)
 
@@ -1637,11 +1693,10 @@ def test_generate_sync_manifest(syn: Synapse) -> None:
     folder_name = "TestName"
     parent_id = SYN_123
     manifest_path = "TestFolder"
-    with patch.object(
-        sync, "_walk_directory_tree"
-    ) as patch_walk_directory_tree, patch.object(
-        sync, "_write_manifest_data"
-    ) as patch_write_manifest_data:
+    with (
+        patch.object(sync, "_walk_directory_tree") as patch_walk_directory_tree,
+        patch.object(sync, "_write_manifest_data") as patch_write_manifest_data,
+    ):
         sync.generate_sync_manifest(syn, folder_name, parent_id, manifest_path)
         patch_walk_directory_tree.assert_called_once_with(syn, folder_name, parent_id)
         patch_write_manifest_data.assert_called_with(

--- a/tests/unit/synapseutils/unit_test_synapseutils_walk.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_walk.py
@@ -35,9 +35,10 @@ def test_help_walk_one_child_file(syn, include_types):
     }
     child = [{"id": "syn2222", "conreteType": "File", "name": "test_file"}]
     expected = [(("parent_folder", "syn123"), [], [("test_file", "syn2222")])]
-    with patch.object(syn, "get", return_value=entity) as mock_syn_get, patch.object(
-        syn, "getChildren", return_value=child
-    ) as mock_get_child:
+    with (
+        patch.object(syn, "get", return_value=entity) as mock_syn_get,
+        patch.object(syn, "getChildren", return_value=child) as mock_get_child,
+    ):
         result = _help_walk(syn=syn, syn_id="syn123", include_types=include_types)
         gen_result = list(result)
         mock_syn_get.assert_called_once_with("syn123", downloadFile=False)
@@ -82,11 +83,10 @@ def test_help_walk_recursive(syn):
             [("test_file_2", "syn22223")],
         ),
     ]
-    with patch.object(
-        syn, "get", side_effect=entity_list
-    ) as mock_syn_get, patch.object(
-        syn, "getChildren", side_effect=child_list
-    ) as mock_get_child:
+    with (
+        patch.object(syn, "get", side_effect=entity_list) as mock_syn_get,
+        patch.object(syn, "getChildren", side_effect=child_list) as mock_get_child,
+    ):
         result = _help_walk(syn=syn, syn_id="syn123", include_types=["folder", "file"])
         gen_result = list(result)
         mock_syn_get.assert_called_once_with("syn123", downloadFile=False)
@@ -103,9 +103,10 @@ def test_help_walk_newpath(syn):
     }
     child = [{"id": "syn2222", "conreteType": "File", "name": "test_file"}]
     expected = [(("testpathnow", "syn123"), [], [("test_file", "syn2222")])]
-    with patch.object(syn, "get", return_value=entity) as mock_syn_get, patch.object(
-        syn, "getChildren", return_value=child
-    ) as mock_get_child:
+    with (
+        patch.object(syn, "get", return_value=entity) as mock_syn_get,
+        patch.object(syn, "getChildren", return_value=child) as mock_get_child,
+    ):
         result = _help_walk(
             syn=syn,
             syn_id="syn123",


### PR DESCRIPTION
# **Problem:**

This pull request makes a minor change to how JSON files are exported in the `schema_generation.py` module. The `sort_keys` parameter in `json.dump` is set to `False`, so the keys in the output JSON files will retain their original order rather than being sorted alphabetically.

- JSON export behavior:
  * Updated both `export_schema` and `export_json` functions to use `sort_keys=False` in `json.dump`, preserving the original key order in exported JSON files. [[1]](diffhunk://#diff-cd4e9e05c7bc72c1ef38afad795296b9a0e6c8306a4058e4a33e9baccfe86908L4117-R4117) [[2]](diffhunk://#diff-cd4e9e05c7bc72c1ef38afad795296b9a0e6c8306a4058e4a33e9baccfe86908L5525-R5525)l problem that this PR solves.