### PR TITLE
fix: fix flaky test: `test_get_docker_repo_by_id`

### DIFF
--- a/tests/integration/synapseclient/operations/async/test_factory_operations_async.py
+++ b/tests/integration/synapseclient/operations/async/test_factory_operations_async.py
@@ -852,10 +852,11 @@ class TestFactoryOperationsGetAsync:
     ) -> None:
         """Test retrieving a Docker repository using get factory function."""
         # GIVEN a Docker repository exists
+        unique_id = str(uuid.uuid4())[:8]
         docker_repo = await DockerRepository(
             parent_id=project_model.id,
-            repository_name="username/test-get-factory",
-            name="Test Factory Repo",
+            repository_name=f"username/test-get-factory-{unique_id}",
+            name=f"Test Factory Repo {unique_id}",
             description="Testing get factory",
         ).store_async(synapse_client=self.syn)
 
@@ -867,8 +868,8 @@ class TestFactoryOperationsGetAsync:
         # THEN the correct DockerRepository is returned
         assert isinstance(retrieved, DockerRepository)
         assert retrieved.id == docker_repo.id
-        assert retrieved.repository_name == "username/test-get-factory"
-        assert retrieved.name == "Test Factory Repo"
+        assert retrieved.repository_name == f"username/test-get-factory-{unique_id}"
+        assert retrieved.name == f"Test Factory Repo {unique_id}"
         assert retrieved.description == "Testing get factory"
         assert retrieved.parent_id == project_model.id
         assert retrieved.etag is not None


### PR DESCRIPTION
# **Problem:**
Fix flakey test: `test_get_docker_repo_by_id`. See error: 
```
=========================== short test summary info ============================
FAILED tests/integration/synapseclient/operations/async/test_factory_operations_async.py::TestFactoryOperationsGetAsync::test_get_docker_repo_by_id - synapseclient.core.exceptions.SynapseHTTPError: 409 Client Error: An entity with the name: Test Factory Repo already exists with a parentId: syn23330046
= 1 failed, 724 passed, 12 skipped, 14235 warnings, 19 rerun in 4223.72s (1:10:23) =

```

# **Solution:**
Makes sure that repository name is unique
