### PR TITLE
fix: Integration test test_wikiAttachment fails due to leaked wiki state from prior runs

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -181,6 +181,11 @@ async def _cleanup(syn: Synapse, items):
                         os.remove(item)
                 except Exception as ex:
                     print(ex)
+            else:
+                sys.stderr.write(
+                    "Don't know how to clean: %s (type: %s)"
+                    % (str(item), type(item).__name__)
+                )
         elif isinstance(
             item,
             (

--- a/tests/integration/synapseclient/test_wikis.py
+++ b/tests/integration/synapseclient/test_wikis.py
@@ -36,7 +36,7 @@ def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup) ->
         attachments=[attachname],
     )
     wiki = syn.store(wiki)
-    schedule_for_cleanup(wiki.id)
+    schedule_for_cleanup(wiki)
 
     # Create a Wiki sub-page
     subwiki = Wiki(
@@ -46,7 +46,7 @@ def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup) ->
         parentWikiId=wiki.id,
     )
     subwiki = syn.store(subwiki)
-    schedule_for_cleanup(subwiki.id)
+    schedule_for_cleanup(subwiki)
 
     # Retrieve the root Wiki from Synapse
     wiki2 = syn.getWiki(project)

--- a/tests/integration/synapseclient/test_wikis.py
+++ b/tests/integration/synapseclient/test_wikis.py
@@ -11,8 +11,18 @@ from synapseclient.core.upload.upload_functions import upload_synapse_s3
 # from unittest import skip
 
 
+@pytest.fixture
+def wiki_project(syn: Synapse, schedule_for_cleanup) -> Project:
+    """Function-scoped project so each wiki test gets a clean, isolated project."""
+    project = syn.store(Project(name=str(uuid.uuid4())))
+    schedule_for_cleanup(project)
+    return project
+
+
 # @skip("Skip integration tests for soon to be removed code")
-def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup) -> None:
+def test_wikiAttachment(
+    syn: Synapse, wiki_project: Project, schedule_for_cleanup
+) -> None:
     # Upload a file to be attached to a Wiki
     filename = utils.make_bogus_data_file()
     attachname = utils.make_bogus_data_file()
@@ -29,27 +39,25 @@ def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup) ->
     Blabber jabber blah blah boo.
     """
     wiki = Wiki(
-        owner=project,
+        owner=wiki_project,
         title="A Test Wiki",
         markdown=md,
         fileHandles=[fileHandle["id"]],
         attachments=[attachname],
     )
     wiki = syn.store(wiki)
-    schedule_for_cleanup(wiki)
 
     # Create a Wiki sub-page
     subwiki = Wiki(
-        owner=project,
+        owner=wiki_project,
         title="A sub-wiki",
         markdown="nothing",
         parentWikiId=wiki.id,
     )
     subwiki = syn.store(subwiki)
-    schedule_for_cleanup(subwiki)
 
     # Retrieve the root Wiki from Synapse
-    wiki2 = syn.getWiki(project)
+    wiki2 = syn.getWiki(wiki_project)
     # due to the new wiki api, we'll get back some new properties,
     # namely markdownFileHandleId and markdown_path, so only compare
     # properties that are in the first object
@@ -57,7 +65,7 @@ def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup) ->
         assert wiki[property_name] == wiki2[property_name]
 
     # Retrieve the sub Wiki from Synapse
-    wiki2 = syn.getWiki(project, subpageId=subwiki.id)
+    wiki2 = syn.getWiki(wiki_project, subpageId=subwiki.id)
     for property_name in wiki:
         assert subwiki[property_name] == wiki2[property_name]
 
@@ -65,12 +73,12 @@ def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup) ->
     wiki["title"] = "A New Title"
     wiki["markdown"] = wiki["markdown"] + "\nNew stuff here!!!\n"
     syn.store(wiki)
-    wiki = syn.getWiki(project)
+    wiki = syn.getWiki(wiki_project)
     assert wiki["title"] == "A New Title"
     assert wiki["markdown"].endswith("\nNew stuff here!!!\n")
 
     # Check the Wiki's metadata
-    headers = syn.getWikiHeaders(project)
+    headers = syn.getWikiHeaders(wiki_project)
     assert len(headers) == 2
     assert headers[0]["title"] in (wiki["title"], subwiki["title"])
 
@@ -81,12 +89,12 @@ def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup) ->
 
 
 # @skip("Skip integration tests for soon to be removed code")
-def test_create_or_update_wiki(syn: Synapse, project: Project) -> None:
+def test_create_or_update_wiki(syn: Synapse, wiki_project: Project) -> None:
     # create wiki once
     syn.store(
         Wiki(
             title="This is the title",
-            owner=project,
+            owner=wiki_project,
             markdown="#Wikis are OK\n\nBlabber jabber blah blah blither blather bonk!",
         )
     )
@@ -96,7 +104,7 @@ def test_create_or_update_wiki(syn: Synapse, project: Project) -> None:
     wiki = syn.store(
         Wiki(
             title=new_title,
-            owner=project,
+            owner=wiki_project,
             markdown="#Wikis are awesome\n\nNew babble boo flabble gibber wiggle sproing!",
         ),
         createOrUpdate=True,
@@ -105,13 +113,11 @@ def test_create_or_update_wiki(syn: Synapse, project: Project) -> None:
 
 
 # @skip("Skip integration tests for soon to be removed code")
-def test_wiki_version(syn: Synapse, project: Project) -> None:
-    # create a new project to avoid artifacts from previous tests
-    project = syn.store(Project(name=str(uuid.uuid4())))
+def test_wiki_version(syn: Synapse, wiki_project: Project) -> None:
     wiki = syn.store(
         Wiki(
             title="Title version 1",
-            owner=project,
+            owner=wiki_project,
             markdown="##A heading\n\nThis is version 1 of the wiki page!\n",
         )
     )
@@ -131,13 +137,15 @@ def test_wiki_version(syn: Synapse, project: Project) -> None:
 
 
 # @skip("Skip integration tests for soon to be removed code")
-def test_wiki_with_empty_string_parent_wiki_id(syn: Synapse, project: Project) -> None:
+def test_wiki_with_empty_string_parent_wiki_id(
+    syn: Synapse, wiki_project: Project
+) -> None:
     # GIVEN a wiki is created with an empty string parentWikiId
     # WHEN it is stored
     wiki_stored = syn.store(
         Wiki(
             title="This is the title",
-            owner=project,
+            owner=wiki_project,
             markdown="#Wikis are OK\n\nBlabber jabber blah blah blither blather bonk!",
             parentWikiId="",
         )

--- a/tests/integration/synapseclient/test_wikis.py
+++ b/tests/integration/synapseclient/test_wikis.py
@@ -5,7 +5,6 @@ import pytest
 
 import synapseclient.core.utils as utils
 from synapseclient import Project, Synapse, Wiki
-from synapseclient.core.exceptions import SynapseHTTPError
 from synapseclient.core.upload.upload_functions import upload_synapse_s3
 
 # from unittest import skip

--- a/tests/integration/synapseclient/test_wikis.py
+++ b/tests/integration/synapseclient/test_wikis.py
@@ -36,6 +36,7 @@ def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup) ->
         attachments=[attachname],
     )
     wiki = syn.store(wiki)
+    schedule_for_cleanup(wiki.id)
 
     # Create a Wiki sub-page
     subwiki = Wiki(
@@ -45,6 +46,7 @@ def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup) ->
         parentWikiId=wiki.id,
     )
     subwiki = syn.store(subwiki)
+    schedule_for_cleanup(subwiki.id)
 
     # Retrieve the root Wiki from Synapse
     wiki2 = syn.getWiki(project)
@@ -76,10 +78,6 @@ def test_wikiAttachment(syn: Synapse, project: Project, schedule_for_cleanup) ->
     file_names = [fh["fileName"] for fh in file_handles]
     for fn in [filename, attachname]:
         assert os.path.basename(fn) in file_names
-
-    syn.delete(subwiki)
-    syn.delete(wiki)
-    pytest.raises(SynapseHTTPError, syn.getWiki, project)
 
 
 # @skip("Skip integration tests for soon to be removed code")


### PR DESCRIPTION
# **Problem:**
See test failure: https://github.com/Sage-Bionetworks/synapsePythonClient/actions/runs/24532218081/job/71718214833?pr=1360
```
=========================== short test summary info ===========================
FAILED tests/integration/synapseclient/test_wikis.py::test_wikiAttachment - AssertionError: assert 6 == 2
 +  where 6 = len([{'id': '831477', 'title': 'A New Title'}, {'id': '831478', 'title': 'A sub-wiki', 'parentId': '831477'}, {'id': '831498', 'title': 'A sub-wiki', 'parentId': '831477'}, {'id': '831502', 'title': 'A sub-wiki', 'parentId': '831477'}, {'id': '831505', 'title': 'A sub-wiki', 'parentId': '831477'}, {'id': '831509', 'title': 'A sub-wiki', 'parentId': '831477'}])
= 1 failed, 691 passed, 7 skipped, 13193 warnings, 8 rerun in 1439.73s (0:23:59) =
Don't know how to clean: 3858474 (type: int)Don't know how to clean: {'list': [{'id': '15551200', 'etag': 'd875c7ab-b290-42dd-99d8-a22d755e3522', 'createdBy': '3705114', 'createdOn': '2026-04-16T20:44:33.000Z', 'modifiedOn': '2026-04-16T20:44:33.000Z', 'concreteType': 'org.sagebionetworks.repo.model.file.S3FileHandle', 'contentType': 'text/plain', 'contentMd5': '17c90b1e31be09e26a3fda758fe0739d', 'fileName': 'tmp7jqdp6vz.txt.gz', 'storageLocationId': 1, 'contentSize': 55, 'status': 'AVAILABLE', 'bucketName': 'devdata.sagebase.org', 'key': '3705114/ea790372-bb47-4d9f-aba1-bdcd0946f4ef/tmp7jqdp6vz.txt.gz', 'isPreview': False}]} (type: dict)Don't know how to clean: {'list': [{'id': '15551074', 'etag': 'ca2ee97d-f9aa-4b27-aa1c-c133d9495e1d', 'createdBy': '3705114', 'createdOn': '2026-04-16T20:44:01.000Z', 'modifiedOn': '2026-04-16T20:44:01.000Z', 'concreteType': 'org.sagebionetworks.repo.model.file.S3FileHandle', 'contentType': 'text/plain', 'contentMd5': 'b59713f6badedcc03112aad5e792d457', 'fileName': 'tmp7v4ul_nk.txt.gz', 'storageLocationId': 1, 'contentSize': 74, 'status': 'AVAILABLE', 'bucketName': 'devdata.sagebase.org', 'key': '3705114/72278a86-53a4-4f10-a9c8-52625bfe003c/tmp7v4ul_nk.txt.gz', 'isPreview': False}]} (type: dict)
```
the shared project fixture already had 5 orphaned sub-wikis from previous run attempts that failed before reaching the cleanup lines (syn.delete(subwiki) / syn.delete(wiki)) at the bottom of the test. The test was then rerun once, creating a 6th sub-wiki and hitting the same assertion failure again.

# **Solution:**
There are a couple of ways that I could potentially handle this: 
** Option 1**: Use try-finally block in each individual test to clean up wiki and subwiki 
** Option 2**: Create isolated project for each test

Option 1 v.s. Option 2: 
* try/finally indents all your test logic one level, making it harder to read
* The rest of the integration tests use `schedule_for_cleanup` to clean up test. 
* With option2, when the project is deleted, all wikis under it are deleted too, so you don't need to track individual wikis at all. 
* More expensive to create isolated project for each test

