### PR TITLE
[SYNPY-1841] Added fields for CurationTask search

### DIFF
--- a/synapseclient/api/curation_services.py
+++ b/synapseclient/api/curation_services.py
@@ -123,6 +123,9 @@ async def delete_curation_task(
 async def list_curation_tasks(
     project_id: str,
     *,
+    assigned_to_me: Optional[bool] = None,
+    assignee_ids: Optional[list[str]] = None,
+    state_filter: Optional[list[str]] = None,
     synapse_client: Optional["Synapse"] = None,
 ) -> AsyncGenerator[Dict[str, Any], None]:
     """
@@ -132,6 +135,14 @@ async def list_curation_tasks(
 
     Arguments:
         project_id: The synId of the project.
+        assigned_to_me: When True, only return tasks that are assigned to the
+            current user. When False or None, the filter is not applied.
+            Cannot be combined with assignee_ids when True. Defaults to None.
+        assignee_ids: Optional list of principal IDs (users or teams) to filter
+            tasks by assignee. Cannot be combined with assigned_to_me=True.
+            Defaults to None.
+        state_filter: Optional list of TaskState string values to filter tasks by
+            their current state. Defaults to None (all states returned).
         synapse_client: If not passed in and caching was not disabled by
             `Synapse.allow_client_caching(False)` this will use the last created
             instance from the Synapse class constructor.
@@ -143,7 +154,14 @@ async def list_curation_tasks(
 
     client = Synapse.get_client(synapse_client=synapse_client)
 
-    request_body = {"projectId": project_id}
+    request_body: Dict[str, Any] = {"projectId": project_id}
+    # Only send the flag when True; False/None both mean "no filter"
+    if assigned_to_me is True:
+        request_body["assignedToMe"] = True
+    if assignee_ids is not None:
+        request_body["assigneeIds"] = assignee_ids
+    if state_filter is not None:
+        request_body["stateFilter"] = state_filter
 
     async for item in rest_post_paginated_async(
         "/curation/task/list", body=request_body, synapse_client=client

--- a/synapseclient/api/curation_services.py
+++ b/synapseclient/api/curation_services.py
@@ -127,7 +127,7 @@ async def list_curation_tasks(
     assignee_ids: Optional[list[str]] = None,
     state_filter: Optional[list[str]] = None,
     synapse_client: Optional["Synapse"] = None,
-) -> AsyncGenerator[Dict[str, Any], None]:
+) -> AsyncGenerator[dict[str, Any], None]:
     """
     Generator to get a list of CurationTasks for a project.
 
@@ -155,7 +155,7 @@ async def list_curation_tasks(
     client = Synapse.get_client(synapse_client=synapse_client)
 
     request_body: Dict[str, Any] = {"projectId": project_id}
-    if assigned_to_me is True:
+    if assigned_to_me:
         request_body["assignedToMe"] = True
     if assignee_ids is not None:
         request_body["assigneeIds"] = assignee_ids

--- a/synapseclient/api/curation_services.py
+++ b/synapseclient/api/curation_services.py
@@ -155,7 +155,6 @@ async def list_curation_tasks(
     client = Synapse.get_client(synapse_client=synapse_client)
 
     request_body: Dict[str, Any] = {"projectId": project_id}
-    # Only send the flag when True; False/None both mean "no filter"
     if assigned_to_me is True:
         request_body["assignedToMe"] = True
     if assignee_ids is not None:

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -26,7 +26,8 @@ import warnings
 import zipfile
 from dataclasses import asdict, fields, is_dataclass
 from email.message import Message
-from typing import TYPE_CHECKING, List, Optional, TypeVar
+from enum import Enum
+from typing import TYPE_CHECKING, List, Optional, TypeVar, Union
 
 import requests
 from deprecated import deprecated
@@ -40,6 +41,7 @@ if TYPE_CHECKING:
     from synapseclient.models.dataset import EntityRef
 
 R = TypeVar("R")
+E = TypeVar("E", bound=Enum)
 
 UNIX_EPOCH = datetime.datetime(1970, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
 ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.000Z"
@@ -1587,3 +1589,30 @@ def test_import_sqlite3() -> None:
     # catch other errors (see SYNPY-177)
     except:  # noqa
         raise
+
+
+def coerce_enum_list(enum_class: type[E], values: list[Union[E, str]]) -> list[str]:
+    """Normalize a list of values to string equivalents of an enum class.
+
+    Accepts enum members or strings. Unrecognized values raise ValueError with
+    the list of valid values.
+
+    Arguments:
+        enum_class: The Enum subclass to coerce values against.
+        values: List of enum members or equivalent strings to coerce.
+
+    Returns:
+        List of string values corresponding to each enum member.
+
+    Raises:
+        ValueError: If any element is not a valid enum member or string.
+    """
+    result = []
+    for value in values:
+        try:
+            result.append(enum_class(value).value)
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid value {value!r}. Valid values are: {[e.value for e in enum_class]}"
+            ) from exc
+    return result

--- a/synapseclient/models/__init__.py
+++ b/synapseclient/models/__init__.py
@@ -12,6 +12,7 @@ from synapseclient.models.curation import (
     FileBasedMetadataTaskProperties,
     Grid,
     RecordBasedMetadataTaskProperties,
+    TaskState,
 )
 from synapseclient.models.dataset import Dataset, DatasetCollection, EntityRef
 from synapseclient.models.docker import DockerRepository
@@ -96,6 +97,7 @@ __all__ = [
     "CurationTask",
     "FileBasedMetadataTaskProperties",
     "RecordBasedMetadataTaskProperties",
+    "TaskState",
     "Grid",
     "UserProfile",
     "UserPreference",

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -491,6 +491,45 @@ class CurationTaskSynchronousProtocol(Protocol):
         )
 
 
+def _coerce_state_filter(
+    state_filter: list[Union["TaskState", str]],
+) -> list[str]:
+    """Normalize a list of state_filter values to their string equivalents.
+
+    Accepts TaskState enum members or strings. Strings are upper-cased before
+    coercion so that values like in_progress are accepted. Non-string,
+    non-TaskState values raise ValueError. Unrecognized strings also raise
+    ValueError with the list of valid values.
+
+    Arguments:
+        state_filter: List of TaskState values or equivalent strings to coerce.
+
+    Returns:
+        List of string values corresponding to each TaskState.
+
+    Raises:
+        ValueError: If any element is not a TaskState, a valid TaskState string,
+            or a recognized state name.
+    """
+    coerced: list[str] = []
+    for s in state_filter:
+        if isinstance(s, TaskState):
+            coerced.append(s.value)
+            continue
+        if not isinstance(s, str):
+            raise ValueError(
+                f"Invalid state_filter value {s!r}. Expected a TaskState or str."
+            )
+        try:
+            coerced.append(TaskState(s.upper()).value)
+        except ValueError as exc:
+            valid = [e.value for e in TaskState]
+            raise ValueError(
+                f"Invalid state_filter value {s!r}. Valid values are: {valid}"
+            ) from exc
+    return coerced
+
+
 @dataclass
 @async_to_sync
 class CurationTask(CurationTaskSynchronousProtocol):
@@ -1057,27 +1096,8 @@ class CurationTask(CurationTaskSynchronousProtocol):
                 "and cannot be used together."
             )
 
-        # Normalize state_filter.
-        # This method accepts TaskState enums or strings, anything else causes a ValueError.
-        # Strings are upper-cased and validated against TaskState; invalid values raise.
         if state_filter is not None:
-            coerced_state_filter = []
-            for s in state_filter:
-                if isinstance(s, TaskState):
-                    coerced_state_filter.append(s.value)
-                    continue
-                if not isinstance(s, str):
-                    raise ValueError(
-                        f"Invalid state_filter value {s!r}. Expected a TaskState or str."
-                    )
-                try:
-                    coerced_state_filter.append(TaskState(s.upper()).value)
-                except ValueError as exc:
-                    valid = [e.value for e in TaskState]
-                    raise ValueError(
-                        f"Invalid state_filter value {s!r}. Valid values are: {valid}"
-                    ) from exc
-            state_filter = coerced_state_filter
+            state_filter = _coerce_state_filter(state_filter)
 
         trace.get_current_span().set_attributes(
             {

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -9,6 +9,7 @@ import asyncio
 import os
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
+from enum import Enum
 from typing import Any, AsyncGenerator, Dict, Generator, Optional, Protocol, Union
 
 from opentelemetry import trace
@@ -49,6 +50,26 @@ from synapseclient.core.utils import delete_none_keys, merge_dataclass_entities
 from synapseclient.models.mixins.asynchronous_job import AsynchronousCommunicator
 from synapseclient.models.recordset import ValidationSummary
 from synapseclient.models.table_components import Column, CsvTableDescriptor, Query
+
+
+class TaskState(str, Enum):
+    """
+    The state of a CurationTask.
+
+    See <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/curation/TaskState.html>.
+    """
+
+    NOT_STARTED = "NOT_STARTED"
+    """The task has been created and assigned but work has not yet started."""
+
+    IN_PROGRESS = "IN_PROGRESS"
+    """The assignee has actively started the task."""
+
+    COMPLETED = "COMPLETED"
+    """The task has been completed and verified."""
+
+    CANCELED = "CANCELED"
+    """The task has been canceled and is no longer needed."""
 
 
 @dataclass
@@ -367,6 +388,9 @@ class CurationTaskSynchronousProtocol(Protocol):
         cls,
         project_id: str,
         *,
+        assigned_to_me: Optional[bool] = None,
+        assignee_ids: Optional[list[str]] = None,
+        state_filter: Optional[list[Union["TaskState", str]]] = None,
         synapse_client: Optional[Synapse] = None,
     ) -> Generator["CurationTask", None, None]:
         """
@@ -374,12 +398,27 @@ class CurationTaskSynchronousProtocol(Protocol):
 
         Arguments:
             project_id: The synId of the project.
+            assigned_to_me: When True, only return tasks assigned to the current user.
+                False and None are identical in effect — neither activates an assignee
+                filter, and both may be combined with assignee_ids freely. Note that
+                False does not mean "tasks not assigned to me". Passing True together
+                with assignee_ids raises a ValueError. Defaults to None.
+            assignee_ids: Optional list of principal IDs (users or teams) to filter
+                tasks by assignee. Cannot be combined with assigned_to_me=True.
+                Defaults to None.
+            state_filter: Optional list of TaskState values or equivalent strings to
+                filter tasks by their current state. Strings are normalized to uppercase
+                before coercion (e.g., "in_progress" is accepted). Defaults to None
+                (all states returned). An empty list results in no tasks being returned.
             synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.
 
         Yields:
             CurationTask objects as they are retrieved from the API.
+
+        Note: Due to generator semantics, argument validation runs on the first
+            iteration of the generator, not at the point where list() is called.
 
         Example: List all curation tasks in a project
             &nbsp;
@@ -398,10 +437,48 @@ class CurationTaskSynchronousProtocol(Protocol):
                 print(f"Instructions: {task.instructions}")
                 print("---")
             ```
+
+        Example: List only curation tasks assigned to the current user
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import CurationTask
+
+            syn = Synapse()
+            syn.login()
+
+            for task in CurationTask.list(project_id="syn9876543", assigned_to_me=True):
+                print(f"Task ID: {task.task_id}")
+                print(f"Data Type: {task.data_type}")
+                print("---")
+            ```
+
+        Example: List only in-progress curation tasks
+            &nbsp;
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import CurationTask, TaskState
+
+            syn = Synapse()
+            syn.login()
+
+            for task in CurationTask.list(
+                project_id="syn9876543",
+                state_filter=[TaskState.IN_PROGRESS],
+            ):
+                print(f"Task ID: {task.task_id}")
+                print(f"Data Type: {task.data_type}")
+                print("---")
+            ```
         """
         yield from wrap_async_generator_to_sync_generator(
             async_gen_func=cls.list_async,
             project_id=project_id,
+            assigned_to_me=assigned_to_me,
+            assignee_ids=assignee_ids,
+            state_filter=state_filter,
             synapse_client=synapse_client,
         )
 
@@ -854,6 +931,9 @@ class CurationTask(CurationTaskSynchronousProtocol):
         cls,
         project_id: str,
         *,
+        assigned_to_me: Optional[bool] = None,
+        assignee_ids: Optional[list[str]] = None,
+        state_filter: Optional[list[Union["TaskState", str]]] = None,
         synapse_client: Optional[Synapse] = None,
     ) -> AsyncGenerator["CurationTask", None]:
         """
@@ -861,12 +941,29 @@ class CurationTask(CurationTaskSynchronousProtocol):
 
         Arguments:
             project_id: The synId of the project.
+            assigned_to_me: When True, only return tasks assigned to the current user.
+                False and None are identical in effect — neither activates an assignee
+                filter, and both may be combined with assignee_ids freely. Note that
+                False does not mean "tasks not assigned to me"; use assignee_ids to
+                express exclusion semantics. Passing True together with assignee_ids
+                raises a ValueError. Defaults to None.
+            assignee_ids: Optional list of principal IDs (users or teams) to filter
+                tasks by assignee. Cannot be combined with assigned_to_me=True.
+                Defaults to None.
+            state_filter: Optional list of TaskState values or equivalent strings to
+                filter tasks by their current state. Strings are normalized to uppercase
+                before coercion (e.g., "in_progress" is accepted). Defaults to None
+                (all states returned). An empty list results in no tasks being returned.
             synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.
 
         Yields:
             CurationTask objects as they are retrieved from the API.
+
+        Note: Due to async generator semantics, argument validation runs on the first
+            iteration of the generator (i.e., when the for loop body is first entered),
+            not at the point where list_async() is called.
 
         Example: List all curation tasks in a project asynchronously
             &nbsp;
@@ -889,7 +986,80 @@ class CurationTask(CurationTaskSynchronousProtocol):
 
             asyncio.run(main())
             ```
+
+        Example: List only curation tasks assigned to the current user asynchronously
+            &nbsp;
+
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import CurationTask
+
+            syn = Synapse()
+            syn.login()
+
+            async def main():
+                async for task in CurationTask.list_async(
+                    project_id="syn9876543", assigned_to_me=True
+                ):
+                    print(f"Task ID: {task.task_id}")
+                    print(f"Data Type: {task.data_type}")
+                    print("---")
+
+            asyncio.run(main())
+            ```
+
+        Example: List only in-progress curation tasks asynchronously
+            &nbsp;
+
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import CurationTask, TaskState
+
+            syn = Synapse()
+            syn.login()
+
+            async def main():
+                async for task in CurationTask.list_async(
+                    project_id="syn9876543",
+                    state_filter=[TaskState.IN_PROGRESS],
+                ):
+                    print(f"Task ID: {task.task_id}")
+                    print(f"Data Type: {task.data_type}")
+                    print("---")
+
+            asyncio.run(main())
+            ```
         """
+        if assigned_to_me is True and assignee_ids is not None:
+            raise ValueError(
+                "assigned_to_me and assignee_ids are mutually exclusive "
+                "and cannot be used together."
+            )
+
+        if state_filter is not None and not state_filter:
+            return
+
+        if state_filter is not None:
+            coerced_state_filter = []
+            for s in state_filter:
+                if isinstance(s, TaskState):
+                    coerced_state_filter.append(s.value)
+                else:
+                    if not isinstance(s, str):
+                        raise ValueError(
+                            f"Invalid state_filter value {s!r}. Expected a TaskState or str."
+                        )
+                    try:
+                        coerced_state_filter.append(TaskState(s.upper()).value)
+                    except ValueError as exc:
+                        valid = [e.value for e in TaskState]
+                        raise ValueError(
+                            f"Invalid state_filter value {s!r}. Valid values are: {valid}"
+                        ) from exc
+            state_filter = coerced_state_filter
+
         trace.get_current_span().set_attributes(
             {
                 "synapse.project_id": project_id,
@@ -897,7 +1067,11 @@ class CurationTask(CurationTaskSynchronousProtocol):
         )
 
         async for task_dict in list_curation_tasks(
-            project_id=project_id, synapse_client=synapse_client
+            project_id=project_id,
+            assigned_to_me=assigned_to_me,
+            assignee_ids=assignee_ids,
+            state_filter=state_filter,
+            synapse_client=synapse_client,
         ):
             task = cls().fill_from_dict(synapse_response=task_dict)
             yield task

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -46,7 +46,11 @@ from synapseclient.core.constants.concrete_types import (
 )
 from synapseclient.core.download.download_functions import download_from_url
 from synapseclient.core.upload.upload_functions_async import upload_synapse_s3
-from synapseclient.core.utils import delete_none_keys, merge_dataclass_entities
+from synapseclient.core.utils import (
+    coerce_enum_list,
+    delete_none_keys,
+    merge_dataclass_entities,
+)
 from synapseclient.models.mixins.asynchronous_job import AsynchronousCommunicator
 from synapseclient.models.recordset import ValidationSummary
 from synapseclient.models.table_components import Column, CsvTableDescriptor, Query
@@ -406,11 +410,10 @@ class CurationTaskSynchronousProtocol(Protocol):
                 tasks by assignee. Cannot be combined with assigned_to_me=True.
                 Passing an empty list raises a ValueError; pass None to return tasks
                 for any assignee. Defaults to None.
-            state_filter: Optional list of TaskState values or equivalent strings to
-                filter tasks by their current state. Strings are normalized to uppercase
-                before coercion (e.g., in_progress is accepted). Defaults to None
-                (all states returned). Passing an empty list raises a ValueError; pass
-                None to return tasks in any state.
+            state_filter: Optional list of TaskState values or exact-case strings to
+                filter tasks by their current state (e.g., "IN_PROGRESS"). Defaults to
+                None (all states returned). Passing an empty list raises a ValueError;
+                pass None to return tasks in any state.
             synapse_client: If not passed in and caching was not disabled by
                 Synapse.allow_client_caching(False) this will use the last created
                 instance from the Synapse class constructor.
@@ -422,8 +425,8 @@ class CurationTaskSynchronousProtocol(Protocol):
             ValueError: If state_filter is an empty list.
             ValueError: If assignee_ids is an empty list.
             ValueError: If assigned_to_me is True and assignee_ids is also provided.
-            ValueError: If any value in state_filter is not a TaskState, a valid
-                TaskState string, or a recognized state name.
+            ValueError: If any value in state_filter is not a TaskState member or
+                an exact-case string matching a TaskState value (e.g., "IN_PROGRESS").
 
         Note: Due to generator semantics, argument validation runs on the first
             iteration of the generator, not at the point where list() is called.
@@ -480,6 +483,27 @@ class CurationTaskSynchronousProtocol(Protocol):
                 print(f"Data Type: {task.data_type}")
                 print("---")
             ```
+
+        Example: List only in-progress curation tasks using a string state filter
+            &nbsp;
+
+            state_filter also accepts plain strings matching TaskState names exactly.
+
+            ```python
+            from synapseclient import Synapse
+            from synapseclient.models import CurationTask
+
+            syn = Synapse()
+            syn.login()
+
+            for task in CurationTask.list(
+                project_id="syn9876543",
+                state_filter=["IN_PROGRESS"],
+            ):
+                print(f"Task ID: {task.task_id}")
+                print(f"Data Type: {task.data_type}")
+                print("---")
+            ```
         """
         yield from wrap_async_generator_to_sync_generator(
             async_gen_func=cls.list_async,
@@ -489,45 +513,6 @@ class CurationTaskSynchronousProtocol(Protocol):
             state_filter=state_filter,
             synapse_client=synapse_client,
         )
-
-
-def _coerce_state_filter(
-    state_filter: list[Union["TaskState", str]],
-) -> list[str]:
-    """Normalize a list of state_filter values to their string equivalents.
-
-    Accepts TaskState enum members or strings. Strings are upper-cased before
-    coercion so that values like in_progress are accepted. Non-string,
-    non-TaskState values raise ValueError. Unrecognized strings also raise
-    ValueError with the list of valid values.
-
-    Arguments:
-        state_filter: List of TaskState values or equivalent strings to coerce.
-
-    Returns:
-        List of string values corresponding to each TaskState.
-
-    Raises:
-        ValueError: If any element is not a TaskState, a valid TaskState string,
-            or a recognized state name.
-    """
-    coerced: list[str] = []
-    for s in state_filter:
-        if isinstance(s, TaskState):
-            coerced.append(s.value)
-            continue
-        if not isinstance(s, str):
-            raise ValueError(
-                f"Invalid state_filter value {s!r}. Expected a TaskState or str."
-            )
-        try:
-            coerced.append(TaskState(s.upper()).value)
-        except ValueError as exc:
-            valid = [e.value for e in TaskState]
-            raise ValueError(
-                f"Invalid state_filter value {s!r}. Valid values are: {valid}"
-            ) from exc
-    return coerced
 
 
 @dataclass
@@ -996,11 +981,10 @@ class CurationTask(CurationTaskSynchronousProtocol):
                 tasks by assignee. Cannot be combined with assigned_to_me=True.
                 Passing an empty list raises a ValueError; pass None to return tasks
                 for any assignee. Defaults to None.
-            state_filter: Optional list of TaskState values or equivalent strings to
-                filter tasks by their current state. Strings are normalized to uppercase
-                before coercion (e.g., in_progress is accepted). Defaults to None
-                (all states returned). Passing an empty list raises a ValueError; pass
-                None to return tasks in any state.
+            state_filter: Optional list of TaskState values or exact-case strings to
+                filter tasks by their current state (e.g., "IN_PROGRESS"). Defaults to
+                None (all states returned). Passing an empty list raises a ValueError;
+                pass None to return tasks in any state.
             synapse_client: If not passed in and caching was not disabled by
                 Synapse.allow_client_caching(False) this will use the last created
                 instance from the Synapse class constructor.
@@ -1012,8 +996,8 @@ class CurationTask(CurationTaskSynchronousProtocol):
             ValueError: If state_filter is an empty list.
             ValueError: If assignee_ids is an empty list.
             ValueError: If assigned_to_me is True and assignee_ids is also provided.
-            ValueError: If any value in state_filter is not a TaskState, a valid
-                TaskState string, or a recognized state name.
+            ValueError: If any value in state_filter is not a TaskState member or
+                an exact-case string matching a TaskState value (e.g., "IN_PROGRESS").
 
         Example: List all curation tasks in a project asynchronously
             &nbsp;
@@ -1081,6 +1065,31 @@ class CurationTask(CurationTaskSynchronousProtocol):
 
             asyncio.run(main())
             ```
+
+        Example: List only in-progress curation tasks using a string state filter asynchronously
+            &nbsp;
+
+            state_filter also accepts plain strings matching TaskState names exactly.
+
+            ```python
+            import asyncio
+            from synapseclient import Synapse
+            from synapseclient.models import CurationTask
+
+            syn = Synapse()
+            syn.login()
+
+            async def main():
+                async for task in CurationTask.list_async(
+                    project_id="syn9876543",
+                    state_filter=["IN_PROGRESS"],
+                ):
+                    print(f"Task ID: {task.task_id}")
+                    print(f"Data Type: {task.data_type}")
+                    print("---")
+
+            asyncio.run(main())
+            ```
         """
         if state_filter == []:
             raise ValueError(
@@ -1092,12 +1101,12 @@ class CurationTask(CurationTaskSynchronousProtocol):
             )
         if assigned_to_me is True and assignee_ids is not None:
             raise ValueError(
-                "assigned_to_me and assignee_ids are mutually exclusive "
-                "and cannot be used together."
+                f"assigned_to_me and assignee_ids are mutually exclusive "
+                f"and cannot be used together. Got assignee_ids={assignee_ids!r}."
             )
 
         if state_filter is not None:
-            state_filter = _coerce_state_filter(state_filter)
+            state_filter = coerce_enum_list(TaskState, state_filter)
 
         trace.get_current_span().set_attributes(
             {

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -404,17 +404,26 @@ class CurationTaskSynchronousProtocol(Protocol):
                 Defaults to None.
             assignee_ids: Optional list of principal IDs (users or teams) to filter
                 tasks by assignee. Cannot be combined with assigned_to_me=True.
-                Defaults to None.
+                Passing an empty list raises a ValueError; pass None to return tasks
+                for any assignee. Defaults to None.
             state_filter: Optional list of TaskState values or equivalent strings to
                 filter tasks by their current state. Strings are normalized to uppercase
-                before coercion (e.g., "in_progress" is accepted). Defaults to None
-                (all states returned). An empty list results in no tasks being returned.
+                before coercion (e.g., in_progress is accepted). Defaults to None
+                (all states returned). Passing an empty list raises a ValueError; pass
+                None to return tasks in any state.
             synapse_client: If not passed in and caching was not disabled by
-                `Synapse.allow_client_caching(False)` this will use the last created
+                Synapse.allow_client_caching(False) this will use the last created
                 instance from the Synapse class constructor.
 
         Yields:
             CurationTask objects as they are retrieved from the API.
+
+        Raises:
+            ValueError: If state_filter is an empty list.
+            ValueError: If assignee_ids is an empty list.
+            ValueError: If assigned_to_me is True and assignee_ids is also provided.
+            ValueError: If any value in state_filter is not a TaskState, a valid
+                TaskState string, or a recognized state name.
 
         Note: Due to generator semantics, argument validation runs on the first
             iteration of the generator, not at the point where list() is called.
@@ -942,21 +951,30 @@ class CurationTask(CurationTaskSynchronousProtocol):
             project_id: The synId of the project.
             assigned_to_me: When True, only return tasks assigned to the current user.
                 Cannot be combined with assignee_ids.
-                False does not mean "tasks not assigned to me"; use assignee_ids to
+                False does not mean "tasks not assigned to me".
                 Defaults to None.
             assignee_ids: Optional list of principal IDs (users or teams) to filter
                 tasks by assignee. Cannot be combined with assigned_to_me=True.
-                Defaults to None.
+                Passing an empty list raises a ValueError; pass None to return tasks
+                for any assignee. Defaults to None.
             state_filter: Optional list of TaskState values or equivalent strings to
                 filter tasks by their current state. Strings are normalized to uppercase
-                before coercion (e.g., "in_progress" is accepted). Defaults to None
-                (all states returned). An empty list results in no tasks being returned.
+                before coercion (e.g., in_progress is accepted). Defaults to None
+                (all states returned). Passing an empty list raises a ValueError; pass
+                None to return tasks in any state.
             synapse_client: If not passed in and caching was not disabled by
-                `Synapse.allow_client_caching(False)` this will use the last created
+                Synapse.allow_client_caching(False) this will use the last created
                 instance from the Synapse class constructor.
 
         Yields:
             CurationTask objects as they are retrieved from the API.
+
+        Raises:
+            ValueError: If state_filter is an empty list.
+            ValueError: If assignee_ids is an empty list.
+            ValueError: If assigned_to_me is True and assignee_ids is also provided.
+            ValueError: If any value in state_filter is not a TaskState, a valid
+                TaskState string, or a recognized state name.
 
         Example: List all curation tasks in a project asynchronously
             &nbsp;
@@ -1025,32 +1043,40 @@ class CurationTask(CurationTaskSynchronousProtocol):
             asyncio.run(main())
             ```
         """
+        if state_filter == []:
+            raise ValueError(
+                "state_filter must not be empty. Pass None to return tasks in any state."
+            )
+        if assignee_ids == []:
+            raise ValueError(
+                "assignee_ids must not be empty. Pass None to return tasks for any assignee."
+            )
         if assigned_to_me is True and assignee_ids is not None:
             raise ValueError(
                 "assigned_to_me and assignee_ids are mutually exclusive "
                 "and cannot be used together."
             )
 
-        if state_filter is not None and not state_filter:
-            return
-
+        # Normalize state_filter.
+        # This method accepts TaskState enums or strings, anything else causes a ValueError.
+        # Strings are upper-cased and validated against TaskState; invalid values raise.
         if state_filter is not None:
             coerced_state_filter = []
             for s in state_filter:
                 if isinstance(s, TaskState):
                     coerced_state_filter.append(s.value)
-                else:
-                    if not isinstance(s, str):
-                        raise ValueError(
-                            f"Invalid state_filter value {s!r}. Expected a TaskState or str."
-                        )
-                    try:
-                        coerced_state_filter.append(TaskState(s.upper()).value)
-                    except ValueError as exc:
-                        valid = [e.value for e in TaskState]
-                        raise ValueError(
-                            f"Invalid state_filter value {s!r}. Valid values are: {valid}"
-                        ) from exc
+                    continue
+                if not isinstance(s, str):
+                    raise ValueError(
+                        f"Invalid state_filter value {s!r}. Expected a TaskState or str."
+                    )
+                try:
+                    coerced_state_filter.append(TaskState(s.upper()).value)
+                except ValueError as exc:
+                    valid = [e.value for e in TaskState]
+                    raise ValueError(
+                        f"Invalid state_filter value {s!r}. Valid values are: {valid}"
+                    ) from exc
             state_filter = coerced_state_filter
 
         trace.get_current_span().set_attributes(

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -399,10 +399,9 @@ class CurationTaskSynchronousProtocol(Protocol):
         Arguments:
             project_id: The synId of the project.
             assigned_to_me: When True, only return tasks assigned to the current user.
-                False and None are identical in effect — neither activates an assignee
-                filter, and both may be combined with assignee_ids freely. Note that
-                False does not mean "tasks not assigned to me". Passing True together
-                with assignee_ids raises a ValueError. Defaults to None.
+                Cannot be combined with assignee_ids.
+                False does not mean "tasks not assigned to me".
+                Defaults to None.
             assignee_ids: Optional list of principal IDs (users or teams) to filter
                 tasks by assignee. Cannot be combined with assigned_to_me=True.
                 Defaults to None.

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -941,11 +941,9 @@ class CurationTask(CurationTaskSynchronousProtocol):
         Arguments:
             project_id: The synId of the project.
             assigned_to_me: When True, only return tasks assigned to the current user.
-                False and None are identical in effect — neither activates an assignee
-                filter, and both may be combined with assignee_ids freely. Note that
+                Cannot be combined with assignee_ids.
                 False does not mean "tasks not assigned to me"; use assignee_ids to
-                express exclusion semantics. Passing True together with assignee_ids
-                raises a ValueError. Defaults to None.
+                Defaults to None.
             assignee_ids: Optional list of principal IDs (users or teams) to filter
                 tasks by assignee. Cannot be combined with assigned_to_me=True.
                 Defaults to None.
@@ -959,10 +957,6 @@ class CurationTask(CurationTaskSynchronousProtocol):
 
         Yields:
             CurationTask objects as they are retrieved from the API.
-
-        Note: Due to async generator semantics, argument validation runs on the first
-            iteration of the generator (i.e., when the for loop body is first entered),
-            not at the point where list_async() is called.
 
         Example: List all curation tasks in a project asynchronously
             &nbsp;

--- a/tests/integration/synapseclient/models/async/test_curation_async.py
+++ b/tests/integration/synapseclient/models/async/test_curation_async.py
@@ -628,7 +628,7 @@ class TestCurationTaskListAsync:
         # THEN I should get an empty list
         assert len(listed_tasks) == 0
 
-    async def test_list_state_filter_not_started_async(
+    async def test_list_filters_async(
         self, project_model: Project, folder_with_view: tuple[Folder, EntityView]
     ) -> None:
         # GIVEN a newly created curation task (default state is NOT_STARTED)
@@ -669,22 +669,6 @@ class TestCurationTaskListAsync:
 
         # THEN the NOT_STARTED task should not appear
         assert task.task_id not in listed_task_ids
-
-    async def test_list_state_filter_string_coercion_async(
-        self, project_model: Project, folder_with_view: tuple[Folder, EntityView]
-    ) -> None:
-        # GIVEN a newly created curation task (default state is NOT_STARTED)
-        folder, entity_view = folder_with_view
-        data_type = f"test_data_type_{str(uuid.uuid4()).replace('-', '_')}"
-        task = await CurationTask(
-            data_type=data_type,
-            project_id=project_model.id,
-            instructions="Test instructions",
-            task_properties=FileBasedMetadataTaskProperties(
-                upload_folder_id=folder.id,
-                file_view_id=entity_view.id,
-            ),
-        ).store_async(synapse_client=self.syn)
 
         # WHEN I list tasks using a lowercase string for state_filter
         listed_task_ids = [

--- a/tests/integration/synapseclient/models/async/test_curation_async.py
+++ b/tests/integration/synapseclient/models/async/test_curation_async.py
@@ -537,10 +537,21 @@ class TestCurationTaskListAsync:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture(scope="function")
+    async def project_for_test(
+        self,
+        syn: Synapse,
+        schedule_for_cleanup: Callable[..., None],
+    ) -> Project:
+        """Create a fresh project per test so tasks from other tests don't appear in listings."""
+        project = await Project(name=str(uuid.uuid4())).store_async(synapse_client=syn)
+        schedule_for_cleanup(project.id)
+        return project
+
+    @pytest.fixture(scope="function")
     async def folder_with_view(
         self,
-        project_model: Project,
+        project_for_test: Project,
         syn: Synapse,
         schedule_for_cleanup: Callable[..., None],
     ) -> tuple[Folder, EntityView]:
@@ -548,13 +559,13 @@ class TestCurationTaskListAsync:
         # Create a folder
         folder = await Folder(
             name=str(uuid.uuid4()),
-            parent_id=project_model.id,
+            parent_id=project_for_test.id,
         ).store_async(synapse_client=syn)
         schedule_for_cleanup(folder.id)
 
         entity_view = await EntityView(
             name=str(uuid.uuid4()),
-            parent_id=project_model.id,
+            parent_id=project_for_test.id,
             scope_ids=[folder.id],
             view_type_mask=ViewTypeMask.FILE.value,
         ).store_async(synapse_client=syn)
@@ -563,7 +574,7 @@ class TestCurationTaskListAsync:
         return folder, entity_view
 
     async def test_list_curation_tasks_async(
-        self, project_model: Project, folder_with_view: tuple[Folder, EntityView]
+        self, project_for_test: Project, folder_with_view: tuple[Folder, EntityView]
     ) -> None:
         # GIVEN a project, folder, and entity view
         folder, entity_view = folder_with_view
@@ -578,7 +589,7 @@ class TestCurationTaskListAsync:
             )
             task = await CurationTask(
                 data_type=data_type,
-                project_id=project_model.id,
+                project_id=project_for_test.id,
                 instructions=f"Instructions for task {i}",
                 task_properties=task_properties,
             ).store_async(synapse_client=self.syn)
@@ -587,12 +598,12 @@ class TestCurationTaskListAsync:
         # WHEN I list all curation tasks for the project asynchronously
         listed_tasks = []
         async for task in CurationTask.list_async(
-            project_id=project_model.id, synapse_client=self.syn
+            project_id=project_for_test.id, synapse_client=self.syn
         ):
             listed_tasks.append(task)
 
-        # THEN I should get all the created tasks
-        assert len(listed_tasks) >= 3  # There might be other tasks from other tests
+        # THEN I should get exactly the 3 created tasks (isolated project)
+        assert len(listed_tasks) == 3
 
         # Check that our created tasks are in the list
         listed_task_ids = [task.task_id for task in listed_tasks]
@@ -604,12 +615,11 @@ class TestCurationTaskListAsync:
 
         # Verify the structure of retrieved tasks
         for task in listed_tasks:
-            if task.task_id in [t[1] for t in tasks_data]:
-                assert task.project_id == project_model.id
-                assert task.task_properties is not None
-                assert task.etag is not None
-                assert task.created_on is not None
-                assert task.created_by is not None
+            assert task.project_id == project_for_test.id
+            assert task.task_properties is not None
+            assert task.etag is not None
+            assert task.created_on is not None
+            assert task.created_by is not None
 
     async def test_list_empty_project_async(self) -> None:
         # GIVEN a project with no curation tasks
@@ -629,14 +639,14 @@ class TestCurationTaskListAsync:
         assert len(listed_tasks) == 0
 
     async def test_list_filters_async(
-        self, project_model: Project, folder_with_view: tuple[Folder, EntityView]
+        self, project_for_test: Project, folder_with_view: tuple[Folder, EntityView]
     ) -> None:
         # GIVEN a newly created curation task (default state is NOT_STARTED)
         folder, entity_view = folder_with_view
         data_type = f"test_data_type_{str(uuid.uuid4()).replace('-', '_')}"
         task = await CurationTask(
             data_type=data_type,
-            project_id=project_model.id,
+            project_id=project_for_test.id,
             instructions="Test instructions",
             task_properties=FileBasedMetadataTaskProperties(
                 upload_folder_id=folder.id,
@@ -648,37 +658,25 @@ class TestCurationTaskListAsync:
         listed_task_ids = [
             t.task_id
             async for t in CurationTask.list_async(
-                project_id=project_model.id,
+                project_id=project_for_test.id,
                 state_filter=[TaskState.NOT_STARTED],
                 synapse_client=self.syn,
             )
         ]
 
-        # THEN the new task should appear
+        # THEN exactly 1 task should appear and it should be our task
+        assert len(listed_task_ids) == 1
         assert task.task_id in listed_task_ids
 
         # WHEN I list tasks filtered to COMPLETED
         listed_task_ids = [
             t.task_id
             async for t in CurationTask.list_async(
-                project_id=project_model.id,
+                project_id=project_for_test.id,
                 state_filter=[TaskState.COMPLETED],
                 synapse_client=self.syn,
             )
         ]
 
-        # THEN the NOT_STARTED task should not appear
-        assert task.task_id not in listed_task_ids
-
-        # WHEN I list tasks using a lowercase string for state_filter
-        listed_task_ids = [
-            t.task_id
-            async for t in CurationTask.list_async(
-                project_id=project_model.id,
-                state_filter=["not_started"],
-                synapse_client=self.syn,
-            )
-        ]
-
-        # THEN the task should appear (string was coerced to TaskState.NOT_STARTED)
-        assert task.task_id in listed_task_ids
+        # THEN no tasks should appear (the only task is NOT_STARTED)
+        assert len(listed_task_ids) == 0

--- a/tests/integration/synapseclient/models/async/test_curation_async.py
+++ b/tests/integration/synapseclient/models/async/test_curation_async.py
@@ -19,6 +19,7 @@ from synapseclient.models import (
     Project,
     RecordBasedMetadataTaskProperties,
     RecordSet,
+    TaskState,
     ViewTypeMask,
 )
 
@@ -626,3 +627,90 @@ class TestCurationTaskListAsync:
 
         # THEN I should get an empty list
         assert len(listed_tasks) == 0
+
+    async def test_list_state_filter_not_started_async(
+        self, project_model: Project, folder_with_view: tuple[Folder, EntityView]
+    ) -> None:
+        # GIVEN a newly created curation task (default state is NOT_STARTED)
+        folder, entity_view = folder_with_view
+        data_type = f"test_data_type_{str(uuid.uuid4()).replace('-', '_')}"
+        task = await CurationTask(
+            data_type=data_type,
+            project_id=project_model.id,
+            instructions="Test instructions",
+            task_properties=FileBasedMetadataTaskProperties(
+                upload_folder_id=folder.id,
+                file_view_id=entity_view.id,
+            ),
+        ).store_async(synapse_client=self.syn)
+
+        # WHEN I list tasks filtered to NOT_STARTED
+        listed_task_ids = [
+            t.task_id
+            async for t in CurationTask.list_async(
+                project_id=project_model.id,
+                state_filter=[TaskState.NOT_STARTED],
+                synapse_client=self.syn,
+            )
+        ]
+
+        # THEN the new task should appear
+        assert task.task_id in listed_task_ids
+
+    async def test_list_state_filter_excludes_other_states_async(
+        self, project_model: Project, folder_with_view: tuple[Folder, EntityView]
+    ) -> None:
+        # GIVEN a newly created curation task (default state is NOT_STARTED)
+        folder, entity_view = folder_with_view
+        data_type = f"test_data_type_{str(uuid.uuid4()).replace('-', '_')}"
+        task = await CurationTask(
+            data_type=data_type,
+            project_id=project_model.id,
+            instructions="Test instructions",
+            task_properties=FileBasedMetadataTaskProperties(
+                upload_folder_id=folder.id,
+                file_view_id=entity_view.id,
+            ),
+        ).store_async(synapse_client=self.syn)
+
+        # WHEN I list tasks filtered to COMPLETED
+        listed_task_ids = [
+            t.task_id
+            async for t in CurationTask.list_async(
+                project_id=project_model.id,
+                state_filter=[TaskState.COMPLETED],
+                synapse_client=self.syn,
+            )
+        ]
+
+        # THEN the NOT_STARTED task should not appear
+        assert task.task_id not in listed_task_ids
+
+    async def test_list_state_filter_string_coercion_async(
+        self, project_model: Project, folder_with_view: tuple[Folder, EntityView]
+    ) -> None:
+        # GIVEN a newly created curation task (default state is NOT_STARTED)
+        folder, entity_view = folder_with_view
+        data_type = f"test_data_type_{str(uuid.uuid4()).replace('-', '_')}"
+        task = await CurationTask(
+            data_type=data_type,
+            project_id=project_model.id,
+            instructions="Test instructions",
+            task_properties=FileBasedMetadataTaskProperties(
+                upload_folder_id=folder.id,
+                file_view_id=entity_view.id,
+            ),
+        ).store_async(synapse_client=self.syn)
+
+        # WHEN I list tasks using a lowercase string for state_filter
+        listed_task_ids = [
+            t.task_id
+            async for t in CurationTask.list_async(
+                project_id=project_model.id,
+                state_filter=["not_started"],
+                synapse_client=self.syn,
+            )
+        ]
+
+        # THEN the task should appear (string was coerced to TaskState.NOT_STARTED)
+        assert task.task_id in listed_task_ids

--- a/tests/integration/synapseclient/models/async/test_curation_async.py
+++ b/tests/integration/synapseclient/models/async/test_curation_async.py
@@ -657,22 +657,6 @@ class TestCurationTaskListAsync:
         # THEN the new task should appear
         assert task.task_id in listed_task_ids
 
-    async def test_list_state_filter_excludes_other_states_async(
-        self, project_model: Project, folder_with_view: tuple[Folder, EntityView]
-    ) -> None:
-        # GIVEN a newly created curation task (default state is NOT_STARTED)
-        folder, entity_view = folder_with_view
-        data_type = f"test_data_type_{str(uuid.uuid4()).replace('-', '_')}"
-        task = await CurationTask(
-            data_type=data_type,
-            project_id=project_model.id,
-            instructions="Test instructions",
-            task_properties=FileBasedMetadataTaskProperties(
-                upload_folder_id=folder.id,
-                file_view_id=entity_view.id,
-            ),
-        ).store_async(synapse_client=self.syn)
-
         # WHEN I list tasks filtered to COMPLETED
         listed_task_ids = [
             t.task_id

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -5,12 +5,14 @@ import logging
 import os
 import re
 import tempfile
+from enum import Enum
 from shutil import rmtree
 from unittest.mock import MagicMock, Mock, call, mock_open, patch
 
 import pytest
 
 from synapseclient.core import constants, utils
+from synapseclient.core.utils import coerce_enum_list
 
 
 def test_is_url() -> None:
@@ -608,3 +610,41 @@ class TestSpinner:
         mock_sys.stdout.write.assert_not_called()
         mock_sys.stdout.flush.assert_not_called()
         assert self.spinner._tick == 1
+
+
+class _Color(Enum):
+    RED = "RED"
+    BLUE = "BLUE"
+
+
+class TestCoerceEnumList:
+    """Tests for coerce_enum_list."""
+
+    @pytest.mark.parametrize(
+        "input_filter,expected",
+        [
+            ([_Color.RED], ["RED"]),
+            ([_Color.BLUE], ["BLUE"]),
+            ([_Color.RED, _Color.BLUE], ["RED", "BLUE"]),
+            (["RED"], ["RED"]),
+            (["BLUE"], ["BLUE"]),
+            ([_Color.RED, "BLUE"], ["RED", "BLUE"]),
+            ([], []),
+        ],
+    )
+    def test_valid_inputs(self, input_filter, expected) -> None:
+        """Accepts enum members, matching strings, mixed lists, and empty lists."""
+        assert coerce_enum_list(_Color, input_filter) == expected
+
+    @pytest.mark.parametrize(
+        "input_filter,match",
+        [
+            (["NOT_A_COLOR"], "Invalid value"),
+            ([42], "Invalid value"),
+            (["red"], "Invalid value"),
+        ],
+    )
+    def test_invalid_inputs_raise_value_error(self, input_filter, match) -> None:
+        """Raises ValueError for unrecognized strings and non-string, non-enum values."""
+        with pytest.raises(ValueError, match=match):
+            coerce_enum_list(_Color, input_filter)

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -24,6 +24,7 @@ from synapseclient.models.curation import (
     SynchronizeGridRequest,
     TaskState,
     UploadToTablePreviewRequest,
+    _coerce_state_filter,
     _create_task_properties_from_dict,
 )
 from synapseclient.models.recordset import ValidationSummary
@@ -1745,3 +1746,41 @@ class TestSynchronizeGrid:
                 error_message = mock_logger.error.call_args[0][0]
                 assert "sync_error_1" in error_message
                 assert "sync_error_2" in error_message
+
+
+class TestCoerceStateFilter:
+    """Tests for the _coerce_state_filter."""
+
+    @pytest.mark.parametrize(
+        "input_filter,expected",
+        [
+            ([TaskState.IN_PROGRESS], ["IN_PROGRESS"]),
+            ([TaskState.COMPLETED], ["COMPLETED"]),
+            (
+                [TaskState.IN_PROGRESS, TaskState.COMPLETED],
+                ["IN_PROGRESS", "COMPLETED"],
+            ),
+            (["IN_PROGRESS"], ["IN_PROGRESS"]),
+            (["in_progress"], ["IN_PROGRESS"]),
+            (["In_Progress"], ["IN_PROGRESS"]),
+            (["COMPLETED"], ["COMPLETED"]),
+            (["completed"], ["COMPLETED"]),
+            ([TaskState.IN_PROGRESS, "completed"], ["IN_PROGRESS", "COMPLETED"]),
+            ([], []),
+        ],
+    )
+    def test_valid_inputs(self, input_filter, expected) -> None:
+        """Accepts TaskState enums, case-insensitive strings, mixed lists, and empty lists."""
+        assert _coerce_state_filter(input_filter) == expected
+
+    @pytest.mark.parametrize(
+        "input_filter,match",
+        [
+            (["NOT_A_REAL_STATE"], "Invalid state_filter value"),
+            ([42], "Expected a TaskState or str"),
+        ],
+    )
+    def test_invalid_inputs_raise_value_error(self, input_filter, match) -> None:
+        """Raises ValueError for unrecognized strings and non-string, non-TaskState values."""
+        with pytest.raises(ValueError, match=match):
+            _coerce_state_filter(input_filter)

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -24,7 +24,6 @@ from synapseclient.models.curation import (
     SynchronizeGridRequest,
     TaskState,
     UploadToTablePreviewRequest,
-    _coerce_state_filter,
     _create_task_properties_from_dict,
 )
 from synapseclient.models.recordset import ValidationSummary
@@ -583,7 +582,9 @@ class TestCurationTask:
         # GIVEN both assigned_to_me and assignee_ids are provided
         # WHEN I call list_async
         # THEN it should raise ValueError on first iteration (generators are lazy)
-        with pytest.raises(ValueError, match="mutually exclusive"):
+        with pytest.raises(
+            ValueError, match="mutually exclusive.*Got assignee_ids=\\['123'\\]"
+        ):
             async for _ in CurationTask.list_async(
                 project_id=PROJECT_ID,
                 assigned_to_me=True,
@@ -673,44 +674,11 @@ class TestCurationTask:
                 synapse_client=self.syn,
             )
 
-    @pytest.mark.parametrize(
-        "input_value",
-        ["NOT_STARTED", "not_started", "Not_Started"],
-    )
-    async def test_list_async_state_filter_coerces_string(
-        self, input_value: str
-    ) -> None:
-        # GIVEN a state_filter with a string value in any case
-        async def mock_list(*args, **kwargs):
-            return
-            yield  # pragma: no cover
-
-        # WHEN I call list_async
-        with patch(
-            "synapseclient.models.curation.list_curation_tasks",
-            side_effect=mock_list,
-        ) as mock_api:
-            async for _ in CurationTask.list_async(
-                project_id=PROJECT_ID,
-                state_filter=[input_value],
-                synapse_client=self.syn,
-            ):
-                pass
-
-            # THEN the API should be called with the normalized uppercase string
-            mock_api.assert_called_once_with(
-                project_id=PROJECT_ID,
-                assigned_to_me=None,
-                assignee_ids=None,
-                state_filter=["NOT_STARTED"],
-                synapse_client=self.syn,
-            )
-
     async def test_list_async_state_filter_invalid_string_raises(self) -> None:
         # GIVEN a state_filter with an invalid string value
         # WHEN I call list_async
         # THEN it should raise ValueError before any API call
-        with pytest.raises(ValueError, match="Invalid state_filter value"):
+        with pytest.raises(ValueError, match="Invalid value"):
             async for _ in CurationTask.list_async(
                 project_id=PROJECT_ID,
                 state_filter=["invalid"],
@@ -1746,41 +1714,3 @@ class TestSynchronizeGrid:
                 error_message = mock_logger.error.call_args[0][0]
                 assert "sync_error_1" in error_message
                 assert "sync_error_2" in error_message
-
-
-class TestCoerceStateFilter:
-    """Tests for the _coerce_state_filter."""
-
-    @pytest.mark.parametrize(
-        "input_filter,expected",
-        [
-            ([TaskState.IN_PROGRESS], ["IN_PROGRESS"]),
-            ([TaskState.COMPLETED], ["COMPLETED"]),
-            (
-                [TaskState.IN_PROGRESS, TaskState.COMPLETED],
-                ["IN_PROGRESS", "COMPLETED"],
-            ),
-            (["IN_PROGRESS"], ["IN_PROGRESS"]),
-            (["in_progress"], ["IN_PROGRESS"]),
-            (["In_Progress"], ["IN_PROGRESS"]),
-            (["COMPLETED"], ["COMPLETED"]),
-            (["completed"], ["COMPLETED"]),
-            ([TaskState.IN_PROGRESS, "completed"], ["IN_PROGRESS", "COMPLETED"]),
-            ([], []),
-        ],
-    )
-    def test_valid_inputs(self, input_filter, expected) -> None:
-        """Accepts TaskState enums, case-insensitive strings, mixed lists, and empty lists."""
-        assert _coerce_state_filter(input_filter) == expected
-
-    @pytest.mark.parametrize(
-        "input_filter,match",
-        [
-            (["NOT_A_REAL_STATE"], "Invalid state_filter value"),
-            ([42], "Expected a TaskState or str"),
-        ],
-    )
-    def test_invalid_inputs_raise_value_error(self, input_filter, match) -> None:
-        """Raises ValueError for unrecognized strings and non-string, non-TaskState values."""
-        with pytest.raises(ValueError, match=match):
-            _coerce_state_filter(input_filter)

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -22,6 +22,7 @@ from synapseclient.models.curation import (
     GridRecordSetExportRequest,
     RecordBasedMetadataTaskProperties,
     SynchronizeGridRequest,
+    TaskState,
     UploadToTablePreviewRequest,
     _create_task_properties_from_dict,
 )
@@ -576,6 +577,145 @@ class TestCurationTask:
             assert isinstance(
                 results[1].task_properties, RecordBasedMetadataTaskProperties
             )
+
+    async def test_list_async_assigned_to_me_and_assignee_ids_raises(self) -> None:
+        # GIVEN both assigned_to_me and assignee_ids are provided
+        # WHEN I call list_async
+        # THEN it should raise ValueError on first iteration (generators are lazy)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            async for _ in CurationTask.list_async(
+                project_id=PROJECT_ID,
+                assigned_to_me=True,
+                assignee_ids=["123"],
+                synapse_client=self.syn,
+            ):
+                pass  # pragma: no cover
+
+    async def test_list_async_passes_assigned_to_me_to_api(self) -> None:
+        # GIVEN assigned_to_me=True
+        async def mock_list(*args, **kwargs):
+            return
+            yield  # pragma: no cover
+
+        # WHEN I call list_async
+        with patch(
+            "synapseclient.models.curation.list_curation_tasks",
+            side_effect=mock_list,
+        ) as mock_api:
+            async for _ in CurationTask.list_async(
+                project_id=PROJECT_ID,
+                assigned_to_me=True,
+                synapse_client=self.syn,
+            ):
+                pass
+
+            # THEN the API should be called with assigned_to_me=True
+            mock_api.assert_called_once_with(
+                project_id=PROJECT_ID,
+                assigned_to_me=True,
+                assignee_ids=None,
+                state_filter=None,
+                synapse_client=self.syn,
+            )
+
+    async def test_list_async_passes_assignee_ids_to_api(self) -> None:
+        # GIVEN a list of assignee_ids
+        async def mock_list(*args, **kwargs):
+            return
+            yield  # pragma: no cover
+
+        # WHEN I call list_async
+        with patch(
+            "synapseclient.models.curation.list_curation_tasks",
+            side_effect=mock_list,
+        ) as mock_api:
+            async for _ in CurationTask.list_async(
+                project_id=PROJECT_ID,
+                assignee_ids=["111", "222"],
+                synapse_client=self.syn,
+            ):
+                pass
+
+            # THEN the API should be called with the serialized assignee_ids
+            mock_api.assert_called_once_with(
+                project_id=PROJECT_ID,
+                assigned_to_me=None,
+                assignee_ids=["111", "222"],
+                state_filter=None,
+                synapse_client=self.syn,
+            )
+
+    async def test_list_async_passes_state_filter_to_api(self) -> None:
+        # GIVEN a state_filter with TaskState enums
+        async def mock_list(*args, **kwargs):
+            return
+            yield  # pragma: no cover
+
+        # WHEN I call list_async
+        with patch(
+            "synapseclient.models.curation.list_curation_tasks",
+            side_effect=mock_list,
+        ) as mock_api:
+            async for _ in CurationTask.list_async(
+                project_id=PROJECT_ID,
+                state_filter=[TaskState.NOT_STARTED, TaskState.IN_PROGRESS],
+                synapse_client=self.syn,
+            ):
+                pass
+
+            # THEN the API should be called with serialized string values
+            mock_api.assert_called_once_with(
+                project_id=PROJECT_ID,
+                assigned_to_me=None,
+                assignee_ids=None,
+                state_filter=["NOT_STARTED", "IN_PROGRESS"],
+                synapse_client=self.syn,
+            )
+
+    @pytest.mark.parametrize(
+        "input_value",
+        ["NOT_STARTED", "not_started", "Not_Started"],
+    )
+    async def test_list_async_state_filter_coerces_string(
+        self, input_value: str
+    ) -> None:
+        # GIVEN a state_filter with a string value in any case
+        async def mock_list(*args, **kwargs):
+            return
+            yield  # pragma: no cover
+
+        # WHEN I call list_async
+        with patch(
+            "synapseclient.models.curation.list_curation_tasks",
+            side_effect=mock_list,
+        ) as mock_api:
+            async for _ in CurationTask.list_async(
+                project_id=PROJECT_ID,
+                state_filter=[input_value],
+                synapse_client=self.syn,
+            ):
+                pass
+
+            # THEN the API should be called with the normalized uppercase string
+            mock_api.assert_called_once_with(
+                project_id=PROJECT_ID,
+                assigned_to_me=None,
+                assignee_ids=None,
+                state_filter=["NOT_STARTED"],
+                synapse_client=self.syn,
+            )
+
+    async def test_list_async_state_filter_invalid_string_raises(self) -> None:
+        # GIVEN a state_filter with an invalid string value
+        # WHEN I call list_async
+        # THEN it should raise ValueError before any API call
+        with pytest.raises(ValueError, match="Invalid state_filter value"):
+            async for _ in CurationTask.list_async(
+                project_id=PROJECT_ID,
+                state_filter=["invalid"],
+                synapse_client=self.syn,
+            ):
+                pass  # pragma: no cover
 
 
 class TestGrid:


### PR DESCRIPTION
# **Problem:**
New fields were added to the list curation tasks endpoint:
- task state
- assignee id
- assigned to me

# **Solution:**
These are now arguments for `CurationTask.list` method

# **Testing:**
Integration and unit tests added
