### PR TITLE
[SYNPY-1836] Support configurable view_type_mask in file-based metadata task

### DIFF
--- a/synapseclient/extensions/curator/file_based_metadata_task.py
+++ b/synapseclient/extensions/curator/file_based_metadata_task.py
@@ -41,6 +41,7 @@ def create_json_schema_entity_view(
     syn: Synapse,
     synapse_entity_id: str,
     entity_view_name: str = "JSON Schema view",
+    view_type_mask: int = ViewTypeMask.FILE,
 ) -> str:
     """
     Creates a Synapse entity view based on a JSON Schema that is bound to a Synapse entity
@@ -69,7 +70,7 @@ def create_json_schema_entity_view(
         name=entity_view_name,
         parent_id=synapse_entity_id,
         scope_ids=[synapse_entity_id],
-        view_type_mask=ViewTypeMask.FILE,
+        view_type_mask=view_type_mask,
         columns=columns,
     ).store(synapse_client=syn)
     # This reorder is so that these show up in the front of the EntityView in Synapse
@@ -319,6 +320,7 @@ def create_file_based_metadata_task(
     schema_uri: Optional[str] = None,
     enable_derived_annotations: bool = False,
     assignee_principal_id: Optional[Union[str, int]] = None,
+    view_type_mask: int = ViewTypeMask.FILE,
     *,
     synapse_client: Optional[Synapse] = None,
 ) -> Tuple[str, str]:
@@ -365,6 +367,9 @@ def create_file_based_metadata_task(
             (default), the task will be unassigned. For metadata tasks, this determines
             the owner of the grid session. Team members can all join grid sessions owned
             by their team, while user-owned grid sessions are restricted to that user only.
+        view_type_mask: The view type mask for the EntityView. Defaults to
+            ViewTypeMask.FILE. Additional types can be added using bitwise OR
+            (e.g., ViewTypeMask.FILE | ViewTypeMask.DOCKER).
         synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.
@@ -415,6 +420,7 @@ def create_file_based_metadata_task(
             syn=synapse_client,
             synapse_entity_id=folder_id,
             entity_view_name=entity_view_name,
+            view_type_mask=view_type_mask,
         )
     except Exception as e:
         synapse_client.logger.exception("Error creating entity view")

--- a/synapseclient/extensions/curator/file_based_metadata_task.py
+++ b/synapseclient/extensions/curator/file_based_metadata_task.py
@@ -41,7 +41,7 @@ def create_json_schema_entity_view(
     syn: Synapse,
     synapse_entity_id: str,
     entity_view_name: str = "JSON Schema view",
-    view_type_mask: int = ViewTypeMask.FILE,
+    view_type_mask: Union[int, ViewTypeMask] = ViewTypeMask.FILE,
 ) -> str:
     """
     Creates a Synapse entity view based on a JSON Schema that is bound to a Synapse entity
@@ -51,6 +51,10 @@ def create_json_schema_entity_view(
         syn: A Synapse object thats been logged in
         synapse_entity_id: The ID of the entity in Synapse to bind the JSON Schema to
         entity_view_name: The name the crated entity view will have
+        view_type_mask: The view type mask for the EntityView. Defaults to
+            ViewTypeMask.FILE. Additional types can be added using bitwise OR
+            (e.g., ViewTypeMask.FILE | ViewTypeMask.DOCKER). Accepts either a
+            ViewTypeMask enum member or its raw integer value.
 
     Returns:
         The Synapse id of the crated entity view
@@ -320,7 +324,7 @@ def create_file_based_metadata_task(
     schema_uri: Optional[str] = None,
     enable_derived_annotations: bool = False,
     assignee_principal_id: Optional[Union[str, int]] = None,
-    view_type_mask: int = ViewTypeMask.FILE,
+    view_type_mask: Union[int, ViewTypeMask] = ViewTypeMask.FILE,
     *,
     synapse_client: Optional[Synapse] = None,
 ) -> Tuple[str, str]:
@@ -334,6 +338,7 @@ def create_file_based_metadata_task(
         ```python
         import synapseclient
         from synapseclient.extensions.curator import create_file_based_metadata_task
+        from synapseclient.models import ViewTypeMask
 
         syn = synapseclient.Synapse()
         syn.login()
@@ -346,7 +351,8 @@ def create_file_based_metadata_task(
             attach_wiki=False,
             entity_view_name="Biospecimen Metadata View",
             schema_uri="sage.schemas.v2571-amp.Biospecimen.schema-0.0.1",
-            assignee_principal_id=123456  # Optional: Assign to a user or team (can be str or int)
+            assignee_principal_id=123456,  # Optional: Assign to a user or team (can be str or int)
+            view_type_mask=ViewTypeMask.FILE | ViewTypeMask.DOCKER,  # Optional: include additional entity types in the view
         )
         ```
 
@@ -369,7 +375,8 @@ def create_file_based_metadata_task(
             by their team, while user-owned grid sessions are restricted to that user only.
         view_type_mask: The view type mask for the EntityView. Defaults to
             ViewTypeMask.FILE. Additional types can be added using bitwise OR
-            (e.g., ViewTypeMask.FILE | ViewTypeMask.DOCKER).
+            (e.g., ViewTypeMask.FILE | ViewTypeMask.DOCKER). Accepts either a
+            ViewTypeMask enum member or its raw integer value.
         synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.

--- a/tests/unit/synapseclient/extensions/unit_test_curator.py
+++ b/tests/unit/synapseclient/extensions/unit_test_curator.py
@@ -52,7 +52,7 @@ from synapseclient.extensions.curator.schema_registry import (
     SchemaRegistryColumnConfig,
     get_latest_schema_uri,
 )
-from synapseclient.models import Column, ColumnType
+from synapseclient.models import Column, ColumnType, ViewTypeMask
 from synapseclient.models.curation import (
     FileBasedMetadataTaskProperties,
     RecordBasedMetadataTaskProperties,
@@ -1465,6 +1465,72 @@ class TestFileBasedHelperFunctions(unittest.TestCase):
         mock_view.reorder_column.assert_any_call(name="createdBy", index=0)
         mock_view.reorder_column.assert_any_call(name="name", index=0)
         mock_view.reorder_column.assert_any_call(name="id", index=0)
+
+    @patch("synapseclient.extensions.curator.file_based_metadata_task.isinstance")
+    @patch("synapseclient.extensions.curator.file_based_metadata_task.EntityView")
+    @patch("synapseclient.extensions.curator.file_based_metadata_task.get")
+    @patch("synapseclient.extensions.curator.file_based_metadata_task.JSONSchema")
+    def test_create_json_schema_entity_view_with_file_and_folder_view_type_mask(
+        self,
+        mock_json_schema_cls,
+        mock_get,
+        mock_entity_view_cls,
+        mock_isinstance,
+    ):
+        """Test that a combined FILE|FOLDER view_type_mask is forwarded to EntityView."""
+        # GIVEN a valid synapse entity with a JSON schema
+        entity_id = "syn12345678"
+        entity_view_name = "Test View"
+        combined_mask = ViewTypeMask.FILE | ViewTypeMask.FOLDER
+
+        mock_entity = Mock()
+        mock_entity.get_schema.return_value = JSONSchemaBinding(
+            object_id=1,
+            object_type="",
+            created_on="",
+            created_by="",
+            enable_derived_annotations=True,
+            json_schema_version_info=JSONSchemaVersionInfo(
+                organization_id="",
+                organization_name="org.name",
+                schema_id="",
+                id="",
+                schema_name="schema.name",
+                version_id="",
+                semantic_version="0.0.1",
+                json_sha256_hex="",
+                created_on="",
+                created_by="",
+            ),
+        )
+        mock_get.return_value = mock_entity
+        mock_isinstance.return_value = True
+
+        mock_json_schema = Mock()
+        mock_json_schema.get_body.return_value = {
+            "properties": {"name": {"type": "string"}, "age": {"type": "integer"}}
+        }
+        mock_json_schema_cls.return_value = mock_json_schema
+
+        mock_view = Mock()
+        mock_view.id = "syn87654321"
+        mock_view.store.return_value = mock_view
+        mock_entity_view_cls.return_value = mock_view
+
+        # WHEN I create the JSON schema entity view with both file and folder types
+        result = create_json_schema_entity_view(
+            syn=self.mock_syn,
+            synapse_entity_id=entity_id,
+            entity_view_name=entity_view_name,
+            view_type_mask=combined_mask,
+        )
+
+        # THEN the entity view should be created with the combined mask
+        assert result == "syn87654321"
+        _, kwargs = mock_entity_view_cls.call_args
+        assert kwargs["view_type_mask"] == combined_mask
+        assert kwargs["view_type_mask"] & ViewTypeMask.FILE
+        assert kwargs["view_type_mask"] & ViewTypeMask.FOLDER
 
     @patch(
         "synapseclient.extensions.curator.file_based_metadata_task.update_wiki_with_entity_view"

--- a/tests/unit/synapseclient/extensions/unit_test_curator.py
+++ b/tests/unit/synapseclient/extensions/unit_test_curator.py
@@ -150,6 +150,7 @@ class TestCreateFileBasedMetadataTask(unittest.TestCase):
             syn=self.mock_syn,
             synapse_entity_id=self.folder_id,
             entity_view_name=self.entity_view_name,
+            view_type_mask=ViewTypeMask.FILE,
         )
         mock_create_wiki.assert_called_once_with(
             syn=self.mock_syn, entity_view_id="syn87654321", owner_id=self.folder_id
@@ -480,6 +481,7 @@ class TestCreateFileBasedMetadataTask(unittest.TestCase):
                     syn=self.mock_syn,
                     synapse_entity_id=self.folder_id,
                     entity_view_name=self.entity_view_name,
+                    view_type_mask=ViewTypeMask.FILE,
                 )
 
 


### PR DESCRIPTION
## Summary

- Adds a `view_type_mask` parameter to `create_file_based_metadata_task` and `create_json_schema_entity_view` so callers can include Docker repositories (or any other entity type) in the generated EntityView, not just files. Defaults to `ViewTypeMask.FILE` for backwards compatibility.
- Adds a unit test that verifies a combined mask (`ViewTypeMask.FILE | ViewTypeMask.FOLDER`) is forwarded to `EntityView`.

Resolves [SYNPY-1836](https://sagebionetworks.jira.com/browse/SYNPY-1836).

## Test plan

- [x] `pytest tests/unit/synapseclient/extensions/unit_test_curator.py::TestFileBasedHelperFunctions` passes locally (18/18)
- [ ] CI green

[SYNPY-1836]: https://sagebionetworks.jira.com/browse/SYNPY-1836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ