### PR TITLE
fix circular dependencies

### DIFF
--- a/synapseclient/models/services/migration.py
+++ b/synapseclient/models/services/migration.py
@@ -50,7 +50,6 @@ from synapseclient.models.table_components import (
     PartialRowSet,
     TableUpdateTransaction,
 )
-from synapseclient.operations import FileOptions, get_async
 
 from .migration_types import (
     IndexingError,
@@ -918,6 +917,8 @@ async def _index_file_entity_async(
         entity_versions.append((entity, None))
 
     elif file_version_strategy == "all":
+        from synapseclient.operations import FileOptions, get_async
+
         async for version in _get_version_numbers_async(entity_id, synapse_client):
             entity = await get_async(
                 synapse_id=entity_id,
@@ -1101,6 +1102,8 @@ async def _index_container_async(
         children.append(child)
 
     async def index_child(child: Dict[str, Any]) -> None:
+        from synapseclient.operations import get_async
+
         async with synapse_client._get_parallel_file_transfer_semaphore(
             asyncio_event_loop=asyncio.get_running_loop()
         ):
@@ -1230,6 +1233,8 @@ async def _create_new_file_version_async(
         to_file_handle_id: The new file handle ID.
         synapse_client: If not passed in and caching was not disabled by `Synapse.allow_client_caching(False)` this will use the last created instance from the Synapse class constructor.
     """
+    from synapseclient.operations import FileOptions, get_async
+
     synapse_client.logger.info(f"Creating new version for file entity {entity_id}")
 
     entity = await get_async(

--- a/tests/unit/synapseclient/services/unit_test_migration_and_types_async.py
+++ b/tests/unit/synapseclient/services/unit_test_migration_and_types_async.py
@@ -1664,7 +1664,9 @@ class TestIndexFileEntityAsync:
         with (
             patch(f"{MODULE}.utils.id_of", return_value="syn3"),
             patch(f"{MODULE}._get_version_numbers_async", _mock_versions),
-            patch(f"{MODULE}.get_async", new=AsyncMock(return_value=entity)),
+            patch(
+                "synapseclient.operations.get_async", new=AsyncMock(return_value=entity)
+            ),
         ):
             await _index_file_entity_async(
                 cursor=cursor,
@@ -1885,7 +1887,10 @@ class TestIndexContainerAsync:
         with (
             patch(f"{MODULE}.get_entity_type", new=AsyncMock(return_value=et)),
             patch(f"{MODULE}.get_children", _mock_get_children),
-            patch(f"{MODULE}.get_async", new=AsyncMock(return_value=child_entity)),
+            patch(
+                "synapseclient.operations.get_async",
+                new=AsyncMock(return_value=child_entity),
+            ),
             patch(f"{MODULE}._index_entity_async", new=AsyncMock()) as mock_index,
         ):
             await _index_container_async(
@@ -2130,7 +2135,9 @@ class TestCreateNewFileVersionAsync:
 
         with (
             patch(f"{MODULE}.Synapse.get_client", return_value=client),
-            patch(f"{MODULE}.get_async", new=AsyncMock(return_value=entity)),
+            patch(
+                "synapseclient.operations.get_async", new=AsyncMock(return_value=entity)
+            ),
         ):
             await _create_new_file_version_async(
                 entity_id="syn3",


### PR DESCRIPTION
# **Problem:**

Currently in develop importing from download operations:
```
from synapseclient.operations import DownloadListItem
```
causes a circular dependency exception:

```
Traceback (most recent call last):
  File "/Users/rxu/synapsePythonClient/test_synpy_1802.py", line 2, in <module>
    from synapseclient.operations import (
  File "/Users/rxu/synapsePythonClient/synapseclient/operations/__init__.py", line 2, in <module>
    from synapseclient.operations.download_list_operations import (
  File "/Users/rxu/synapsePythonClient/synapseclient/operations/download_list_operations.py", line 26, in <module>
    from synapseclient.models.mixins.asynchronous_job import AsynchronousCommunicator
  File "/Users/rxu/synapsePythonClient/synapseclient/models/__init__.py", line 3, in <module>
    from synapseclient.models.agent import (
  File "/Users/rxu/synapsePythonClient/synapseclient/models/agent.py", line 17, in <module>
    from synapseclient.models.mixins import AsynchronousCommunicator
  File "/Users/rxu/synapsePythonClient/synapseclient/models/mixins/__init__.py", line 24, in <module>
    from synapseclient.models.mixins.storable_container import StorableContainer
  File "/Users/rxu/synapsePythonClient/synapseclient/models/mixins/storable_container.py", line 47, in <module>
    from synapseclient.models.protocols.storable_container_protocol import (
  File "/Users/rxu/synapsePythonClient/synapseclient/models/protocols/storable_container_protocol.py", line 11, in <module>
    from synapseclient.models.services.storable_entity_components import (
  File "/Users/rxu/synapsePythonClient/synapseclient/models/services/__init__.py", line 1, in <module>
    from synapseclient.models.services.migration import (
  File "/Users/rxu/synapsePythonClient/synapseclient/models/services/migration.py", line 53, in <module>
    from synapseclient.operations import FileOptions, get_async
ImportError: cannot import name 'FileOptions' from partially initialized module 'synapseclient.operations' (most likely due to a circular import) (/Users/rxu/synapsePythonClient/synapseclient/operations/__init__.py)
```

# **Solution:**
In `synapseclient/models/services/migration.py`, imports from the `operations` directory were moved into the various methods instead of being a module-level import. Some testing patches had to be changed to accommodate this.


