### PR TITLE
Add missing MY_PROXY_SECRET_KEY variable in tutorials

### DIFF
--- a/docs/tutorials/python/tutorial_scripts/proxy_storage_location.py
+++ b/docs/tutorials/python/tutorial_scripts/proxy_storage_location.py
@@ -24,14 +24,11 @@ my_project = Project(name="My uniquely named project about Alzheimer's Disease")
 # Replace with your proxy server URL and provide the shared secret key via the
 # MY_PROXY_SECRET_KEY environment variable.
 MY_PROXY_URL = "https://my-proxy-server.example.com"
-MY_PROXY_SECRET_KEY = os.environ.get(
-    "MY_PROXY_SECRET_KEY", "REPLACE_WITH_YOUR_PROXY_SECRET_KEY"
-)
+MY_PROXY_SECRET_KEY = os.environ.get("MY_PROXY_SECRET_KEY")
 
 # Replace with the path to a local file to register via the proxy
 FILE_PATH = "/path/to/your/file.csv"
 
-# --8<-- [start:create_proxy_storage_location]
 # Use this when a proxy server controls access to the underlying storage.
 my_proxy_folder = Folder(name="my-folder-for-proxy", parent_id=my_project.id)
 my_proxy_folder = my_proxy_folder.store()

--- a/docs/tutorials/python/tutorial_scripts/proxy_storage_location.py
+++ b/docs/tutorials/python/tutorial_scripts/proxy_storage_location.py
@@ -23,6 +23,7 @@ my_project = Project(name="My uniquely named project about Alzheimer's Disease")
 # --8<-- [start:create_proxy_storage_location]
 # Replace with your proxy server URL and shared secret key
 MY_PROXY_URL = "https://my-proxy-server.example.com"
+MY_PROXY_SECRET_KEY = "MY_PROXY_SECRET_KEY"
 
 # Replace with the path to a local file to register via the proxy
 FILE_PATH = "/path/to/your/file.csv"

--- a/docs/tutorials/python/tutorial_scripts/proxy_storage_location.py
+++ b/docs/tutorials/python/tutorial_scripts/proxy_storage_location.py
@@ -21,9 +21,12 @@ my_project = Project(name="My uniquely named project about Alzheimer's Disease")
 # --8<-- [end:setup]
 
 # --8<-- [start:create_proxy_storage_location]
-# Replace with your proxy server URL and shared secret key
+# Replace with your proxy server URL and provide the shared secret key via the
+# MY_PROXY_SECRET_KEY environment variable.
 MY_PROXY_URL = "https://my-proxy-server.example.com"
-MY_PROXY_SECRET_KEY = "MY_PROXY_SECRET_KEY"
+MY_PROXY_SECRET_KEY = os.environ.get(
+    "MY_PROXY_SECRET_KEY", "REPLACE_WITH_YOUR_PROXY_SECRET_KEY"
+)
 
 # Replace with the path to a local file to register via the proxy
 FILE_PATH = "/path/to/your/file.csv"

--- a/docs/tutorials/python/tutorial_scripts/storage_location.py
+++ b/docs/tutorials/python/tutorial_scripts/storage_location.py
@@ -143,9 +143,7 @@ object_store_folder.set_storage_location(
 # Replace with your proxy server URL and provide the shared secret key via the
 # MY_PROXY_SECRET_KEY environment variable.
 MY_PROXY_URL = "https://my-proxy-server.example.com"
-MY_PROXY_SECRET_KEY = os.environ.get(
-    "MY_PROXY_SECRET_KEY", "REPLACE_WITH_YOUR_PROXY_SECRET_KEY"
-)
+MY_PROXY_SECRET_KEY = os.environ.get("MY_PROXY_SECRET_KEY")
 proxy_storage = StorageLocation(
     storage_type=StorageLocationType.PROXY,
     proxy_url=MY_PROXY_URL,

--- a/docs/tutorials/python/tutorial_scripts/storage_location.py
+++ b/docs/tutorials/python/tutorial_scripts/storage_location.py
@@ -3,6 +3,8 @@ Tutorial code for the Storage Location and project settings.
 """
 
 # --8<-- [start:setup]
+import os
+
 import synapseclient
 from synapseclient.models import Folder, Project, StorageLocation, StorageLocationType
 
@@ -137,8 +139,13 @@ object_store_folder.set_storage_location(
 # Step 8: Create a Proxy storage location
 # Use this when a proxy server controls access to the underlying storage.
 # --8<-- [start:create_proxy_storage_location]
+
+# Replace with your proxy server URL and provide the shared secret key via the
+# MY_PROXY_SECRET_KEY environment variable.
 MY_PROXY_URL = "https://my-proxy-server.example.com"
-MY_PROXY_SECRET_KEY = "MY_PROXY_SECRET_KEY"
+MY_PROXY_SECRET_KEY = os.environ.get(
+    "MY_PROXY_SECRET_KEY", "REPLACE_WITH_YOUR_PROXY_SECRET_KEY"
+)
 proxy_storage = StorageLocation(
     storage_type=StorageLocationType.PROXY,
     proxy_url=MY_PROXY_URL,

--- a/docs/tutorials/python/tutorial_scripts/storage_location.py
+++ b/docs/tutorials/python/tutorial_scripts/storage_location.py
@@ -137,12 +137,12 @@ object_store_folder.set_storage_location(
 # Step 8: Create a Proxy storage location
 # Use this when a proxy server controls access to the underlying storage.
 # --8<-- [start:create_proxy_storage_location]
-
 MY_PROXY_URL = "https://my-proxy-server.example.com"
+MY_PROXY_SECRET_KEY = "MY_PROXY_SECRET_KEY"
 proxy_storage = StorageLocation(
     storage_type=StorageLocationType.PROXY,
     proxy_url=MY_PROXY_URL,
-    secret_key=my_proxy_secret_key,
+    secret_key=MY_PROXY_SECRET_KEY,
     benefactor_id=my_project.id,
     description="Proxy-controlled storage",
 ).store()


### PR DESCRIPTION
# **Problem:**
The [proxy storage location tutorial](https://python-docs.synapse.org/en/latest/tutorials/python/proxy_storage_location/#2-create-a-proxy-storage-location) and [storage location tutorials (proxy storage section)](https://python-docs.synapse.org/en/latest/tutorials/python/storage_location/#8-create-a-proxy-storage-location) were missing the definition for the `MY_PROXY_SECRET_KEY` variable prior to calling it later in `StorageLocation`

# **Solution:**
This PR adds the missing variable to the tutorials

# **Testing:**
`mkdocs serve` result

Proxy storage location tutorial
<img width="888" height="305" alt="image" src="https://github.com/user-attachments/assets/1d37af02-18cc-4e87-a6b3-9abae60d58ee" />


Storage locations tutorial
<img width="891" height="289" alt="image" src="https://github.com/user-attachments/assets/caaba798-eb24-4c5b-9793-30f4914d86ef" />



