### PR TITLE
[SYNPY-1810] Migrate all docs to new reference style

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -19,12 +19,18 @@ MkDocs with Material theme, mkdocstrings (Google-style docstrings), termynal (CL
 - **reference/** — API reference auto-generated from docstrings via mkdocstrings. Split into `experimental/sync/` and `experimental/async/` for new OOP API.
 - **explanations/** — Deep conceptual content ("why" not just "how"). Design decisions, internal machinery.
 
-### File inclusion pattern (markdown-include)
-Tutorial code lives in `tutorials/python/tutorial_scripts/*.py` and is embedded in markdown via line-range includes:
+### File inclusion pattern (pymdownx.snippets)
+Tutorial code lives in `tutorials/python/tutorial_scripts/*.py` and is embedded in markdown via named-tag includes (the `--8<--` directive must be the only content on its line):
 ```markdown
-{!docs/tutorials/python/tutorial_scripts/annotation.py!lines=5-23}
+--8<-- "docs/tutorials/python/tutorial_scripts/annotation.py:retrieve_synapse_ids"
 ```
-Single source of truth — edit the `.py` file, not the markdown. Changing line numbers in scripts requires updating the line ranges in the corresponding `.md` files.
+In the paired `.py` file, wrap the region with matching comment markers:
+```python
+# --8<-- [start:retrieve_synapse_ids]
+<code to include>
+# --8<-- [end:retrieve_synapse_ids]
+```
+Single source of truth — edit the `.py` file, not the markdown. Use descriptive snake_case tag names (e.g. `setup`, `create_dataset`) rather than `step_1`. To include the whole file, omit the tag: `--8<-- "docs/tutorials/python/tutorial_scripts/annotation.py"`.
 
 ### mkdocstrings reference generation
 Reference markdown files use `::: synapseclient.ClassName` syntax to trigger auto-generation from docstrings. Key configuration:

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -6,7 +6,7 @@ User-facing documentation for the Synapse Python Client. Built with MkDocs + Mat
 
 ## Stack
 
-MkDocs with Material theme, mkdocstrings (Google-style docstrings), termynal (CLI animations), markdown-include (file embedding).
+MkDocs with Material theme, mkdocstrings (Google-style docstrings), termynal (CLI animations), pymdownx.snippets (named-tag embeddings).
 
 ### Python style
 - Use built-in generics (`list`, `dict`, `tuple`, `set`) instead of `typing.List`, `typing.Dict`, etc. (Python 3.9+)

--- a/docs/tutorials/python/annotation.md
+++ b/docs/tutorials/python/annotation.md
@@ -25,19 +25,19 @@ In this tutorial you will:
 
 #### First let's retrieve all of the Synapse IDs we are going to use
 ```python
-{!docs/tutorials/python/tutorial_scripts/annotation.py!lines=5-23}
+--8<-- "docs/tutorials/python/tutorial_scripts/annotation.py:retrieve_synapse_ids"
 ```
 
 #### Next let's define the annotations I want to set
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/annotation.py!lines=25-31}
+--8<-- "docs/tutorials/python/tutorial_scripts/annotation.py:define_annotations"
 ```
 
 #### Finally we'll loop over all of the files and set their annotations
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/annotation.py!lines=33-51}
+--8<-- "docs/tutorials/python/tutorial_scripts/annotation.py:set_annotations_loop"
 ```
 
 
@@ -64,7 +64,7 @@ In order for the following script to work please replace the files with ones tha
 already exist on your local machine.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/annotation.py!lines=53-78}
+--8<-- "docs/tutorials/python/tutorial_scripts/annotation.py:upload_with_annotations"
 ```
 
 <details class="example">
@@ -115,7 +115,7 @@ files in the synapse web UI. It should look similar to:
   <summary>Click to show me</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/annotation.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/annotation.py"
 ```
 </details>
 

--- a/docs/tutorials/python/dataset.md
+++ b/docs/tutorials/python/dataset.md
@@ -29,7 +29,7 @@ In this tutorial, you will:
 Let's get started by authenticating with Synapse and retrieving the ID of your project.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset.py!lines=3-24}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset.py:setup"
 ```
 
 ## 2. Create your Dataset
@@ -37,7 +37,7 @@ Let's get started by authenticating with Synapse and retrieving the ID of your p
 Next, we will create the dataset. We will use the project ID to tell Synapse where we want the dataset to be created. After this step, we will have a Dataset object with all of the needed information to start building the dataset.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset.py!lines=29-30}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset.py:create_dataset"
 ```
 
 Because we haven't added any files to the dataset yet, it will be empty, but if you view the dataset's schema in the UI, you will notice that datasets come with default columns that help to describe each file that we add to the dataset.
@@ -50,20 +50,20 @@ Let's add some files to the dataset now. There are three ways to add files to a 
 
 1. Add an Entity Reference to a file with its ID and version
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset.py!lines=34-36}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset.py:add_entity_ref"
 ```
 2. Add a File with its ID and version
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset.py!lines=38-40}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset.py:add_file"
 ```
 3. Add a Folder. When adding a folder, all child files inside of the folder are added to the dataset recursively.
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset.py!lines=42-44}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset.py:add_folder"
 ```
 
 Whenever we make changes to the dataset, we need to call the `store()` method to save the changes to Synapse.
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset.py!lines=46}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset.py:store_dataset"
 ```
 
 And now we are able to see our dataset with all of the files that we added to it.
@@ -75,7 +75,7 @@ And now we are able to see our dataset with all of the files that we added to it
 Now that we have a dataset with some files in it, we can retrieve the dataset from Synapse the next time we need to use it.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset.py!lines=50-52}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset.py:retrieve_dataset"
 ```
 
 ## 5. Query the dataset
@@ -83,7 +83,7 @@ Now that we have a dataset with some files in it, we can retrieve the dataset fr
 Now that we have a dataset with some files in it, we can query the dataset to find files that match certain criteria.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset.py!lines=56-59}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset.py:query_dataset"
 ```
 
 ## 6. Add a custom column to the dataset
@@ -91,13 +91,13 @@ Now that we have a dataset with some files in it, we can query the dataset to fi
 We can also add a custom column to the dataset. This will allow us to annotate files in the dataset with additional information.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset.py!lines=63-69}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset.py:add_custom_column"
 ```
 
 Our custom column isn't all that useful empty, so let's update the dataset with some values.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset.py!lines=72-80}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset.py:update_custom_column_values"
 ```
 
 ## 7. Save a snapshot of the dataset
@@ -105,7 +105,7 @@ Our custom column isn't all that useful empty, so let's update the dataset with 
 Finally, let's save a snapshot of the dataset. This creates a read-only version of the dataset that captures the current state of the dataset and can be referenced later.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset.py!lines=84-88}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset.py:snapshot_dataset"
 ```
 
 ## Source Code for this Tutorial
@@ -114,7 +114,7 @@ Finally, let's save a snapshot of the dataset. This creates a read-only version 
   <summary>Click to show me</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset.py"
 ```
 </details>
 

--- a/docs/tutorials/python/dataset_collection.md
+++ b/docs/tutorials/python/dataset_collection.md
@@ -23,7 +23,7 @@ In this tutorial, you will:
 Let's get started by authenticating with Synapse and retrieving the ID of your project.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset_collection.py!lines=3-16}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset_collection.py:setup"
 ```
 
 ## 2. Create your Dataset Collection
@@ -31,7 +31,7 @@ Let's get started by authenticating with Synapse and retrieving the ID of your p
 Next, we will create the Dataset Collection using the project ID to tell Synapse where we want the Dataset Collection to be created. After this step, we will have a Dataset Collection object with all of the necessary information to start building the collection.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset_collection.py!lines=25-33}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset_collection.py:create_collection"
 ```
 
 Because we haven't added any datasets to the collection yet, it will be empty, but if you view the Dataset Collection's schema in the UI, you will notice that Dataset Collections come with default columns.
@@ -43,13 +43,13 @@ Because we haven't added any datasets to the collection yet, it will be empty, b
 Now, let's add some datasets to the collection. We will loop through our dataset ids and add each dataset to the collection using the `add_item` method.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset_collection.py!lines=37-38}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset_collection.py:add_datasets"
 ```
 
 Whenever we make changes to the Dataset Collection, we need to call the `store()` method to save the changes to Synapse.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset_collection.py!lines=40}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset_collection.py:store_collection"
 ```
 
 And now we are able to see our Dataset Collection with all of the datasets that we added to it.
@@ -61,7 +61,7 @@ And now we are able to see our Dataset Collection with all of the datasets that 
 Now that our Dataset Collection has been created and we have added some Datasets to it, we can retrieve the Dataset Collection from Synapse the next time we need to use it.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset_collection.py!lines=44-46}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset_collection.py:retrieve_collection"
 ```
 
 ## 5. Add a custom column to the Dataset Collection
@@ -69,13 +69,13 @@ Now that our Dataset Collection has been created and we have added some Datasets
 In addition to the default columns, you may want to annotate items in your DatasetCollection using custom columns.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset_collection.py!lines=50-56}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset_collection.py:add_custom_column"
 ```
 
 Our custom column isn't all that useful empty, so let's update the Dataset Collection with some values.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset_collection.py!lines=59-67}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset_collection.py:update_custom_column_values"
 ```
 
 ## 6. Query the Dataset Collection
@@ -83,7 +83,7 @@ Our custom column isn't all that useful empty, so let's update the Dataset Colle
 If you want to query your DatasetCollection for items that match certain criteria, you can do so using the `query` method.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset_collection.py!lines=71-74}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset_collection.py:query_collection"
 ```
 
 ## 7. Save a snapshot of the Dataset Collection
@@ -91,7 +91,7 @@ If you want to query your DatasetCollection for items that match certain criteri
 Finally, let's save a snapshot of the Dataset Collection. This creates a read-only version of the Dataset Collection that captures the current state of the Dataset Collection and can be referenced later.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset_collection.py!lines=77}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset_collection.py:snapshot_collection"
 ```
 
 ## Source Code for this Tutorial
@@ -100,7 +100,7 @@ Finally, let's save a snapshot of the Dataset Collection. This creates a read-on
   <summary>Click to show me</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/dataset_collection.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/dataset_collection.py"
 ```
 </details>
 

--- a/docs/tutorials/python/download_data_by_synid.md
+++ b/docs/tutorials/python/download_data_by_synid.md
@@ -28,7 +28,7 @@ Create a dictionary that maps each Synapse ID to the local path where that file
 should be saved. Files can be directed to different directories as needed.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/download_data_by_synid.py!lines=13-30}
+--8<-- "docs/tutorials/python/tutorial_scripts/download_data_by_synid.py:syn_id_mapping"
 ```
 
 
@@ -38,7 +38,7 @@ Use `File.get_async()` together with `asyncio.gather` to kick off every download
 at the same time and wait for them all to finish.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/download_data_by_synid.py!lines=31-43}
+--8<-- "docs/tutorials/python/tutorial_scripts/download_data_by_synid.py:concurrent_download"
 ```
 
 <details class="example">
@@ -55,7 +55,7 @@ Retrieved 12 files
   <summary>Click to show me</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/download_data_by_synid.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/download_data_by_synid.py"
 ```
 </details>
 

--- a/docs/tutorials/python/download_data_in_bulk.md
+++ b/docs/tutorials/python/download_data_in_bulk.md
@@ -168,6 +168,6 @@ File in single_cell_RNAseq_batch_2: SRR12345678_R2.fastq.gz
   <summary>Click to show me</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/download_data_in_bulk.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/download_data_in_bulk.py"
 ```
 </details>

--- a/docs/tutorials/python/entityview.md
+++ b/docs/tutorials/python/entityview.md
@@ -44,7 +44,7 @@ and [File](./file.md) tutorials.
 
 First let's set up some constants we'll use in this script, and find the ID of our project
 ```python
-{!docs/tutorials/python/tutorial_scripts/entityview.py!lines=5-22}
+--8<-- "docs/tutorials/python/tutorial_scripts/entityview.py:setup"
 ```
 
 ## 2. Create a EntityView with Columns
@@ -53,19 +53,19 @@ Now, we will create 4 columns to add to our EntityView. Recall that any data add
 these columns will be stored as an annotation on the underlying File.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/entityview.py!lines=24-31}
+--8<-- "docs/tutorials/python/tutorial_scripts/entityview.py:create_columns"
 ```
 
 Next we're going to store what we have to Synapse and print out the results
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/entityview.py!lines=33-47}
+--8<-- "docs/tutorials/python/tutorial_scripts/entityview.py:create_view"
 ```
 
 ## 3. Query the EntityView
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/entityview.py!lines=49-54}
+--8<-- "docs/tutorials/python/tutorial_scripts/entityview.py:query_view"
 ```
 
 <details class="example">
@@ -85,7 +85,7 @@ value. Since the results were returned as a Pandas DataFrame you have many
 options to search through and set values on your data.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/entityview.py!lines=56-66}
+--8<-- "docs/tutorials/python/tutorial_scripts/entityview.py:update_rows"
 ```
 
 A note on `wait_for_eventually_consistent_view`: EntityViews in Synapse are eventually
@@ -104,7 +104,7 @@ to include in your view. In order to accomplish this you may modify the `scope_i
 attribute on your view.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/entityview.py!lines=69-73}
+--8<-- "docs/tutorials/python/tutorial_scripts/entityview.py:update_scope"
 ```
 
 ## 6. Update the types of Entities included in your EntityView
@@ -113,7 +113,7 @@ You may also want to change what types of Entities may be included in your view.
 accomplish this you'll be modifying the `view_type_mask` attribute on your view.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/entityview.py!lines=75-79}
+--8<-- "docs/tutorials/python/tutorial_scripts/entityview.py:update_view_type_mask"
 ```
 
 ## Results
@@ -128,7 +128,7 @@ Synapse web UI. It should look similar to:
   <summary>Click to show me</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/entityview.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/entityview.py"
 ```
 </details>
 

--- a/docs/tutorials/python/evaluation.md
+++ b/docs/tutorials/python/evaluation.md
@@ -20,7 +20,7 @@ In this tutorial you will:
 In this first part, we'll be showing you how to interact with an Evaluation object as well as introducing you to its two core functionalities `store()` and `get()`.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/evaluation.py!lines=5-46}
+--8<-- "docs/tutorials/python/tutorial_scripts/evaluation.py:create_and_update"
 ```
 
 ## 2. Update the ACL of an Evaluation on Synapse
@@ -28,13 +28,13 @@ In this first part, we'll be showing you how to interact with an Evaluation obje
 Like Synapse entities, Evaluations have ACLs that can be used to control who has access to your evaluations and what level of access they have. Updating the ACL of an Evaluation object is slightly different from updating other Evaluation components, because the ACL is not an attribute of the Evaluation object. Let's see an example of how this looks:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/evaluation.py!lines=54-64}
+--8<-- "docs/tutorials/python/tutorial_scripts/evaluation.py:update_acl"
 ```
 
 You can also remove principals from an ACL by simply feeding `update_acl` an empty list for the `access_type` argument, like so:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/evaluation.py!lines=66-67}
+--8<-- "docs/tutorials/python/tutorial_scripts/evaluation.py:remove_from_acl"
 ```
 
 ## 3. Retrieve and delete all Evaluations from a given Project
@@ -42,7 +42,7 @@ You can also remove principals from an ACL by simply feeding `update_acl` an emp
 Now we will show how you can retrieve lists of Evaluation objects, rather than retrieving them one-by-one with `get()`. This is a powerful tool if you want to perform the same action on all the evaluations in a given project, for example, like what we're about to do here:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/evaluation.py!lines=69-75}
+--8<-- "docs/tutorials/python/tutorial_scripts/evaluation.py:retrieve_and_delete"
 ```
 
 ## Source code for this tutorial
@@ -51,7 +51,7 @@ Now we will show how you can retrieve lists of Evaluation objects, rather than r
   <summary>Click to show me</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/evaluation.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/evaluation.py"
 ```
 </details>
 

--- a/docs/tutorials/python/file.md
+++ b/docs/tutorials/python/file.md
@@ -50,19 +50,19 @@ In this tutorial you will:
 
 #### First let's retrieve all of the Synapse IDs we are going to use
 ```python
-{!docs/tutorials/python/tutorial_scripts/file.py!lines=5-30}
+--8<-- "docs/tutorials/python/tutorial_scripts/file.py:retrieve_folder_ids"
 ```
 
 #### Next let's create all of the File objects to upload content
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/file.py!lines=32-75}
+--8<-- "docs/tutorials/python/tutorial_scripts/file.py:create_file_objects"
 ```
 
 #### Finally we'll store the files in Synapse
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/file.py!lines=77-85}
+--8<-- "docs/tutorials/python/tutorial_scripts/file.py:store_files"
 ```
 
 
@@ -83,7 +83,7 @@ Uploading [####################]100.00%   2.0bytes/2.0bytes (1.8bytes/s) SRR1234
 ## 2. Print stored attributes about your files
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/file.py!lines=87-99}
+--8<-- "docs/tutorials/python/tutorial_scripts/file.py:print_attributes"
 ```
 
 <details class="example">
@@ -103,7 +103,7 @@ My file was last modified on: 2023-12-28T21:55:17.971Z
 Now that your project has a number of Folders and Files let's explore how we can traverse the content stored within the Project.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/file.py!lines=101-112}
+--8<-- "docs/tutorials/python/tutorial_scripts/file.py:walk_project"
 ```
 
 
@@ -138,7 +138,7 @@ Now that you have created your files you'll be able to inspect this on the Files
   <summary>Click to show me</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/file.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/file.py"
 ```
 </details>
 

--- a/docs/tutorials/python/folder.md
+++ b/docs/tutorials/python/folder.md
@@ -55,13 +55,13 @@ In this tutorial you will:
 ## 1. Create a new folder
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/folder.py!lines=5-35}
+--8<-- "docs/tutorials/python/tutorial_scripts/folder.py:create_folder"
 ```
 
 ## 2. Print stored attributes about your folder
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/folder.py!lines=35-49}
+--8<-- "docs/tutorials/python/tutorial_scripts/folder.py:print_attributes"
 ```
 
 <details class="example">
@@ -79,7 +79,7 @@ My folder was last modified on: 2023-12-28T20:52:50.193Z
 ## 3. Create 2 sub-folders
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/folder.py!lines=52-59}
+--8<-- "docs/tutorials/python/tutorial_scripts/folder.py:create_subfolders"
 ```
 
 ## Results
@@ -94,7 +94,7 @@ Now that you have created your folders you'll be able to inspect this on the Fil
   <summary>Click to show me</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/folder.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/folder.py"
 ```
 </details>
 

--- a/docs/tutorials/python/json_schema.md
+++ b/docs/tutorials/python/json_schema.md
@@ -25,13 +25,13 @@ By the end of this tutorial, you will:
 ## 1. Set Up Synapse Python Client
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=1-10}
+--8<-- "docs/tutorials/python/tutorial_scripts/json_schema.py:setup"
 ```
 
 ## 2. Take a Look at the Constants and Structure of the JSON Schema
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=13-43}
+--8<-- "docs/tutorials/python/tutorial_scripts/json_schema.py:constants_and_schema"
 ```
 
 Derived annotations allow you to define default values for annotations based on schema rules, ensuring consistency and reducing manual input errors. As you can see here, you could use derived annotations to prescribe default annotation values. Please read more about derived annotations [here](https://help.synapse.org/docs/JSON-Schemas.3107291536.html#JSONSchemas-DerivedAnnotations).
@@ -40,12 +40,12 @@ Derived annotations allow you to define default values for annotations based on 
 ## 3. Try Create Test Organization and JSON Schema if They Do Not Exist
 Next, try creating a test organization and register a schema if they do not already exist:
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=46-62}
+--8<-- "docs/tutorials/python/tutorial_scripts/json_schema.py:create_org_and_schema"
 ```
 
 Note: If you update your schema, you can re-register it with the organization by assigning a new version number to reflect the changes. Synapse does not allow re-creating a schema with the same version number, so please ensure that each schema version within an organization is unique:
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=64-97}
+--8<-- "docs/tutorials/python/tutorial_scripts/json_schema.py:update_schema_version"
 ```
 
 ## 4. Bind the JSON Schema to the Folder
@@ -54,7 +54,7 @@ After creating the organization, you can now bind your json schema to a test fol
 When you bind the schema, you may also include the boolean property `enable_derived_annotations` to have Synapse automatically calculate derived annotations based on the schema:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=100-108}
+--8<-- "docs/tutorials/python/tutorial_scripts/json_schema.py:bind_schema"
 ```
 
 <details class="example">
@@ -77,7 +77,7 @@ JSON schema was bound successfully. Please see details below:
 ## 5. Retrieve the Bound Schema
 Next, we can retrieve the bound schema:
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=110-113}
+--8<-- "docs/tutorials/python/tutorial_scripts/json_schema.py:retrieve_bound_schema"
 ```
 
 <details class="example">
@@ -106,12 +106,12 @@ JSON Schema was retrieved successfully. Please see details below:
 ## 6. Add Invalid Annotations to the Folder and Store, and Validate the Folder against the Schema
 Try adding invalid annotations to your folder: This step and the step below demonstrate how the system handles invalid annotations and how the schema validation process works.
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=115-119}
+--8<-- "docs/tutorials/python/tutorial_scripts/json_schema.py:add_invalid_annotations"
 ```
 
 Try validating the folder. You should be able to see messages related to invalid annotations.
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=123-125}
+--8<-- "docs/tutorials/python/tutorial_scripts/json_schema.py:validate_folder"
 ```
 
 
@@ -147,12 +147,12 @@ This step is only relevant for container entities, such as a folder or a project
 
 Try creating a test file locally and store the file in the folder that we created earlier. Then, try adding invalid annotations to that file. This step demonstrates how the files inside a folder also inherit the schema from the parent entity.
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=129-134}
+--8<-- "docs/tutorials/python/tutorial_scripts/json_schema.py:create_file_with_invalid_annotations"
 ```
 
 You could then use `get_schema_validation_statistics` to get information such as the number of children with invalid annotations inside a container.
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=137-141}
+--8<-- "docs/tutorials/python/tutorial_scripts/json_schema.py:validation_statistics"
 ```
 
 
@@ -171,7 +171,7 @@ Validation statistics were retrieved successfully. Please see details below:
 
 You could also use `get_invalid_validation` to see more detailed results of all the children inside a container, which includes all validation messages and validation exception details.
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!lines=143-146}
+--8<-- "docs/tutorials/python/tutorial_scripts/json_schema.py:invalid_validation_details"
 ```
 
 <details class="example">
@@ -206,7 +206,7 @@ In the synapse web UI, you could also see your invalid annotations being marked 
   <summary>Click to show me</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/json_schema.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/json_schema.py"
 ```
 </details>
 

--- a/docs/tutorials/python/materializedview.md
+++ b/docs/tutorials/python/materializedview.md
@@ -30,7 +30,7 @@ You will want to replace `"My uniquely named project about Alzheimer's Disease"`
 the name of your project.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/materializedview.py!lines=3-72}
+--8<-- "docs/tutorials/python/tutorial_scripts/materializedview.py:setup"
 ```
 
 ## 2. Create and query a Materialized View
@@ -39,7 +39,7 @@ First, we will create a simple Materialized View that selects all rows from a ta
 then query it to retrieve the results.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/materializedview.py!lines=75-97}
+--8<-- "docs/tutorials/python/tutorial_scripts/materializedview.py:basic_view"
 ```
 
 <details class="example">
@@ -62,7 +62,7 @@ Next, we will create a Materialized View that combines data from two tables usin
 clause and then query it to retrieve the results.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/materializedview.py!lines=100-130}
+--8<-- "docs/tutorials/python/tutorial_scripts/materializedview.py:join_view"
 ```
 
 <details class="example">
@@ -86,7 +86,7 @@ rows from another table using a LEFT JOIN clause and then query it to retrieve t
 results.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/materializedview.py!lines=133-163}
+--8<-- "docs/tutorials/python/tutorial_scripts/materializedview.py:left_join_view"
 ```
 
 <details class="example">
@@ -111,7 +111,7 @@ matches rows from another table using a RIGHT JOIN clause and then query it to r
 the results.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/materializedview.py!lines=166-196}
+--8<-- "docs/tutorials/python/tutorial_scripts/materializedview.py:right_join_view"
 ```
 
 <details class="example">
@@ -135,7 +135,7 @@ Finally, we can create a Materialized View that combines rows from two tables us
 UNION clause and then query it to retrieve the results.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/materializedview.py!lines=199-229}
+--8<-- "docs/tutorials/python/tutorial_scripts/materializedview.py:union_view"
 ```
 
 <details class="example">
@@ -160,7 +160,7 @@ Results from the materialized view with UNION:
   <summary>Click to show me</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/materializedview.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/materializedview.py"
 ```
 </details>
 

--- a/docs/tutorials/python/migration.md
+++ b/docs/tutorials/python/migration.md
@@ -81,7 +81,7 @@ Detailed tracebacks are saved in the exception column of the CSV:
   <summary>Click to show me</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/migration.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/migration.py"
 ```
 </details>
 

--- a/docs/tutorials/python/project.md
+++ b/docs/tutorials/python/project.md
@@ -89,7 +89,7 @@ I just got my project: My uniquely named project about Alzheimer's Disease, id: 
   <summary>Click to show me</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/project.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/project.py"
 ```
 </details>
 

--- a/docs/tutorials/python/proxy_storage_location.md
+++ b/docs/tutorials/python/proxy_storage_location.md
@@ -90,7 +90,7 @@ your proxy server.
   <summary>Click to show me</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/proxy_storage_location.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/proxy_storage_location.py"
 ```
 </details>
 

--- a/docs/tutorials/python/sharing_settings.md
+++ b/docs/tutorials/python/sharing_settings.md
@@ -77,13 +77,13 @@ The inheritance and benefactor concepts apply consistently across all entity typ
 **⚠️ IMPORTANT**: Before running the tutorial, you MUST edit the script to set a valid `PRINCIPAL_ID`.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/sharing_settings.py!lines=17-34}
+--8<-- "docs/tutorials/python/tutorial_scripts/sharing_settings.py:setup_and_project"
 ```
 
 ## 2. Create a main folder to set custom sharing settings
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/sharing_settings.py!lines=36-45}
+--8<-- "docs/tutorials/python/tutorial_scripts/sharing_settings.py:create_main_folder"
 ```
 
 ## 3. Examine Current Permissions
@@ -91,7 +91,7 @@ The inheritance and benefactor concepts apply consistently across all entity typ
 The `get_permissions()` method returns the permissions that the current user has on an entity
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/sharing_settings.py!lines=46-49}
+--8<-- "docs/tutorials/python/tutorial_scripts/sharing_settings.py:get_permissions"
 ```
 
 <details class="example">
@@ -108,7 +108,7 @@ Current user permissions on main folder: ['READ', 'UPDATE', 'CREATE', 'DELETE', 
 The `get_acl()` method gets the specific permissions for a given principal (user or team):
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/sharing_settings.py!lines=51-62}
+--8<-- "docs/tutorials/python/tutorial_scripts/sharing_settings.py:get_acl"
 ```
 
 Depending on if you've already given permissions to given user/team your may see
@@ -129,7 +129,7 @@ Principal ######## permissions on folder only: []
 Use `set_permissions()` to grant specific permissions to a user or team:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/sharing_settings.py!lines=63-79}
+--8<-- "docs/tutorials/python/tutorial_scripts/sharing_settings.py:set_permissions"
 ```
 
 <details class="example">
@@ -149,7 +149,7 @@ Verified new permissions: ['DOWNLOAD', 'READ']
 Create a sub-folder and give it more restrictive permissions than its parent:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/sharing_settings.py!lines=80-101}
+--8<-- "docs/tutorials/python/tutorial_scripts/sharing_settings.py:create_sub_folder"
 ```
 
 <details class="example">
@@ -171,7 +171,7 @@ the `log_tree=True` argument for the method we can get an ascii tree representat
 the ACLs on the project. Alternatively you will also be able to loop over the data.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/sharing_settings.py!lines=102-117}
+--8<-- "docs/tutorials/python/tutorial_scripts/sharing_settings.py:list_acl"
 ```
 
 <details class="example">
@@ -209,7 +209,7 @@ Using `overwrite=False` will allow you to add Permissions Non-destructively.
 **Note:** The default behavior is `overwrite=True` which will replace the permissions for the given Principal.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/sharing_settings.py!lines=118-132}
+--8<-- "docs/tutorials/python/tutorial_scripts/sharing_settings.py:advanced_permissions"
 ```
 
 <details class="example">
@@ -227,7 +227,7 @@ Updated permissions after adding UPDATE: ['READ', 'DOWNLOAD', 'UPDATE']
 Remove permissions for a specific principal by setting an empty access type list:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/sharing_settings.py!lines=133-147}
+--8<-- "docs/tutorials/python/tutorial_scripts/sharing_settings.py:remove_permissions"
 ```
 
 <details class="example">
@@ -245,7 +245,7 @@ After removal - Principal ####### permissions: []
 Use `delete_permissions()` to remove entire ACLs and revert to inheritance:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/sharing_settings.py!lines=149-167}
+--8<-- "docs/tutorials/python/tutorial_scripts/sharing_settings.py:delete_acls"
 ```
 
 <details class="example">
@@ -282,7 +282,7 @@ Sub-folder now inherits permissions: []
 Get a complete view of your permission structure:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/sharing_settings.py!lines=168-172}
+--8<-- "docs/tutorials/python/tutorial_scripts/sharing_settings.py:final_overview"
 ```
 
 <details class="example">
@@ -344,7 +344,7 @@ ACL Tree Structure:
   <summary>Click to show me</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/sharing_settings.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/sharing_settings.py"
 ```
 </details>
 

--- a/docs/tutorials/python/submission.md
+++ b/docs/tutorials/python/submission.md
@@ -65,7 +65,7 @@ As an organizer of a Synapse challenge, you will
 Script setup:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submission_participant.py!lines=13-30}
+--8<-- "docs/tutorials/python/tutorial_scripts/submission_participant.py:setup"
 ```
 
 ## 1. Participating in a Synapse challenge
@@ -73,37 +73,37 @@ Script setup:
 ### 1. Make a submission to an existing evaluation queue on Synapse
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submission_participant.py!lines=32-54}
+--8<-- "docs/tutorials/python/tutorial_scripts/submission_participant.py:make_submission"
 ```
 
 ### 2. Fetch your existing submission
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submission_participant.py!lines=56-71}
+--8<-- "docs/tutorials/python/tutorial_scripts/submission_participant.py:fetch_submission"
 ```
 
 ### 3. Count your submissions
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submission_participant.py!lines=72-82}
+--8<-- "docs/tutorials/python/tutorial_scripts/submission_participant.py:count_submissions"
 ```
 
 ### 4. Fetch all of your submissions from an existing evaluation queue on Synapse
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submission_participant.py!lines=82-95}
+--8<-- "docs/tutorials/python/tutorial_scripts/submission_participant.py:fetch_all_submissions"
 ```
 
 ### 5. Check the status of your submission
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submission_participant.py!lines=97-119}
+--8<-- "docs/tutorials/python/tutorial_scripts/submission_participant.py:check_status"
 ```
 
 ### 6. Cancel your submission
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submission_participant.py!lines=120-137}
+--8<-- "docs/tutorials/python/tutorial_scripts/submission_participant.py:cancel_submission"
 ```
 
 ## 2. Organizing a Synapse challenge
@@ -112,37 +112,37 @@ Script setup:
 Script setup:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submission_organizer.py!lines=12-31}
+--8<-- "docs/tutorials/python/tutorial_scripts/submission_organizer.py:setup"
 ```
 
 ### 1. Annotate a submission to score it
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submission_organizer.py!lines=33-60}
+--8<-- "docs/tutorials/python/tutorial_scripts/submission_organizer.py:annotate_submission"
 ```
 
 ### 2. Batch-update submission statuses
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submission_organizer.py!lines=62-99}
+--8<-- "docs/tutorials/python/tutorial_scripts/submission_organizer.py:batch_update"
 ```
 
 ### 3. Fetch the submission bundle for a given submission
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submission_organizer.py!lines=101-136}
+--8<-- "docs/tutorials/python/tutorial_scripts/submission_organizer.py:fetch_bundle"
 ```
 
 ### 4. Allow cancellation of submissions
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submission_organizer.py!lines=138-177}
+--8<-- "docs/tutorials/python/tutorial_scripts/submission_organizer.py:allow_cancellation"
 ```
 
 ### 5. Delete submissions
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submission_organizer.py!lines=179-209}
+--8<-- "docs/tutorials/python/tutorial_scripts/submission_organizer.py:delete_submissions"
 ```
 
 ## Source code for this tutorial
@@ -151,7 +151,7 @@ Script setup:
   <summary>Click to show me (source code for Participant)</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submission_participant.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/submission_participant.py"
 ```
 </details>
 
@@ -159,7 +159,7 @@ Script setup:
   <summary>Click to show me (source code for Organizer)</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submission_organizer.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/submission_organizer.py"
 ```
 </details>
 

--- a/docs/tutorials/python/submissionview.md
+++ b/docs/tutorials/python/submissionview.md
@@ -35,7 +35,7 @@ The name of the Evaluation must also be globally unique. Please update
 `"Test Evaluation Queue for Alzheimer conference"` with a new value.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submissionview.py!lines=13-44}
+--8<-- "docs/tutorials/python/tutorial_scripts/submissionview.py:setup_and_evaluation"
 ```
 
 ## 2. Create a SubmissionView for the evaluation queue
@@ -45,7 +45,7 @@ in its scope. We'll also add custom columns for metrics that will be used for sc
 submissions.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submissionview.py!lines=46-82}
+--8<-- "docs/tutorials/python/tutorial_scripts/submissionview.py:create_submissionview"
 ```
 
 ## 3. Create and submit a file to the evaluation queue
@@ -54,7 +54,7 @@ Now let's create a test file and submit it to our evaluation queue. For convenie
 we'll use a temporary file that will be automatically cleaned up after execution.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submissionview.py!lines=84-105}
+--8<-- "docs/tutorials/python/tutorial_scripts/submissionview.py:submit_file"
 ```
 
 ## 4. Query and update the submission status
@@ -66,7 +66,7 @@ Note: Due to Synapse's eventual consistency model, we need to wait briefly for t
 submission to appear in the view.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submissionview.py!lines=107-126}
+--8<-- "docs/tutorials/python/tutorial_scripts/submissionview.py:query_and_update"
 ```
 
 <details class="example">
@@ -93,7 +93,7 @@ The name of the Evaluation must also be globally unique. Please update
 `"Second Test Evaluation Queue for Alzheimer conference"` with a new value.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submissionview.py!lines=128-143}
+--8<-- "docs/tutorials/python/tutorial_scripts/submissionview.py:modify_scope"
 ```
 
 ## 6. Create a snapshot of the view
@@ -102,7 +102,7 @@ SubmissionViews support creating snapshots, which capture the state of all submi
 specific point in time. This is useful for archiving or comparing submission states.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submissionview.py!lines=145-152}
+--8<-- "docs/tutorials/python/tutorial_scripts/submissionview.py:create_snapshot"
 ```
 
 ## 7. Query the snapshot
@@ -111,7 +111,7 @@ After creating a snapshot, you can query it to retrieve the state of submissions
 time the snapshot was created. This is useful for historical analysis or auditing.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submissionview.py!lines=153-162}
+--8<-- "docs/tutorials/python/tutorial_scripts/submissionview.py:query_snapshot"
 ```
 
 ## Source Code for this Tutorial
@@ -120,7 +120,7 @@ time the snapshot was created. This is useful for historical analysis or auditin
   <summary>Click to show me</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/submissionview.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/submissionview.py"
 ```
 </details>
 

--- a/docs/tutorials/python/tutorial_scripts/annotation.py
+++ b/docs/tutorials/python/tutorial_scripts/annotation.py
@@ -2,6 +2,7 @@
 Here is where you'll find the code for the Annotation tutorial.
 """
 
+# --8<-- [start:retrieve_synapse_ids]
 # Step 1: Add several annotations to stored files
 import os
 
@@ -21,7 +22,9 @@ batch_1_folder = Folder(
 ).get()
 
 print(f"Batch 1 Folder ID: {batch_1_folder.id}")
+# --8<-- [end:retrieve_synapse_ids]
 
+# --8<-- [start:define_annotations]
 # Define the annotations I want to set
 annotation_values = {
     "species": "Homo sapiens",
@@ -29,7 +32,9 @@ annotation_values = {
     "assay": "SCRNA-seq",
     "fileFormat": "fastq",
 }
+# --8<-- [end:define_annotations]
 
+# --8<-- [start:set_annotations_loop]
 batch_1_folder.sync_from_synapse(download_file=False)
 # Loop over all of the files and set their annotations
 for file_batch_1 in batch_1_folder.files:
@@ -48,7 +53,9 @@ for file_batch_1 in batch_1_folder.files:
     print(
         f"Set the annotations for File: {file_batch_1.name}, ID: {file_batch_1.id}, Annotations: {existing_annotations_for_file}"
     )
+# --8<-- [end:set_annotations_loop]
 
+# --8<-- [start:upload_with_annotations]
 # Step 2: Upload 2 new files and set the annotations at the same time
 # In order for the following script to work please replace the files with ones that
 # already exist on your local machine.
@@ -75,3 +82,4 @@ print(
 print(
     f"Stored file: {batch_1_scrnaseq_new_file_2.name}, ID: {batch_1_scrnaseq_new_file_2.id}, Annotations: {batch_1_scrnaseq_new_file_2.annotations}"
 )
+# --8<-- [end:upload_with_annotations]

--- a/docs/tutorials/python/tutorial_scripts/dataset.py
+++ b/docs/tutorials/python/tutorial_scripts/dataset.py
@@ -1,5 +1,6 @@
 """Here is where you'll find the code for the dataset tutorial."""
 
+# --8<-- [start:setup]
 import pandas as pd
 
 from synapseclient import Synapse
@@ -22,44 +23,60 @@ project = Project(
 ).get()  # Replace with your project name
 project_id = project.id
 print(f"My project ID is {project_id}")
+# --8<-- [end:setup]
 
+# --8<-- [start:create_dataset]
 # Next, let's create the dataset. We'll use the project id as the parent id.
 # To begin, the dataset will be empty, but if you view the dataset's schema in the UI,
 # you will notice that datasets come with default columns.
 my_new_dataset = Dataset(parent_id=project_id, name="My New Dataset").store()
 print(f"My Dataset's ID is {my_new_dataset.id}")
+# --8<-- [end:create_dataset]
 
 # Now, let's add some files to the dataset. There are three ways to add files to a dataset:
 # 1. Add an Entity Reference to a file with its ID and version
+# --8<-- [start:add_entity_ref]
 my_new_dataset.add_item(
     EntityRef(id="syn51790029", version=1)
 )  # Replace with the ID of the file you want to add
+# --8<-- [end:add_entity_ref]
 # 2. Add a File with its ID and version
+# --8<-- [start:add_file]
 my_new_dataset.add_item(
     File(id="syn51790028", version_number=1)
 )  # Replace with the ID of the file you want to add
+# --8<-- [end:add_file]
 # 3. Add a Folder. In this case, all child files of the folder are added to the dataset recursively.
+# --8<-- [start:add_folder]
 my_new_dataset.add_item(
     Folder(id="syn64893446")
 )  # Replace with the ID of the folder you want to add
+# --8<-- [end:add_folder]
 # Our changes won't be persisted to Synapse until we call the store() method.
+# --8<-- [start:store_dataset]
 my_new_dataset.store()
+# --8<-- [end:store_dataset]
 
 # Now that our Dataset with all of our files has been created, the next time
 # we want to use it, we can retrieve it from Synapse.
+# --8<-- [start:retrieve_dataset]
 my_retrieved_dataset = Dataset(id=my_new_dataset.id).get()
 print(f"My Dataset's ID is {my_retrieved_dataset.id}")
 print(len(my_retrieved_dataset.items))
+# --8<-- [end:retrieve_dataset]
 
 # If you want to query your dataset for files that match certain criteria, you can do so
 # using the query method.
+# --8<-- [start:query_dataset]
 rows = Dataset.query(
     query=f"SELECT * FROM {my_retrieved_dataset.id} WHERE name like '%test%'"
 )
 print(rows)
+# --8<-- [end:query_dataset]
 
 # In addition to the default columns, you may want to annotate items in your dataset using
 # custom columns.
+# --8<-- [start:add_custom_column]
 my_retrieved_dataset.add_column(
     column=Column(
         name="my_annotation",
@@ -67,8 +84,10 @@ my_retrieved_dataset.add_column(
     )
 )
 my_retrieved_dataset.store()
+# --8<-- [end:add_custom_column]
 
 # Now that our custom column has been added, we can update the dataset with new values.
+# --8<-- [start:update_custom_column_values]
 modified_data = pd.DataFrame(
     {
         "id": "syn51790028",  # The ID of one of our Files
@@ -78,11 +97,14 @@ modified_data = pd.DataFrame(
 my_retrieved_dataset.update_rows(
     values=modified_data, primary_keys=["id"], dry_run=False
 )
+# --8<-- [end:update_custom_column_values]
 
 
 # Finally, let's save a snapshot of the dataset.
+# --8<-- [start:snapshot_dataset]
 snapshot_info = my_retrieved_dataset.snapshot(
     comment="My first snapshot",
     label="My first snapshot",
 )
 print(snapshot_info)
+# --8<-- [end:snapshot_dataset]

--- a/docs/tutorials/python/tutorial_scripts/dataset.py
+++ b/docs/tutorials/python/tutorial_scripts/dataset.py
@@ -25,10 +25,11 @@ project_id = project.id
 print(f"My project ID is {project_id}")
 # --8<-- [end:setup]
 
-# --8<-- [start:create_dataset]
 # Next, let's create the dataset. We'll use the project id as the parent id.
 # To begin, the dataset will be empty, but if you view the dataset's schema in the UI,
 # you will notice that datasets come with default columns.
+
+# --8<-- [start:create_dataset]
 my_new_dataset = Dataset(parent_id=project_id, name="My New Dataset").store()
 print(f"My Dataset's ID is {my_new_dataset.id}")
 # --8<-- [end:create_dataset]

--- a/docs/tutorials/python/tutorial_scripts/dataset_collection.py
+++ b/docs/tutorials/python/tutorial_scripts/dataset_collection.py
@@ -1,5 +1,6 @@
 """Here is where you'll find the code for the DatasetCollection tutorial."""
 
+# --8<-- [start:setup]
 import pandas as pd
 
 from synapseclient import Synapse
@@ -14,6 +15,7 @@ project = Project(
 ).get()  # Replace with your project name
 project_id = project.id
 print(f"My project ID is {project_id}")
+# --8<-- [end:setup]
 
 # This tutorial assumes that you have already created datasets that you would like to add to a DatasetCollection.
 # If you need help creating datasets, you can refer to the dataset tutorial.
@@ -22,6 +24,7 @@ print(f"My project ID is {project_id}")
 # Let's create the DatasetCollection. We'll use the project id as the parent id.
 # At first, the DatasetCollection will be empty, but if you view the DatasetCollection's schema in the UI,
 # you will notice that DatasetCollections come with default columns.
+# --8<-- [start:create_collection]
 DATASET_IDS = [
     "syn65987017",
     "syn65987019",
@@ -31,22 +34,30 @@ test_dataset_collection = DatasetCollection(
     parent_id=project_id, name="test_dataset_collection"
 ).store()
 print(f"My DatasetCollection's ID is {test_dataset_collection.id}")
+# --8<-- [end:create_collection]
 
 # Now, let's add some datasets to the collection. We will loop through our dataset ids and add each dataset to the
 # collection using the `add_item` method.
+# --8<-- [start:add_datasets]
 for dataset_id in DATASET_IDS:
     test_dataset_collection.add_item(Dataset(id=dataset_id).get())
+# --8<-- [end:add_datasets]
 # Our changes won't be persisted to Synapse until we call the `store` method on our DatasetCollection.
+# --8<-- [start:store_collection]
 test_dataset_collection.store()
+# --8<-- [end:store_collection]
 
 # Now that our DatasetCollection with all of our datasets has been created, the next time we want to use it,
 # we can retrieve it from Synapse.
+# --8<-- [start:retrieve_collection]
 my_retrieved_dataset_collection = DatasetCollection(id=test_dataset_collection.id).get()
 print(f"My DatasetCollection's ID is still {my_retrieved_dataset_collection.id}")
 print(f"My DatasetCollection has {len(my_retrieved_dataset_collection.items)} items")
+# --8<-- [end:retrieve_collection]
 
 # In addition to the default columns, you may want to annotate items in your DatasetCollection using
 # custom columns.
+# --8<-- [start:add_custom_column]
 my_retrieved_dataset_collection.add_column(
     column=Column(
         name="my_annotation",
@@ -54,8 +65,10 @@ my_retrieved_dataset_collection.add_column(
     )
 )
 my_retrieved_dataset_collection.store()
+# --8<-- [end:add_custom_column]
 
 # Now that our custom column has been added, we can update the DatasetCollection with new annotations.
+# --8<-- [start:update_custom_column_values]
 modified_data = pd.DataFrame(
     {
         "id": DATASET_IDS,
@@ -65,13 +78,18 @@ modified_data = pd.DataFrame(
 my_retrieved_dataset_collection.update_rows(
     values=modified_data, primary_keys=["id"], dry_run=False
 )
+# --8<-- [end:update_custom_column_values]
 
 # If you want to query your DatasetCollection for items that match certain criteria, you can do so
 # using the `query` method.
+# --8<-- [start:query_collection]
 rows = my_retrieved_dataset_collection.query(
     query=f"SELECT id, my_annotation FROM {my_retrieved_dataset_collection.id} WHERE my_annotation = 'good dataset'"
 )
 print(rows)
+# --8<-- [end:query_collection]
 
 # Create a snapshot of the DatasetCollection
+# --8<-- [start:snapshot_collection]
 my_retrieved_dataset_collection.snapshot(comment="test snapshot")
+# --8<-- [end:snapshot_collection]

--- a/docs/tutorials/python/tutorial_scripts/download_data_by_synid.py
+++ b/docs/tutorials/python/tutorial_scripts/download_data_by_synid.py
@@ -10,6 +10,7 @@ from synapseclient.models import File
 syn = Synapse()
 syn.login()
 
+# --8<-- [start:syn_id_mapping]
 # A mapping of Synapse IDs to the local directory each file should be downloaded to.
 # Files can be directed to different directories as needed.
 SYN_IDS_AND_PATHS = {
@@ -26,8 +27,10 @@ SYN_IDS_AND_PATHS = {
     "syn60584405": "~/temp/subdir2",
     "syn60584400": "~/temp/subdir3",
 }
+# --8<-- [end:syn_id_mapping]
 
 
+# --8<-- [start:concurrent_download]
 async def main():
     # Build a list of concurrent download tasks — one per Synapse ID
     tasks = []
@@ -41,3 +44,4 @@ async def main():
 
 
 asyncio.run(main())
+# --8<-- [end:concurrent_download]

--- a/docs/tutorials/python/tutorial_scripts/entityview.py
+++ b/docs/tutorials/python/tutorial_scripts/entityview.py
@@ -2,6 +2,7 @@
 Here is where you'll find the code for the EntityView tutorial.
 """
 
+# --8<-- [start:setup]
 import pandas as pd
 
 from synapseclient import Synapse
@@ -20,7 +21,9 @@ syn.login()
 # First let's get the project we want to create the EntityView in
 my_project = Project(name="My uniquely named project about Alzheimer's Disease").get()
 project_id = my_project.id
+# --8<-- [end:setup]
 
+# --8<-- [start:create_columns]
 # Next let's add some columns to the EntityView, the data in these columns will end up
 # being stored as annotations on the files
 columns = [
@@ -29,7 +32,9 @@ columns = [
     Column(name="assay", column_type=ColumnType.STRING),
     Column(name="fileFormat", column_type=ColumnType.STRING),
 ]
+# --8<-- [end:create_columns]
 
+# --8<-- [start:create_view]
 # Then we will create a EntityView that is scoped to the project, and will contain a row
 # for each file in the project
 view = EntityView(
@@ -45,14 +50,18 @@ print(f"My EntityView ID is: {view.id}")
 # When the columns are printed you'll notice that it contains a number of columns that
 # are automatically added by Synapse in addition to the ones we added
 print(view.columns.keys())
+# --8<-- [end:create_view]
 
+# --8<-- [start:query_view]
 # Query the EntityView
 results_as_dataframe: pd.DataFrame = query(
     query=f"SELECT id, name, species, dataType, assay, fileFormat, path FROM {view.id} WHERE path like '%single_cell_RNAseq_batch_1%'",
     include_row_id_and_row_version=False,
 )
 print(results_as_dataframe)
+# --8<-- [end:query_view]
 
+# --8<-- [start:update_rows]
 # Finally let's update the annotations on the files in the project
 results_as_dataframe["species"] = ["Homo sapiens"] * len(results_as_dataframe)
 results_as_dataframe["dataType"] = ["geneExpression"] * len(results_as_dataframe)
@@ -64,16 +73,21 @@ view.update_rows(
     primary_keys=["id"],
     wait_for_eventually_consistent_view=True,
 )
+# --8<-- [end:update_rows]
 
 
+# --8<-- [start:update_scope]
 # Over time you may have a need to add or remove scopes from the EntityView, you may
 # use `add` or `remove` along with the Synapse ID of the scope you wish to add/remove
 view.scope_ids.add("syn1234")
 # view.scope_ids.remove("syn1234")
 view.store()
+# --8<-- [end:update_scope]
 
+# --8<-- [start:update_view_type_mask]
 # You may also need to add or remove the types of Entities that may show up in your view
 # You will be able to specify multiple types using the bitwise OR operator, or a single value
 view.view_type_mask = ViewTypeMask.FILE | ViewTypeMask.FOLDER
 # view.view_type_mask = ViewTypeMask.FILE
 view.store()
+# --8<-- [end:update_view_type_mask]

--- a/docs/tutorials/python/tutorial_scripts/evaluation.py
+++ b/docs/tutorials/python/tutorial_scripts/evaluation.py
@@ -2,6 +2,7 @@
 Here is where you'll find the code for the Evaluation tutorial.
 """
 
+# --8<-- [start:create_and_update]
 from synapseclient import Synapse
 from synapseclient.models import Evaluation, Project
 
@@ -44,6 +45,7 @@ evaluation.store()
 print("Evaluation has been updated with the following name and description:")
 print(evaluation.name)
 print(evaluation.description)
+# --8<-- [end:create_and_update]
 
 # Confirm what's in Synapse matches the evaluation stored
 from_synapse = Evaluation(id=evaluation.id).get()
@@ -51,6 +53,7 @@ from_synapse = Evaluation(id=evaluation.id).get()
 print("The following evaluation has been retrieved from Synapse:")
 print(from_synapse)
 
+# --8<-- [start:update_acl]
 # Update the Evaluation's ACL on Synapse by adding a new user
 assert (
     PRINCIPAL_ID is not None
@@ -62,10 +65,14 @@ evaluation.update_acl(principal_id=PRINCIPAL_ID, access_type=["READ", "SUBMIT"])
 acl = evaluation.get_acl()
 print("The following ACL has been retrieved from Synapse:")
 print(acl)
+# --8<-- [end:update_acl]
 
+# --8<-- [start:remove_from_acl]
 # Now let's remove the user we just added from the Evaluation's ACL
 evaluation.update_acl(principal_id=PRINCIPAL_ID, access_type=[])
+# --8<-- [end:remove_from_acl]
 
+# --8<-- [start:retrieve_and_delete]
 # Finally let's retrieve all Evaluations stored within this project, including the one we just created
 evaluations_list = Evaluation.get_evaluations_by_project(project_id)
 
@@ -73,3 +80,4 @@ evaluations_list = Evaluation.get_evaluations_by_project(project_id)
 # for evaluation_to_delete in evaluations_list:
 #     print(f"Deleting evaluation: {evaluation_to_delete.name}")
 #     evaluation_to_delete.delete()
+# --8<-- [end:retrieve_and_delete]

--- a/docs/tutorials/python/tutorial_scripts/file.py
+++ b/docs/tutorials/python/tutorial_scripts/file.py
@@ -2,6 +2,7 @@
 Here is where you'll find the code for the File tutorial.
 """
 
+# --8<-- [start:retrieve_folder_ids]
 # Step 1: Upload several files to Synapse
 import os
 
@@ -27,7 +28,9 @@ biospecimen_experiment_1_folder = Folder(
 biospecimen_experiment_2_folder = Folder(
     parent_id=my_project.id, name="biospecimen_experiment_2"
 ).get()
+# --8<-- [end:retrieve_folder_ids]
 
+# --8<-- [start:create_file_objects]
 # Create a File object for each file I want to upload
 biospecimen_experiment_1_a_2022 = File(
     path=os.path.expanduser("~/my_ad_project/biospecimen_experiment_1/fileA.txt"),
@@ -72,7 +75,9 @@ batch_2_scrnaseq_file_2 = File(
     ),
     parent_id=batch_2_folder.id,
 )
+# --8<-- [end:create_file_objects]
 
+# --8<-- [start:store_files]
 # Upload each file to Synapse
 biospecimen_experiment_1_a_2022.store()
 biospecimen_experiment_1_b_2022.store()
@@ -82,7 +87,9 @@ batch_1_scrnaseq_file_1.store()
 batch_1_scrnaseq_file_2.store()
 batch_2_scrnaseq_file_1.store()
 batch_2_scrnaseq_file_2.store()
+# --8<-- [end:store_files]
 
+# --8<-- [start:print_attributes]
 # Step 2: Print stored attributes about your file
 batch_1_scrnaseq_file_1_id = batch_1_scrnaseq_file_1.id
 print(f"My file ID is: {batch_1_scrnaseq_file_1_id}")
@@ -96,7 +103,9 @@ print(
 )
 
 print(f"My file was last modified on: {batch_1_scrnaseq_file_1.modified_on}")
+# --8<-- [end:print_attributes]
 
+# --8<-- [start:walk_project]
 # Step 3: List all Folders and Files within my project
 my_project.sync_from_synapse(download_file=False)
 dir_mapping = my_project.map_directory_to_all_contained_files("./")
@@ -104,3 +113,4 @@ for directory_name, file_entities in dir_mapping.items():
     print(f"Directory: {directory_name}")
     for file_entity in file_entities:
         print(f"\tFile: {file_entity.name}, ID: {file_entity.id}")
+# --8<-- [end:walk_project]

--- a/docs/tutorials/python/tutorial_scripts/folder.py
+++ b/docs/tutorials/python/tutorial_scripts/folder.py
@@ -34,8 +34,9 @@ biospecimen_experiment_2_folder = Folder(
 biospecimen_experiment_2_folder.store()
 
 # --8<-- [start:print_attributes]
-# Step 2: Print stored attributes about your folder
+
 # --8<-- [end:create_folder]
+# Step 2: Print stored attributes about your folder
 my_scrnaseq_batch_1_folder_id = my_scrnaseq_batch_1_folder.id
 print(f"My folder ID is: {my_scrnaseq_batch_1_folder_id}")
 
@@ -49,11 +50,12 @@ print(
 
 print(f"My folder was last modified on: {my_scrnaseq_batch_1_folder.modified_on}")
 
-# Step 3: Create 2 sub-folders
 # --8<-- [end:print_attributes]
+
+# --8<-- [start:create_subfolders]
+# Step 3: Create 2 sub-folders
 hierarchical_root_folder = Folder(name="experiment_notes", parent_id=my_project.id)
 hierarchical_root_folder.store()
-# --8<-- [start:create_subfolders]
 
 folder_notes_2023 = Folder(name="notes_2023", parent_id=hierarchical_root_folder.id)
 folder_notes_2023.store()

--- a/docs/tutorials/python/tutorial_scripts/folder.py
+++ b/docs/tutorials/python/tutorial_scripts/folder.py
@@ -2,6 +2,7 @@
 Here is where you'll find the code for the Folder tutorial.
 """
 
+# --8<-- [start:create_folder]
 # Step 1: Create a new folder
 import synapseclient
 from synapseclient.models import Folder, Project
@@ -32,7 +33,9 @@ biospecimen_experiment_2_folder = Folder(
 )
 biospecimen_experiment_2_folder.store()
 
+# --8<-- [start:print_attributes]
 # Step 2: Print stored attributes about your folder
+# --8<-- [end:create_folder]
 my_scrnaseq_batch_1_folder_id = my_scrnaseq_batch_1_folder.id
 print(f"My folder ID is: {my_scrnaseq_batch_1_folder_id}")
 
@@ -47,11 +50,14 @@ print(
 print(f"My folder was last modified on: {my_scrnaseq_batch_1_folder.modified_on}")
 
 # Step 3: Create 2 sub-folders
+# --8<-- [end:print_attributes]
 hierarchical_root_folder = Folder(name="experiment_notes", parent_id=my_project.id)
 hierarchical_root_folder.store()
+# --8<-- [start:create_subfolders]
 
 folder_notes_2023 = Folder(name="notes_2023", parent_id=hierarchical_root_folder.id)
 folder_notes_2023.store()
 
 folder_notes_2022 = Folder(name="notes_2022", parent_id=hierarchical_root_folder.id)
 folder_notes_2022.store()
+# --8<-- [end:create_subfolders]

--- a/docs/tutorials/python/tutorial_scripts/folder.py
+++ b/docs/tutorials/python/tutorial_scripts/folder.py
@@ -32,10 +32,9 @@ biospecimen_experiment_2_folder = Folder(
     name="biospecimen_experiment_2", parent_id=my_project.id
 )
 biospecimen_experiment_2_folder.store()
+# --8<-- [end:create_folder]
 
 # --8<-- [start:print_attributes]
-
-# --8<-- [end:create_folder]
 # Step 2: Print stored attributes about your folder
 my_scrnaseq_batch_1_folder_id = my_scrnaseq_batch_1_folder.id
 print(f"My folder ID is: {my_scrnaseq_batch_1_folder_id}")

--- a/docs/tutorials/python/tutorial_scripts/json_schema.py
+++ b/docs/tutorials/python/tutorial_scripts/json_schema.py
@@ -1,3 +1,4 @@
+# --8<-- [start:setup]
 import time
 from pprint import pprint
 
@@ -8,8 +9,10 @@ from synapseclient.models import File, Folder, JSONSchema, Project, SchemaOrgani
 # 1. Set up Synapse Python client
 syn = synapseclient.Synapse()
 syn.login()
+# --8<-- [end:setup]
 
 # 2. Take a look at the constants and structure of the JSON schema
+# --8<-- [start:constants_and_schema]
 # Replace your own project name here
 PROJECT_ENT = Project(name="My uniquely named project about Alzheimer's Disease").get()
 # Replace your own json schema organization name here
@@ -41,8 +44,10 @@ schema_body = {
         },
     },
 }
+# --8<-- [end:constants_and_schema]
 
 # 3. Try create test organization and json schema if they do not exist
+# --8<-- [start:create_org_and_schema]
 organization = SchemaOrganization(name=ORG_NAME)
 try:
     organization.store()
@@ -60,7 +65,9 @@ except Exception as e:
     schema.store(schema_body=schema_body, version=VERSION)
 
 schema.get_body()
+# --8<-- [end:create_org_and_schema]
 
+# --8<-- [start:update_schema_version]
 # If you want to make an update, you can re-register your schema with the organization:
 updated_schema = {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -95,8 +102,10 @@ except synapseclient.core.exceptions.SynapseHTTPError as e:
 
 schema.store(schema_body=updated_schema, version=NEW_VERSION)
 schema.get_body(version=VERSION)
+# --8<-- [end:update_schema_version]
 # 4. Bind the JSON schema to the folder
 
+# --8<-- [start:bind_schema]
 # Create a test folder for JSON schema experiments
 test_folder = Folder(name="test_folder", parent_id=PROJECT_ENT.id).store()
 
@@ -106,25 +115,33 @@ bound_schema = test_folder.bind_schema(
 json_schema_version_info = bound_schema.json_schema_version_info
 syn.logger.info("JSON schema was bound successfully. Please see details below:")
 pprint(vars(json_schema_version_info))
+# --8<-- [end:bind_schema]
 
+# --8<-- [start:retrieve_bound_schema]
 # 5. Retrieve the Bound Schema
 schema = test_folder.get_schema()
 syn.logger.info("JSON Schema was retrieved successfully. Please see details below:")
 pprint(vars(schema))
+# --8<-- [end:retrieve_bound_schema]
 
+# --8<-- [start:add_invalid_annotations]
 # 6. Add Invalid Annotations to the Folder and Store
 test_folder.annotations = {
     "patient_id": "1234",
     "cognitive_score": "invalid str",
 }
 test_folder.store()
+# --8<-- [end:add_invalid_annotations]
 
 time.sleep(2)
+# --8<-- [start:validate_folder]
 
 validation_results = test_folder.validate_schema()
 syn.logger.info("Validation was completed. Please see details below:")
+# --8<-- [end:validate_folder]
 pprint(vars(validation_results))
 
+# --8<-- [start:create_file_with_invalid_annotations]
 # 7. Create a File with Invalid Annotations and Upload It
 # Then, view validation statistics and invalid validation results
 path_to_file = make_bogus_data_file(n=5)
@@ -132,16 +149,21 @@ path_to_file = make_bogus_data_file(n=5)
 annotations = {"patient_id": "123456", "cognitive_score": "invalid child str"}
 
 child_file = File(path=path_to_file, parent_id=test_folder.id, annotations=annotations)
+# --8<-- [end:create_file_with_invalid_annotations]
 child_file = child_file.store()
 time.sleep(2)
+# --8<-- [start:validation_statistics]
 
 validation_statistics = test_folder.get_schema_validation_statistics()
 syn.logger.info(
     "Validation statistics were retrieved successfully. Please see details below:"
 )
+# --8<-- [end:validation_statistics]
 pprint(vars(validation_statistics))
+# --8<-- [start:invalid_validation_details]
 
 invalid_validation = invalid_results = test_folder.get_invalid_validation()
 for child in invalid_validation:
     syn.logger.info("See details of validation results: ")
+    # --8<-- [end:invalid_validation_details]
     pprint(vars(child))

--- a/docs/tutorials/python/tutorial_scripts/materializedview.py
+++ b/docs/tutorials/python/tutorial_scripts/materializedview.py
@@ -1,5 +1,6 @@
 """Here is where you'll find the code for the MaterializedView tutorial."""
 
+# --8<-- [start:setup]
 import pandas as pd
 
 from synapseclient import Synapse
@@ -70,8 +71,10 @@ data2 = pd.DataFrame(
     ]
 )
 table2.upsert_rows(values=data2, primary_keys=["sample_id"])
+# --8<-- [end:setup]
 
 
+# --8<-- [start:basic_view]
 def create_materialized_view():
     """
     Example: Create a new materialized view with a defining SQL query.
@@ -97,6 +100,10 @@ def create_materialized_view():
     print(query_result)
 
 
+# --8<-- [end:basic_view]
+
+
+# --8<-- [start:join_view]
 def create_materialized_view_with_join():
     """
     Example: Create a materialized view with a JOIN clause.
@@ -130,6 +137,10 @@ def create_materialized_view_with_join():
     print(query_result)
 
 
+# --8<-- [end:join_view]
+
+
+# --8<-- [start:left_join_view]
 def create_materialized_view_with_left_join():
     """
     Example: Create a materialized view with a LEFT JOIN clause.
@@ -163,6 +174,10 @@ def create_materialized_view_with_left_join():
     print(query_result)
 
 
+# --8<-- [end:left_join_view]
+
+
+# --8<-- [start:right_join_view]
 def create_materialized_view_with_right_join():
     """
     Example: Create a materialized view with a RIGHT JOIN clause.
@@ -196,6 +211,10 @@ def create_materialized_view_with_right_join():
     print(query_result)
 
 
+# --8<-- [end:right_join_view]
+
+
+# --8<-- [start:union_view]
 def create_materialized_view_with_union():
     """
     Example: Create a materialized view with a UNION clause.
@@ -227,6 +246,9 @@ def create_materialized_view_with_union():
     # Print the results to the console
     print("Results from the materialized view with UNION:")
     print(query_result)
+
+
+# --8<-- [end:union_view]
 
 
 def main():

--- a/docs/tutorials/python/tutorial_scripts/sharing_settings.py
+++ b/docs/tutorials/python/tutorial_scripts/sharing_settings.py
@@ -14,6 +14,7 @@ Examples of principal IDs:
 - Public access: 273949
 """
 
+# --8<-- [start:setup_and_project]
 import synapseclient
 from synapseclient.models import Folder, Project
 
@@ -32,7 +33,9 @@ syn = synapseclient.login()
 # Step 1: Get or create a project for this tutorial
 print("=== Step 1: Getting project ===")
 project = Project(name="My uniquely named project about Alzheimer's Disease").get()
+# --8<-- [end:setup_and_project]
 
+# --8<-- [start:create_main_folder]
 # Step 2: Create a main folder to set custom sharing settings
 print("\n=== Step 2: Creating main to set custom permissions ===")
 main_folder = Folder(
@@ -43,11 +46,15 @@ main_folder = Folder(
 main_folder = main_folder.store()
 print(f"Created main folder: {main_folder.name} (ID: {main_folder.id})")
 
+# --8<-- [end:create_main_folder]
+# --8<-- [start:get_permissions]
 # Step 3: Demonstrate get_permissions() - Get current user's permissions
 print("\n=== Step 3: Getting current user's permissions ===")
 permissions = main_folder.get_permissions()
 print(f"Current user permissions on main folder: {permissions.access_types}")
+# --8<-- [end:get_permissions]
 
+# --8<-- [start:get_acl]
 # Step 4: Demonstrate get_acl() - Get ACL for specific principal
 print("\n=== Step 4: Getting ACL for specific principal ===")
 # First check what permissions the principal currently has (likely inherited from project)
@@ -60,6 +67,8 @@ print(
 folder_only_acl = main_folder.get_acl(principal_id=PRINCIPAL_ID, check_benefactor=False)
 print(f"Principal {PRINCIPAL_ID} permissions on folder only: {folder_only_acl}")
 
+# --8<-- [end:get_acl]
+# --8<-- [start:set_permissions]
 # Step 5: Demonstrate set_permissions() - Set specific permissions for the main folder
 print("\n=== Step 5: Setting permissions on main folder ===")
 main_folder_permissions = ["READ", "DOWNLOAD"]
@@ -77,6 +86,8 @@ print(
 new_acl = main_folder.get_acl(principal_id=PRINCIPAL_ID, check_benefactor=False)
 print(f"Verified new permissions: {new_acl}")
 
+# --8<-- [end:set_permissions]
+# --8<-- [start:create_sub_folder]
 # Step 6: Create a sub-folder with different sharing settings
 print("\n=== Step 6: Creating sub-folder with different permissions ===")
 sub_folder = Folder(
@@ -99,6 +110,8 @@ print(
     f"Set more restrictive permissions for principal {PRINCIPAL_ID} on sub-folder: {sub_folder_permissions}"
 )
 
+# --8<-- [end:create_sub_folder]
+# --8<-- [start:list_acl]
 # Step 7: Demonstrate list_acl() - List all ACLs
 print("\n=== Step 7: Listing ACLs ===")
 
@@ -115,6 +128,8 @@ for entity_acl in recursive_acl_result.all_entity_acls:
     for acl_entry in entity_acl.acl_entries:
         print(f"  Principal {acl_entry.principal_id}: {acl_entry.permissions}")
 
+# --8<-- [end:list_acl]
+# --8<-- [start:advanced_permissions]
 # Step 8: Demonstrate additional set_permissions() options
 print("\n=== Step 8: Demonstrating additional permission options ===")
 
@@ -130,6 +145,8 @@ main_folder.set_permissions(
 updated_acl = main_folder.get_acl(principal_id=PRINCIPAL_ID)
 print(f"Updated permissions after adding UPDATE: {updated_acl}")
 
+# --8<-- [end:advanced_permissions]
+# --8<-- [start:remove_permissions]
 # Step 9: Demonstrate permission removal using set_permissions with empty list
 print("\n=== Step 9: Removing specific permissions ===")
 print(
@@ -145,7 +162,9 @@ main_folder.set_permissions(
 
 removed_acl = main_folder.get_acl(principal_id=PRINCIPAL_ID)
 print(f"After removal - Principal {PRINCIPAL_ID} permissions: {removed_acl}")
+# --8<-- [end:remove_permissions]
 
+# --8<-- [start:delete_acls]
 # Step 10: Demonstrate delete_permissions() with dry run
 print("\n=== Step 10: Demonstrating delete_permissions() ===")
 
@@ -165,8 +184,11 @@ sub_folder.delete_permissions(include_self=True)
 inherited_acl = sub_folder.get_acl(principal_id=PRINCIPAL_ID)
 print(f"Sub-folder now inherits permissions: {inherited_acl}")
 
+# --8<-- [end:delete_acls]
+# --8<-- [start:final_overview]
 # Step 11: Final ACL overview
 print("\n=== Step 11: Final ACL overview ===")
 final_overview = main_folder.list_acl(
     recursive=True, include_container_content=True, log_tree=True
 )
+# --8<-- [end:final_overview]

--- a/docs/tutorials/python/tutorial_scripts/submission_organizer.py
+++ b/docs/tutorials/python/tutorial_scripts/submission_organizer.py
@@ -9,6 +9,8 @@ This tutorial demonstrates how to:
 5. Delete submissions
 """
 
+# --8<-- [start:setup]
+
 from synapseclient import Synapse
 from synapseclient.models import SubmissionBundle, SubmissionStatus
 
@@ -29,7 +31,9 @@ assert (
 
 print(f"Working with Evaluation: {EVALUATION_ID}")
 print(f"Managing Submission: {SUBMISSION_ID}")
+# --8<-- [end:setup]
 
+# --8<-- [start:annotate_submission]
 # ==============================================================================
 # 1. Annotate a submission to score it
 # ==============================================================================
@@ -58,7 +62,9 @@ print(f"Status: {updated_status.status}")
 print(f"Annotations added:")
 for key, value in updated_status.submission_annotations.items():
     print(f"  {key}: {value}")
+# --8<-- [end:annotate_submission]
 
+# --8<-- [start:batch_update]
 # ==============================================================================
 # 2. Batch-update submission statuses
 # ==============================================================================
@@ -97,6 +103,9 @@ if statuses_to_update:
 else:
     print("No submissions found with 'RECEIVED' status to update")
 
+# --8<-- [end:batch_update]
+
+# --8<-- [start:fetch_bundle]
 # ==============================================================================
 # 3. Fetch the submission bundle for a given submission
 # ==============================================================================
@@ -134,6 +143,9 @@ for i, bundle in enumerate(bundles[:5]):  # Show first 5
                 if key in ["accuracy", "f1_score", "precision", "recall"]:
                     print(f"    {key}: {value}")
 
+# --8<-- [end:fetch_bundle]
+
+# --8<-- [start:allow_cancellation]
 # ==============================================================================
 # 4. Allow cancellation of submissions
 # ==============================================================================
@@ -173,6 +185,9 @@ target_status.can_cancel = True
 target_status = target_status.store()
 print(f"Cancellation enabled for submission {SUBMISSION_ID}")
 
+# --8<-- [end:allow_cancellation]
+
+# --8<-- [start:delete_submissions]
 # ==============================================================================
 # 5. Delete submissions
 # ==============================================================================
@@ -206,3 +221,4 @@ print(f"\nDeletion step is commented out by default.")
 print(f"Uncomment the deletion code if you want to test this functionality.")
 
 print(f"\n=== Organizer tutorial completed! ===")
+# --8<-- [end:delete_submissions]

--- a/docs/tutorials/python/tutorial_scripts/submission_participant.py
+++ b/docs/tutorials/python/tutorial_scripts/submission_participant.py
@@ -75,6 +75,7 @@ print(f"  Submitter: {retrieved_submission.submitter_alias}")
 print(f"  Created On: {retrieved_submission.created_on}")
 
 # --8<-- [end:fetch_submission]
+
 # --8<-- [start:count_submissions]
 # ==============================================================================
 # 3. Count your submissions
@@ -85,11 +86,11 @@ print("\n=== 3. Counting submissions ===")
 # Get the total count of submissions for this evaluation
 submission_count = Submission.get_submission_count(evaluation_id=EVALUATION_ID)
 
-# --8<-- [start:fetch_all_submissions]
 print(f"Total submissions in evaluation: {submission_count}")
 # --8<-- [end:count_submissions]
 
 
+# --8<-- [start:fetch_all_submissions]
 # ==============================================================================
 # 4. Fetch all of your submissions from an existing evaluation queue
 # ==============================================================================
@@ -129,6 +130,7 @@ else:
     print(f"  No submission annotations available")
 
 # --8<-- [end:check_status]
+
 # --8<-- [start:cancel_submission]
 # ==============================================================================
 # 6. Cancel your submission (optional)
@@ -148,8 +150,8 @@ print("\n=== 6. Cancelling submission ===")
 
 print(f"\nCancellation is commented out by default.")
 print(f"Uncomment the cancellation code if you want to test this functionality.")
-# --8<-- [end:cancel_submission]
 
 print(f"\n=== Tutorial completed! ===")
 print(f"Your submission ID {submission_id} is ready for evaluation.")
 print(f"Check back later to see if the organizers have scored your submission.")
+# --8<-- [end:cancel_submission]

--- a/docs/tutorials/python/tutorial_scripts/submission_participant.py
+++ b/docs/tutorials/python/tutorial_scripts/submission_participant.py
@@ -10,6 +10,7 @@ This tutorial demonstrates how to:
 6. Cancel your submission
 """
 
+# --8<-- [start:setup]
 from synapseclient import Synapse
 from synapseclient.models import Submission, SubmissionStatus
 
@@ -28,7 +29,9 @@ assert (
 
 print(f"Working with Evaluation: {EVALUATION_ID}")
 print(f"Submitting Entity: {ENTITY_ID}")
+# --8<-- [end:setup]
 
+# --8<-- [start:make_submission]
 # ==============================================================================
 # 1. Make a submission to an existing evaluation queue on Synapse
 # ==============================================================================
@@ -52,7 +55,9 @@ print(f"Created On: {submission.created_on}")
 
 # Store the submission ID for later use
 submission_id = submission.id
+# --8<-- [end:make_submission]
 
+# --8<-- [start:fetch_submission]
 # ==============================================================================
 # 2. Fetch your existing submission
 # ==============================================================================
@@ -69,6 +74,8 @@ print(f"  Entity ID: {retrieved_submission.entity_id}")
 print(f"  Submitter: {retrieved_submission.submitter_alias}")
 print(f"  Created On: {retrieved_submission.created_on}")
 
+# --8<-- [end:fetch_submission]
+# --8<-- [start:count_submissions]
 # ==============================================================================
 # 3. Count your submissions
 # ==============================================================================
@@ -78,7 +85,9 @@ print("\n=== 3. Counting submissions ===")
 # Get the total count of submissions for this evaluation
 submission_count = Submission.get_submission_count(evaluation_id=EVALUATION_ID)
 
+# --8<-- [start:fetch_all_submissions]
 print(f"Total submissions in evaluation: {submission_count}")
+# --8<-- [end:count_submissions]
 
 
 # ==============================================================================
@@ -93,7 +102,9 @@ user_submissions = list(Submission.get_user_submissions(evaluation_id=EVALUATION
 print(f"Found {len(user_submissions)} submissions from the current user:")
 for i, sub in enumerate(user_submissions, 1):
     print(f"  {i}. ID: {sub.id}, Name: {sub.name}, Created: {sub.created_on}")
+# --8<-- [end:fetch_all_submissions]
 
+# --8<-- [start:check_status]
 # ==============================================================================
 # 5. Check the status of your submission
 # ==============================================================================
@@ -117,6 +128,8 @@ if status.submission_annotations:
 else:
     print(f"  No submission annotations available")
 
+# --8<-- [end:check_status]
+# --8<-- [start:cancel_submission]
 # ==============================================================================
 # 6. Cancel your submission (optional)
 # ==============================================================================
@@ -135,6 +148,7 @@ print("\n=== 6. Cancelling submission ===")
 
 print(f"\nCancellation is commented out by default.")
 print(f"Uncomment the cancellation code if you want to test this functionality.")
+# --8<-- [end:cancel_submission]
 
 print(f"\n=== Tutorial completed! ===")
 print(f"Your submission ID {submission_id} is ready for evaluation.")

--- a/docs/tutorials/python/tutorial_scripts/submissionview.py
+++ b/docs/tutorials/python/tutorial_scripts/submissionview.py
@@ -11,6 +11,8 @@ path and name as needed.
 
 """
 
+# --8<-- [start:setup_and_evaluation]
+
 import tempfile
 
 import pandas as pd
@@ -42,7 +44,9 @@ evaluation = Evaluation(
 )
 evaluation = syn.store(evaluation)
 print(f"Created evaluation queue with ID: {evaluation.id}")
+# --8<-- [end:setup_and_evaluation]
 
+# --8<-- [start:create_submissionview]
 # Step 2: Create a SubmissionView for the evaluation queue
 view = SubmissionView(
     name="SubmissionView for Alzheimer conference",
@@ -80,7 +84,9 @@ view.reorder_column(name="evaluationid", index=4)
 view.store()
 
 print("Available columns in the view:", list(view.columns.keys()))
+# --8<-- [end:create_submissionview]
 
+# --8<-- [start:submit_file]
 # Step 3: Create and submit a file to the evaluation queue
 with tempfile.NamedTemporaryFile(
     mode="w", suffix=".txt", delete=True, delete_on_close=False
@@ -103,7 +109,9 @@ with tempfile.NamedTemporaryFile(
     )
 
     print(f"Created submission with ID: {submission.id}")
+# --8<-- [end:submit_file]
 
+# --8<-- [start:query_and_update]
 # Step 4: Query and update the submission status
 # Query the SubmissionView to see our submission
 query = f"SELECT * FROM {view.id} WHERE id = '{submission.id}'"
@@ -124,7 +132,9 @@ submission_status.score = 0.7
 submission_status = syn.store(submission_status)
 print(f"Updated submission status to: {submission_status.status}")
 
+# --8<-- [end:query_and_update]
 # Step 5: Modify the SubmissionView scope
+# --8<-- [start:modify_scope]
 # First let's make sure we have the latest view from Synapse:
 view.get()
 
@@ -141,7 +151,9 @@ print(f"Created second evaluation queue with ID: {second_evaluation.id}")
 view.scope_ids.append(second_evaluation.id)
 view.store()  # Store the updated view
 print("Updated SubmissionView scope. Current scope IDs:", view.scope_ids)
+# --8<-- [end:modify_scope]
 
+# --8<-- [start:create_snapshot]
 # Step 6: Create a snapshot of the view
 snapshot_info = view.snapshot(
     comment="Initial submission review snapshot",
@@ -150,6 +162,8 @@ print("Created snapshot of the SubmissionView:")
 print(snapshot_info)
 snapshot_version = snapshot_info.snapshot_version_number
 print(f"Snapshot version number: {snapshot_version}")
+# --8<-- [end:create_snapshot]
+# --8<-- [start:query_snapshot]
 
 # Step 7: Query the snapshot we just created
 # You may also get the snapshot version from the view object directly by looking at the version number
@@ -160,3 +174,4 @@ snapshot_query = f"SELECT * FROM {view.id}.{snapshot_version}"
 snapshot_results = view.query(snapshot_query)
 print("Query results from the snapshot:")
 print(snapshot_results)
+# --8<-- [end:query_snapshot]

--- a/docs/tutorials/python/tutorial_scripts/virtualtable.py
+++ b/docs/tutorials/python/tutorial_scripts/virtualtable.py
@@ -1,5 +1,6 @@
 """Here is where you'll find the code for the VirtualTable tutorial."""
 
+# --8<-- [start:setup]
 import pandas as pd
 
 from synapseclient import Synapse
@@ -70,10 +71,12 @@ data2 = pd.DataFrame(
     ]
 )
 table2.upsert_rows(values=data2, primary_keys=["sample_id"])
+# --8<-- [end:setup]
 # Note: VirtualTables do not support JOIN or UNION operations in the defining_sql.
 # If you need to combine data from multiple tables, consider using a MaterializedView instead.
 
 
+# --8<-- [start:basic_view]
 def create_basic_virtual_table():
     """
     Example: Create a basic virtual table with a simple SELECT query.
@@ -99,6 +102,10 @@ def create_basic_virtual_table():
     print(query_result)
 
 
+# --8<-- [end:basic_view]
+
+
+# --8<-- [start:column_selection]
 def create_virtual_table_with_column_selection():
     """
     Example: Create a virtual table that selects only specific columns.
@@ -124,6 +131,10 @@ def create_virtual_table_with_column_selection():
     print(query_result)
 
 
+# --8<-- [end:column_selection]
+
+
+# --8<-- [start:filtering]
 def create_virtual_table_with_filtering():
     """
     Example: Create a virtual table with a WHERE clause for filtering.
@@ -149,6 +160,10 @@ def create_virtual_table_with_filtering():
     print(query_result)
 
 
+# --8<-- [end:filtering]
+
+
+# --8<-- [start:ordering]
 def create_virtual_table_with_ordering():
     """
     Example: Create a virtual table with an ORDER BY clause.
@@ -174,6 +189,10 @@ def create_virtual_table_with_ordering():
     print(query_result)
 
 
+# --8<-- [end:ordering]
+
+
+# --8<-- [start:aggregation]
 def create_virtual_table_with_aggregation():
     """
     Example: Create a virtual table with an aggregate function.
@@ -197,6 +216,9 @@ def create_virtual_table_with_aggregation():
     # Print the results to the console
     print("Results from the virtual table with aggregation:")
     print(query_result)
+
+
+# --8<-- [end:aggregation]
 
 
 def main():

--- a/docs/tutorials/python/tutorial_scripts/wiki.py
+++ b/docs/tutorials/python/tutorial_scripts/wiki.py
@@ -82,19 +82,20 @@ assert (
 ), "Wiki page title does not match after restore"
 # --8<-- [end:verify_restore]
 
-# --8<-- [start:get_wiki_by_id]
 # Get the wiki page
+
+# --8<-- [start:get_wiki_by_id]
 # Once you know the Wiki page id, you can retrieve the Wiki page with the id
 retrieved_wiki = WikiPage(owner_id=project.id, id=root_wiki_page.id).get()
 # --8<-- [end:get_wiki_by_id]
 
-# --8<-- [start:get_wiki_by_title]
 # Or you can retrieve the Wiki page with the title
+# --8<-- [start:get_wiki_by_title]
 retrieved_wiki = WikiPage(owner_id=project.id, title=root_wiki_page.title).get()
 # --8<-- [end:get_wiki_by_title]
 
-# --8<-- [start:verify_retrieved_wiki]
 # Check if the retrieved Wiki page is the same as the original Wiki page
+# --8<-- [start:verify_retrieved_wiki]
 assert (
     root_wiki_page.markdown_file_handle_id == retrieved_wiki.markdown_file_handle_id
 ), "Markdown file handle ID does not match retrieved wiki page"
@@ -106,8 +107,8 @@ assert (
 ), "Wiki page title does not match retrieved wiki page"
 # --8<-- [end:verify_retrieved_wiki]
 
-# --8<-- [start:create_sub_wiki]
 # Create a sub-wiki page
+# --8<-- [start:create_sub_wiki]
 sub_wiki_1 = WikiPage(
     owner_id=project.id,
     title="Sub Wiki Page 1",
@@ -244,8 +245,9 @@ wiki_page_attachment = WikiPage(owner_id=project.id, id=sub_wiki_4.id).get_attac
 unzipped_attachment_file_path = WikiPage.unzip_gzipped_file(wiki_page_attachment)
 # --8<-- [end:download_attachment]
 
-# --8<-- [start:get_attachment_preview_url]
 # Download an attachment preview. Instead of using the file_name from the attachmenthandle response when isPreview=True, you should use the original file name in the get_attachment_preview request. The downloaded file will still be named according to the file_name provided in the response when isPreview=True.
+
+# --8<-- [start:get_attachment_preview_url]
 # Get attachment preview URL without downloading
 attachment_preview_url = WikiPage(
     owner_id=project.id, id=sub_wiki_4.id
@@ -269,21 +271,22 @@ attachment_preview = WikiPage(
 # --8<-- [start:get_wiki_header_tree]
 # Section 4: WikiHeader - Working with Wiki Hierarchy
 # Get wiki header tree (hierarchy)
-# --8<-- [end:get_wiki_header_tree]
 headers = WikiHeader.get(owner_id=project.id)
+# --8<-- [end:get_wiki_header_tree]
 
 # --8<-- [start:get_wiki_history]
 # Section 5. WikiHistorySnapshot - Version History
 # Get wiki history for root_wiki_page
-# --8<-- [end:get_wiki_history]
 history = WikiHistorySnapshot.get(owner_id=project.id, id=root_wiki_page.id)
+# --8<-- [end:get_wiki_history]
 
 # --8<-- [start:get_order_hint]
 # Section 6. WikiOrderHint - Ordering Wiki Pages
 # Set the wiki order hint
-# --8<-- [end:get_order_hint]
-# --8<-- [start:set_order_hint]
 order_hint = WikiOrderHint(owner_id=project.id).get()
+# --8<-- [end:get_order_hint]
+
+# --8<-- [start:set_order_hint]
 # As you can see from the printed message, the order hint is not set by default, so you need to set it explicitly at the beginning.
 order_hint.id_list = [
     root_wiki_page.id,

--- a/docs/tutorials/python/tutorial_scripts/wiki.py
+++ b/docs/tutorials/python/tutorial_scripts/wiki.py
@@ -13,6 +13,7 @@ This script shows how to:
 
 """
 
+# --8<-- [start:setup_and_imports]
 import os
 
 from synapseclient import Synapse
@@ -29,7 +30,9 @@ syn.login()
 
 # Get the project
 project = Project(name="My uniquely named project about Alzheimer's Disease").get()
+# --8<-- [end:setup_and_imports]
 
+# --8<-- [start:create_root_wiki_plain_text]
 # Section1: Create, read, and update wiki pages
 # Create a new wiki page for the project with plain text markdown
 root_wiki_page = WikiPage(
@@ -37,7 +40,9 @@ root_wiki_page = WikiPage(
     title="My Root Wiki Page",
     markdown="# Welcome to My Root Wiki\n\nThis is a sample root wiki page created with the Synapse client.",
 ).store()
+# --8<-- [end:create_root_wiki_plain_text]
 
+# --8<-- [start:create_root_wiki_from_file]
 # OR you can create a wiki page with an existing markdown file. More instructions can be found in section 2.
 markdown_file_path = "path/to/your_markdown_file.md"
 root_wiki_page = WikiPage(
@@ -45,7 +50,9 @@ root_wiki_page = WikiPage(
     title="My First Root Wiki Page Version with existing markdown file",
     markdown=markdown_file_path,
 ).store()
+# --8<-- [end:create_root_wiki_from_file]
 
+# --8<-- [start:update_wiki_page]
 # Update the wiki page
 root_wiki_page_new = WikiPage(
     owner_id=project.id,
@@ -53,12 +60,16 @@ root_wiki_page_new = WikiPage(
     markdown="# Welcome to My Root Wiki NEW\n\nThis is a sample root wiki page created with the Synapse client.",
     id=root_wiki_page.id,
 ).store()
+# --8<-- [end:update_wiki_page]
 
+# --8<-- [start:restore_wiki_page]
 # Restore the wiki page to the original version
 wiki_page_restored = WikiPage(
     owner_id=project.id, id=root_wiki_page.id, wiki_version="0"
 ).restore()
+# --8<-- [end:restore_wiki_page]
 
+# --8<-- [start:verify_restore]
 # check if the content is restored
 assert (
     root_wiki_page.markdown_file_handle_id == wiki_page_restored.markdown_file_handle_id
@@ -69,14 +80,20 @@ assert (
 assert (
     root_wiki_page.title == wiki_page_restored.title
 ), "Wiki page title does not match after restore"
+# --8<-- [end:verify_restore]
 
+# --8<-- [start:get_wiki_by_id]
 # Get the wiki page
 # Once you know the Wiki page id, you can retrieve the Wiki page with the id
 retrieved_wiki = WikiPage(owner_id=project.id, id=root_wiki_page.id).get()
+# --8<-- [end:get_wiki_by_id]
 
+# --8<-- [start:get_wiki_by_title]
 # Or you can retrieve the Wiki page with the title
 retrieved_wiki = WikiPage(owner_id=project.id, title=root_wiki_page.title).get()
+# --8<-- [end:get_wiki_by_title]
 
+# --8<-- [start:verify_retrieved_wiki]
 # Check if the retrieved Wiki page is the same as the original Wiki page
 assert (
     root_wiki_page.markdown_file_handle_id == retrieved_wiki.markdown_file_handle_id
@@ -87,7 +104,9 @@ assert (
 assert (
     root_wiki_page.title == retrieved_wiki.title
 ), "Wiki page title does not match retrieved wiki page"
+# --8<-- [end:verify_retrieved_wiki]
 
+# --8<-- [start:create_sub_wiki]
 # Create a sub-wiki page
 sub_wiki_1 = WikiPage(
     owner_id=project.id,
@@ -95,7 +114,9 @@ sub_wiki_1 = WikiPage(
     parent_id=root_wiki_page.id,
     markdown="# Sub Page 1\n\nThis is a sub-page of another wiki.",
 ).store()
+# --8<-- [end:create_sub_wiki]
 
+# --8<-- [start:create_wiki_from_markdown_string]
 # Section 2: WikiPage Markdown Operations
 # Create wiki page from markdown text
 markdown_content = """# Sample Markdown Content
@@ -120,8 +141,10 @@ sub_wiki_2 = WikiPage(
     title="Sub Page 2 created from markdown text",
     markdown=markdown_content,
 ).store()
+# --8<-- [end:create_wiki_from_markdown_string]
 
 
+# --8<-- [start:create_wiki_from_markdown_file]
 # Create a wiki page from a markdown file
 markdown_file_path = "~/temp/temp_markdown_file.md.gz"
 
@@ -132,7 +155,9 @@ sub_wiki_3 = WikiPage(
     title="Sub Page 3 created from markdown file",
     markdown=markdown_file_path,
 ).store()
+# --8<-- [end:create_wiki_from_markdown_file]
 
+# --8<-- [start:get_markdown_file_url]
 # Download the markdown file
 # Note: If the markdown is generated from plain text using the client, the downloaded file will be named wiki_markdown_<wiki_page_title>.md.gz. If it is generated from an existing markdown file, the downloaded file will retain the original filename.
 # Download the markdown file for sub_wiki_2 that is created from markdown text
@@ -142,17 +167,23 @@ wiki_page_markdown_2_url = WikiPage(
 ).get_markdown_file(
     download_file=False,
 )
+# --8<-- [end:get_markdown_file_url]
 
+# --8<-- [start:download_markdown_from_text]
 # Download the markdown file for sub_wiki_2 that is created from markdown text
 wiki_page_markdown_2 = WikiPage(
     owner_id=project.id, id=sub_wiki_2.id
 ).get_markdown_file(download_file=True, download_location=".")
+# --8<-- [end:download_markdown_from_text]
 
+# --8<-- [start:download_markdown_from_file]
 # Download the markdown file for sub_wiki_3 that is created from a markdown file
 wiki_page_markdown_3 = WikiPage(
     owner_id=project.id, id=sub_wiki_3.id
 ).get_markdown_file(download_file=True, download_location=".")
+# --8<-- [end:download_markdown_from_file]
 
+# --8<-- [start:create_wiki_with_attachment]
 # Section 3: WikiPage with Attachments
 # Create a temporary file for the attachment
 attachment_file_name = "path/to/temp_attachment.txt"
@@ -168,7 +199,9 @@ sub_wiki_4 = WikiPage(
     markdown=f"# Sub Page 4 with Attachments\n\nThis is a attachment: ${{previewattachment?fileName={attachment_file_name_reformatted}}}",
     attachments=[attachment_file_name],
 ).store()
+# --8<-- [end:create_wiki_with_attachment]
 
+# --8<-- [start:create_wiki_with_image]
 # Inlucde images in the markdown file
 image_file_path = "path/to/test_image.png"
 # use the original file name instead of the gzipped file name for images
@@ -181,12 +214,16 @@ sub_wiki_5 = WikiPage(
     markdown=markdown_content,
     attachments=[image_file_path],
 ).store()
+# --8<-- [end:create_wiki_with_image]
 
+# --8<-- [start:get_attachment_handles]
 # Get attachment handles
 attachment_handles = WikiPage(
     owner_id=project.id, id=sub_wiki_4.id
 ).get_attachment_handles()
+# --8<-- [end:get_attachment_handles]
 
+# --8<-- [start:get_attachment_url]
 # Get attachment URL without downloading
 wiki_page_attachment_url = WikiPage(
     owner_id=project.id, id=sub_wiki_4.id
@@ -194,7 +231,9 @@ wiki_page_attachment_url = WikiPage(
     file_name=os.path.basename(attachment_file_name),
     download_file=False,
 )
+# --8<-- [end:get_attachment_url]
 
+# --8<-- [start:download_attachment]
 # Download an attachment
 wiki_page_attachment = WikiPage(owner_id=project.id, id=sub_wiki_4.id).get_attachment(
     file_name=os.path.basename(attachment_file_name),
@@ -203,7 +242,9 @@ wiki_page_attachment = WikiPage(owner_id=project.id, id=sub_wiki_4.id).get_attac
 )
 # Unzip the attachment file
 unzipped_attachment_file_path = WikiPage.unzip_gzipped_file(wiki_page_attachment)
+# --8<-- [end:download_attachment]
 
+# --8<-- [start:get_attachment_preview_url]
 # Download an attachment preview. Instead of using the file_name from the attachmenthandle response when isPreview=True, you should use the original file name in the get_attachment_preview request. The downloaded file will still be named according to the file_name provided in the response when isPreview=True.
 # Get attachment preview URL without downloading
 attachment_preview_url = WikiPage(
@@ -212,7 +253,9 @@ attachment_preview_url = WikiPage(
     file_name=os.path.basename(attachment_file_name),
     download_file=False,
 )
+# --8<-- [end:get_attachment_preview_url]
 
+# --8<-- [start:download_attachment_preview]
 # Download an attachment preview
 attachment_preview = WikiPage(
     owner_id=project.id, id=sub_wiki_4.id
@@ -221,17 +264,25 @@ attachment_preview = WikiPage(
     download_file=True,
     download_location=".",
 )
+# --8<-- [end:download_attachment_preview]
 
+# --8<-- [start:get_wiki_header_tree]
 # Section 4: WikiHeader - Working with Wiki Hierarchy
 # Get wiki header tree (hierarchy)
+# --8<-- [end:get_wiki_header_tree]
 headers = WikiHeader.get(owner_id=project.id)
 
+# --8<-- [start:get_wiki_history]
 # Section 5. WikiHistorySnapshot - Version History
 # Get wiki history for root_wiki_page
+# --8<-- [end:get_wiki_history]
 history = WikiHistorySnapshot.get(owner_id=project.id, id=root_wiki_page.id)
 
+# --8<-- [start:get_order_hint]
 # Section 6. WikiOrderHint - Ordering Wiki Pages
 # Set the wiki order hint
+# --8<-- [end:get_order_hint]
+# --8<-- [start:set_order_hint]
 order_hint = WikiOrderHint(owner_id=project.id).get()
 # As you can see from the printed message, the order hint is not set by default, so you need to set it explicitly at the beginning.
 order_hint.id_list = [
@@ -243,7 +294,9 @@ order_hint.id_list = [
     sub_wiki_5.id,
 ]
 order_hint.store()
+# --8<-- [end:set_order_hint]
 
+# --8<-- [start:update_order_hint]
 # Update wiki order hint
 order_hint = WikiOrderHint(owner_id=project.id).get()
 order_hint.id_list = [
@@ -255,7 +308,9 @@ order_hint.id_list = [
     sub_wiki_5.id,
 ]
 order_hint.store()
+# --8<-- [end:update_order_hint]
 
+# --8<-- [start:delete_wiki_page]
 # Delete a wiki page
 sub_wiki_6 = WikiPage(
     owner_id=project.id,
@@ -264,3 +319,4 @@ sub_wiki_6 = WikiPage(
     markdown=f"# Sub Page 6 to be deleted\n\nThis is a sub page to be deleted.",
 ).store()
 wiki_page_to_delete = WikiPage(owner_id=project.id, id=sub_wiki_6.id).delete()
+# --8<-- [end:delete_wiki_page]

--- a/docs/tutorials/python/virtualtable.md
+++ b/docs/tutorials/python/virtualtable.md
@@ -31,7 +31,7 @@ You will want to replace `"My uniquely named project about Alzheimer's Disease"`
 the name of your project.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=3-72}
+--8<-- "docs/tutorials/python/tutorial_scripts/virtualtable.py:setup"
 ```
 
 **Note**: Virtual Tables do not support JOIN or UNION operations in the defining SQL query.
@@ -44,7 +44,7 @@ First, we will create a simple Virtual Table that selects all rows from a table 
 then query it to retrieve the results.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=77-99}
+--8<-- "docs/tutorials/python/tutorial_scripts/virtualtable.py:basic_view"
 ```
 
 <details class="example">
@@ -66,7 +66,7 @@ Results from the basic virtual table:
 Next, we'll create a Virtual Table that selects only specific columns from the source table.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=102-124}
+--8<-- "docs/tutorials/python/tutorial_scripts/virtualtable.py:column_selection"
 ```
 
 <details class="example">
@@ -88,7 +88,7 @@ Results from the virtual table with column selection:
 We can create a Virtual Table that filters rows from the source table using a WHERE clause.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=127-149}
+--8<-- "docs/tutorials/python/tutorial_scripts/virtualtable.py:filtering"
 ```
 
 <details class="example">
@@ -107,7 +107,7 @@ Results from the virtual table with filtering:
 You can also create a Virtual Table that orders the rows from the source table using an ORDER BY clause.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=152-174}
+--8<-- "docs/tutorials/python/tutorial_scripts/virtualtable.py:ordering"
 ```
 
 <details class="example">
@@ -129,7 +129,7 @@ Results from the virtual table with ordering:
 Finally, we can create a Virtual Table that aggregates data using functions like COUNT, along with GROUP BY.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/virtualtable.py!lines=177-199}
+--8<-- "docs/tutorials/python/tutorial_scripts/virtualtable.py:aggregation"
 ```
 
 <details class="example">
@@ -148,7 +148,7 @@ Results from the virtual table with aggregation:
   <summary>Click to show me</summary>
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/virtualtable.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/virtualtable.py"
 ```
 </details>
 

--- a/docs/tutorials/python/wiki.md
+++ b/docs/tutorials/python/wiki.md
@@ -31,16 +31,16 @@ In this tutorial you will:
 ## 1. Create a Wiki page
 ### Initial setup
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=16-31}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:setup_and_imports"
 ```
 A Wiki page requires an owner object, a title, and markdown. Here is an example to create a new root Wiki page for your project with plain text markdown:
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=33-38}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:create_root_wiki_plain_text"
 ```
 
 Alternatively, you can create a Wiki page from an existing markdown file.
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=41-46}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:create_root_wiki_from_file"
 ```
 <details class="example">
   <summary>You'll notice the output looks like:</summary>
@@ -57,7 +57,7 @@ Created Wiki page: My Root Wiki Page with ID: ...
 To update an existing Wiki page, create a new WikiPage object with the same `id` and new content:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=48-54}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:update_wiki_page"
 ```
 
 <details class="example">
@@ -74,12 +74,12 @@ Updated Wiki page: My First Root Wiki Page NEW with ID: ...
 
 You can restore a Wiki page to any previous version by specifying the `Wiki_version` parameter:
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=56-59}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:restore_wiki_page"
 ```
 
 Check if the content is restored.
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=61-71}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:verify_restore"
 ```
 
 ## 4. Get a Wiki page
@@ -87,23 +87,23 @@ You can retrieve Wiki pages in several ways. To find a Wiki page id, you can get
 
 Once you know the Wiki page id, you can retrieve a specific Wiki page:
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=73-75}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:get_wiki_by_id"
 ```
 
 Alternatively, you can retrieve a Wiki page by its title:
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=77-78}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:get_wiki_by_title"
 ```
 
 Verify that the retrieved Wiki page matches the original Wiki page
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=80-89}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:verify_retrieved_wiki"
 ```
 
 ## 5. Create a sub-Wiki page
 You can create a sub-Wiki page under an existing Wiki page.
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=91-96}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:create_sub_wiki"
 ```
 <details class="example">
   <summary>You'll notice the output looks like:</summary>
@@ -119,7 +119,7 @@ Created sub-wiki page: Sub Wiki Page 1 with ID: ... under parent: ...
 You can create a Wiki page from a single-line or multi-line Python string. Here is an example of creating a Wiki page from a multi-line Python string:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=98-121}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:create_wiki_from_markdown_string"
 ```
 
 ### Create a Wiki page from a markdown file
@@ -127,7 +127,7 @@ You can create a Wiki page from a single-line or multi-line Python string. Here 
 You can also create a Wiki page from an existing markdown file. Markdown files may be uploaded in either non-gzipped or gzipped format:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=123-133}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:create_wiki_from_markdown_file"
 ```
 
 ## 7. Download Wiki page markdown
@@ -135,12 +135,12 @@ You can download the markdown content of a Wiki page back to a file.
 
 ### Download the markdown file URL for a Wiki page
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=135-143}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:get_markdown_file_url"
 ```
 
 ### Download the markdown file for a Wiki page that is created from plain text, the downloaded file will be named `wiki_markdown_<wiki_page_title>.md`
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=145-148}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:download_markdown_from_text"
 ```
 
 <details class="example">
@@ -153,7 +153,7 @@ Downloaded and unzipped the markdown file for wiki page ... to path/to/wiki_mark
 
 ### Download the markdown file for a Wiki page that is created from a markdown file
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=150-153}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:download_markdown_from_file"
 ```
 <details class="example">
   <summary>You'll notice the output looks like:</summary>
@@ -171,7 +171,7 @@ Wiki pages can include file attachments, which are useful for sharing supplement
 First, create a file to attach. Then create a Wiki page with the attachment. Note that attachment file names in markdown need special formatting: replace `.` with `%2E` and `_` with `%5F`. You can utilize the static method `WikiPage.reformat_attachment_file_name` to reformat the file name.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=155-169}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:create_wiki_with_attachment"
 ```
 
 <details class="example">
@@ -185,7 +185,7 @@ Created sub-wiki page: Sub Page 4 with Attachments with ID: ... under parent: ..
 
 To include images in your Wiki page, you DO NOT need to reformat the file name for image files (e.g., PNG, JPG, JPEG).
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=171-182}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:create_wiki_with_image"
 ```
 
 <details class="example">
@@ -202,7 +202,7 @@ Created sub-wiki page: Sub Page 5 with Attachments with ID: ... under parent: ..
 Retrieve the file handles of all attachments on a Wiki page:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=184-187}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:get_attachment_handles"
 ```
 
 <details class="example">
@@ -217,7 +217,7 @@ Retrieve the file handles of all attachments on a Wiki page:
 You can retrieve the URL of an attachment without downloading it. Attachment file name can be in either non-gzipped or gzipped format.
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=189-195}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:get_attachment_url"
 ```
 
 <details class="example">
@@ -231,14 +231,14 @@ You can retrieve the URL of an attachment without downloading it. Attachment fil
 
 Download an attachment file to your local machine and unzip it using `WikiPage.unzip_gzipped_file` function.
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=197-204}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:download_attachment"
 ```
 
 ### Get attachment preview URL
 You can also retrieve preview URLs for attachments. When using `get_attachment_preview`, specify the original file name, not the file name returned in the attachment handle response when isPreview=True. The file name can be in either non-gzipped or gzipped format.
 The downloaded file will still be named according to the file name provided in the response when isPreview=True. Note that image attachments do not have preview files.
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=206-213}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:get_attachment_preview_url"
 ```
 
 ### Download an attachment preview
@@ -246,7 +246,7 @@ The downloaded file will still be named according to the file name provided in t
 Download the preview version of an attachment:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=215-223}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:download_attachment_preview"
 ```
 
 The downloaded preview file will be named `preview.<your attachment file type>` (or according to the file name in the attachment handle response when `isPreview=True`).
@@ -260,7 +260,7 @@ WikiHeader allows you to retrieve the hierarchical structure of Wiki pages withi
 Retrieve the complete Wiki page hierarchy for a project:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=224-226}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:get_wiki_header_tree"
 ```
 
 <details class="example">
@@ -279,7 +279,7 @@ WikiHistorySnapshot provides access to the version history of Wiki pages, allowi
 Retrieve the version history for a specific Wiki page:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=228-230}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:get_wiki_history"
 ```
 <details class="example">
   <summary>You'll notice the output shows the history of versions:</summary>
@@ -297,7 +297,7 @@ WikiOrderHint allows you to control the order in which Wiki pages are displayed.
 First, retrieve the current order hint (which may be empty initially):
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=232-234}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:get_order_hint"
 ```
 
 <details class="example">
@@ -312,7 +312,7 @@ WikiOrderHint(owner_id='...', owner_object_type='ENTITY', id_list=[], etag='...'
 Set the order of Wiki pages by providing a list of Wiki page IDs in the desired order:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=235-244}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:set_order_hint"
 ```
 
 <details class="example">
@@ -327,7 +327,7 @@ WikiOrderHint(id_list=['...', '...', ...])
 You can update the order hint at any time by retrieving it, modifying the `id_list`, and storing it again:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=246-256}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:update_order_hint"
 ```
 
 ## 13. Delete Wiki pages
@@ -335,7 +335,7 @@ You can update the order hint at any time by retrieving it, modifying the `id_li
 Delete a Wiki page by providing the owner ID and Wiki page ID:
 
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!lines=258-265}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py:delete_wiki_page"
 ```
 
 ## Source Code for this Tutorial
@@ -343,7 +343,7 @@ Delete a Wiki page by providing the owner ID and Wiki page ID:
 <details class="quote">
   <summary>Click to show me</summary>
 ```python
-{!docs/tutorials/python/tutorial_scripts/wiki.py!}
+--8<-- "docs/tutorials/python/tutorial_scripts/wiki.py"
 ```
 </details>
 


### PR DESCRIPTION
# **Problem:**

Tutorial scripts were referenced in the markdown by it's code line indices which would have to be kept up to date if there was a change in the tutorial script. 

# **Solution:**

Use new code snippet style

# **Testing:**

NA

I manually went through every tutorial page and validated it against what's in the stable doc site: https://synapsepythonclient--1386.org.readthedocs.build/en/1386/