### PR TITLE
Add validate-release workflow

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -1,0 +1,39 @@
+# GitHub Action workflow for validating releases against the Synapse backendname: validate-release
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[boto3,pandas,pysftp,tests,curator]"
+      - name: Run unit tests
+        run: pytest -sv tests/unit
+      - name: Check for Secret availability
+        id: secret-check
+        run: |
+          if [ -z "${{ secrets.encrypted_d17283647768_key }}" ]  || [ -z "${{ secrets.encrypted_d17283647768_iv }}" ]; then
+            echo "secrets_available=false" >> $GITHUB_OUTPUT;
+          else
+            echo "secrets_available=true" >> $GITHUB_OUTPUT;
+          fi
+      - name: Run integration tests (if secrets available)
+        if: steps.secret-check.outputs.secrets_available == 'true'
+        run: |
+          # decrypt the encrypted test synapse configuration
+          openssl aes-256-cbc -K ${{ secrets.encrypted_d17283647768_key }} -iv ${{ secrets.encrypted_d17283647768_iv }} -in test.synapseConfig.enc -out test.synapseConfig -d
+          mv test.synapseConfig ~/.synapseConfig
+          pytest -sv tests/integration

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -27,12 +27,11 @@ jobs:
           if [ -z "${{ secrets.encrypted_d17283647768_key }}" ]  || [ -z "${{ secrets.encrypted_d17283647768_iv }}" ]; then
             echo "secrets_available=false" >> $GITHUB_OUTPUT;
             echo "Secrets for integration tests are not available. Cancelling integration tests.";
-            exit(2);
+            exit 1;
           else
             echo "secrets_available=true" >> $GITHUB_OUTPUT;
           fi
       - name: Run integration tests (if secrets available)
-        if: steps.secret-check.outputs.secrets_available == 'true'
         run: |
           # decrypt the encrypted test synapse configuration
           openssl aes-256-cbc -K ${{ secrets.encrypted_d17283647768_key }} -iv ${{ secrets.encrypted_d17283647768_iv }} -in test.synapseConfig.enc -out test.synapseConfig -d

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -1,16 +1,17 @@
-# GitHub Action workflow for validating releases against the Synapse backendname: validate-release
+# GitHub Action workflow for current release against the Synapse dev backend (running staging code).
+name: validate-synapse-release
 
 on:
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: validate-release-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   validate-release:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -20,13 +21,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[boto3,pandas,pysftp,tests,curator]"
-      - name: Run unit tests
-        run: pytest -sv tests/unit
       - name: Check for Secret availability
         id: secret-check
         run: |
           if [ -z "${{ secrets.encrypted_d17283647768_key }}" ]  || [ -z "${{ secrets.encrypted_d17283647768_iv }}" ]; then
             echo "secrets_available=false" >> $GITHUB_OUTPUT;
+            echo "Secrets for integration tests are not available. Cancelling integration tests.";
+            exit(2);
           else
             echo "secrets_available=true" >> $GITHUB_OUTPUT;
           fi
@@ -36,4 +37,4 @@ jobs:
           # decrypt the encrypted test synapse configuration
           openssl aes-256-cbc -K ${{ secrets.encrypted_d17283647768_key }} -iv ${{ secrets.encrypted_d17283647768_iv }} -in test.synapseConfig.enc -out test.synapseConfig -d
           mv test.synapseConfig ~/.synapseConfig
-          pytest -sv tests/integration
+          pytest -sv --reruns 3 tests/integration -n 8 --ignore=tests/integration/synapseclient/test_command_line_client.py --dist loadscope

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -5,11 +5,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: validate-release-${{ github.ref }}
+  group: validate-synapse-release-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  validate-release:
+  validate-synapse-release:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.8.0
+    rev: 1.8.6
     hooks:
       - id: bandit
         args: ["-c", "pyproject.toml"]


### PR DESCRIPTION
# **Problem:**

- We used to run a Jenkins job to validate the python client against the staging repo and prevent releasing
   breaking changes. The Jenkins server has been sunset, I ran integration tests from my laptop but need
   a permanent solution.

# **Solution:**

- I would like to create dispatch workflow in the SynapsePython client repo to run a single pass integration test.

# **Testing:**

- None, I just trimmed an existing workflow. Considered testing in my fork but that means adding secrets etc., since
  this is a dispatch workflow it should have no effect on existing operations and can be debugged in the SageBio repo.
