### PR TITLE
[SYNPY-1814] fix: Integration test test_wikiAttachment fails due to leaked wiki state from prior runs

### DIFF
--- a/docs/reference/experimental/async/curator.md
+++ b/docs/reference/experimental/async/curator.md
@@ -56,6 +56,7 @@ at your own risk.
         members:
             - create_async
             - export_to_record_set_async
+            - import_csv_async
 ---
 [](){ #query-reference-async }
 ::: synapseclient.models.Query

--- a/synapseclient/core/constants/concrete_types.py
+++ b/synapseclient/core/constants/concrete_types.py
@@ -128,3 +128,7 @@ LIST_GRID_SESSIONS_REQUEST = (
 LIST_GRID_SESSIONS_RESPONSE = (
     "org.sagebionetworks.repo.model.grid.ListGridSessionsResponse"
 )
+GRID_CSV_IMPORT_REQUEST = "org.sagebionetworks.repo.model.grid.GridCsvImportRequest"
+UPLOAD_TO_TABLE_PREVIEW_REQUEST = (
+    "org.sagebionetworks.repo.model.table.UploadToTablePreviewRequest"
+)

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -2101,6 +2101,8 @@ class Grid(GridSynchronousProtocol):
         preview_response = await upload_to_table_preview.send_job_and_wait_async(
             timeout=timeout
         )
+        # ROW_ID and ROW_VERSION must be prepended to the schema to avoid:
+        # SynapseHTTPError: 400 Client Error: The CSV header does not match the schema size.
         all_columns = [
             Column(name="ROW_ID", column_type=ColumnType.STRING),
             Column(name="ROW_VERSION", column_type=ColumnType.STRING),

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -1586,6 +1586,53 @@ class GridSynchronousProtocol(Protocol):
             ```
         """
 
+    def import_csv(
+        self,
+        file_handle_id: str,
+        csv_table_descriptor: Optional[CsvTableDescriptor] = None,
+        *,
+        timeout: int = 120,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "Grid":
+        """
+        Import a CSV file into this grid session. Previews the file to determine
+        the column schema, then imports the data. Currently supports only grids
+        created from a record set.
+
+        Arguments:
+            file_handle_id: The id of the file handle that contains the CSV data.
+            csv_table_descriptor: The description of the CSV format (delimiter,
+                quote character, etc.). If not provided, the default CSV format
+                will be used.
+            timeout: The number of seconds to wait for each async job to complete
+                or progress before raising a SynapseTimeoutError. Defaults to 120.
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            The Grid object.
+
+        Raises:
+            ValueError: If session_id is not provided.
+
+        Example: Import a CSV file into a grid session
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Grid
+
+            syn = Synapse()
+            syn.login()
+
+            grid = Grid(session_id="abc-123-def")
+            grid = grid.import_csv(file_handle_id="123456")
+            print(f"Import complete for session: {grid.session_id}")
+            ```
+        """
+        return self
+
 
 @dataclass
 @async_to_sync
@@ -2024,6 +2071,9 @@ class Grid(GridSynchronousProtocol):
 
         Returns:
             The Grid object.
+
+        Raises:
+            ValueError: If session_id is not provided.
 
         Example: Import a CSV file into a grid session asynchronously
             &nbsp;

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -997,7 +997,9 @@ class GridCsvImportRequest(AsynchronousCommunicator):
     A request to import a CSV file into a grid. Currently supports only grid
     created from a record set.
 
-    This result is modeled from: <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/grid/GridCsvImportRequest.html>
+    This request is modeled from: <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/grid/GridCsvImportRequest.html>
+
+    The response is modeled from: <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/grid/GridCsvImportResponse.html>
     """
 
     concrete_type: str = GRID_CSV_IMPORT_REQUEST

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -6,7 +6,7 @@ data or metadata in Synapse.
 """
 
 from dataclasses import dataclass, field, replace
-from typing import Any, AsyncGenerator, Dict, Generator, Optional, Protocol, Union
+from typing import Any, AsyncGenerator, Dict, Generator, List, Optional, Protocol, Union
 
 from opentelemetry import trace
 
@@ -28,15 +28,22 @@ from synapseclient.core.async_utils import (
 from synapseclient.core.constants.concrete_types import (
     CREATE_GRID_REQUEST,
     FILE_BASED_METADATA_TASK_PROPERTIES,
+    GRID_CSV_IMPORT_REQUEST,
     GRID_RECORD_SET_EXPORT_REQUEST,
     LIST_GRID_SESSIONS_REQUEST,
     LIST_GRID_SESSIONS_RESPONSE,
     RECORD_BASED_METADATA_TASK_PROPERTIES,
+    UPLOAD_TO_TABLE_PREVIEW_REQUEST,
 )
 from synapseclient.core.utils import delete_none_keys, merge_dataclass_entities
 from synapseclient.models.mixins.asynchronous_job import AsynchronousCommunicator
 from synapseclient.models.recordset import ValidationSummary
-from synapseclient.models.table_components import Query
+from synapseclient.models.table_components import (
+    Column,
+    ColumnType,
+    CsvTableDescriptor,
+    Query,
+)
 
 
 @dataclass
@@ -990,6 +997,158 @@ class CreateGridRequest(AsynchronousCommunicator):
 
 
 @dataclass
+class GridCsvImportRequest(AsynchronousCommunicator):
+    """
+    A request to import a CSV file into a grid. Currently supports only grid
+    created from a record set.
+
+    This result is modeled from: <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/grid/GridCsvImportRequest.html>
+    """
+
+    concrete_type: str = GRID_CSV_IMPORT_REQUEST
+    """The concrete type for this request."""
+
+    session_id: Optional[str] = None
+    """The grid session ID."""
+
+    file_handle_id: Optional[str] = None
+    """The id of the file handle that contains the CSV data."""
+
+    csv_descriptor: CsvTableDescriptor = field(default_factory=CsvTableDescriptor)
+    """The description of a csv for upload or download."""
+
+    schema: Optional[List[Column]] = None
+    """The list of ColumnModel that describe the CSV file. Currently this is is required."""
+
+    # Response fields (populated by fill_from_dict)
+    total_count: Optional[int] = field(default=None, compare=False)
+    """The total number of rows in the CSV."""
+
+    created_count: Optional[int] = field(default=None, compare=False)
+    """The number of rows that were created."""
+
+    updated_count: Optional[int] = field(default=None, compare=False)
+    """The number of rows that were updated."""
+
+    def fill_from_dict(
+        self, synapse_response: Union[Dict[str, Any], Any]
+    ) -> "GridCsvImportRequest":
+        """
+        Converts a response from the REST API into this dataclass.
+
+        Arguments:
+            synapse_response: The response from the REST API.
+
+        Returns:
+            The GridCsvImportRequest object.
+        """
+        self.session_id = synapse_response.get("sessionId", self.session_id)
+        self.total_count = synapse_response.get("totalCount", None)
+        self.created_count = synapse_response.get("createdCount", None)
+        self.updated_count = synapse_response.get("updatedCount", None)
+        return self
+
+    def to_synapse_request(self) -> Dict[str, Any]:
+        """
+        Converts this dataclass to a dictionary suitable for a Synapse REST API request.
+
+        Returns:
+            A dictionary representation of this object for API requests.
+        """
+        request_dict: Dict[str, Any] = {"concreteType": self.concrete_type}
+        if self.session_id is not None:
+            request_dict["sessionId"] = self.session_id
+        if self.file_handle_id is not None:
+            request_dict["fileHandleId"] = self.file_handle_id
+        if self.csv_descriptor is not None:
+            request_dict["csvDescriptor"] = self.csv_descriptor.to_synapse_request()
+        if self.schema is not None:
+            request_dict["schema"] = [col.to_synapse_request() for col in self.schema]
+        return request_dict
+
+
+@dataclass
+class UploadToTablePreviewRequest(AsynchronousCommunicator):
+    """
+    Request for a preview of an upload to a Table.
+
+    This result is modeled from: <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/UploadToTablePreviewRequest.html>
+    """
+
+    concrete_type: str = UPLOAD_TO_TABLE_PREVIEW_REQUEST
+    """The concrete type for this request."""
+
+    upload_file_handle_id: Optional[str] = None
+    """The ID of the file handle for a type of UPLOAD"""
+
+    line_to_skip: Optional[int] = None
+    """The number of lines to skip from the start of the file. The default value of 0 will be used if this is not provided by the caller."""
+
+    csv_table_descriptor: CsvTableDescriptor = field(default_factory=CsvTableDescriptor)
+    """The description of a csv for upload or download."""
+
+    do_full_file_scan: Optional[bool] = None
+    """When set to true the full file will be scanned for a schema suggestions. A full scan is more accurate but can take more time. When set to false only a sub-set of the first rows will be scanned, which can be faster but is less accurate. The default value is false."""
+
+    # Response fields (populated by fill_from_dict)
+    suggested_columns: Optional[List[Column]] = field(default=None, compare=False)
+    """The suggested columns for the table based on the file scan."""
+
+    sample_rows: Optional[List[List[Optional[str]]]] = field(
+        default=None, compare=False
+    )
+    """A sample of the rows in the file."""
+
+    rows_scanned: Optional[int] = field(default=None, compare=False)
+    """The number of rows scanned from the file."""
+
+    def fill_from_dict(
+        self, synapse_response: Union[Dict[str, Any], Any]
+    ) -> "UploadToTablePreviewRequest":
+        """
+        Converts a response from the REST API into this dataclass.
+
+        Arguments:
+            synapse_response: The response from the REST API.
+
+        Returns:
+            The UploadToTablePreviewRequest object.
+        """
+        suggested_columns_data = synapse_response.get("suggestedColumns", None)
+        if suggested_columns_data:
+            self.suggested_columns = [
+                Column().fill_from_dict(col) for col in suggested_columns_data
+            ]
+
+        sample_rows_data = synapse_response.get("sampleRows", None)
+        if sample_rows_data:
+            self.sample_rows = [row.get("values", []) for row in sample_rows_data]
+
+        self.rows_scanned = synapse_response.get("rowsScanned", None)
+        return self
+
+    def to_synapse_request(self) -> Dict[str, Any]:
+        """
+        Converts this dataclass to a dictionary suitable for a Synapse REST API request.
+
+        Returns:
+            A dictionary representation of this object for API requests.
+        """
+        request_dict: Dict[str, Any] = {"concreteType": self.concrete_type}
+        if self.upload_file_handle_id is not None:
+            request_dict["uploadFileHandleId"] = self.upload_file_handle_id
+        if self.line_to_skip is not None:
+            request_dict["linesToSkip"] = self.line_to_skip
+        if self.csv_table_descriptor is not None:
+            request_dict["csvTableDescriptor"] = (
+                self.csv_table_descriptor.to_synapse_request()
+            )
+        if self.do_full_file_scan is not None:
+            request_dict["doFullFileScan"] = self.do_full_file_scan
+        return request_dict
+
+
+@dataclass
 class GridRecordSetExportRequest(AsynchronousCommunicator):
     """
     A request to export a grid created from a record set back to the original record set.
@@ -1838,3 +1997,75 @@ class Grid(GridSynchronousProtocol):
         await delete_grid_session(
             session_id=self.session_id, synapse_client=synapse_client
         )
+
+    async def import_csv_async(
+        self,
+        file_handle_id: str,
+        csv_table_descriptor: Optional[CsvTableDescriptor] = None,
+        *,
+        timeout: int = 120,
+        synapse_client: Optional[Synapse] = None,
+    ) -> "Grid":
+        """
+        Import a CSV file into this grid session. Previews the file to determine
+        the column schema, then imports the data. Currently supports only grids
+        created from a record set.
+
+        Arguments:
+            file_handle_id: The id of the file handle that contains the CSV data.
+            csv_table_descriptor: The description of the CSV format (delimiter,
+                quote character, etc.). If not provided, the default CSV format
+                will be used.
+            timeout: The number of seconds to wait for each async job to complete
+                or progress before raising a SynapseTimeoutError. Defaults to 120.
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
+
+        Returns:
+            The Grid object.
+
+        Example: Import a CSV file into a grid session asynchronously
+            &nbsp;
+
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import Grid
+
+            syn = Synapse()
+            syn.login()
+
+            async def main():
+                grid = Grid(session_id="abc-123-def")
+                grid = await grid.import_csv_async(file_handle_id="123456")
+                print(f"Import complete for session: {grid.session_id}")
+
+            asyncio.run(main())
+            ```
+        """
+        upload_to_table_preview = UploadToTablePreviewRequest(
+            csv_table_descriptor=csv_table_descriptor,
+            upload_file_handle_id=file_handle_id,
+        )
+        preview_response = await upload_to_table_preview.send_job_and_wait_async(
+            timeout=timeout
+        )
+        all_columns = [
+            Column(name="ROW_ID", column_type=ColumnType.STRING),
+            Column(name="ROW_VERSION", column_type=ColumnType.STRING),
+        ] + preview_response.suggested_columns
+        import_request = GridCsvImportRequest(
+            session_id=self.session_id,
+            file_handle_id=file_handle_id,
+            schema=all_columns,
+        )
+        if csv_table_descriptor:
+            import_request.csv_descriptor = csv_table_descriptor
+        import_response = await import_request.send_job_and_wait_async(
+            synapse_client=synapse_client, timeout=timeout
+        )
+        print(
+            f"CSV import to grid session {self.session_id} completed successfully, total count: {import_response.total_count}, total created: {import_response.created_count}, total updated: {import_response.updated_count}"
+        )
+        return self

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -2110,6 +2110,8 @@ class Grid(GridSynchronousProtocol):
             file_handle_id=file_handle_id,
             schema=all_columns,
         )
+        if csv_table_descriptor:
+            import_request.csv_descriptor = csv_table_descriptor
         import_response = await import_request.send_job_and_wait_async(
             timeout=timeout, synapse_client=synapse_client
         )

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -1584,7 +1584,7 @@ class GridSynchronousProtocol(Protocol):
     def import_csv(
         self,
         file_handle_id: str,
-        csv_table_descriptor: Optional[CsvTableDescriptor] = None,
+        csv_table_descriptor: Optional[CsvTableDescriptor] = CsvTableDescriptor(),
         *,
         timeout: int = 120,
         synapse_client: Optional[Synapse] = None,

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -1077,11 +1077,11 @@ class UploadToTablePreviewRequest(AsynchronousCommunicator):
     This response is modeled from: <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/UploadToTablePreviewResult.html>
     """
 
+    upload_file_handle_id: str
+    """The ID of the file handle for a type of UPLOAD"""
+
     concrete_type: str = UPLOAD_TO_TABLE_PREVIEW_REQUEST
     """The concrete type for this request."""
-
-    upload_file_handle_id: Optional[str] = None
-    """The ID of the file handle for a type of UPLOAD"""
 
     lines_to_skip: Optional[int] = None
     """The number of lines to skip from the start of the file. The default value of 0 will be used if this is not provided by the caller."""
@@ -1089,7 +1089,7 @@ class UploadToTablePreviewRequest(AsynchronousCommunicator):
     csv_table_descriptor: CsvTableDescriptor = field(default_factory=CsvTableDescriptor)
     """The description of a csv for upload or download."""
 
-    do_full_file_scan: Optional[bool] = False
+    do_full_file_scan: Optional[bool] = None
     """When set to true the full file will be scanned for a schema suggestions. A full scan is more accurate but can take more time. When set to false only a sub-set of the first rows will be scanned, which can be faster but is less accurate. The default value is false."""
 
     # Response fields (populated by fill_from_dict)
@@ -1141,11 +1141,8 @@ class UploadToTablePreviewRequest(AsynchronousCommunicator):
             "uploadFileHandleId": self.upload_file_handle_id,
             "linesToSkip": self.lines_to_skip,
             "doFullFileScan": self.do_full_file_scan,
+            "csvTableDescriptor": self.csv_table_descriptor.to_synapse_request(),
         }
-        if self.csv_table_descriptor is not None:
-            request_dict["csvTableDescriptor"] = (
-                self.csv_table_descriptor.to_synapse_request()
-            )
         delete_none_keys(request_dict)
         return request_dict
 
@@ -2050,7 +2047,7 @@ class Grid(GridSynchronousProtocol):
     async def import_csv_async(
         self,
         file_handle_id: str,
-        csv_table_descriptor: Optional[CsvTableDescriptor] = None,
+        csv_table_descriptor: Optional[CsvTableDescriptor] = CsvTableDescriptor(),
         *,
         timeout: int = 120,
         synapse_client: Optional[Synapse] = None,
@@ -2102,6 +2099,12 @@ class Grid(GridSynchronousProtocol):
                 "session_id is required to import a CSV into a GridSession"
             )
 
+        trace.get_current_span().set_attributes(
+            {
+                "synapse.session_id": self.session_id or "",
+            }
+        )
+
         upload_to_table_preview = UploadToTablePreviewRequest(
             csv_table_descriptor=csv_table_descriptor,
             upload_file_handle_id=file_handle_id,
@@ -2116,9 +2119,8 @@ class Grid(GridSynchronousProtocol):
             session_id=self.session_id,
             file_handle_id=file_handle_id,
             schema=all_columns,
+            csv_descriptor=csv_table_descriptor,
         )
-        if csv_table_descriptor:
-            import_request.csv_descriptor = csv_table_descriptor
         import_response = await import_request.send_job_and_wait_async(
             timeout=timeout, synapse_client=synapse_client
         )

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -38,12 +38,7 @@ from synapseclient.core.constants.concrete_types import (
 from synapseclient.core.utils import delete_none_keys, merge_dataclass_entities
 from synapseclient.models.mixins.asynchronous_job import AsynchronousCommunicator
 from synapseclient.models.recordset import ValidationSummary
-from synapseclient.models.table_components import (
-    Column,
-    ColumnType,
-    CsvTableDescriptor,
-    Query,
-)
+from synapseclient.models.table_components import Column, CsvTableDescriptor, Query
 
 
 @dataclass
@@ -2106,15 +2101,10 @@ class Grid(GridSynchronousProtocol):
         )
 
         preview_response = await upload_to_table_preview.send_job_and_wait_async(
-            timeout=timeout
+            timeout=timeout, synapse_client=synapse_client
         )
 
-        # ROW_ID and ROW_VERSION must be prepended to the schema to avoid:
-        # SynapseHTTPError: 400 Client Error: The CSV header does not match the schema size.
-        all_columns = [
-            Column(name="ROW_ID", column_type=ColumnType.STRING),
-            Column(name="ROW_VERSION", column_type=ColumnType.STRING),
-        ] + preview_response.suggested_columns
+        all_columns = preview_response.suggested_columns
         import_request = GridCsvImportRequest(
             session_id=self.session_id,
             file_handle_id=file_handle_id,
@@ -2123,7 +2113,7 @@ class Grid(GridSynchronousProtocol):
         if csv_table_descriptor:
             import_request.csv_descriptor = csv_table_descriptor
         import_response = await import_request.send_job_and_wait_async(
-            synapse_client=synapse_client, timeout=timeout
+            timeout=timeout, synapse_client=synapse_client
         )
         client = Synapse.get_client(synapse_client=synapse_client)
         client.logger.info(

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -1002,14 +1002,14 @@ class GridCsvImportRequest(AsynchronousCommunicator):
     The response is modeled from: <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/grid/GridCsvImportResponse.html>
     """
 
-    concrete_type: str = GRID_CSV_IMPORT_REQUEST
-    """The concrete type for this request."""
-
-    session_id: Optional[str] = None
+    session_id: str
     """The grid session ID."""
 
-    file_handle_id: Optional[str] = None
+    file_handle_id: str
     """The id of the file handle that contains the CSV data."""
+
+    concrete_type: str = GRID_CSV_IMPORT_REQUEST
+    """The concrete type for this request."""
 
     csv_descriptor: CsvTableDescriptor = field(default_factory=CsvTableDescriptor)
     """The description of a csv for upload or download."""
@@ -1052,15 +1052,18 @@ class GridCsvImportRequest(AsynchronousCommunicator):
         Returns:
             A dictionary representation of this object for API requests.
         """
-        request_dict: Dict[str, Any] = {"concreteType": self.concrete_type}
-        if self.session_id is not None:
-            request_dict["sessionId"] = self.session_id
-        if self.file_handle_id is not None:
-            request_dict["fileHandleId"] = self.file_handle_id
-        if self.csv_descriptor is not None:
-            request_dict["csvDescriptor"] = self.csv_descriptor.to_synapse_request()
-        if self.schema is not None:
-            request_dict["schema"] = [col.to_synapse_request() for col in self.schema]
+        request_dict = {
+            "concreteType": self.concrete_type,
+            "sessionId": self.session_id,
+            "fileHandleId": self.file_handle_id,
+            "csvDescriptor": self.csv_descriptor.to_synapse_request(),
+            "schema": (
+                [col.to_synapse_request() for col in self.schema]
+                if self.schema
+                else None
+            ),
+        }
+        delete_none_keys(request_dict)
         return request_dict
 
 

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -1013,7 +1013,7 @@ class GridCsvImportRequest(AsynchronousCommunicator):
     """The description of a csv for upload or download."""
 
     schema: Optional[List[Column]] = None
-    """The list of ColumnModel that describe the CSV file. Currently this is is required."""
+    """The list of ColumnModel that describe the CSV file. Currently this is required."""
 
     # Response fields (populated by fill_from_dict)
     total_count: Optional[int] = field(default=None, compare=False)
@@ -2110,13 +2110,15 @@ class Grid(GridSynchronousProtocol):
             file_handle_id=file_handle_id,
             schema=all_columns,
         )
-        if csv_table_descriptor:
-            import_request.csv_descriptor = csv_table_descriptor
         import_response = await import_request.send_job_and_wait_async(
             timeout=timeout, synapse_client=synapse_client
         )
         client = Synapse.get_client(synapse_client=synapse_client)
         client.logger.info(
-            f"CSV import to grid session {self.session_id} completed successfully, total count: {import_response.total_count}, total created: {import_response.created_count}, total updated: {import_response.updated_count}"
+            f"CSV import to grid session {self.session_id} completed successfully, "
+            f"total count: {import_response.total_count}, "
+            f"total created: {import_response.created_count}, "
+            f"total updated: {import_response.updated_count}"
         )
+
         return self

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -1081,7 +1081,7 @@ class UploadToTablePreviewRequest(AsynchronousCommunicator):
     upload_file_handle_id: Optional[str] = None
     """The ID of the file handle for a type of UPLOAD"""
 
-    line_to_skip: Optional[int] = None
+    lines_to_skip: Optional[int] = None
     """The number of lines to skip from the start of the file. The default value of 0 will be used if this is not provided by the caller."""
 
     csv_table_descriptor: CsvTableDescriptor = field(default_factory=CsvTableDescriptor)
@@ -1137,8 +1137,8 @@ class UploadToTablePreviewRequest(AsynchronousCommunicator):
         request_dict: Dict[str, Any] = {"concreteType": self.concrete_type}
         if self.upload_file_handle_id is not None:
             request_dict["uploadFileHandleId"] = self.upload_file_handle_id
-        if self.line_to_skip is not None:
-            request_dict["linesToSkip"] = self.line_to_skip
+        if self.lines_to_skip is not None:
+            request_dict["linesToSkip"] = self.lines_to_skip
         if self.csv_table_descriptor is not None:
             request_dict["csvTableDescriptor"] = (
                 self.csv_table_descriptor.to_synapse_request()
@@ -2094,13 +2094,21 @@ class Grid(GridSynchronousProtocol):
             asyncio.run(main())
             ```
         """
+
+        if not self.session_id:
+            raise ValueError(
+                "session_id is required to import a CSV into a GridSession"
+            )
+
         upload_to_table_preview = UploadToTablePreviewRequest(
             csv_table_descriptor=csv_table_descriptor,
             upload_file_handle_id=file_handle_id,
         )
+
         preview_response = await upload_to_table_preview.send_job_and_wait_async(
             timeout=timeout
         )
+
         # ROW_ID and ROW_VERSION must be prepended to the schema to avoid:
         # SynapseHTTPError: 400 Client Error: The CSV header does not match the schema size.
         all_columns = [
@@ -2117,7 +2125,8 @@ class Grid(GridSynchronousProtocol):
         import_response = await import_request.send_job_and_wait_async(
             synapse_client=synapse_client, timeout=timeout
         )
-        print(
+        client = Synapse.get_client(synapse_client=synapse_client)
+        client.logger.info(
             f"CSV import to grid session {self.session_id} completed successfully, total count: {import_response.total_count}, total created: {import_response.created_count}, total updated: {import_response.updated_count}"
         )
         return self

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -6,7 +6,7 @@ data or metadata in Synapse.
 """
 
 from dataclasses import dataclass, field, replace
-from typing import Any, AsyncGenerator, Dict, Generator, List, Optional, Protocol, Union
+from typing import Any, AsyncGenerator, Dict, Generator, Optional, Protocol, Union
 
 from opentelemetry import trace
 
@@ -1093,10 +1093,10 @@ class UploadToTablePreviewRequest(AsynchronousCommunicator):
     """When set to true the full file will be scanned for a schema suggestions. A full scan is more accurate but can take more time. When set to false only a sub-set of the first rows will be scanned, which can be faster but is less accurate. The default value is false."""
 
     # Response fields (populated by fill_from_dict)
-    suggested_columns: Optional[List[Column]] = field(default=None, compare=False)
+    suggested_columns: Optional[list[Column]] = field(default=None, compare=False)
     """The suggested columns for the table based on the file scan."""
 
-    sample_rows: Optional[List[List[Optional[str]]]] = field(
+    sample_rows: Optional[list[list[Optional[str]]]] = field(
         default=None, compare=False
     )
     """A sample of the rows in the file."""

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -1057,11 +1057,7 @@ class GridCsvImportRequest(AsynchronousCommunicator):
             "sessionId": self.session_id,
             "fileHandleId": self.file_handle_id,
             "csvDescriptor": self.csv_descriptor.to_synapse_request(),
-            "schema": (
-                [col.to_synapse_request() for col in self.schema]
-                if self.schema
-                else None
-            ),
+            "schema": [col.to_synapse_request() for col in self.schema],
         }
         delete_none_keys(request_dict)
         return request_dict

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -1008,14 +1008,14 @@ class GridCsvImportRequest(AsynchronousCommunicator):
     file_handle_id: str
     """The id of the file handle that contains the CSV data."""
 
+    schema: list[Column]
+    """The list of ColumnModel that describe the CSV file. Currently this is required."""
+
     concrete_type: str = GRID_CSV_IMPORT_REQUEST
     """The concrete type for this request."""
 
     csv_descriptor: CsvTableDescriptor = field(default_factory=CsvTableDescriptor)
     """The description of a csv for upload or download."""
-
-    schema: Optional[List[Column]] = None
-    """The list of ColumnModel that describe the CSV file. Currently this is required."""
 
     # Response fields (populated by fill_from_dict)
     total_count: Optional[int] = field(default=None, compare=False)
@@ -1089,7 +1089,7 @@ class UploadToTablePreviewRequest(AsynchronousCommunicator):
     csv_table_descriptor: CsvTableDescriptor = field(default_factory=CsvTableDescriptor)
     """The description of a csv for upload or download."""
 
-    do_full_file_scan: Optional[bool] = None
+    do_full_file_scan: Optional[bool] = False
     """When set to true the full file will be scanned for a schema suggestions. A full scan is more accurate but can take more time. When set to false only a sub-set of the first rows will be scanned, which can be faster but is less accurate. The default value is false."""
 
     # Response fields (populated by fill_from_dict)
@@ -1140,9 +1140,12 @@ class UploadToTablePreviewRequest(AsynchronousCommunicator):
             "concreteType": self.concrete_type,
             "uploadFileHandleId": self.upload_file_handle_id,
             "linesToSkip": self.lines_to_skip,
-            "csvTableDescriptor": self.csv_table_descriptor.to_synapse_request(),
             "doFullFileScan": self.do_full_file_scan,
         }
+        if self.csv_table_descriptor is not None:
+            request_dict["csvTableDescriptor"] = (
+                self.csv_table_descriptor.to_synapse_request()
+            )
         delete_none_keys(request_dict)
         return request_dict
 

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -1072,7 +1072,9 @@ class UploadToTablePreviewRequest(AsynchronousCommunicator):
     """
     Request for a preview of an upload to a Table.
 
-    This result is modeled from: <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/UploadToTablePreviewRequest.html>
+    This request is modeled from: <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/UploadToTablePreviewRequest.html>
+
+    This response is modeled from: <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/UploadToTablePreviewResult.html>
     """
 
     concrete_type: str = UPLOAD_TO_TABLE_PREVIEW_REQUEST
@@ -1134,17 +1136,14 @@ class UploadToTablePreviewRequest(AsynchronousCommunicator):
         Returns:
             A dictionary representation of this object for API requests.
         """
-        request_dict: Dict[str, Any] = {"concreteType": self.concrete_type}
-        if self.upload_file_handle_id is not None:
-            request_dict["uploadFileHandleId"] = self.upload_file_handle_id
-        if self.lines_to_skip is not None:
-            request_dict["linesToSkip"] = self.lines_to_skip
-        if self.csv_table_descriptor is not None:
-            request_dict["csvTableDescriptor"] = (
-                self.csv_table_descriptor.to_synapse_request()
-            )
-        if self.do_full_file_scan is not None:
-            request_dict["doFullFileScan"] = self.do_full_file_scan
+        request_dict = {
+            "concreteType": self.concrete_type,
+            "uploadFileHandleId": self.upload_file_handle_id,
+            "linesToSkip": self.lines_to_skip,
+            "csvTableDescriptor": self.csv_table_descriptor.to_synapse_request(),
+            "doFullFileScan": self.do_full_file_scan,
+        }
+        delete_none_keys(request_dict)
         return request_dict
 
 

--- a/synapseclient/models/mixins/asynchronous_job.py
+++ b/synapseclient/models/mixins/asynchronous_job.py
@@ -37,7 +37,7 @@ ASYNC_JOB_URIS = {
     CREATE_SCHEMA_REQUEST: "/schema/type/create/async",
     QUERY_TABLE_CSV_REQUEST: "/entity/{entityId}/table/download/csv/async",
     QUERY_BUNDLE_REQUEST: "/entity/{entityId}/table/query/async",
-    GRID_CSV_IMPORT_REQUEST: "/grid/import/csv/async/",
+    GRID_CSV_IMPORT_REQUEST: "/grid/import/csv/async",
     UPLOAD_TO_TABLE_PREVIEW_REQUEST: "/table/upload/csv/preview/async",
 }
 

--- a/synapseclient/models/mixins/asynchronous_job.py
+++ b/synapseclient/models/mixins/asynchronous_job.py
@@ -15,10 +15,12 @@ from synapseclient.core.constants.concrete_types import (
     CREATE_GRID_REQUEST,
     CREATE_SCHEMA_REQUEST,
     GET_VALIDATION_SCHEMA_REQUEST,
+    GRID_CSV_IMPORT_REQUEST,
     GRID_RECORD_SET_EXPORT_REQUEST,
     QUERY_BUNDLE_REQUEST,
     QUERY_TABLE_CSV_REQUEST,
     TABLE_UPDATE_TRANSACTION_REQUEST,
+    UPLOAD_TO_TABLE_PREVIEW_REQUEST,
 )
 from synapseclient.core.exceptions import (
     SynapseError,
@@ -35,6 +37,8 @@ ASYNC_JOB_URIS = {
     CREATE_SCHEMA_REQUEST: "/schema/type/create/async",
     QUERY_TABLE_CSV_REQUEST: "/entity/{entityId}/table/download/csv/async",
     QUERY_BUNDLE_REQUEST: "/entity/{entityId}/table/query/async",
+    GRID_CSV_IMPORT_REQUEST: "/grid/import/csv/async/",
+    UPLOAD_TO_TABLE_PREVIEW_REQUEST: "/table/upload/csv/preview/async",
 }
 
 

--- a/tests/integration/synapseclient/models/async/test_grid_async.py
+++ b/tests/integration/synapseclient/models/async/test_grid_async.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 
 from synapseclient import Synapse
-from synapseclient.models import Grid, Project, RecordSet
+from synapseclient.models import File, Grid, Project, RecordSet
 from tests.integration import ASYNC_JOB_TIMEOUT_SEC
 
 
@@ -183,3 +183,65 @@ class TestGridAsync:
             match="session_id is required to delete a GridSession",
         ):
             await grid.delete_async(synapse_client=self.syn)
+
+    async def test_import_csv_to_grid_session_async(
+        self, record_set_fixture: RecordSet, schedule_for_cleanup: Callable[..., None]
+    ) -> None:
+        """Test importing a CSV file into a grid session."""
+
+        # GIVEN: Create a grid session first
+        grid = Grid(record_set_id=record_set_fixture.id)
+        created_grid = await grid.create_async(
+            timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
+        )
+
+        assert created_grid.session_id is not None
+
+        # AND a CSV file uploaded to Synapse
+        test_data = pd.DataFrame(
+            {
+                "id": [6, 7, 8, 9, 10],
+                "name": ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"],
+                "value": [10.5, 20.3, 30.7, 40.1, 50.9],
+                "category": ["A", "B", "A", "C", "B"],
+                "active": [True, False, False, True, True],
+            }
+        )
+
+        project_name = str(uuid.uuid4())
+        project = Project(name=project_name)
+        project = await project.store_async(synapse_client=self.syn)
+
+        # Create a temporary CSV file
+        with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as temp_csv:
+            test_data.to_csv(temp_csv.name, index=False)
+            self.schedule_for_cleanup(temp_csv.name)
+
+            file = await File(path=temp_csv.name, parent_id=project.id).store_async(
+                synapse_client=self.syn
+            )
+
+        # WHEN: Importing the CSV into the grid session
+        imported_grid = await created_grid.import_csv_async(
+            file_handle_id=file.file_handle.id,
+            timeout=ASYNC_JOB_TIMEOUT_SEC,
+            synapse_client=self.syn,
+        )
+
+        schedule_for_cleanup(file.id)
+        schedule_for_cleanup(project.id)
+
+        # THEN: The import should complete and return the Grid with the same session
+        assert imported_grid.session_id == created_grid.session_id
+
+        # WHEN: Exporting the grid back to the record set
+        exported_grid = await imported_grid.export_to_record_set_async(
+            timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
+        )
+
+        # THEN: The export should contain 10 total rows
+        # (5 from the original record set + 5 imported)
+        assert exported_grid.validation_summary_statistics is not None
+        assert (
+            exported_grid.validation_summary_statistics.total_number_of_children == 10
+        )

--- a/tests/integration/synapseclient/models/async/test_grid_async.py
+++ b/tests/integration/synapseclient/models/async/test_grid_async.py
@@ -193,52 +193,58 @@ class TestGridAsync:
 
         # GIVEN: Create a grid session first
         grid = Grid(record_set_id=record_set_fixture.id)
-        created_grid = await grid.create_async(
-            timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
-        )
+        try:
+            created_grid = await grid.create_async(
+                timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
+            )
 
-        assert created_grid.session_id is not None
+            assert created_grid.session_id is not None
 
-        # AND a CSV file uploaded to Synapse
-        test_data = pd.DataFrame(
-            {
-                "id": [6, 7, 8, 9, 10],
-                "name": ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"],
-                "value": [10.5, 20.3, 30.7, 40.1, 50.9],
-                "category": ["A", "B", "A", "C", "B"],
-                "active": [True, False, False, True, True],
-            }
-        )
+            # AND a CSV file uploaded to Synapse
+            test_data = pd.DataFrame(
+                {
+                    "id": [6, 7, 8, 9, 10],
+                    "name": ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"],
+                    "value": [10.5, 20.3, 30.7, 40.1, 50.9],
+                    "category": ["A", "B", "A", "C", "B"],
+                    "active": [True, False, False, True, True],
+                }
+            )
 
-        # Create a temporary CSV file
-        with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as temp_csv:
-            test_data.to_csv(temp_csv.name, index=False)
-            self.schedule_for_cleanup(temp_csv.name)
+            # Create a temporary CSV file
+            with tempfile.NamedTemporaryFile(
+                "w", suffix=".csv", delete=False
+            ) as temp_csv:
+                test_data.to_csv(temp_csv.name, index=False)
+                self.schedule_for_cleanup(temp_csv.name)
 
-            file = await File(
-                path=temp_csv.name, parent_id=project_model.id
-            ).store_async(synapse_client=self.syn)
+                file = await File(
+                    path=temp_csv.name, parent_id=project_model.id
+                ).store_async(synapse_client=self.syn)
 
-            self.schedule_for_cleanup(file.id)
+                self.schedule_for_cleanup(file.id)
 
-        # WHEN: Importing the CSV into the grid session
-        imported_grid = await created_grid.import_csv_async(
-            file_handle_id=file.file_handle.id,
-            timeout=ASYNC_JOB_TIMEOUT_SEC,
-            synapse_client=self.syn,
-        )
+            # WHEN: Importing the CSV into the grid session
+            imported_grid = await created_grid.import_csv_async(
+                file_handle_id=file.file_handle.id,
+                timeout=ASYNC_JOB_TIMEOUT_SEC,
+                synapse_client=self.syn,
+            )
 
-        # THEN: The import should complete and return the Grid with the same session
-        assert imported_grid.session_id == created_grid.session_id
+            # THEN: The import should complete and return the Grid with the same session
+            assert imported_grid.session_id == created_grid.session_id
 
-        # WHEN: Exporting the grid back to the record set
-        exported_grid = await imported_grid.export_to_record_set_async(
-            timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
-        )
+            # WHEN: Exporting the grid back to the record set
+            exported_grid = await imported_grid.export_to_record_set_async(
+                timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
+            )
 
-        # THEN: The export should contain 10 total rows
-        # (5 from the original record set + 5 imported)
-        assert exported_grid.validation_summary_statistics is not None
-        assert (
-            exported_grid.validation_summary_statistics.total_number_of_children == 10
-        )
+            # THEN: The export should contain 10 total rows
+            # (5 from the original record set + 5 imported)
+            assert exported_grid.validation_summary_statistics is not None
+            assert (
+                exported_grid.validation_summary_statistics.total_number_of_children
+                == 10
+            )
+        finally:
+            await created_grid.delete_async(synapse_client=self.syn)

--- a/tests/integration/synapseclient/models/async/test_grid_async.py
+++ b/tests/integration/synapseclient/models/async/test_grid_async.py
@@ -188,7 +188,6 @@ class TestGridAsync:
         self,
         project_model,
         record_set_fixture: RecordSet,
-        schedule_for_cleanup: Callable[..., None],
     ) -> None:
         """Test importing a CSV file into a grid session."""
 
@@ -220,7 +219,7 @@ class TestGridAsync:
                 path=temp_csv.name, parent_id=project_model.id
             ).store_async(synapse_client=self.syn)
 
-            schedule_for_cleanup(file.id)
+            self.schedule_for_cleanup(file.id)
 
         # WHEN: Importing the CSV into the grid session
         imported_grid = await created_grid.import_csv_async(

--- a/tests/integration/synapseclient/models/async/test_grid_async.py
+++ b/tests/integration/synapseclient/models/async/test_grid_async.py
@@ -185,7 +185,10 @@ class TestGridAsync:
             await grid.delete_async(synapse_client=self.syn)
 
     async def test_import_csv_to_grid_session_async(
-        self, record_set_fixture: RecordSet, schedule_for_cleanup: Callable[..., None]
+        self,
+        project_model,
+        record_set_fixture: RecordSet,
+        schedule_for_cleanup: Callable[..., None],
     ) -> None:
         """Test importing a CSV file into a grid session."""
 
@@ -208,18 +211,16 @@ class TestGridAsync:
             }
         )
 
-        project_name = str(uuid.uuid4())
-        project = Project(name=project_name)
-        project = await project.store_async(synapse_client=self.syn)
-
         # Create a temporary CSV file
         with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as temp_csv:
             test_data.to_csv(temp_csv.name, index=False)
             self.schedule_for_cleanup(temp_csv.name)
 
-            file = await File(path=temp_csv.name, parent_id=project.id).store_async(
-                synapse_client=self.syn
-            )
+            file = await File(
+                path=temp_csv.name, parent_id=project_model.id
+            ).store_async(synapse_client=self.syn)
+
+            schedule_for_cleanup(file.id)
 
         # WHEN: Importing the CSV into the grid session
         imported_grid = await created_grid.import_csv_async(
@@ -227,9 +228,6 @@ class TestGridAsync:
             timeout=ASYNC_JOB_TIMEOUT_SEC,
             synapse_client=self.syn,
         )
-
-        schedule_for_cleanup(file.id)
-        schedule_for_cleanup(project.id)
 
         # THEN: The import should complete and return the Grid with the same session
         assert imported_grid.session_id == created_grid.session_id

--- a/tests/integration/synapseclient/test_wikis.py
+++ b/tests/integration/synapseclient/test_wikis.py
@@ -12,7 +12,7 @@ from synapseclient.core.upload.upload_functions import upload_synapse_s3
 
 
 # @skip("Skip integration tests for soon to be removed code")
-def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup) -> None:
+def test_wikiAttachment(syn: Synapse, project, schedule_for_cleanup) -> None:
     # Upload a file to be attached to a Wiki
     filename = utils.make_bogus_data_file()
     attachname = utils.make_bogus_data_file()
@@ -78,7 +78,6 @@ def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup) ->
     file_names = [fh["fileName"] for fh in file_handles]
     for fn in [filename, attachname]:
         assert os.path.basename(fn) in file_names
-    pytest.raises(SynapseHTTPError, syn.getWiki, project)
 
 
 # @skip("Skip integration tests for soon to be removed code")

--- a/tests/integration/synapseclient/test_wikis.py
+++ b/tests/integration/synapseclient/test_wikis.py
@@ -36,6 +36,7 @@ def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup) ->
         attachments=[attachname],
     )
     wiki = syn.store(wiki)
+    schedule_for_cleanup(wiki.id)
 
     # Create a Wiki sub-page
     subwiki = Wiki(
@@ -45,6 +46,7 @@ def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup) ->
         parentWikiId=wiki.id,
     )
     subwiki = syn.store(subwiki)
+    schedule_for_cleanup(subwiki.id)
 
     # Retrieve the root Wiki from Synapse
     wiki2 = syn.getWiki(project)
@@ -76,9 +78,6 @@ def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup) ->
     file_names = [fh["fileName"] for fh in file_handles]
     for fn in [filename, attachname]:
         assert os.path.basename(fn) in file_names
-
-    syn.delete(subwiki)
-    syn.delete(wiki)
     pytest.raises(SynapseHTTPError, syn.getWiki, project)
 
 

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -862,15 +862,11 @@ class TestGrid:
             updated_count=1,
         )
 
-        # Set up mock preview class: constructor returns a mock whose
-        # send_job_and_wait_async returns the mock_preview_response
         mock_preview_instance = MagicMock()
         mock_preview_instance.send_job_and_wait_async = AsyncMock(
             return_value=mock_preview_response
         )
 
-        # Set up mock import class: constructor returns a mock whose
-        # send_job_and_wait_async returns the mock_import_response
         mock_import_instance = MagicMock()
         mock_import_instance.send_job_and_wait_async = AsyncMock(
             return_value=mock_import_response

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -840,7 +840,7 @@ class TestGrid:
         grid = Grid(session_id=SESSION_ID)
 
         csv_table_descriptor = CsvTableDescriptor(
-            separator=",",
+            separator=";",
             quote_character='"',
             escape_character="\\",
             line_end=os.linesep,
@@ -907,6 +907,7 @@ class TestGrid:
             session_id=SESSION_ID,
             file_handle_id=FILE_HANDLE_ID,
             schema=expected_columns,
+            csv_descriptor=csv_table_descriptor,
         )
 
         # AND the log message contains the import counts
@@ -985,7 +986,7 @@ class TestUploadToTablePreviewRequest:
         }
 
         # WHEN I fill an UploadToTablePreviewRequest from the response
-        preview_req = UploadToTablePreviewRequest()
+        preview_req = UploadToTablePreviewRequest(upload_file_handle_id=FILE_HANDLE_ID)
         preview_response = preview_req.fill_from_dict(raw_synapse_response)
 
         # THEN the fields should be populated correctly
@@ -1010,7 +1011,21 @@ class TestUploadToTablePreviewRequest:
         ]
         assert preview_response.rows_scanned == 1
 
-    def test_to_synapse_request(self) -> None:
+    def test_to_synapse_request_with_minimal_fields(self) -> None:
+        # GIVEN an UploadToTablePreviewRequest with only required fields set
+        preview_req = UploadToTablePreviewRequest(
+            upload_file_handle_id=FILE_HANDLE_ID,
+        )
+
+        # WHEN I convert it to a synapse request
+        result = preview_req.to_synapse_request()
+
+        # THEN it should contain the correct fields and defaults
+        assert result["concreteType"] == UPLOAD_TO_TABLE_PREVIEW_REQUEST
+        assert result["uploadFileHandleId"] == FILE_HANDLE_ID
+        assert result["csvTableDescriptor"] == CsvTableDescriptor().to_synapse_request()
+
+    def test_to_synapse_request_with_all_fields(self) -> None:
         # GIVEN an UploadToTablePreviewRequest
         preview_req = UploadToTablePreviewRequest(
             upload_file_handle_id=FILE_HANDLE_ID,
@@ -1068,16 +1083,38 @@ class TestGridCsvImportRequest:
         assert result.created_count == 1
         assert result.updated_count == 2
 
-    def test_to_synapse_request(self) -> None:
+    def test_to_synapse_request_with_minimal_fields(self) -> None:
+        # GIVEN a GridCsvImportRequest with only required fields set
+        import_req = GridCsvImportRequest(
+            session_id=SESSION_ID,
+            file_handle_id=FILE_HANDLE_ID,
+            schema=[Column(name="col1", column_type="STRING")],
+        )
+
+        # WHEN I convert it to a synapse request
+        result = import_req.to_synapse_request()
+
+        # THEN it should contain the correct fields and defaults
+        assert result["concreteType"] == GRID_CSV_IMPORT_REQUEST
+        assert result["sessionId"] == SESSION_ID
+        assert result["fileHandleId"] == FILE_HANDLE_ID
+        assert result["csvDescriptor"] == CsvTableDescriptor().to_synapse_request()
+        assert len(result["schema"]) == 1
+        assert (
+            result["schema"][0]
+            == Column(name="col1", column_type="STRING").to_synapse_request()
+        )
+
+    def test_to_synapse_request_with_all_fields(self) -> None:
         # GIVEN a GridCsvImportRequest with all fields set
         import_req = GridCsvImportRequest(
             session_id=SESSION_ID,
             file_handle_id=FILE_HANDLE_ID,
             csv_descriptor=CsvTableDescriptor(
-                separator=",",
+                separator=";",
                 quote_character='"',
                 escape_character="\\",
-                line_end="\n",
+                line_end="\t",
                 is_first_line_header=True,
             ),
             schema=[
@@ -1095,10 +1132,10 @@ class TestGridCsvImportRequest:
         assert result["concreteType"] == GRID_CSV_IMPORT_REQUEST
         assert result["sessionId"] == SESSION_ID
         assert result["fileHandleId"] == FILE_HANDLE_ID
-        assert result["csvDescriptor"]["separator"] == ","
+        assert result["csvDescriptor"]["separator"] == ";"
         assert result["csvDescriptor"]["quoteCharacter"] == '"'
         assert result["csvDescriptor"]["escapeCharacter"] == "\\"
-        assert result["csvDescriptor"]["lineEnd"] == "\n"
+        assert result["csvDescriptor"]["lineEnd"] == "\t"
         assert result["csvDescriptor"]["isFirstLineHeader"] is True
         assert len(result["schema"]) == 4
         assert (

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -7,6 +7,7 @@ import pytest
 from synapseclient import Synapse
 from synapseclient.core.constants.concrete_types import (
     FILE_BASED_METADATA_TASK_PROPERTIES,
+    GRID_CSV_IMPORT_REQUEST,
     RECORD_BASED_METADATA_TASK_PROPERTIES,
     UPLOAD_TO_TABLE_PREVIEW_REQUEST,
 )
@@ -15,6 +16,7 @@ from synapseclient.models.curation import (
     CurationTask,
     FileBasedMetadataTaskProperties,
     Grid,
+    GridCsvImportRequest,
     GridRecordSetExportRequest,
     RecordBasedMetadataTaskProperties,
     UploadToTablePreviewRequest,
@@ -902,7 +904,7 @@ class TestUploadToTablePreviewRequest:
             name="Diagnosis", column_type="STRING", maximum_size=7
         )
         assert preview_response.suggested_columns[4] == Column(
-            name="PatientID", column_type="INTEGER"
+            name="PatientID", column_type="INTEGER", max_size=None
         )
         assert preview_response.sample_rows == [
             [None, "Female", "test", "Healthy", "1", None, None, None]
@@ -937,6 +939,77 @@ class TestUploadToTablePreviewRequest:
         assert result["csvTableDescriptor"]["escapeCharacter"] == "\\"
         assert result["csvTableDescriptor"]["lineEnd"] == "\n"
         assert result["csvTableDescriptor"]["isFirstLineHeader"] is True
+
+
+class TestGridCsvImportRequest:
+    """Tests for the GridCsvImportRequest helper dataclass."""
+
+    def test_fill_from_dict(self) -> None:
+        # GIVEN a response with grid CSV import data
+        raw_synapse_response = {
+            "jobId": "1234",
+            "concreteType": "org.sagebionetworks.repo.model.grid.GridCsvImportResponse",
+            "sessionId": SESSION_ID,
+            "totalCount": 3,
+            "createdCount": 1,
+            "updatedCount": 2,
+        }
+
+        # WHEN I fill a GridCsvImportRequest from the response
+        import_req = GridCsvImportRequest(session_id=SESSION_ID)
+        result = import_req.fill_from_dict(raw_synapse_response)
+
+        # THEN the response fields should be populated correctly
+        assert result.session_id == SESSION_ID
+        assert result.total_count == 3
+        assert result.created_count == 1
+        assert result.updated_count == 2
+
+    def test_to_synapse_request(self) -> None:
+        # GIVEN a GridCsvImportRequest with all fields set
+        import_req = GridCsvImportRequest(
+            session_id=SESSION_ID,
+            file_handle_id="1234567",
+            csv_descriptor=CsvTableDescriptor(
+                separator=",",
+                quote_character='"',
+                escape_character="\\",
+                line_end="\n",
+                is_first_line_header=True,
+            ),
+            schema=[
+                Column(name="ROW_ID", column_type="STRING"),
+                Column(name="ROW_VERSION", column_type="STRING"),
+                Column(name="PatientID", column_type="INTEGER"),
+                Column(name="Diagnosis", column_type="STRING"),
+            ],
+        )
+
+        # WHEN I convert it to a synapse request
+        result = import_req.to_synapse_request()
+
+        # THEN it should contain the correct fields
+        assert result["concreteType"] == GRID_CSV_IMPORT_REQUEST
+        assert result["sessionId"] == SESSION_ID
+        assert result["fileHandleId"] == "1234567"
+        assert result["csvDescriptor"]["separator"] == ","
+        assert result["csvDescriptor"]["quoteCharacter"] == '"'
+        assert result["csvDescriptor"]["escapeCharacter"] == "\\"
+        assert result["csvDescriptor"]["lineEnd"] == "\n"
+        assert result["csvDescriptor"]["isFirstLineHeader"] is True
+        assert len(result["schema"]) == 4
+        assert (
+            result["schema"][0]
+            == Column(name="ROW_ID", column_type="STRING").to_synapse_request()
+        )
+        assert (
+            result["schema"][2]
+            == Column(name="PatientID", column_type="INTEGER").to_synapse_request()
+        )
+        assert (
+            result["schema"][3]
+            == Column(name="Diagnosis", column_type="STRING").to_synapse_request()
+        )
 
 
 class TestGridRecordSetExportRequest:

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -45,6 +45,7 @@ SOURCE_ENTITY_ID = "syn5555555"
 GRID_ETAG = "grid-etag-456"
 STARTED_BY = "user-1"
 STARTED_ON = "2024-03-01T00:00:00.000Z"
+FILE_HANDLE_ID = "1234567"
 
 
 def _get_file_based_task_api_response():
@@ -830,7 +831,7 @@ class TestGrid:
             match="session_id is required to import a CSV into a GridSession",
         ):
             await grid.import_csv_async(
-                synapse_client=self.syn, file_handle_id="1234567"
+                synapse_client=self.syn, file_handle_id=FILE_HANDLE_ID
             )
 
     async def test_import_csv_async(self) -> None:
@@ -856,7 +857,8 @@ class TestGrid:
         )
         # Mock import response with row counts
         mock_import_response = GridCsvImportRequest(
-            file_handle_id="1234567",
+            session_id=SESSION_ID,
+            file_handle_id=FILE_HANDLE_ID,
             total_count=1,
             created_count=1,
             updated_count=1,
@@ -886,7 +888,7 @@ class TestGrid:
         ):
             result = await grid.import_csv_async(
                 synapse_client=self.syn,
-                file_handle_id="1234567",
+                file_handle_id=FILE_HANDLE_ID,
                 csv_table_descriptor=csv_table_descriptor,
             )
 
@@ -896,13 +898,13 @@ class TestGrid:
         # AND UploadToTablePreviewRequest was constructed with the right arguments
         MockPreview.assert_called_once_with(
             csv_table_descriptor=csv_table_descriptor,
-            upload_file_handle_id="1234567",
+            upload_file_handle_id=FILE_HANDLE_ID,
         )
 
         # AND GridCsvImportRequest was constructed with the schema from the preview
         MockImport.assert_called_once_with(
             session_id=SESSION_ID,
-            file_handle_id="1234567",
+            file_handle_id=FILE_HANDLE_ID,
             schema=expected_columns,
         )
 
@@ -1010,7 +1012,7 @@ class TestUploadToTablePreviewRequest:
     def test_to_synapse_request(self) -> None:
         # GIVEN an UploadToTablePreviewRequest
         preview_req = UploadToTablePreviewRequest(
-            upload_file_handle_id="1234567",
+            upload_file_handle_id=FILE_HANDLE_ID,
             lines_to_skip=1,
             do_full_file_scan=True,
             csv_table_descriptor=CsvTableDescriptor(
@@ -1027,7 +1029,7 @@ class TestUploadToTablePreviewRequest:
 
         # THEN it should contain the correct fields
         assert result["concreteType"] == UPLOAD_TO_TABLE_PREVIEW_REQUEST
-        assert result["uploadFileHandleId"] == "1234567"
+        assert result["uploadFileHandleId"] == FILE_HANDLE_ID
         assert result["linesToSkip"] == 1
         assert result["doFullFileScan"] is True
         assert result["csvTableDescriptor"]["separator"] == ";"
@@ -1052,7 +1054,9 @@ class TestGridCsvImportRequest:
         }
 
         # WHEN I fill a GridCsvImportRequest from the response
-        import_req = GridCsvImportRequest(session_id=SESSION_ID)
+        import_req = GridCsvImportRequest(
+            session_id=SESSION_ID, file_handle_id=FILE_HANDLE_ID
+        )
         result = import_req.fill_from_dict(raw_synapse_response)
 
         # THEN the response fields should be populated correctly
@@ -1065,7 +1069,7 @@ class TestGridCsvImportRequest:
         # GIVEN a GridCsvImportRequest with all fields set
         import_req = GridCsvImportRequest(
             session_id=SESSION_ID,
-            file_handle_id="1234567",
+            file_handle_id=FILE_HANDLE_ID,
             csv_descriptor=CsvTableDescriptor(
                 separator=",",
                 quote_character='"',
@@ -1087,7 +1091,7 @@ class TestGridCsvImportRequest:
         # THEN it should contain the correct fields
         assert result["concreteType"] == GRID_CSV_IMPORT_REQUEST
         assert result["sessionId"] == SESSION_ID
-        assert result["fileHandleId"] == "1234567"
+        assert result["fileHandleId"] == FILE_HANDLE_ID
         assert result["csvDescriptor"]["separator"] == ","
         assert result["csvDescriptor"]["quoteCharacter"] == '"'
         assert result["csvDescriptor"]["escapeCharacter"] == "\\"

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -8,6 +8,7 @@ from synapseclient import Synapse
 from synapseclient.core.constants.concrete_types import (
     FILE_BASED_METADATA_TASK_PROPERTIES,
     RECORD_BASED_METADATA_TASK_PROPERTIES,
+    UPLOAD_TO_TABLE_PREVIEW_REQUEST,
 )
 from synapseclient.models.curation import (
     CreateGridRequest,
@@ -16,9 +17,11 @@ from synapseclient.models.curation import (
     Grid,
     GridRecordSetExportRequest,
     RecordBasedMetadataTaskProperties,
+    UploadToTablePreviewRequest,
     _create_task_properties_from_dict,
 )
 from synapseclient.models.recordset import ValidationSummary
+from synapseclient.models.table_components import Column, CsvTableDescriptor
 
 TASK_ID = 42
 TASK_ID_2 = 99
@@ -854,6 +857,86 @@ class TestCreateGridRequest:
         assert "concreteType" in result
         assert result["recordSetId"] == RECORD_SET_ID
         assert "initialQuery" not in result
+
+
+class TestUploadToTablePreviewRequest:
+    """Tests for the UploadToTablePreviewRequest helper dataclass."""
+
+    def test_fill_from_dict(self) -> None:
+        # GIVEN a response with upload to table preview data
+        raw_synapse_response = {
+            "jobId": "1234",
+            "concreteType": "org.sagebionetworks.repo.model.table.UploadToTablePreviewResult",
+            "suggestedColumns": [
+                {"name": "etag", "columnType": "STRING", "maximumSize": 50},
+                {"name": "Sex", "columnType": "STRING", "maximumSize": 6},
+                {"name": "Component", "columnType": "STRING", "maximumSize": 4},
+                {"name": "Diagnosis", "columnType": "STRING", "maximumSize": 7},
+                {"name": "PatientID", "columnType": "INTEGER"},
+                {"name": "CancerType", "columnType": "STRING", "maximumSize": 50},
+                {"name": "YearofBirth", "columnType": "STRING", "maximumSize": 50},
+                {"name": "FamilyHistory", "columnType": "STRING", "maximumSize": 50},
+            ],
+            "sampleRows": [
+                {"values": [None, "Female", "test", "Healthy", "1", None, None, None]}
+            ],
+            "rowsScanned": 1,
+        }
+
+        # WHEN I fill an UploadToTablePreviewRequest from the response
+        preview_req = UploadToTablePreviewRequest()
+        preview_response = preview_req.fill_from_dict(raw_synapse_response)
+
+        # THEN the fields should be populated correctly
+        assert len(preview_response.suggested_columns) == 8
+        assert preview_response.suggested_columns[0] == Column(
+            name="etag", column_type="STRING", maximum_size=50
+        )
+        assert preview_response.suggested_columns[1] == Column(
+            name="Sex", column_type="STRING", maximum_size=6
+        )
+        assert preview_response.suggested_columns[2] == Column(
+            name="Component", column_type="STRING", maximum_size=4
+        )
+        assert preview_response.suggested_columns[3] == Column(
+            name="Diagnosis", column_type="STRING", maximum_size=7
+        )
+        assert preview_response.suggested_columns[4] == Column(
+            name="PatientID", column_type="INTEGER"
+        )
+        assert preview_response.sample_rows == [
+            [None, "Female", "test", "Healthy", "1", None, None, None]
+        ]
+        assert preview_response.rows_scanned == 1
+
+    def test_to_synapse_request(self) -> None:
+        # GIVEN an UploadToTablePreviewRequest
+        preview_req = UploadToTablePreviewRequest(
+            upload_file_handle_id="1234567",
+            lines_to_skip=1,
+            do_full_file_scan=True,
+            csv_table_descriptor=CsvTableDescriptor(
+                separator=";",
+                quote_character='"',
+                escape_character="\\",
+                line_end="\n",
+                is_first_line_header=True,
+            ),
+        )
+
+        # WHEN I convert it to a synapse request
+        result = preview_req.to_synapse_request()
+
+        # THEN it should contain the correct fields
+        assert result["concreteType"] == UPLOAD_TO_TABLE_PREVIEW_REQUEST
+        assert result["uploadFileHandleId"] == "1234567"
+        assert result["linesToSkip"] == 1
+        assert result["doFullFileScan"] is True
+        assert result["csvTableDescriptor"]["separator"] == ";"
+        assert result["csvTableDescriptor"]["quoteCharacter"] == '"'
+        assert result["csvTableDescriptor"]["escapeCharacter"] == "\\"
+        assert result["csvTableDescriptor"]["lineEnd"] == "\n"
+        assert result["csvTableDescriptor"]["isFirstLineHeader"] is True
 
 
 class TestGridRecordSetExportRequest:

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -850,6 +850,7 @@ class TestGrid:
 
         # Mock preview response with suggested columns
         mock_preview_response = UploadToTablePreviewRequest(
+            upload_file_handle_id=FILE_HANDLE_ID,
             csv_table_descriptor=csv_table_descriptor,
             suggested_columns=expected_columns,
             sample_rows=[["value1"]],

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -1,7 +1,7 @@
 """Unit tests for the CurationTask and Grid models."""
 
 import os
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -838,7 +838,6 @@ class TestGrid:
         # GIVEN a Grid with a session_id
         grid = Grid(session_id=SESSION_ID)
 
-        # Mock the CreateGridRequest's send_job_and_wait_async
         csv_table_descriptor = CsvTableDescriptor(
             separator=",",
             quote_character='"',
@@ -846,47 +845,72 @@ class TestGrid:
             line_end=os.linesep,
             is_first_line_header=True,
         )
-        mock_preview = UploadToTablePreviewRequest(
+        expected_columns = [Column(name="col1", column_type="STRING", maximum_size=50)]
+
+        # Mock preview response with suggested columns
+        mock_preview_response = UploadToTablePreviewRequest(
             csv_table_descriptor=csv_table_descriptor,
-            suggested_columns=[
-                Column(name="col1", column_type="STRING", maximum_size=50)
-            ],
+            suggested_columns=expected_columns,
             sample_rows=[["value1"]],
             rows_scanned=1,
         )
-        mock_import = GridCsvImportRequest(
+        # Mock import response with row counts
+        mock_import_response = GridCsvImportRequest(
             file_handle_id="1234567",
-            csv_descriptor=csv_table_descriptor,
-            schema=UploadToTablePreviewRequest.suggested_columns,
             total_count=1,
             created_count=1,
             updated_count=1,
         )
 
+        # Set up mock preview class: constructor returns a mock whose
+        # send_job_and_wait_async returns the mock_preview_response
+        mock_preview_instance = MagicMock()
+        mock_preview_instance.send_job_and_wait_async = AsyncMock(
+            return_value=mock_preview_response
+        )
+
+        # Set up mock import class: constructor returns a mock whose
+        # send_job_and_wait_async returns the mock_import_response
+        mock_import_instance = MagicMock()
+        mock_import_instance.send_job_and_wait_async = AsyncMock(
+            return_value=mock_import_response
+        )
+
         # WHEN I call import_csv_async
         with (
-            patch.object(
-                UploadToTablePreviewRequest,
-                "send_job_and_wait_async",
-                new_callable=AsyncMock,
-                return_value=mock_preview,
-            ),
-            patch.object(
-                GridCsvImportRequest,
-                "send_job_and_wait_async",
-                new_callable=AsyncMock,
-                return_value=mock_import,
-            ),
+            patch(
+                "synapseclient.models.curation.UploadToTablePreviewRequest",
+                return_value=mock_preview_instance,
+            ) as MockPreview,
+            patch(
+                "synapseclient.models.curation.GridCsvImportRequest",
+                return_value=mock_import_instance,
+            ) as MockImport,
             patch.object(self.syn, "logger") as mock_logger,
         ):
             result = await grid.import_csv_async(
-                synapse_client=self.syn, file_handle_id="1234567"
+                synapse_client=self.syn,
+                file_handle_id="1234567",
+                csv_table_descriptor=csv_table_descriptor,
             )
 
-        # THEN the grid should be populated with session data
+        # THEN the grid is returned with the same session
         assert result.session_id == SESSION_ID
 
-        # AND the log message should contain the import counts
+        # AND UploadToTablePreviewRequest was constructed with the right arguments
+        MockPreview.assert_called_once_with(
+            csv_table_descriptor=csv_table_descriptor,
+            upload_file_handle_id="1234567",
+        )
+
+        # AND GridCsvImportRequest was constructed with the schema from the preview
+        MockImport.assert_called_once_with(
+            session_id=SESSION_ID,
+            file_handle_id="1234567",
+            schema=expected_columns,
+        )
+
+        # AND the log message contains the import counts
         mock_logger.info.assert_called_once()
         log_message = mock_logger.info.call_args[0][0]
         assert "total count: 1" in log_message

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -859,6 +859,7 @@ class TestGrid:
         mock_import_response = GridCsvImportRequest(
             session_id=SESSION_ID,
             file_handle_id=FILE_HANDLE_ID,
+            schema=expected_columns,
             total_count=1,
             created_count=1,
             updated_count=1,
@@ -1055,7 +1056,9 @@ class TestGridCsvImportRequest:
 
         # WHEN I fill a GridCsvImportRequest from the response
         import_req = GridCsvImportRequest(
-            session_id=SESSION_ID, file_handle_id=FILE_HANDLE_ID
+            session_id=SESSION_ID,
+            file_handle_id=FILE_HANDLE_ID,
+            schema=[Column(name="col1", column_type="STRING")],
         )
         result = import_req.fill_from_dict(raw_synapse_response)
 

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -1,5 +1,6 @@
 """Unit tests for the CurationTask and Grid models."""
 
+import os
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -817,6 +818,81 @@ class TestGrid:
             assert len(results) == 1
             assert results[0].session_id == SESSION_ID
 
+    async def test_import_csv_async_without_session_id(self) -> None:
+        """Test that calling import_csv_async without a session_id raises a ValueError."""
+        # GIVEN a Grid without a session_id
+        grid = Grid()
+
+        # WHEN I call import_csv_async
+        # THEN it should raise ValueError
+        with pytest.raises(
+            ValueError,
+            match="session_id is required to import a CSV into a GridSession",
+        ):
+            await grid.import_csv_async(
+                synapse_client=self.syn, file_handle_id="1234567"
+            )
+
+    async def test_import_csv_async(self) -> None:
+        """Test the import_csv_async method of the Grid class, ensuring it correctly calls the preview and import requests and logs the results."""
+        # GIVEN a Grid with a session_id
+        grid = Grid(session_id=SESSION_ID)
+
+        # Mock the CreateGridRequest's send_job_and_wait_async
+        csv_table_descriptor = CsvTableDescriptor(
+            separator=",",
+            quote_character='"',
+            escape_character="\\",
+            line_end=os.linesep,
+            is_first_line_header=True,
+        )
+        mock_preview = UploadToTablePreviewRequest(
+            csv_table_descriptor=csv_table_descriptor,
+            suggested_columns=[
+                Column(name="col1", column_type="STRING", maximum_size=50)
+            ],
+            sample_rows=[["value1"]],
+            rows_scanned=1,
+        )
+        mock_import = GridCsvImportRequest(
+            file_handle_id="1234567",
+            csv_descriptor=csv_table_descriptor,
+            schema=UploadToTablePreviewRequest.suggested_columns,
+            total_count=1,
+            created_count=1,
+            updated_count=1,
+        )
+
+        # WHEN I call import_csv_async
+        with (
+            patch.object(
+                UploadToTablePreviewRequest,
+                "send_job_and_wait_async",
+                new_callable=AsyncMock,
+                return_value=mock_preview,
+            ),
+            patch.object(
+                GridCsvImportRequest,
+                "send_job_and_wait_async",
+                new_callable=AsyncMock,
+                return_value=mock_import,
+            ),
+            patch.object(self.syn, "logger") as mock_logger,
+        ):
+            result = await grid.import_csv_async(
+                synapse_client=self.syn, file_handle_id="1234567"
+            )
+
+        # THEN the grid should be populated with session data
+        assert result.session_id == SESSION_ID
+
+        # AND the log message should contain the import counts
+        mock_logger.info.assert_called_once()
+        log_message = mock_logger.info.call_args[0][0]
+        assert "total count: 1" in log_message
+        assert "total created: 1" in log_message
+        assert "total updated: 1" in log_message
+
 
 class TestCreateGridRequest:
     """Tests for the CreateGridRequest helper dataclass."""
@@ -904,7 +980,7 @@ class TestUploadToTablePreviewRequest:
             name="Diagnosis", column_type="STRING", maximum_size=7
         )
         assert preview_response.suggested_columns[4] == Column(
-            name="PatientID", column_type="INTEGER", max_size=None
+            name="PatientID", column_type="INTEGER", maximum_size=None
         )
         assert preview_response.sample_rows == [
             [None, "Female", "test", "Healthy", "1", None, None, None]


### PR DESCRIPTION
# **Problem:**
See test failure: https://github.com/Sage-Bionetworks/synapsePythonClient/actions/runs/24532218081/job/71718214833?pr=1360
```
=========================== short test summary info ===========================
FAILED tests/integration/synapseclient/test_wikis.py::test_wikiAttachment - AssertionError: assert 6 == 2
 +  where 6 = len([{'id': '831477', 'title': 'A New Title'}, {'id': '831478', 'title': 'A sub-wiki', 'parentId': '831477'}, {'id': '831498', 'title': 'A sub-wiki', 'parentId': '831477'}, {'id': '831502', 'title': 'A sub-wiki', 'parentId': '831477'}, {'id': '831505', 'title': 'A sub-wiki', 'parentId': '831477'}, {'id': '831509', 'title': 'A sub-wiki', 'parentId': '831477'}])
= 1 failed, 691 passed, 7 skipped, 13193 warnings, 8 rerun in 1439.73s (0:23:59) =
Don't know how to clean: 3858474 (type: int)Don't know how to clean: {'list': [{'id': '15551200', 'etag': 'd875c7ab-b290-42dd-99d8-a22d755e3522', 'createdBy': '3705114', 'createdOn': '2026-04-16T20:44:33.000Z', 'modifiedOn': '2026-04-16T20:44:33.000Z', 'concreteType': 'org.sagebionetworks.repo.model.file.S3FileHandle', 'contentType': 'text/plain', 'contentMd5': '17c90b1e31be09e26a3fda758fe0739d', 'fileName': 'tmp7jqdp6vz.txt.gz', 'storageLocationId': 1, 'contentSize': 55, 'status': 'AVAILABLE', 'bucketName': 'devdata.sagebase.org', 'key': '3705114/ea790372-bb47-4d9f-aba1-bdcd0946f4ef/tmp7jqdp6vz.txt.gz', 'isPreview': False}]} (type: dict)Don't know how to clean: {'list': [{'id': '15551074', 'etag': 'ca2ee97d-f9aa-4b27-aa1c-c133d9495e1d', 'createdBy': '3705114', 'createdOn': '2026-04-16T20:44:01.000Z', 'modifiedOn': '2026-04-16T20:44:01.000Z', 'concreteType': 'org.sagebionetworks.repo.model.file.S3FileHandle', 'contentType': 'text/plain', 'contentMd5': 'b59713f6badedcc03112aad5e792d457', 'fileName': 'tmp7v4ul_nk.txt.gz', 'storageLocationId': 1, 'contentSize': 74, 'status': 'AVAILABLE', 'bucketName': 'devdata.sagebase.org', 'key': '3705114/72278a86-53a4-4f10-a9c8-52625bfe003c/tmp7v4ul_nk.txt.gz', 'isPreview': False}]} (type: dict)
```
the shared project fixture already had 5 orphaned sub-wikis from previous run attempts that failed before reaching the cleanup lines (syn.delete(subwiki) / syn.delete(wiki)) at the bottom of the test. The test was then rerun once, creating a 6th sub-wiki and hitting the same assertion failure again.

# **Solution:**
Use **schedule_for_cleanup** to cleanup 