### PR TITLE
[SYNPY-1782] Download CSV from Grid session 

### DIFF
--- a/docs/reference/experimental/async/curator.md
+++ b/docs/reference/experimental/async/curator.md
@@ -56,6 +56,7 @@ at your own risk.
         members:
             - create_async
             - export_to_record_set_async
+            - download_csv_async
 ---
 [](){ #query-reference-async }
 ::: synapseclient.models.Query

--- a/docs/reference/experimental/sync/curator.md
+++ b/docs/reference/experimental/sync/curator.md
@@ -56,6 +56,7 @@ at your own risk.
         members:
             - create
             - export_to_record_set
+            - download_csv
 ---
 [](){ #query-reference }
 ::: synapseclient.models.Query

--- a/synapseclient/core/constants/concrete_types.py
+++ b/synapseclient/core/constants/concrete_types.py
@@ -140,6 +140,9 @@ DOWNLOAD_LIST_MANIFEST_REQUEST = (
 
 # Grid Session Types
 CREATE_GRID_REQUEST = "org.sagebionetworks.repo.model.grid.CreateGridRequest"
+DOWNLOAD_FROM_GRID_REQUEST = (
+    "org.sagebionetworks.repo.model.grid.DownloadFromGridRequest"
+)
 GRID_RECORD_SET_EXPORT_REQUEST = (
     "org.sagebionetworks.repo.model.grid.GridRecordSetExportRequest"
 )

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -1467,7 +1467,7 @@ class GridSynchronousProtocol(Protocol):
 
         Arguments:
             destination: Local directory path where the CSV will be saved.
-                If not provided, defaults to the current working directory.
+                If not provided, defaults to the current working directory. The directory must already exist.
             write_header: Whether the first line should contain column names
                 as a header. Defaults to True.
             include_row_id_and_row_version: Whether the first two columns
@@ -1997,7 +1997,7 @@ class Grid(GridSynchronousProtocol):
         then downloads the resulting CSV to the local filesystem.
 
         Arguments:
-            destination: Local directory path where the CSV will be saved.
+            destination: Local directory path where the CSV will be saved. The directory must already exist.
                 If not provided, defaults to the current working directory.
             write_header: Whether the first line should contain column names
                 as a header. Defaults to True.

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -1078,7 +1078,7 @@ class DownloadFromGridRequest(AsynchronousCommunicator):
 
     This request is modeled from: <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/grid/DownloadFromGridRequest.html>
 
-    The response is modeled from: <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/grid/DownloadFromGridResponse.html>
+    The response is modeled from: <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/grid/DownloadFromGridResult.html>
     """
 
     session_id: str

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -5,6 +5,7 @@ Curation tasks are used to guide data contributors through the process of contri
 data or metadata in Synapse.
 """
 
+import os
 from dataclasses import dataclass, field, replace
 from typing import Any, AsyncGenerator, Dict, Generator, Optional, Protocol, Union
 
@@ -1449,7 +1450,7 @@ class GridSynchronousProtocol(Protocol):
     def download_csv(
         self,
         *,
-        destination: str = ".",
+        destination: Optional[str] = None,
         write_header: bool = True,
         include_row_id_and_row_version: bool = True,
         include_etag: bool = True,
@@ -1466,7 +1467,7 @@ class GridSynchronousProtocol(Protocol):
 
         Arguments:
             destination: Local directory path where the CSV will be saved.
-                Defaults to the current working directory.
+                If not provided, defaults to the current working directory.
             write_header: Whether the first line should contain column names
                 as a header. Defaults to True.
             include_row_id_and_row_version: Whether the first two columns
@@ -1979,8 +1980,8 @@ class Grid(GridSynchronousProtocol):
     )
     async def download_csv_async(
         self,
-        destination: str = ".",
         *,
+        destination: Optional[str] = None,
         write_header: bool = True,
         include_row_id_and_row_version: bool = True,
         include_etag: bool = True,
@@ -1997,7 +1998,7 @@ class Grid(GridSynchronousProtocol):
 
         Arguments:
             destination: Local directory path where the CSV will be saved.
-                Defaults to the current working directory.
+                If not provided, defaults to the current working directory.
             write_header: Whether the first line should contain column names
                 as a header. Defaults to True.
             include_row_id_and_row_version: Whether the first two columns
@@ -2044,9 +2045,13 @@ class Grid(GridSynchronousProtocol):
         if not self.session_id:
             raise ValueError("session_id is required to download a GridSession as CSV")
 
-        trace.get_current_span().set_attributes(
-            {"synapse.session_id": self.session_id or ""}
-        )
+        if not destination:
+            destination = os.getcwd()
+
+        if not os.path.isdir(destination):
+            raise ValueError(f"Destination {destination} is not a valid directory.")
+
+        trace.get_current_span().set_attributes({"synapse.session_id": self.session_id})
 
         effective_descriptor = csv_table_descriptor or CsvTableDescriptor()
         request = DownloadFromGridRequest(

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -2334,9 +2334,9 @@ class Grid(GridSynchronousProtocol):
             write_header: Whether the first line should contain column names
                 as a header. Defaults to True.
             include_row_id_and_row_version: Whether the first two columns
-                should contain row ID and version. Defaults to True.
+                should contain row ID and version. Defaults to False.
             include_etag: Whether a column should contain the row etag.
-                Defaults to True.
+                Defaults to False.
             csv_table_descriptor: The description of the CSV format (delimiter,
                 quote character, etc.). If not provided, the default CSV format
                 will be used.

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -2067,7 +2067,9 @@ class Grid(GridSynchronousProtocol):
         )
         if not download_response.results_file_handle_id:
             raise ValueError(
-                "Download job did not return a file handle ID for the CSV result"
+                f"Download job for grid session '{self.session_id}' completed but "
+                "did not return a file handle ID. The CSV result may be empty or "
+                "the job may have failed silently."
             )
 
         return await download_by_file_handle(

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -1088,13 +1088,13 @@ class DownloadFromGridRequest(AsynchronousCommunicator):
     concrete_type: str = DOWNLOAD_FROM_GRID_REQUEST
     """The concrete type for this request."""
 
-    write_header: Optional[bool] = True
+    write_header: bool = True
     """Should the first line contain the columns names as a header in the resulting file? Set to 'true' to include the headers else, 'false'."""
 
-    include_row_id_and_row_version: Optional[bool] = False
+    include_row_id_and_row_version: bool = False
     """Should the first two columns contain the row ID and row version?"""
 
-    include_etag: Optional[bool] = False
+    include_etag: bool = False
     """Should the first (or third if includeRowIdAndRowVersion is true) column contain the row etag?"""
 
     csv_table_descriptor: CsvTableDescriptor = field(default_factory=CsvTableDescriptor)

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -5,6 +5,7 @@ Curation tasks are used to guide data contributors through the process of contri
 data or metadata in Synapse.
 """
 
+import asyncio
 import os
 from dataclasses import dataclass, field, replace
 from typing import Any, AsyncGenerator, Dict, Generator, Optional, Protocol, Union
@@ -17,6 +18,8 @@ from synapseclient.api import (
     delete_curation_task,
     delete_grid_session,
     get_curation_task,
+    get_file_handle,
+    get_file_handle_presigned_url,
     list_curation_tasks,
     list_grid_sessions,
     update_curation_task,
@@ -38,7 +41,7 @@ from synapseclient.core.constants.concrete_types import (
     RECORD_BASED_METADATA_TASK_PROPERTIES,
     UPLOAD_TO_TABLE_PREVIEW_REQUEST,
 )
-from synapseclient.core.download.download_functions import download_by_file_handle
+from synapseclient.core.download.download_functions import download_from_url
 from synapseclient.core.upload.upload_functions_async import upload_synapse_s3
 from synapseclient.core.utils import delete_none_keys, merge_dataclass_entities
 from synapseclient.models.mixins.asynchronous_job import AsynchronousCommunicator
@@ -2385,10 +2388,24 @@ class Grid(GridSynchronousProtocol):
                 "the job may have failed silently."
             )
 
-        return await download_by_file_handle(
+        file_handle = await get_file_handle(
             file_handle_id=download_response.results_file_handle_id,
-            synapse_id=download_response.results_file_handle_id,
-            entity_type="FileEntity",
-            destination=destination,
+            synapse_client=synapse_client,
+        )
+        presigned_url = await get_file_handle_presigned_url(
+            file_handle_id=download_response.results_file_handle_id,
+            synapse_client=synapse_client,
+        )
+        file_name = (
+            file_name or file_handle.get("fileName") or f"grid_{self.session_id}.csv"
+        )
+        file_path = os.path.join(destination, file_name)
+        return await asyncio.to_thread(
+            download_from_url,
+            url=presigned_url,
+            destination=file_path,
+            file_handle_id=file_handle["id"],
+            expected_md5=file_handle.get("contentMd5"),
+            url_is_presigned=True,
             synapse_client=synapse_client,
         )

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -8,6 +8,7 @@ data or metadata in Synapse.
 import asyncio
 import os
 from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Dict, Generator, Optional, Protocol, Union
 
 from opentelemetry import trace
@@ -1090,10 +1091,10 @@ class DownloadFromGridRequest(AsynchronousCommunicator):
     write_header: Optional[bool] = True
     """Should the first line contain the columns names as a header in the resulting file? Set to 'true' to include the headers else, 'false'."""
 
-    include_row_id_and_row_version: Optional[bool] = True
+    include_row_id_and_row_version: Optional[bool] = False
     """Should the first two columns contain the row ID and row version?"""
 
-    include_etag: Optional[bool] = True
+    include_etag: Optional[bool] = False
     """Should the first (or third if includeRowIdAndRowVersion is true) column contain the row etag?"""
 
     csv_table_descriptor: CsvTableDescriptor = field(default_factory=CsvTableDescriptor)
@@ -1610,8 +1611,8 @@ class GridSynchronousProtocol(Protocol):
         *,
         destination: Optional[str] = None,
         write_header: bool = True,
-        include_row_id_and_row_version: bool = True,
-        include_etag: bool = True,
+        include_row_id_and_row_version: bool = False,
+        include_etag: bool = False,
         csv_table_descriptor: Optional[CsvTableDescriptor] = None,
         file_name: Optional[str] = None,
         timeout: int = 120,
@@ -1662,6 +1663,21 @@ class GridSynchronousProtocol(Protocol):
 
             grid = Grid(session_id="abc-123-def")
             path = grid.download_csv(destination="./downloads")
+            print(f"Downloaded CSV to: {path}")
+            ```
+
+        Example: Download a grid session as a CSV with a custom file name
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Grid
+
+            syn = Synapse()
+            syn.login()
+
+            grid = Grid(session_id="abc-123-def")
+            path = grid.download_csv(destination="./downloads", file_name="my_export.csv")
             print(f"Downloaded CSV to: {path}")
             ```
         """
@@ -2299,8 +2315,8 @@ class Grid(GridSynchronousProtocol):
         *,
         destination: Optional[str] = None,
         write_header: bool = True,
-        include_row_id_and_row_version: bool = True,
-        include_etag: bool = True,
+        include_row_id_and_row_version: bool = False,
+        include_etag: bool = False,
         csv_table_descriptor: Optional[CsvTableDescriptor] = None,
         file_name: Optional[str] = None,
         timeout: int = 120,
@@ -2357,6 +2373,27 @@ class Grid(GridSynchronousProtocol):
 
             asyncio.run(main())
             ```
+
+        Example: Download a grid session as a CSV with a custom file name asynchronously
+            &nbsp;
+
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import Grid
+
+            syn = Synapse()
+            syn.login()
+
+            async def main():
+                grid = Grid(session_id="abc-123-def")
+                path = await grid.download_csv_async(
+                    destination="./downloads", file_name="my_export.csv"
+                )
+                print(f"Downloaded CSV to: {path}")
+
+            asyncio.run(main())
+            ```
         """
         if not self.session_id:
             raise ValueError("session_id is required to download a GridSession as CSV")
@@ -2396,9 +2433,9 @@ class Grid(GridSynchronousProtocol):
             file_handle_id=download_response.results_file_handle_id,
             synapse_client=synapse_client,
         )
-        file_name = (
-            file_name or file_handle.get("fileName") or f"grid_{self.session_id}.csv"
-        )
+        if not file_name:
+            timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S")
+            file_name = f"grid_{self.session_id}-{timestamp}.csv"
         file_path = os.path.join(destination, file_name)
         return await asyncio.to_thread(
             download_from_url,

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -1630,9 +1630,9 @@ class GridSynchronousProtocol(Protocol):
             write_header: Whether the first line should contain column names
                 as a header. Defaults to True.
             include_row_id_and_row_version: Whether the first two columns
-                should contain row ID and version. Defaults to True.
+                should contain row ID and version. Defaults to False.
             include_etag: Whether a column should contain the row etag.
-                Defaults to True.
+                Defaults to False.
             csv_table_descriptor: The description of the CSV format (delimiter,
                 quote character, etc.). If not provided, the default CSV format
                 will be used.

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -22,21 +22,24 @@ from synapseclient.api import (
 )
 from synapseclient.core.async_utils import (
     async_to_sync,
+    otel_trace_method,
     skip_async_to_sync,
     wrap_async_generator_to_sync_generator,
 )
 from synapseclient.core.constants.concrete_types import (
     CREATE_GRID_REQUEST,
+    DOWNLOAD_FROM_GRID_REQUEST,
     FILE_BASED_METADATA_TASK_PROPERTIES,
     GRID_RECORD_SET_EXPORT_REQUEST,
     LIST_GRID_SESSIONS_REQUEST,
     LIST_GRID_SESSIONS_RESPONSE,
     RECORD_BASED_METADATA_TASK_PROPERTIES,
 )
+from synapseclient.core.download.download_functions import download_by_file_handle
 from synapseclient.core.utils import delete_none_keys, merge_dataclass_entities
 from synapseclient.models.mixins.asynchronous_job import AsynchronousCommunicator
 from synapseclient.models.recordset import ValidationSummary
-from synapseclient.models.table_components import Query
+from synapseclient.models.table_components import CsvTableDescriptor, Query
 
 
 @dataclass
@@ -990,6 +993,76 @@ class CreateGridRequest(AsynchronousCommunicator):
 
 
 @dataclass
+class DownloadFromGridRequest(AsynchronousCommunicator):
+    """
+    A CSV Grid download request.
+
+    This request is modeled from: <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/grid/DownloadFromGridRequest.html>
+
+    The response is modeled from: <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/grid/DownloadFromGridResponse.html>
+    """
+
+    session_id: str
+    """The grid session ID."""
+
+    concrete_type: str = field(default=DOWNLOAD_FROM_GRID_REQUEST)
+    """The concrete type for this request."""
+
+    write_header: Optional[bool] = True
+    """Should the first line contain the columns names as a header in the resulting file? Set to 'true' to include the headers else, 'false'."""
+
+    include_row_id_and_row_version: Optional[bool] = True
+    """Should the first two columns contain the row ID and row version?"""
+
+    include_etag: Optional[bool] = True
+    """Should the first (or third if includeRowIdAndRowVersion is true) column contain the row etag?"""
+
+    csv_table_descriptor: CsvTableDescriptor = field(default_factory=CsvTableDescriptor)
+    """The description of a csv for upload or download."""
+
+    file_name: Optional[str] = None
+    """The optional name for the downloaded table."""
+
+    # Response fields (populated by fill_from_dict)
+    results_file_handle_id: Optional[str] = None
+    """The file handle ID of the generated CSV. Populated from the async job response."""
+
+    def fill_from_dict(
+        self, synapse_response: Dict[str, Any]
+    ) -> "DownloadFromGridRequest":
+        """
+        Converts a response from the REST API into this dataclass.
+
+        Arguments:
+            synapse_response: The response from the REST API.
+
+        Returns:
+            The DownloadFromGridRequest object.
+        """
+        self.results_file_handle_id = synapse_response.get("resultsFileHandleId")
+        return self
+
+    def to_synapse_request(self) -> Dict[str, Any]:
+        """
+        Converts this dataclass to a dictionary suitable for a Synapse REST API request.
+
+        Returns:
+            A dictionary representation of this object for API requests.
+        """
+        request_dict = {
+            "concreteType": self.concrete_type,
+            "sessionId": self.session_id,
+            "writeHeader": self.write_header,
+            "includeRowIdAndRowVersion": self.include_row_id_and_row_version,
+            "includeEtag": self.include_etag,
+            "csvTableDescriptor": self.csv_table_descriptor.to_synapse_request(),
+            "fileName": self.file_name,
+        }
+        delete_none_keys(request_dict)
+        return request_dict
+
+
+@dataclass
 class GridRecordSetExportRequest(AsynchronousCommunicator):
     """
     A request to export a grid created from a record set back to the original record set.
@@ -1372,6 +1445,68 @@ class GridSynchronousProtocol(Protocol):
             ```
         """
         return None
+
+    def download_csv(
+        self,
+        *,
+        destination: str = ".",
+        write_header: bool = True,
+        include_row_id_and_row_version: bool = True,
+        include_etag: bool = True,
+        csv_table_descriptor: Optional[CsvTableDescriptor] = None,
+        file_name: Optional[str] = None,
+        timeout: int = 120,
+        synapse_client: Optional[Synapse] = None,
+    ) -> str:
+        """
+        Download the current state of this grid session as a CSV file.
+
+        Submits a DownloadFromGridRequest async job, waits for it to complete,
+        then downloads the resulting CSV to the local filesystem.
+
+        Arguments:
+            destination: Local directory path where the CSV will be saved.
+                Defaults to the current working directory.
+            write_header: Whether the first line should contain column names
+                as a header. Defaults to True.
+            include_row_id_and_row_version: Whether the first two columns
+                should contain row ID and version. Defaults to True.
+            include_etag: Whether a column should contain the row etag.
+                Defaults to True.
+            csv_table_descriptor: The description of the CSV format (delimiter,
+                quote character, etc.). If not provided, the default CSV format
+                will be used.
+            file_name: The optional name for the downloaded file. If not
+                provided, Synapse will generate a name.
+            timeout: The number of seconds to wait for the async job to
+                complete or progress before raising a SynapseTimeoutError.
+                Defaults to 120.
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last
+                created instance from the Synapse class constructor.
+
+        Returns:
+            The local path to the downloaded CSV file.
+
+        Raises:
+            ValueError: If session_id is not provided.
+
+        Example: Download a grid session as a CSV
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import Grid
+
+            syn = Synapse()
+            syn.login()
+
+            grid = Grid(session_id="abc-123-def")
+            path = grid.download_csv(destination="./downloads")
+            print(f"Downloaded CSV to: {path}")
+            ```
+        """
+        return ""
 
     @classmethod
     def list(
@@ -1837,4 +1972,103 @@ class Grid(GridSynchronousProtocol):
 
         await delete_grid_session(
             session_id=self.session_id, synapse_client=synapse_client
+        )
+
+    @otel_trace_method(
+        method_to_trace_name=lambda self, *args, **kwargs: f"Grid_DownloadCsv: ID: {self.session_id}"
+    )
+    async def download_csv_async(
+        self,
+        destination: str = ".",
+        *,
+        write_header: bool = True,
+        include_row_id_and_row_version: bool = True,
+        include_etag: bool = True,
+        csv_table_descriptor: Optional[CsvTableDescriptor] = None,
+        file_name: Optional[str] = None,
+        timeout: int = 120,
+        synapse_client: Optional[Synapse] = None,
+    ) -> str:
+        """
+        Asynchronously download the current state of this grid session as a CSV file.
+
+        Submits a DownloadFromGridRequest async job, waits for it to complete,
+        then downloads the resulting CSV to the local filesystem.
+
+        Arguments:
+            destination: Local directory path where the CSV will be saved.
+                Defaults to the current working directory.
+            write_header: Whether the first line should contain column names
+                as a header. Defaults to True.
+            include_row_id_and_row_version: Whether the first two columns
+                should contain row ID and version. Defaults to True.
+            include_etag: Whether a column should contain the row etag.
+                Defaults to True.
+            csv_table_descriptor: The description of the CSV format (delimiter,
+                quote character, etc.). If not provided, the default CSV format
+                will be used.
+            file_name: The optional name for the downloaded file. If not
+                provided, Synapse will generate a name.
+            timeout: The number of seconds to wait for the async job to
+                complete or progress before raising a SynapseTimeoutError.
+                Defaults to 120.
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last
+                created instance from the Synapse class constructor.
+
+        Returns:
+            The local path to the downloaded CSV file.
+
+        Raises:
+            ValueError: If session_id is not provided.
+
+        Example: Download a grid session as a CSV asynchronously
+            &nbsp;
+
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import Grid
+
+            syn = Synapse()
+            syn.login()
+
+            async def main():
+                grid = Grid(session_id="abc-123-def")
+                path = await grid.download_csv_async(destination="./downloads")
+                print(f"Downloaded CSV to: {path}")
+
+            asyncio.run(main())
+            ```
+        """
+        if not self.session_id:
+            raise ValueError("session_id is required to download a GridSession as CSV")
+
+        trace.get_current_span().set_attributes(
+            {"synapse.session_id": self.session_id or ""}
+        )
+
+        effective_descriptor = csv_table_descriptor or CsvTableDescriptor()
+        request = DownloadFromGridRequest(
+            session_id=self.session_id,
+            write_header=write_header,
+            include_row_id_and_row_version=include_row_id_and_row_version,
+            include_etag=include_etag,
+            csv_table_descriptor=effective_descriptor,
+            file_name=file_name,
+        )
+        download_response = await request.send_job_and_wait_async(
+            timeout=timeout, synapse_client=synapse_client
+        )
+        if not download_response.results_file_handle_id:
+            raise ValueError(
+                "Download job did not return a file handle ID for the CSV result"
+            )
+
+        return await download_by_file_handle(
+            file_handle_id=download_response.results_file_handle_id,
+            synapse_id=download_response.results_file_handle_id,
+            entity_type="FileEntity",
+            destination=destination,
+            synapse_client=synapse_client,
         )

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -2424,14 +2424,15 @@ class Grid(GridSynchronousProtocol):
                 "did not return a file handle ID. The CSV result may be empty or "
                 "the job may have failed silently."
             )
-
-        file_handle = await get_file_handle(
-            file_handle_id=download_response.results_file_handle_id,
-            synapse_client=synapse_client,
-        )
-        presigned_url = await get_file_handle_presigned_url(
-            file_handle_id=download_response.results_file_handle_id,
-            synapse_client=synapse_client,
+        file_handle, presigned_url = await asyncio.gather(
+            get_file_handle(
+                file_handle_id=download_response.results_file_handle_id,
+                synapse_client=synapse_client,
+            ),
+            get_file_handle_presigned_url(
+                file_handle_id=download_response.results_file_handle_id,
+                synapse_client=synapse_client,
+            ),
         )
         if not file_name:
             timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S")

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -1084,7 +1084,7 @@ class DownloadFromGridRequest(AsynchronousCommunicator):
     session_id: str
     """The grid session ID."""
 
-    concrete_type: str = field(default=DOWNLOAD_FROM_GRID_REQUEST)
+    concrete_type: str = DOWNLOAD_FROM_GRID_REQUEST
     """The concrete type for this request."""
 
     write_header: Optional[bool] = True

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -1637,7 +1637,7 @@ class GridSynchronousProtocol(Protocol):
                 quote character, etc.). If not provided, the default CSV format
                 will be used.
             file_name: The optional name for the downloaded file. If not
-                provided, Synapse will generate a name.
+                provided, defaults to `grid_{session_id}-{timestamp}.csv`.
             timeout: The number of seconds to wait for the async job to
                 complete or progress before raising a SynapseTimeoutError.
                 Defaults to 120.
@@ -2341,7 +2341,7 @@ class Grid(GridSynchronousProtocol):
                 quote character, etc.). If not provided, the default CSV format
                 will be used.
             file_name: The optional name for the downloaded file. If not
-                provided, Synapse will generate a name.
+                provided, defaults to `grid_{session_id}-{timestamp}.csv`.
             timeout: The number of seconds to wait for the async job to
                 complete or progress before raising a SynapseTimeoutError.
                 Defaults to 120.

--- a/synapseclient/models/mixins/asynchronous_job.py
+++ b/synapseclient/models/mixins/asynchronous_job.py
@@ -14,6 +14,7 @@ from synapseclient.core.constants.concrete_types import (
     AGENT_CHAT_REQUEST,
     CREATE_GRID_REQUEST,
     CREATE_SCHEMA_REQUEST,
+    DOWNLOAD_FROM_GRID_REQUEST,
     DOWNLOAD_LIST_MANIFEST_REQUEST,
     GET_VALIDATION_SCHEMA_REQUEST,
     GRID_RECORD_SET_EXPORT_REQUEST,
@@ -30,6 +31,7 @@ from synapseclient.core.exceptions import (
 ASYNC_JOB_URIS = {
     AGENT_CHAT_REQUEST: "/agent/chat/async",
     CREATE_GRID_REQUEST: "/grid/session/async",
+    DOWNLOAD_FROM_GRID_REQUEST: "/grid/download/csv/async",
     DOWNLOAD_LIST_MANIFEST_REQUEST: "/download/list/manifest/async",
     GRID_RECORD_SET_EXPORT_REQUEST: "/grid/export/recordset/async",
     TABLE_UPDATE_TRANSACTION_REQUEST: "/entity/{entityId}/table/transaction/async",

--- a/tests/integration/synapseclient/models/async/test_grid_async.py
+++ b/tests/integration/synapseclient/models/async/test_grid_async.py
@@ -268,9 +268,6 @@ class TestGridAsync:
             df = pd.read_csv(csv_path)
             expected_df = pd.DataFrame(
                 {
-                    "ROW_ID": [float("nan")] * 5,
-                    "ROW_VERSION": [float("nan")] * 5,
-                    "etag": [None] * 5,
                     "id": [1, 2, 3, 4, 5],
                     "name": ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"],
                     "value": [10.5, 20.3, 30.7, 40.1, 50.9],

--- a/tests/integration/synapseclient/models/async/test_grid_async.py
+++ b/tests/integration/synapseclient/models/async/test_grid_async.py
@@ -249,30 +249,36 @@ class TestGridAsync:
     async def test_download_csv_async(self, record_set_fixture: RecordSet) -> None:
         # GIVEN: Create a grid session first
         grid = Grid(record_set_id=record_set_fixture.id)
-        created_grid = await grid.create_async(
-            timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
-        )
+        try:
+            created_grid = await grid.create_async(
+                timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
+            )
 
-        # WHEN: Downloading the grid results as CSV
-        temp_dir = tempfile.mkdtemp()
-        self.schedule_for_cleanup(temp_dir)
-        csv_path = await created_grid.download_csv_async(
-            synapse_client=self.syn, timeout=ASYNC_JOB_TIMEOUT_SEC, destination=temp_dir
-        )
+            # WHEN: Downloading the grid results as CSV
+            temp_dir = tempfile.mkdtemp()
+            self.schedule_for_cleanup(temp_dir)
+            csv_path = await created_grid.download_csv_async(
+                synapse_client=self.syn,
+                timeout=ASYNC_JOB_TIMEOUT_SEC,
+                destination=temp_dir,
+            )
 
-        # THEN: The CSV content should be returned and match the original data
-        assert os.path.exists(csv_path)
-        df = pd.read_csv(csv_path)
-        expected_df = pd.DataFrame(
-            {
-                "ROW_ID": [float("nan")] * 5,
-                "ROW_VERSION": [float("nan")] * 5,
-                "etag": [None] * 5,
-                "id": [1, 2, 3, 4, 5],
-                "name": ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"],
-                "value": [10.5, 20.3, 30.7, 40.1, 50.9],
-                "category": ["A", "B", "A", "C", "B"],
-                "active": [True, False, True, True, False],
-            }
-        )
-        pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+            # THEN: The CSV content should be returned and match the original data
+            assert os.path.exists(csv_path)
+            df = pd.read_csv(csv_path)
+            expected_df = pd.DataFrame(
+                {
+                    "ROW_ID": [float("nan")] * 5,
+                    "ROW_VERSION": [float("nan")] * 5,
+                    "etag": [None] * 5,
+                    "id": [1, 2, 3, 4, 5],
+                    "name": ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"],
+                    "value": [10.5, 20.3, 30.7, 40.1, 50.9],
+                    "category": ["A", "B", "A", "C", "B"],
+                    "active": [True, False, True, True, False],
+                }
+            )
+            pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+        finally:
+            if created_grid is not None and created_grid.session_id:
+                await created_grid.delete_async(synapse_client=self.syn)

--- a/tests/integration/synapseclient/models/async/test_grid_async.py
+++ b/tests/integration/synapseclient/models/async/test_grid_async.py
@@ -183,3 +183,34 @@ class TestGridAsync:
             match="session_id is required to delete a GridSession",
         ):
             await grid.delete_async(synapse_client=self.syn)
+
+    async def test_download_csv_async(self, record_set_fixture: RecordSet) -> None:
+        # GIVEN: Create a grid session first
+        grid = Grid(record_set_id=record_set_fixture.id)
+        created_grid = await grid.create_async(
+            timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
+        )
+
+        # WHEN: Downloading the grid results as CSV
+        temp_dir = tempfile.mkdtemp()
+        self.schedule_for_cleanup(temp_dir)
+        csv_path = await created_grid.download_csv_async(
+            synapse_client=self.syn, timeout=ASYNC_JOB_TIMEOUT_SEC, destination=temp_dir
+        )
+
+        # THEN: The CSV content should be returned and match the original data
+        assert os.path.exists(csv_path)
+        df = pd.read_csv(csv_path)
+        expected_df = pd.DataFrame(
+            {
+                "ROW_ID": [float("nan")] * 5,
+                "ROW_VERSION": [float("nan")] * 5,
+                "etag": [None] * 5,
+                "id": [1, 2, 3, 4, 5],
+                "name": ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"],
+                "value": [10.5, 20.3, 30.7, 40.1, 50.9],
+                "category": ["A", "B", "A", "C", "B"],
+                "active": [True, False, True, True, False],
+            }
+        )
+        pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -1393,7 +1393,7 @@ class TestGridDownloadCsv:
 
         # WHEN I call download_csv_async with an invalid destination
         with pytest.raises(
-            ValueError, match=f"Destination ./nonexistent_dir is not a valid directory."
+            ValueError, match="Destination ./nonexistent_dir is not a valid directory."
         ):
             await grid.download_csv_async(
                 synapse_client=self.syn, destination="./nonexistent_dir"

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -961,7 +961,7 @@ class TestGridDownloadCsv:
             result = await grid.download_csv_async(synapse_client=self.syn)
             current_dir = os.getcwd()
 
-            # # THEN the download request should be sent
+            # THEN the download request should be sent
             mock_send.assert_called_once()
             mock_download.assert_called_once_with(
                 synapse_client=self.syn,

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -1358,6 +1358,25 @@ class TestGridDownloadCsv:
         mock_download_request = DownloadFromGridRequest(session_id=SESSION_ID)
         mock_download_request.results_file_handle_id = FILE_HANDLE_ID
 
+        mock_file_handle = {
+            "id": "172705303",
+            "etag": "mock-etag",
+            "createdBy": "3443707",
+            "createdOn": "2026-04-30T21:21:40.000Z",
+            "modifiedOn": "2026-04-30T21:21:40.000Z",
+            "concreteType": "org.sagebionetworks.repo.model.file.S3FileHandle",
+            "contentType": "text/csv",
+            "contentMd5": "mock-med5",
+            "fileName": "Job-1234.csv",
+            "contentSize": 100,
+            "status": "AVAILABLE",
+            "bucketName": "proddata.sagebase.org",
+            "key": "1234/5678/Job-1234.csv",
+            "isPreview": False,
+        }
+        mock_presigned_url = "https://presigned.example.com/file.csv"
+        expected_download_path = "/tmp/downloaded.csv"
+
         with (
             patch.object(
                 DownloadFromGridRequest,
@@ -1366,26 +1385,102 @@ class TestGridDownloadCsv:
                 return_value=mock_download_request,
             ) as mock_send,
             patch(
-                "synapseclient.models.curation.download_by_file_handle",
+                "synapseclient.models.curation.get_file_handle",
                 new_callable=AsyncMock,
-                return_value="test.csv",
-            ) as mock_download,
+                return_value=mock_file_handle,
+            ) as mock_get_file_handle,
+            patch(
+                "synapseclient.models.curation.get_file_handle_presigned_url",
+                new_callable=AsyncMock,
+                return_value=mock_presigned_url,
+            ) as mock_get_presigned_url,
+            patch(
+                "synapseclient.models.curation.download_from_url",
+                return_value=expected_download_path,
+            ) as mock_download_from_url,
         ):
             result = await grid.download_csv_async(synapse_client=self.syn)
             current_dir = os.getcwd()
 
-            # THEN the download request should be sent
+            # THEN the async job should be submitted
             mock_send.assert_called_once()
-            mock_download.assert_called_once_with(
-                synapse_client=self.syn,
+
+            # AND the file handle metadata should be fetched
+            mock_get_file_handle.assert_called_once_with(
                 file_handle_id=FILE_HANDLE_ID,
-                entity_type="FileEntity",
-                synapse_id=FILE_HANDLE_ID,
-                destination=current_dir,
+                synapse_client=self.syn,
             )
 
-            # AND the result should be the file handle ID
-            assert result == "test.csv"
+            # AND a presigned URL should be fetched
+            mock_get_presigned_url.assert_called_once_with(
+                file_handle_id=FILE_HANDLE_ID,
+                synapse_client=self.syn,
+            )
+
+            # AND download_from_url should be called with the presigned URL and MD5
+            call_kwargs = mock_download_from_url.call_args
+            assert call_kwargs.kwargs["url"] == mock_presigned_url
+            assert call_kwargs.kwargs["file_handle_id"] == mock_file_handle["id"]
+            assert call_kwargs.kwargs["expected_md5"] == mock_file_handle["contentMd5"]
+            assert call_kwargs.kwargs["url_is_presigned"] is True
+            # AND the destination filename follows the grid_{session_id}-{timestamp}.csv convention
+            assert call_kwargs.kwargs["destination"].startswith(current_dir)
+            assert f"grid_{SESSION_ID}-" in call_kwargs.kwargs["destination"]
+            assert call_kwargs.kwargs["destination"].endswith(".csv")
+
+            # AND the result is the path returned by download_from_url
+            assert result == expected_download_path
+
+    async def test_download_csv_async_with_custom_file_name(self):
+        # GIVEN a Grid with a session_id and a caller-supplied file_name
+        grid = Grid(session_id=SESSION_ID)
+        custom_file_name = "my_export.csv"
+
+        mock_download_request = DownloadFromGridRequest(session_id=SESSION_ID)
+        mock_download_request.results_file_handle_id = FILE_HANDLE_ID
+
+        mock_file_handle = {
+            "id": "172705303",
+            "contentMd5": "mock-md5",
+            "fileName": "Job-1234.csv",
+        }
+        expected_download_path = "/tmp/my_export.csv"
+
+        with (
+            patch.object(
+                DownloadFromGridRequest,
+                "send_job_and_wait_async",
+                new_callable=AsyncMock,
+                return_value=mock_download_request,
+            ),
+            patch(
+                "synapseclient.models.curation.get_file_handle",
+                new_callable=AsyncMock,
+                return_value=mock_file_handle,
+            ),
+            patch(
+                "synapseclient.models.curation.get_file_handle_presigned_url",
+                new_callable=AsyncMock,
+                return_value="https://presigned.example.com/file.csv",
+            ),
+            patch(
+                "synapseclient.models.curation.download_from_url",
+                return_value=expected_download_path,
+            ) as mock_download_from_url,
+        ):
+            result = await grid.download_csv_async(
+                file_name=custom_file_name, synapse_client=self.syn
+            )
+            current_dir = os.getcwd()
+
+            # THEN the destination uses exactly the caller-supplied file_name
+            call_kwargs = mock_download_from_url.call_args
+            assert call_kwargs.kwargs["destination"] == os.path.join(
+                current_dir, custom_file_name
+            )
+
+            # AND the result is the path returned by download_from_url
+            assert result == expected_download_path
 
     async def test_download_csv_async_with_invalid_dir(self):
         # GIVEN a Grid with a session_id

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -1366,7 +1366,7 @@ class TestGridDownloadCsv:
             "modifiedOn": "2026-04-30T21:21:40.000Z",
             "concreteType": "org.sagebionetworks.repo.model.file.S3FileHandle",
             "contentType": "text/csv",
-            "contentMd5": "mock-med5",
+            "contentMd5": "mock-md5",
             "fileName": "Job-1234.csv",
             "contentSize": 100,
             "status": "AVAILABLE",

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -922,7 +922,7 @@ class TestDownloadFromGridRequest:
         assert response.results_file_handle_id == FILE_HANDLE_ID
 
 
-class TestGridDownnloadCsv:
+class TestGridDownloadCsv:
 
     @pytest.fixture(autouse=True, scope="function")
     def init_syn(self, syn: Synapse) -> None:

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -922,6 +922,58 @@ class TestDownloadFromGridRequest:
         assert response.results_file_handle_id == FILE_HANDLE_ID
 
 
+class TestGridDownnloadCsv:
+
+    @pytest.fixture(autouse=True, scope="function")
+    def init_syn(self, syn: Synapse) -> None:
+        self.syn = syn
+
+    async def test_download_csv_without_session_id(self) -> None:
+        # GIVEN a Grid without a session_id
+        grid = Grid()
+
+        # WHEN I call download_csv
+        # THEN it should raise ValueError
+        with pytest.raises(ValueError, match="session_id is required to download"):
+            grid.download_csv(synapse_client=self.syn)
+
+    async def test_download_csv_async(self):
+        # GIVEN a Grid with a session_id
+        grid = Grid(session_id=SESSION_ID)
+
+        # Mock the DownloadFromGridRequest's send_job_and_wait_async
+        mock_download_request = DownloadFromGridRequest(session_id=SESSION_ID)
+        mock_download_request.results_file_handle_id = FILE_HANDLE_ID
+
+        with (
+            patch.object(
+                DownloadFromGridRequest,
+                "send_job_and_wait_async",
+                new_callable=AsyncMock,
+                return_value=mock_download_request,
+            ) as mock_send,
+            patch(
+                "synapseclient.models.curation.download_by_file_handle",
+                new_callable=AsyncMock,
+                return_value="test.csv",
+            ) as mock_download,
+        ):
+            result = await grid.download_csv_async(synapse_client=self.syn)
+
+            # # THEN the download request should be sent
+            mock_send.assert_called_once()
+            mock_download.assert_called_once_with(
+                synapse_client=self.syn,
+                file_handle_id=FILE_HANDLE_ID,
+                destination=".",
+                entity_type="FileEntity",
+                synapse_id=FILE_HANDLE_ID,
+            )
+
+            # AND the result should be the file handle ID
+            assert result == "test.csv"
+
+
 class TestGridRecordSetExportRequest:
     """Tests for the GridRecordSetExportRequest helper dataclass."""
 

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -42,6 +42,7 @@ SOURCE_ENTITY_ID = "syn5555555"
 GRID_ETAG = "grid-etag-456"
 STARTED_BY = "user-1"
 STARTED_ON = "2024-03-01T00:00:00.000Z"
+FILE_HANDLE_ID = "1234567"
 
 
 def _get_file_based_task_api_response():
@@ -905,6 +906,20 @@ class TestDownloadFromGridRequest:
         assert result["csvTableDescriptor"]["lineEnd"] == os.linesep
         assert result["csvTableDescriptor"]["separator"] == ";"
         assert result["csvTableDescriptor"]["isFirstLineHeader"] is False
+
+    def test_fill_from_dict(self) -> None:
+        # GIVEN a response with download data
+        raw_synapse_response = {
+            "jobId": "123",
+            "concreteType": "org.sagebionetworks.repo.model.grid.DownloadFromGridResult",
+            "sessionId": SESSION_ID,
+            "resultsFileHandleId": FILE_HANDLE_ID,
+        }
+        response = DownloadFromGridRequest(session_id=SESSION_ID).fill_from_dict(
+            raw_synapse_response
+        )
+        assert response.session_id == SESSION_ID
+        assert response.results_file_handle_id == FILE_HANDLE_ID
 
 
 class TestGridRecordSetExportRequest:

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -986,6 +986,30 @@ class TestGridDownloadCsv:
                 synapse_client=self.syn, destination="./nonexistent_dir"
             )
 
+    async def test_download_csv_async_empty_file_handle_id(self):
+        # GIVEN a Grid with a session_id
+        grid = Grid(session_id=SESSION_ID)
+
+        # Mock the DownloadFromGridRequest's send_job_and_wait_async to return an empty file handle ID
+        mock_download_request = DownloadFromGridRequest(session_id=SESSION_ID)
+        mock_download_request.results_file_handle_id = ""
+
+        with patch.object(
+            DownloadFromGridRequest,
+            "send_job_and_wait_async",
+            new_callable=AsyncMock,
+            return_value=mock_download_request,
+        ):
+            # WHEN I call download_csv_async
+            # THEN it should raise ValueError for empty file handle ID
+            with pytest.raises(
+                ValueError,
+                match=f"Download job for grid session '{SESSION_ID}' completed but "
+                "did not return a file handle ID. The CSV result may be empty or "
+                "the job may have failed silently.",
+            ):
+                await grid.download_csv_async(synapse_client=self.syn)
+
 
 class TestGridRecordSetExportRequest:
     """Tests for the GridRecordSetExportRequest helper dataclass."""

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -1,5 +1,6 @@
 """Unit tests for the CurationTask and Grid models."""
 
+import os
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -12,6 +13,7 @@ from synapseclient.core.constants.concrete_types import (
 from synapseclient.models.curation import (
     CreateGridRequest,
     CurationTask,
+    DownloadFromGridRequest,
     FileBasedMetadataTaskProperties,
     Grid,
     GridRecordSetExportRequest,
@@ -19,6 +21,7 @@ from synapseclient.models.curation import (
     _create_task_properties_from_dict,
 )
 from synapseclient.models.recordset import ValidationSummary
+from synapseclient.models.table_components import CsvTableDescriptor
 
 TASK_ID = 42
 TASK_ID_2 = 99
@@ -854,6 +857,54 @@ class TestCreateGridRequest:
         assert "concreteType" in result
         assert result["recordSetId"] == RECORD_SET_ID
         assert "initialQuery" not in result
+
+
+class TestDownloadFromGridRequest:
+    """Tests for the DownloadFromGridRequest helper dataclass."""
+
+    def test_to_synapse_request(self) -> None:
+        # GIVEN a DownloadFromGridRequest with a session_id
+        request = DownloadFromGridRequest(session_id=SESSION_ID)
+
+        # WHEN I convert it to a synapse request
+        result = request.to_synapse_request()
+
+        # THEN it should contain the correct fields
+        assert "concreteType" in result
+        assert result["sessionId"] == SESSION_ID
+
+    def test_to_synapse_request_all_fields(self) -> None:
+        # GIVEN a DownloadFromGridRequest with all fields set
+        table_descriptor = CsvTableDescriptor(
+            quote_character='"',
+            escape_character="\\",
+            line_end=os.linesep,
+            separator=";",
+            is_first_line_header=False,
+        )
+        request = DownloadFromGridRequest(
+            session_id=SESSION_ID,
+            write_header=False,
+            include_row_id_and_row_version=False,
+            include_etag=False,
+            csv_table_descriptor=table_descriptor,
+            file_name="my_grid_data.csv",
+        )
+
+        # WHEN I convert it to a synapse request
+        result = request.to_synapse_request()
+
+        # THEN it should contain all the correct fields
+        assert "concreteType" in result
+        assert result["sessionId"] == SESSION_ID
+        assert result["includeRowIdAndRowVersion"] is False
+        assert result["includeEtag"] is False
+        assert result["fileName"] == "my_grid_data.csv"
+        assert result["csvTableDescriptor"]["quoteCharacter"] == '"'
+        assert result["csvTableDescriptor"]["escapeCharacter"] == "\\"
+        assert result["csvTableDescriptor"]["lineEnd"] == os.linesep
+        assert result["csvTableDescriptor"]["separator"] == ";"
+        assert result["csvTableDescriptor"]["isFirstLineHeader"] is False
 
 
 class TestGridRecordSetExportRequest:

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -935,7 +935,7 @@ class TestGridDownnloadCsv:
         # WHEN I call download_csv
         # THEN it should raise ValueError
         with pytest.raises(ValueError, match="session_id is required to download"):
-            grid.download_csv(synapse_client=self.syn)
+            await grid.download_csv_async(synapse_client=self.syn)
 
     async def test_download_csv_async(self):
         # GIVEN a Grid with a session_id

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -959,19 +959,32 @@ class TestGridDownnloadCsv:
             ) as mock_download,
         ):
             result = await grid.download_csv_async(synapse_client=self.syn)
+            current_dir = os.getcwd()
 
             # # THEN the download request should be sent
             mock_send.assert_called_once()
             mock_download.assert_called_once_with(
                 synapse_client=self.syn,
                 file_handle_id=FILE_HANDLE_ID,
-                destination=".",
                 entity_type="FileEntity",
                 synapse_id=FILE_HANDLE_ID,
+                destination=current_dir,
             )
 
             # AND the result should be the file handle ID
             assert result == "test.csv"
+
+    async def test_download_csv_async_with_invalid_dir(self):
+        # GIVEN a Grid with a session_id
+        grid = Grid(session_id=SESSION_ID)
+
+        # WHEN I call download_csv_async with an invalid destination
+        with pytest.raises(
+            ValueError, match=f"Destination ./nonexistent_dir is not a valid directory."
+        ):
+            await grid.download_csv_async(
+                synapse_client=self.syn, destination="./nonexistent_dir"
+            )
 
 
 class TestGridRecordSetExportRequest:


### PR DESCRIPTION
# **Problem:**
Couldn't download csv from grid. 

# **Solution:**
* Calls `get_file_handle_presigned_url` to get a pre-signed URL 
* When file_name is not provided, name the file as `grid_<session_id>_timestamp`. This is to align with the front-end [here](https://github.com/Sage-Bionetworks/synapse-web-monorepo/blob/main/packages/synapse-react-client/src/components/DataGrid/hooks/useExportDataGridToCsv.ts#L31)
* Downloads via asyncio.to_thread(download_from_url, ...) to get MD5 validation, retries, and progress tracking — consistent with how `download_list_manifest_async` handles presigned URL downloads. This is to align with front-end behavior when exporting a csv. See [here](https://github.com/Sage-Bionetworks/synapse-web-monorepo/blob/main/packages/synapse-react-client/src/components/DataGrid/hooks/useExportDataGridToCsv.ts#L19-L22)