### PR TITLE
[SYNPY-1489] Added ability to set grid authorization type field to CurationTask

### DIFF
--- a/docs/guides/extensions/curator/metadata_curation.md
+++ b/docs/guides/extensions/curator/metadata_curation.md
@@ -139,7 +139,6 @@ Both [create_record_based_metadata_task][synapseclient.extensions.curator.create
 - `SOURCE_BENEFACTOR` extends access to anyone with `EDIT` rights on the source entity. Use it when curation should be open to all editors of the source.
 
 ```python
-from synapseclient.models import AuthorizationMode
 
 entity_view_id, task_id = create_file_based_metadata_task(
     synapse_client=syn,

--- a/docs/guides/extensions/curator/metadata_curation.md
+++ b/docs/guides/extensions/curator/metadata_curation.md
@@ -135,8 +135,8 @@ print(f"Created CurationTask: {task_id}")
 
 Both `create_record_based_metadata_task` and `create_file_based_metadata_task` accept an optional `suggested_authorization_mode` that tells clients how to scope access when a grid session is created for the task:
 
-- `AuthorizationMode.SESSION_OWNER` (the server default applied when the mode is omitted) limits access to the session owner and their team. Use it when curation should be restricted to a specific user or team.
-- `AuthorizationMode.SOURCE_BENEFACTOR` extends access to anyone with `EDIT` rights on the source entity. Use it when curation should be open to all editors of the source.
+- `SESSION_OWNER` (the server default applied when the mode is omitted) limits access to the session owner and their team. Use it when curation should be restricted to a specific user or team.
+- `SOURCE_BENEFACTOR` extends access to anyone with `EDIT` rights on the source entity. Use it when curation should be open to all editors of the source.
 
 ```python
 from synapseclient.models import AuthorizationMode
@@ -148,7 +148,7 @@ entity_view_id, task_id = create_file_based_metadata_task(
     instructions="Annotate each file with metadata according to the schema requirements.",
     entity_view_name="Animal Study Files View",
     schema_uri=schema_uri,
-    suggested_authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
+    suggested_authorization_mode="SOURCE_BENEFACTOR",
 )
 ```
 

--- a/docs/guides/extensions/curator/metadata_curation.md
+++ b/docs/guides/extensions/curator/metadata_curation.md
@@ -133,7 +133,7 @@ print(f"Created CurationTask: {task_id}")
 
 ### Controlling who can access the grid session
 
-Both [create_record_based_metadata_task][synapseclient.extensions.curator.create_record_based_metadata_task] and [create_file_based_metadata_task][synapseclient.extensions.curator.create_file_based_metadata_task] accept an optional `suggested_authorization_mode` that tells clients how to scope access when a grid session is created for the task:
+Both [create_record_based_metadata_task][synapseclient.extensions.curator.create_record_based_metadata_task] and [create_file_based_metadata_task][synapseclient.extensions.curator.create_file_based_metadata_task] accept an optional `authorization_mode` that tells clients how to scope access when a grid session is created for the task:
 
 - `SESSION_OWNER` (the server default applied when the mode is omitted) limits access to the session owner and their team. Use it when curation should be restricted to a specific user or team.
 - `SOURCE_BENEFACTOR` extends access to anyone with `EDIT` rights on the source entity. Use it when curation should be open to all editors of the source.
@@ -148,14 +148,14 @@ entity_view_id, task_id = create_file_based_metadata_task(
     instructions="Annotate each file with metadata according to the schema requirements.",
     entity_view_name="Animal Study Files View",
     schema_uri=schema_uri,
-    suggested_authorization_mode="SOURCE_BENEFACTOR",
+    authorization_mode="SOURCE_BENEFACTOR",
 )
 ```
 
 When [CurationTask.create_grid_session][synapseclient.models.CurationTask.create_grid_session] is later called, it forwards this mode to the new grid session and the server uses it to determine access: `SESSION_OWNER` limits access to the session owner (the caller, or an explicit `owner_principal_id`) and their team, while `SOURCE_BENEFACTOR` lets the session inherit access from the source entity's benefactor.
 
 !!! warning "Changing the mode invalidates the active session"
-    Updating `suggested_authorization_mode` on an existing task causes the server to automatically clear `activeSessionId` on the task status. The previously active grid session is no longer linked to the task, so you must create a new grid session before curation can continue.
+    Updating `authorization_mode` on an existing task causes the server to automatically clear `activeSessionId` on the task status. The previously active grid session is no longer linked to the task, so you must create a new grid session before curation can continue.
 
 ## Complete example script
 

--- a/docs/guides/extensions/curator/metadata_curation.md
+++ b/docs/guides/extensions/curator/metadata_curation.md
@@ -133,7 +133,7 @@ print(f"Created CurationTask: {task_id}")
 
 ### Controlling who can access the grid session
 
-Both `create_record_based_metadata_task` and `create_file_based_metadata_task` accept an optional `suggested_authorization_mode` that tells clients how to scope access when a grid session is created for the task:
+Both [create_record_based_metadata_task][synapseclient.extensions.curator.create_record_based_metadata_task] and [create_file_based_metadata_task][synapseclient.extensions.curator.create_file_based_metadata_task] accept an optional `suggested_authorization_mode` that tells clients how to scope access when a grid session is created for the task:
 
 - `SESSION_OWNER` (the server default applied when the mode is omitted) limits access to the session owner and their team. Use it when curation should be restricted to a specific user or team.
 - `SOURCE_BENEFACTOR` extends access to anyone with `EDIT` rights on the source entity. Use it when curation should be open to all editors of the source.

--- a/docs/guides/extensions/curator/metadata_curation.md
+++ b/docs/guides/extensions/curator/metadata_curation.md
@@ -135,7 +135,7 @@ print(f"Created CurationTask: {task_id}")
 
 Both `create_record_based_metadata_task` and `create_file_based_metadata_task` accept an optional `suggested_authorization_mode` that tells clients how to scope access when a grid session is created for the task:
 
-- `AuthorizationMode.SESSION_OWNER` (the default behavior when the mode is omitted) limits access to the session owner and their team. Use it when curation should be restricted to a specific user or team.
+- `AuthorizationMode.SESSION_OWNER` (the server default applied when the mode is omitted) limits access to the session owner and their team. Use it when curation should be restricted to a specific user or team.
 - `AuthorizationMode.SOURCE_BENEFACTOR` extends access to anyone with `EDIT` rights on the source entity. Use it when curation should be open to all editors of the source.
 
 ```python

--- a/docs/guides/extensions/curator/metadata_curation.md
+++ b/docs/guides/extensions/curator/metadata_curation.md
@@ -131,6 +131,32 @@ print(f"Created CurationTask: {task_id}")
 - Automatic schema binding to the folder for validation
 - Optional wiki attached to the folder
 
+### Controlling who can access the grid session
+
+Both `create_record_based_metadata_task` and `create_file_based_metadata_task` accept an optional `suggested_authorization_mode` that tells clients how to scope access when a grid session is created for the task:
+
+- `AuthorizationMode.SESSION_OWNER` (the default behavior when the mode is omitted) limits access to the session owner and their team. Use it when curation should be restricted to a specific user or team.
+- `AuthorizationMode.SOURCE_BENEFACTOR` extends access to anyone with `EDIT` rights on the source entity. Use it when curation should be open to all editors of the source.
+
+```python
+from synapseclient.models import AuthorizationMode
+
+entity_view_id, task_id = create_file_based_metadata_task(
+    synapse_client=syn,
+    folder_id="syn987654321",
+    curation_task_name="FileMetadata_Curation",
+    instructions="Annotate each file with metadata according to the schema requirements.",
+    entity_view_name="Animal Study Files View",
+    schema_uri=schema_uri,
+    suggested_authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
+)
+```
+
+When [CurationTask.create_grid_session][synapseclient.models.CurationTask.create_grid_session] is later called, it forwards this mode to the new grid session and the server uses it to determine access: `SESSION_OWNER` limits access to the session owner (the caller, or an explicit `owner_principal_id`) and their team, while `SOURCE_BENEFACTOR` lets the session inherit access from the source entity's benefactor.
+
+!!! warning "Changing the mode invalidates the active session"
+    Updating `suggested_authorization_mode` on an existing task causes the server to automatically clear `activeSessionId` on the task status. The previously active grid session is no longer linked to the task, so you must create a new grid session before curation can continue.
+
 ## Complete example script
 
 Here's the full script that demonstrates both workflow types:

--- a/docs/reference/experimental/async/curator.md
+++ b/docs/reference/experimental/async/curator.md
@@ -54,6 +54,12 @@ at your own risk.
         inherited_members: true
         members:
 ---
+[](){ #AuthorizationMode-reference-async }
+::: synapseclient.models.AuthorizationMode
+    options:
+        inherited_members: true
+        members:
+---
 [](){ #grid-reference-async }
 ::: synapseclient.models.Grid
     options:

--- a/docs/reference/experimental/sync/curator.md
+++ b/docs/reference/experimental/sync/curator.md
@@ -54,6 +54,12 @@ at your own risk.
         inherited_members: true
         members:
 ---
+[](){ #AuthorizationMode-reference }
+::: synapseclient.models.AuthorizationMode
+    options:
+        inherited_members: true
+        members:
+---
 [](){ #grid-reference }
 ::: synapseclient.models.Grid
     options:

--- a/synapseclient/extensions/curator/file_based_metadata_task.py
+++ b/synapseclient/extensions/curator/file_based_metadata_task.py
@@ -354,8 +354,8 @@ def create_file_based_metadata_task(
             attach_wiki=False,
             entity_view_name="Biospecimen Metadata View",
             schema_uri="sage.schemas.v2571-amp.Biospecimen.schema-0.0.1",
-            assignee_principal_id=123456,
-            view_type_mask=ViewTypeMask.FILE | ViewTypeMask.DOCKER,
+            assignee_principal_id=123456, # Optional: Assign to a user or team (can be str or int)
+            view_type_mask=ViewTypeMask.FILE | ViewTypeMask.DOCKER, # Optional: include additional entity types in the view
             suggested_authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
         )
         ```

--- a/synapseclient/extensions/curator/file_based_metadata_task.py
+++ b/synapseclient/extensions/curator/file_based_metadata_task.py
@@ -12,6 +12,7 @@ from synapseclient import Wiki  # type: ignore
 from synapseclient.core.exceptions import SynapseHTTPError  # type: ignore
 from synapseclient.extensions.curator.utils import project_id_from_entity_id
 from synapseclient.models import (  # type: ignore
+    AuthorizationMode,
     Column,
     ColumnType,
     EntityView,
@@ -325,6 +326,8 @@ def create_file_based_metadata_task(
     enable_derived_annotations: bool = False,
     assignee_principal_id: Optional[Union[str, int]] = None,
     view_type_mask: Union[int, ViewTypeMask] = ViewTypeMask.FILE,
+    suggested_authorization_mode: Optional[Union[AuthorizationMode, str]] = None,
+    collaborator_principal_ids: Optional[list[str]] = None,
     *,
     synapse_client: Optional[Synapse] = None,
 ) -> Tuple[str, str]:
@@ -338,7 +341,7 @@ def create_file_based_metadata_task(
         ```python
         import synapseclient
         from synapseclient.extensions.curator import create_file_based_metadata_task
-        from synapseclient.models import ViewTypeMask
+        from synapseclient.models import AuthorizationMode, ViewTypeMask
 
         syn = synapseclient.Synapse()
         syn.login()
@@ -351,8 +354,9 @@ def create_file_based_metadata_task(
             attach_wiki=False,
             entity_view_name="Biospecimen Metadata View",
             schema_uri="sage.schemas.v2571-amp.Biospecimen.schema-0.0.1",
-            assignee_principal_id=123456,  # Optional: Assign to a user or team (can be str or int)
-            view_type_mask=ViewTypeMask.FILE | ViewTypeMask.DOCKER,  # Optional: include additional entity types in the view
+            assignee_principal_id=123456,
+            view_type_mask=ViewTypeMask.FILE | ViewTypeMask.DOCKER,
+            suggested_authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
         )
         ```
 
@@ -377,6 +381,13 @@ def create_file_based_metadata_task(
             ViewTypeMask.FILE. Additional types can be added using bitwise OR
             (e.g., ViewTypeMask.FILE | ViewTypeMask.DOCKER). Accepts either a
             ViewTypeMask enum member or its raw integer value.
+        suggested_authorization_mode: The authorization mode a client should use when
+            creating a linked grid session for this task. When omitted, clients follow
+            legacy behavior: find or create a personal, unlinked grid session.
+        collaborator_principal_ids: The set of principal IDs that should collaborate on
+            the grid session. Used to set the owner(s) of a linked GridSession when
+            suggested_authorization_mode is SESSION_OWNER. Reserved for future
+            multi-owner support; not actively used at this time.
         synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.
@@ -481,6 +492,8 @@ def create_file_based_metadata_task(
             task_properties=FileBasedMetadataTaskProperties(
                 upload_folder_id=folder_id,
                 file_view_id=entity_view_id,
+                suggested_authorization_mode=suggested_authorization_mode,
+                collaborator_principal_ids=collaborator_principal_ids,
             ),
         ).store(synapse_client=synapse_client)
     except Exception as e:

--- a/synapseclient/extensions/curator/file_based_metadata_task.py
+++ b/synapseclient/extensions/curator/file_based_metadata_task.py
@@ -380,14 +380,19 @@ def create_file_based_metadata_task(
             ViewTypeMask.FILE. Additional types can be added using bitwise OR
             (e.g., ViewTypeMask.FILE | ViewTypeMask.DOCKER). Accepts either a
             ViewTypeMask enum member or its raw integer value.
-        suggested_authorization_mode: The authorization mode a client should use when
-            creating a linked grid session for this task. When omitted, clients follow
-            legacy behavior: find or create a personal, unlinked grid session.
-            SESSION_OWNER limits access to the session owner and their team;
-            SOURCE_BENEFACTOR extends access to anyone with EDIT rights on the source
-            entity. Note that changing suggested_authorization_mode after the task has
-            been created causes the server to clear activeSessionId on the task status,
-            so a new grid session must be created before curation can continue.
+        suggested_authorization_mode: Recommends who is allowed to access the curation
+            grid session that a client opens for this task. The value is stored on the
+            task as a suggestion; the client applies it when it creates a new session.
+            Choose from:
+            - SESSION_OWNER: only the person or team who owns the session can access it.
+            - SOURCE_BENEFACTOR: anyone with EDIT permission on the
+              data being curated can access the session. This lets editors collaborate
+              in the same session without being added to a shared ownership team.
+            When omitted (None, the default), no recommendation is stored and clients
+            fall back to their usual behavior of finding or creating a private session
+            for the current user. Changing this value after the task already exists
+            resets the task's active session, so a new grid session must be opened
+            before curation can continue.
         synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.

--- a/synapseclient/extensions/curator/file_based_metadata_task.py
+++ b/synapseclient/extensions/curator/file_based_metadata_task.py
@@ -327,7 +327,6 @@ def create_file_based_metadata_task(
     assignee_principal_id: Optional[Union[str, int]] = None,
     view_type_mask: Union[int, ViewTypeMask] = ViewTypeMask.FILE,
     suggested_authorization_mode: Optional[Union[AuthorizationMode, str]] = None,
-    collaborator_principal_ids: Optional[list[str]] = None,
     *,
     synapse_client: Optional[Synapse] = None,
 ) -> Tuple[str, str]:
@@ -384,10 +383,11 @@ def create_file_based_metadata_task(
         suggested_authorization_mode: The authorization mode a client should use when
             creating a linked grid session for this task. When omitted, clients follow
             legacy behavior: find or create a personal, unlinked grid session.
-        collaborator_principal_ids: The set of principal IDs that should collaborate on
-            the grid session. Used to set the owner(s) of a linked GridSession when
-            suggested_authorization_mode is SESSION_OWNER. Reserved for future
-            multi-owner support; not actively used at this time.
+            SESSION_OWNER limits access to the session owner and their team;
+            SOURCE_BENEFACTOR extends access to anyone with EDIT rights on the source
+            entity. Note that changing suggested_authorization_mode after the task has
+            been created causes the server to clear activeSessionId on the task status,
+            so a new grid session must be created before curation can continue.
         synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.
@@ -493,7 +493,6 @@ def create_file_based_metadata_task(
                 upload_folder_id=folder_id,
                 file_view_id=entity_view_id,
                 suggested_authorization_mode=suggested_authorization_mode,
-                collaborator_principal_ids=collaborator_principal_ids,
             ),
         ).store(synapse_client=synapse_client)
     except Exception as e:

--- a/synapseclient/extensions/curator/file_based_metadata_task.py
+++ b/synapseclient/extensions/curator/file_based_metadata_task.py
@@ -326,7 +326,7 @@ def create_file_based_metadata_task(
     enable_derived_annotations: bool = False,
     assignee_principal_id: Optional[Union[str, int]] = None,
     view_type_mask: Union[int, ViewTypeMask] = ViewTypeMask.FILE,
-    suggested_authorization_mode: Optional[Union[AuthorizationMode, str]] = None,
+    authorization_mode: Optional[Union[AuthorizationMode, str]] = None,
     *,
     synapse_client: Optional[Synapse] = None,
 ) -> Tuple[str, str]:
@@ -355,7 +355,7 @@ def create_file_based_metadata_task(
             schema_uri="sage.schemas.v2571-amp.Biospecimen.schema-0.0.1",
             assignee_principal_id=123456, # Optional: Assign to a user or team (can be str or int)
             view_type_mask=ViewTypeMask.FILE | ViewTypeMask.DOCKER, # Optional: include additional entity types in the view
-            suggested_authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
+            authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
         )
         ```
 
@@ -380,7 +380,7 @@ def create_file_based_metadata_task(
             ViewTypeMask.FILE. Additional types can be added using bitwise OR
             (e.g., ViewTypeMask.FILE | ViewTypeMask.DOCKER). Accepts either a
             ViewTypeMask enum member or its raw integer value.
-        suggested_authorization_mode: Recommends who is allowed to access the curation
+        authorization_mode: Recommends who is allowed to access the curation
             grid session that a client opens for this task. The value is stored on the
             task as a suggestion; the client applies it when it creates a new session.
             Choose from:
@@ -497,7 +497,7 @@ def create_file_based_metadata_task(
             task_properties=FileBasedMetadataTaskProperties(
                 upload_folder_id=folder_id,
                 file_view_id=entity_view_id,
-                suggested_authorization_mode=suggested_authorization_mode,
+                suggested_authorization_mode=authorization_mode,
             ),
         ).store(synapse_client=synapse_client)
     except Exception as e:

--- a/synapseclient/extensions/curator/file_based_metadata_task.py
+++ b/synapseclient/extensions/curator/file_based_metadata_task.py
@@ -346,16 +346,16 @@ def create_file_based_metadata_task(
         syn.login()
 
         entity_view_id, task_id = create_file_based_metadata_task(
-            synapse_client=syn,
             folder_id="syn12345678",
             curation_task_name="BiospecimenMetadataTemplate",
             instructions="Please curate this metadata according to the schema requirements",
-            attach_wiki=False,
-            entity_view_name="Biospecimen Metadata View",
-            schema_uri="sage.schemas.v2571-amp.Biospecimen.schema-0.0.1",
+            attach_wiki=False, # Optional: whether to attach a Synapse Wiki
+            entity_view_name="Biospecimen Metadata View", # Optional: name for the created entity view
+            schema_uri="sage.schemas.v2571-amp.Biospecimen.schema-0.0.1", # Optional: JSON schema URI to bind to the folder
             assignee_principal_id=123456, # Optional: Assign to a user or team (can be str or int)
             view_type_mask=ViewTypeMask.FILE | ViewTypeMask.DOCKER, # Optional: include additional entity types in the view
-            authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
+            authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR, # Optional: recommended access mode for the grid session
+            synapse_client=syn, # Optional: defaults to the last created Synapse client
         )
         ```
 

--- a/synapseclient/extensions/curator/record_based_metadata_task.py
+++ b/synapseclient/extensions/curator/record_based_metadata_task.py
@@ -14,6 +14,7 @@ from synapseclient.core.typing_utils import DataFrame as DATA_FRAME_TYPE
 from synapseclient.core.utils import test_import_pandas
 from synapseclient.extensions.curator.utils import project_id_from_entity_id
 from synapseclient.models import (
+    AuthorizationMode,
     CurationTask,
     Grid,
     JSONSchema,
@@ -111,6 +112,8 @@ def create_record_based_metadata_task(
     bind_schema_to_record_set: bool = True,
     enable_derived_annotations: bool = False,
     assignee_principal_id: Optional[Union[str, int]] = None,
+    suggested_authorization_mode: Optional[Union[AuthorizationMode, str]] = None,
+    collaborator_principal_ids: Optional[list[str]] = None,
     *,
     synapse_client: Optional[Synapse] = None,
     project_id: Optional[str] = None,  # Deprecated, will be removed in v5.0.0
@@ -136,13 +139,13 @@ def create_record_based_metadata_task(
     Example: Creating a record-based metadata curation task with a schema URI
         In this example, we create a RecordSet and CurationTask for biospecimen metadata
         curation using a schema URI. By default this will also bind the schema to the
-        RecordSet, however the `bind_schema_to_record_set` parameter can be set to
+        RecordSet, however the bind_schema_to_record_set parameter can be set to
         False to skip that step.
-
 
         ```python
         import synapseclient
         from synapseclient.extensions.curator import create_record_based_metadata_task
+        from synapseclient.models import AuthorizationMode
 
         syn = synapseclient.Synapse()
         syn.login()
@@ -156,8 +159,9 @@ def create_record_based_metadata_task(
             upsert_keys=["specimenID"],
             instructions="Please curate this metadata according to the schema requirements",
             schema_uri="schema-org-schema.name.schema-v1.0.0",
-            assignee_principal_id=123456,  # Optional: Assign to a user or team (can be str or int)
-            create_grid=False,  # Opt out of deprecated Grid creation
+            assignee_principal_id=123456,
+            suggested_authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
+            create_grid=False,
         )
         ```
 
@@ -182,6 +186,13 @@ def create_record_based_metadata_task(
             (default), the task will be unassigned. For metadata tasks, this determines
             the owner of the grid session. Team members can all join grid sessions owned
             by their team, while user-owned grid sessions are restricted to that user only.
+        suggested_authorization_mode: The authorization mode a client should use when
+            creating a linked grid session for this task. When omitted, clients follow
+            legacy behavior: find or create a personal, unlinked grid session.
+        collaborator_principal_ids: The set of principal IDs that should collaborate on
+            the grid session. Used to set the owner(s) of a linked GridSession when
+            suggested_authorization_mode is SESSION_OWNER. Reserved for future
+            multi-owner support; not actively used at this time.
         synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.
@@ -286,6 +297,8 @@ def create_record_based_metadata_task(
             ),
             task_properties=RecordBasedMetadataTaskProperties(
                 record_set_id=record_set_id,
+                suggested_authorization_mode=suggested_authorization_mode,
+                collaborator_principal_ids=collaborator_principal_ids,
             ),
         ).store(synapse_client=synapse_client)
         synapse_client.logger.info(

--- a/synapseclient/extensions/curator/record_based_metadata_task.py
+++ b/synapseclient/extensions/curator/record_based_metadata_task.py
@@ -159,9 +159,9 @@ def create_record_based_metadata_task(
             upsert_keys=["specimenID"],
             instructions="Please curate this metadata according to the schema requirements",
             schema_uri="schema-org-schema.name.schema-v1.0.0",
-            assignee_principal_id=123456,
+            assignee_principal_id=123456,  # Optional: Assign to a user or team (can be str or int)
             suggested_authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
-            create_grid=False,
+            create_grid=False,  # Opt out of deprecated Grid creation
         )
         ```
 

--- a/synapseclient/extensions/curator/record_based_metadata_task.py
+++ b/synapseclient/extensions/curator/record_based_metadata_task.py
@@ -112,7 +112,7 @@ def create_record_based_metadata_task(
     bind_schema_to_record_set: bool = True,
     enable_derived_annotations: bool = False,
     assignee_principal_id: Optional[Union[str, int]] = None,
-    suggested_authorization_mode: Optional[Union[AuthorizationMode, str]] = None,
+    authorization_mode: Optional[Union[AuthorizationMode, str]] = None,
     *,
     synapse_client: Optional[Synapse] = None,
     project_id: Optional[str] = None,  # Deprecated, will be removed in v5.0.0
@@ -159,7 +159,7 @@ def create_record_based_metadata_task(
             instructions="Please curate this metadata according to the schema requirements",
             schema_uri="schema-org-schema.name.schema-v1.0.0",
             assignee_principal_id=123456,  # Optional: Assign to a user or team (can be str or int)
-            suggested_authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
+            authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
             create_grid=False,  # Opt out of deprecated Grid creation
         )
         ```
@@ -185,7 +185,7 @@ def create_record_based_metadata_task(
             (default), the task will be unassigned. For metadata tasks, this determines
             the owner of the grid session. Team members can all join grid sessions owned
             by their team, while user-owned grid sessions are restricted to that user only.
-        suggested_authorization_mode: Recommends who is allowed to access the curation
+        authorization_mode: Recommends who is allowed to access the curation
             grid session that a client opens for this task. The value is stored on the
             task as a suggestion; the client applies it when it creates a new session.
             Choose from:
@@ -302,7 +302,7 @@ def create_record_based_metadata_task(
             ),
             task_properties=RecordBasedMetadataTaskProperties(
                 record_set_id=record_set_id,
-                suggested_authorization_mode=suggested_authorization_mode,
+                suggested_authorization_mode=authorization_mode,
             ),
         ).store(synapse_client=synapse_client)
         synapse_client.logger.info(

--- a/synapseclient/extensions/curator/record_based_metadata_task.py
+++ b/synapseclient/extensions/curator/record_based_metadata_task.py
@@ -113,7 +113,6 @@ def create_record_based_metadata_task(
     enable_derived_annotations: bool = False,
     assignee_principal_id: Optional[Union[str, int]] = None,
     suggested_authorization_mode: Optional[Union[AuthorizationMode, str]] = None,
-    collaborator_principal_ids: Optional[list[str]] = None,
     *,
     synapse_client: Optional[Synapse] = None,
     project_id: Optional[str] = None,  # Deprecated, will be removed in v5.0.0
@@ -189,10 +188,11 @@ def create_record_based_metadata_task(
         suggested_authorization_mode: The authorization mode a client should use when
             creating a linked grid session for this task. When omitted, clients follow
             legacy behavior: find or create a personal, unlinked grid session.
-        collaborator_principal_ids: The set of principal IDs that should collaborate on
-            the grid session. Used to set the owner(s) of a linked GridSession when
-            suggested_authorization_mode is SESSION_OWNER. Reserved for future
-            multi-owner support; not actively used at this time.
+            SESSION_OWNER limits access to the session owner and their team;
+            SOURCE_BENEFACTOR extends access to anyone with EDIT rights on the source
+            entity. Note that changing suggested_authorization_mode after the task has
+            been created causes the server to clear activeSessionId on the task status,
+            so a new grid session must be created before curation can continue.
         synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.
@@ -298,7 +298,6 @@ def create_record_based_metadata_task(
             task_properties=RecordBasedMetadataTaskProperties(
                 record_set_id=record_set_id,
                 suggested_authorization_mode=suggested_authorization_mode,
-                collaborator_principal_ids=collaborator_principal_ids,
             ),
         ).store(synapse_client=synapse_client)
         synapse_client.logger.info(

--- a/synapseclient/extensions/curator/record_based_metadata_task.py
+++ b/synapseclient/extensions/curator/record_based_metadata_task.py
@@ -185,14 +185,19 @@ def create_record_based_metadata_task(
             (default), the task will be unassigned. For metadata tasks, this determines
             the owner of the grid session. Team members can all join grid sessions owned
             by their team, while user-owned grid sessions are restricted to that user only.
-        suggested_authorization_mode: The authorization mode a client should use when
-            creating a linked grid session for this task. When omitted, clients follow
-            legacy behavior: find or create a personal, unlinked grid session.
-            SESSION_OWNER limits access to the session owner and their team;
-            SOURCE_BENEFACTOR extends access to anyone with EDIT rights on the source
-            entity. Note that changing suggested_authorization_mode after the task has
-            been created causes the server to clear activeSessionId on the task status,
-            so a new grid session must be created before curation can continue.
+        suggested_authorization_mode: Recommends who is allowed to access the curation
+            grid session that a client opens for this task. The value is stored on the
+            task as a suggestion; the client applies it when it creates a new session.
+            Choose from:
+            - SESSION_OWNER: only the person or team who owns the session can access it.
+            - SOURCE_BENEFACTOR: anyone with EDIT permission on the
+              data being curated can access the session. This lets editors collaborate
+              in the same session without being added to a shared ownership team.
+            When omitted (None, the default), no recommendation is stored and clients
+            fall back to their usual behavior of finding or creating a private session
+            for the current user. Changing this value after the task already exists
+            resets the task's active session, so a new grid session must be opened
+            before curation can continue.
         synapse_client: If not passed in and caching was not disabled by
                 `Synapse.allow_client_caching(False)` this will use the last created
                 instance from the Synapse class constructor.

--- a/synapseclient/models/__init__.py
+++ b/synapseclient/models/__init__.py
@@ -8,6 +8,7 @@ from synapseclient.models.agent import (
 )
 from synapseclient.models.annotations import Annotations
 from synapseclient.models.curation import (
+    AuthorizationMode,
     CurationTask,
     FileBasedMetadataTaskProperties,
     Grid,
@@ -94,6 +95,7 @@ __all__ = [
     "Team",
     "TeamMember",
     "TeamMembershipStatus",
+    "AuthorizationMode",
     "CurationTask",
     "FileBasedMetadataTaskProperties",
     "RecordBasedMetadataTaskProperties",

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -10,7 +10,16 @@ import os
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, AsyncGenerator, Dict, Generator, Optional, Protocol, Union
+from typing import (
+    Any,
+    AsyncGenerator,
+    ClassVar,
+    Dict,
+    Generator,
+    Optional,
+    Protocol,
+    Union,
+)
 
 from opentelemetry import trace
 
@@ -52,6 +61,7 @@ from synapseclient.core.utils import (
     merge_dataclass_entities,
 )
 from synapseclient.models.mixins.asynchronous_job import AsynchronousCommunicator
+from synapseclient.models.mixins.enum_coercion import EnumCoercionMixin
 from synapseclient.models.recordset import ValidationSummary
 from synapseclient.models.table_components import Column, CsvTableDescriptor, Query
 
@@ -76,8 +86,23 @@ class TaskState(str, Enum):
     """The task has been canceled and is no longer needed."""
 
 
+class AuthorizationMode(str, Enum):
+    """
+    The authorization mode a client should use when creating a linked grid session
+    for a CurationTask.
+
+    See <https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/grid/AuthorizationMode.html>.
+    """
+
+    SESSION_OWNER = "SESSION_OWNER"
+    """The grid session is owned by one or more explicit principals (collaborator_principal_ids)."""
+
+    SOURCE_BENEFACTOR = "SOURCE_BENEFACTOR"
+    """The grid session inherits permissions from the benefactor of the source entity."""
+
+
 @dataclass
-class FileBasedMetadataTaskProperties:
+class FileBasedMetadataTaskProperties(EnumCoercionMixin):
     """
     A CurationTaskProperties for file-based data, describing where data is uploaded
     and a view which contains the annotations.
@@ -89,11 +114,27 @@ class FileBasedMetadataTaskProperties:
         file_view_id: The synId of the FileView that shows all data of this type
     """
 
+    _ENUM_FIELDS: ClassVar[dict[str, type]] = {
+        "suggested_authorization_mode": AuthorizationMode
+    }
+
     upload_folder_id: Optional[str] = None
     """The synId of the folder where data files of this type are to be uploaded"""
 
     file_view_id: Optional[str] = None
     """The synId of the FileView that shows all data of this type"""
+
+    suggested_authorization_mode: Optional[Union[AuthorizationMode, str]] = None
+    """The authorization mode a client should use when creating a linked grid session for
+    this task. When omitted, clients follow legacy behavior: find or create a personal,
+    unlinked grid session. When this field changes, the server automatically clears
+    activeSessionId from the task status. Accepts either an AuthorizationMode enum
+    value or its string equivalent (e.g., "SOURCE_BENEFACTOR")."""
+
+    collaborator_principal_ids: Optional[list[str]] = None
+    """The set of principal IDs that should collaborate on the grid session. Used to set
+    the owner(s) of a linked GridSession when suggested_authorization_mode is SESSION_OWNER.
+    Reserved for future multi-owner support; not actively used at this time."""
 
     def fill_from_dict(
         self, synapse_response: Union[Dict[str, Any], Any]
@@ -109,6 +150,12 @@ class FileBasedMetadataTaskProperties:
         """
         self.upload_folder_id = synapse_response.get("uploadFolderId", None)
         self.file_view_id = synapse_response.get("fileViewId", None)
+        self.suggested_authorization_mode = synapse_response.get(
+            "suggestedAuthorizationMode", None
+        )
+        self.collaborator_principal_ids = synapse_response.get(
+            "collaboratorPrincipalIds", None
+        )
         return self
 
     def to_synapse_request(self) -> Dict[str, Any]:
@@ -118,16 +165,23 @@ class FileBasedMetadataTaskProperties:
         Returns:
             A dictionary representation of this object for API requests.
         """
-        request_dict = {"concreteType": FILE_BASED_METADATA_TASK_PROPERTIES}
-        if self.upload_folder_id is not None:
-            request_dict["uploadFolderId"] = self.upload_folder_id
-        if self.file_view_id is not None:
-            request_dict["fileViewId"] = self.file_view_id
+        request_dict = {
+            "concreteType": FILE_BASED_METADATA_TASK_PROPERTIES,
+            "uploadFolderId": self.upload_folder_id,
+            "fileViewId": self.file_view_id,
+            "suggestedAuthorizationMode": (
+                self.suggested_authorization_mode.value
+                if self.suggested_authorization_mode is not None
+                else None
+            ),
+            "collaboratorPrincipalIds": self.collaborator_principal_ids,
+        }
+        delete_none_keys(request_dict)
         return request_dict
 
 
 @dataclass
-class RecordBasedMetadataTaskProperties:
+class RecordBasedMetadataTaskProperties(EnumCoercionMixin):
     """
     A CurationTaskProperties for record-based metadata.
 
@@ -137,8 +191,24 @@ class RecordBasedMetadataTaskProperties:
         record_set_id: The synId of the RecordSet that will contain all record-based metadata
     """
 
+    _ENUM_FIELDS: ClassVar[Dict[str, type]] = {
+        "suggested_authorization_mode": AuthorizationMode
+    }
+
     record_set_id: Optional[str] = None
     """The synId of the RecordSet that will contain all record-based metadata"""
+
+    suggested_authorization_mode: Optional[Union[AuthorizationMode, str]] = None
+    """The authorization mode a client should use when creating a linked grid session for
+    this task. When omitted, clients follow legacy behavior: find or create a personal,
+    unlinked grid session. When this field changes, the server automatically clears
+    activeSessionId from the task status. Accepts either an AuthorizationMode enum
+    value or its string equivalent (e.g., "SOURCE_BENEFACTOR")."""
+
+    collaborator_principal_ids: Optional[list[str]] = None
+    """The set of principal IDs that should collaborate on the grid session. Used to set
+    the owner(s) of a linked GridSession when suggested_authorization_mode is SESSION_OWNER.
+    Reserved for future multi-owner support; not actively used at this time."""
 
     def fill_from_dict(
         self, synapse_response: Union[Dict[str, Any], Any]
@@ -153,6 +223,12 @@ class RecordBasedMetadataTaskProperties:
             The RecordBasedMetadataTaskProperties object.
         """
         self.record_set_id = synapse_response.get("recordSetId", None)
+        self.suggested_authorization_mode = synapse_response.get(
+            "suggestedAuthorizationMode", None
+        )
+        self.collaborator_principal_ids = synapse_response.get(
+            "collaboratorPrincipalIds", None
+        )
         return self
 
     def to_synapse_request(self) -> Dict[str, Any]:
@@ -162,9 +238,17 @@ class RecordBasedMetadataTaskProperties:
         Returns:
             A dictionary representation of this object for API requests.
         """
-        request_dict = {"concreteType": RECORD_BASED_METADATA_TASK_PROPERTIES}
-        if self.record_set_id is not None:
-            request_dict["recordSetId"] = self.record_set_id
+        request_dict = {
+            "concreteType": RECORD_BASED_METADATA_TASK_PROPERTIES,
+            "recordSetId": self.record_set_id,
+            "suggestedAuthorizationMode": (
+                self.suggested_authorization_mode.value
+                if self.suggested_authorization_mode is not None
+                else None
+            ),
+            "collaboratorPrincipalIds": self.collaborator_principal_ids,
+        }
+        delete_none_keys(request_dict)
         return request_dict
 
 

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -2166,7 +2166,9 @@ class CreateGridRequest(EnumCoercionMixin, AsynchronousCommunicator):
         )
         request_dict["ownerPrincipalId"] = self.owner_principal_id
         request_dict["authorizationMode"] = (
-            self.authorization_mode.value if self.authorization_mode else None
+            self.authorization_mode.value
+            if self.authorization_mode is not None
+            else None
         )
         delete_none_keys(request_dict)
         return request_dict

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -100,10 +100,16 @@ class AuthorizationMode(str, Enum):
     """
 
     SESSION_OWNER = "SESSION_OWNER"
-    """The grid session is owned by one or more explicit principals (collaborator_principal_ids)."""
+    """Access is limited to the session owner or members of the owner's team. This is
+    the default setting. When a view serves as the source, the owner can access all
+    available rows, while other team members see data according to the owner's
+    permission scope."""
 
     SOURCE_BENEFACTOR = "SOURCE_BENEFACTOR"
-    """The grid session inherits permissions from the benefactor of the source entity."""
+    """Access is granted to any user who has EDIT (UPDATE) access on all benefactor IDs
+    captured when the session was created. This mode allows project administrators to
+    enable collaborative grid access for all editors without maintaining a separate
+    ownership team. User visibility of rows depends on their individual permissions."""
 
 
 @dataclass
@@ -131,15 +137,18 @@ class FileBasedMetadataTaskProperties(EnumCoercionMixin):
 
     suggested_authorization_mode: Optional[Union[AuthorizationMode, str]] = None
     """The authorization mode a client should use when creating a linked grid session for
-    this task. When omitted, clients follow legacy behavior: find or create a personal,
-    unlinked grid session. When this field changes, the server automatically clears
-    activeSessionId from the task status. Accepts either an AuthorizationMode enum
-    value or its string equivalent (e.g., "SOURCE_BENEFACTOR")."""
+    this task. SESSION_OWNER limits access to the session owner and their team; use it
+    when curation should be scoped to a specific user or team. SOURCE_BENEFACTOR extends
+    access to anyone with EDIT rights on the source entity; use it when curation should
+    be open to all editors of the source. When omitted, clients follow legacy behavior:
+    find or create a personal, unlinked grid session. When this field changes, the server
+    automatically clears activeSessionId from the task status. Accepts either an
+    AuthorizationMode enum value or its string equivalent (e.g., "SOURCE_BENEFACTOR")."""
 
     collaborator_principal_ids: Optional[list[str]] = None
-    """The set of principal IDs that should collaborate on the grid session. Used to set
-    the owner(s) of a linked GridSession when suggested_authorization_mode is SESSION_OWNER.
-    Reserved for future multi-owner support; not actively used at this time."""
+    """Not actively used at this time.
+    The set of principal IDs that should collaborate on the grid session. Used to set
+    the owner(s) of a linked GridSession when suggested_authorization_mode is SESSION_OWNER"""
 
     def fill_from_dict(
         self, synapse_response: Union[Dict[str, Any], Any]
@@ -205,15 +214,18 @@ class RecordBasedMetadataTaskProperties(EnumCoercionMixin):
 
     suggested_authorization_mode: Optional[Union[AuthorizationMode, str]] = None
     """The authorization mode a client should use when creating a linked grid session for
-    this task. When omitted, clients follow legacy behavior: find or create a personal,
-    unlinked grid session. When this field changes, the server automatically clears
-    activeSessionId from the task status. Accepts either an AuthorizationMode enum
-    value or its string equivalent (e.g., "SOURCE_BENEFACTOR")."""
+    this task. SESSION_OWNER limits access to the session owner and their team; use it
+    when curation should be scoped to a specific user or team. SOURCE_BENEFACTOR extends
+    access to anyone with EDIT rights on the source entity; use it when curation should
+    be open to all editors of the source. When omitted, clients follow legacy behavior:
+    find or create a personal, unlinked grid session. When this field changes, the server
+    automatically clears activeSessionId from the task status. Accepts either an
+    AuthorizationMode enum value or its string equivalent (e.g., "SOURCE_BENEFACTOR")."""
 
     collaborator_principal_ids: Optional[list[str]] = None
-    """The set of principal IDs that should collaborate on the grid session. Used to set
-    the owner(s) of a linked GridSession when suggested_authorization_mode is SESSION_OWNER.
-    Reserved for future multi-owner support; not actively used at this time."""
+    """Not actively used at this time.
+    The set of principal IDs that should collaborate on the grid session. Used to set
+    the owner(s) of a linked GridSession when suggested_authorization_mode is SESSION_OWNER"""
 
     def fill_from_dict(
         self, synapse_response: Union[Dict[str, Any], Any]
@@ -703,6 +715,15 @@ class CurationTaskSynchronousProtocol(Protocol):
 
         Always creates a new Grid session. To attach an existing session to a task,
         use set_active_grid_session instead.
+
+        The new session is created with the task's suggested_authorization_mode
+        (from task_properties), which the server uses to determine access:
+
+        - SESSION_OWNER: access is limited to the session owner (owner_principal_id,
+          or the caller when not provided) and their team.
+        - SOURCE_BENEFACTOR: access is inherited from the benefactor of the source
+          entity (anyone with EDIT rights).
+        - Unset (legacy): the caller becomes the owner.
 
         After the Grid is created, updates the CurationTaskStatus to point its
         active_session_id at the new session. If that update fails for any reason,
@@ -1728,6 +1749,15 @@ class CurationTask(CurationTaskSynchronousProtocol):
         Always creates a new Grid session. To attach an existing session to a task,
         use set_active_grid_session_async instead.
 
+        The new session is created with the task's suggested_authorization_mode
+        (from task_properties), which the server uses to determine access:
+
+        - SESSION_OWNER: access is limited to the session owner (owner_principal_id,
+          or the caller when not provided) and their team.
+        - SOURCE_BENEFACTOR: access is inherited from the benefactor of the source
+          entity (anyone with EDIT rights).
+        - Unset (legacy): the caller becomes the owner.
+
         After the Grid is created, updates the CurationTaskStatus to point its
         active_session_id at the new session. If that update fails for any reason,
         the newly created Grid is deleted on a best-effort basis and the original
@@ -1792,6 +1822,7 @@ class CurationTask(CurationTaskSynchronousProtocol):
             grid = Grid(
                 record_set_id=self.task_properties.record_set_id,
                 owner_principal_id=owner_principal_id,
+                authorization_mode=self.task_properties.suggested_authorization_mode,
             )
         elif isinstance(self.task_properties, FileBasedMetadataTaskProperties):
             if not self.task_properties.file_view_id:
@@ -1810,6 +1841,7 @@ class CurationTask(CurationTaskSynchronousProtocol):
                     sql=f"SELECT * FROM {self.task_properties.file_view_id}"
                 ),
                 owner_principal_id=owner_principal_id,
+                authorization_mode=self.task_properties.suggested_authorization_mode,
             )
         else:
             raise ValueError(
@@ -2018,7 +2050,7 @@ class CurationTask(CurationTaskSynchronousProtocol):
 
 
 @dataclass
-class CreateGridRequest(AsynchronousCommunicator):
+class CreateGridRequest(EnumCoercionMixin, AsynchronousCommunicator):
     """
     Start a job to create a new Grid session.
 
@@ -2035,6 +2067,8 @@ class CreateGridRequest(AsynchronousCommunicator):
             In order to allow other users to access the grid, set this value to the id of a team.
             When a team ID is provided as the owner, all members of that team will have equal access to the grid.
             Note: If a team ID is provided, the creator of the grid must be a member of the team.
+        authorization_mode: Controls access permissions and row visibility at session
+            creation time. See AuthorizationMode. Defaults to SESSION_OWNER when omitted.
         session_id: The session ID of the created grid (populated from response)
     """
 
@@ -2057,8 +2091,14 @@ class CreateGridRequest(AsynchronousCommunicator):
     When a team ID is provided as the owner, all members of that team will have equal access to the grid.
     Note: If a team ID is provided, the creator of the grid must be a member of the team."""
 
+    authorization_mode: Optional[AuthorizationMode] = None
+    """Controls access permissions and row visibility at session creation time.
+    See AuthorizationMode. When omitted, the service defaults to SESSION_OWNER."""
+
     session_id: Optional[str] = None
     """The session ID of the created grid (populated from response)"""
+
+    _ENUM_FIELDS: ClassVar[Dict[str, type]] = {"authorization_mode": AuthorizationMode}
 
     _grid_session_data: Optional[Dict[str, Any]] = field(default=None, compare=False)
     """Internal storage of the full grid session data from the response for later use."""
@@ -2125,6 +2165,9 @@ class CreateGridRequest(AsynchronousCommunicator):
             self.initial_query.to_synapse_request() if self.initial_query else None
         )
         request_dict["ownerPrincipalId"] = self.owner_principal_id
+        request_dict["authorizationMode"] = (
+            self.authorization_mode.value if self.authorization_mode else None
+        )
         delete_none_keys(request_dict)
         return request_dict
 
@@ -3007,7 +3050,7 @@ class GridSynchronousProtocol(Protocol):
 
 @dataclass
 @async_to_sync
-class Grid(GridSynchronousProtocol):
+class Grid(EnumCoercionMixin, GridSynchronousProtocol):
     """
     A GridSession provides functionality to create and manage grid sessions in Synapse.
     Grid sessions are used for curation workflows where data can be edited in a grid format
@@ -3020,6 +3063,9 @@ class Grid(GridSynchronousProtocol):
         owner_principal_id: The principal ID (user or team) that will own the
             created grid session. When not provided, the principal ID of the
             caller is used.
+        authorization_mode: Controls access permissions and row visibility at
+            session creation time. See AuthorizationMode. When not provided, the
+            service default (SESSION_OWNER) is used.
         session_id: The unique sessionId that identifies the grid session
         started_by: The user that started this session
         started_on: The date-time when the session was started
@@ -3088,6 +3134,11 @@ class Grid(GridSynchronousProtocol):
     """The principal ID (user or team) that will own the created grid session.
     When not provided, the principal ID of the caller is used."""
 
+    authorization_mode: Optional[AuthorizationMode] = None
+    """Controls access permissions and row visibility at session creation time.
+    See AuthorizationMode. When not provided, the service default (SESSION_OWNER)
+    is used."""
+
     session_id: Optional[str] = None
     """The unique sessionId that identifies the grid session"""
 
@@ -3120,6 +3171,8 @@ class Grid(GridSynchronousProtocol):
 
     validation_summary_statistics: Optional[ValidationSummary] = None
     """Summary statistics for validation results"""
+
+    _ENUM_FIELDS: ClassVar[Dict[str, type]] = {"authorization_mode": AuthorizationMode}
 
     async def create_async(
         self,
@@ -3206,6 +3259,7 @@ class Grid(GridSynchronousProtocol):
             record_set_id=self.record_set_id,
             initial_query=self.initial_query,
             owner_principal_id=self.owner_principal_id,
+            authorization_mode=self.authorization_mode,
         )
         result = await create_request.send_job_and_wait_async(
             timeout=timeout, synapse_client=synapse_client

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -123,6 +123,16 @@ class FileBasedMetadataTaskProperties(EnumCoercionMixin):
     Attributes:
         upload_folder_id: The synId of the folder where data files of this type are to be uploaded
         file_view_id: The synId of the FileView that shows all data of this type
+        suggested_authorization_mode: Recommends who is allowed to access the curation
+            grid session that a client opens for this task. The value is stored on the
+            task as a suggestion; the client applies it when it creates a new session.
+            Choose from SESSION_OWNER (only the person or team who owns the session can
+            access it) or SOURCE_BENEFACTOR (anyone with EDIT permission on the data being
+            curated can access the session). When omitted (None, the default), no
+            recommendation is stored and clients fall back to their usual behavior.
+        collaborator_principal_ids: Not actively used at this time. The set of principal
+            IDs that should collaborate on the grid session. Used to set the owner(s) of a
+            linked GridSession when suggested_authorization_mode is SESSION_OWNER.
     """
 
     _ENUM_FIELDS: ClassVar[dict[str, type]] = {
@@ -208,6 +218,16 @@ class RecordBasedMetadataTaskProperties(EnumCoercionMixin):
 
     Attributes:
         record_set_id: The synId of the RecordSet that will contain all record-based metadata
+        suggested_authorization_mode: Recommends who is allowed to access the curation
+            grid session that a client opens for this task. The value is stored on the
+            task as a suggestion; the client applies it when it creates a new session.
+            Choose from SESSION_OWNER (only the person or team who owns the session can
+            access it) or SOURCE_BENEFACTOR (anyone with EDIT permission on the data being
+            curated can access the session). When omitted (None, the default), no
+            recommendation is stored and clients fall back to their usual behavior.
+        collaborator_principal_ids: Not actively used at this time. The set of principal
+            IDs that should collaborate on the grid session. Used to set the owner(s) of a
+            linked GridSession when suggested_authorization_mode is SESSION_OWNER.
     """
 
     _ENUM_FIELDS: ClassVar[dict[str, type]] = {

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -136,14 +136,19 @@ class FileBasedMetadataTaskProperties(EnumCoercionMixin):
     """The synId of the FileView that shows all data of this type"""
 
     suggested_authorization_mode: Optional[Union[AuthorizationMode, str]] = None
-    """The authorization mode a client should use when creating a linked grid session for
-    this task. SESSION_OWNER limits access to the session owner and their team; use it
-    when curation should be scoped to a specific user or team. SOURCE_BENEFACTOR extends
-    access to anyone with EDIT rights on the source entity; use it when curation should
-    be open to all editors of the source. When omitted, clients follow legacy behavior:
-    find or create a personal, unlinked grid session. When this field changes, the server
-    automatically clears activeSessionId from the task status. Accepts either an
-    AuthorizationMode enum value or its string equivalent (e.g., "SOURCE_BENEFACTOR")."""
+    """Recommends who is allowed to access the curation
+        grid session that a client opens for this task. The value is stored on the
+        task as a suggestion; the client applies it when it creates a new session.
+        Choose from:
+        - SESSION_OWNER: only the person or team who owns the session can access it.
+        - SOURCE_BENEFACTOR: anyone with EDIT permission on the
+            data being curated can access the session. This lets editors collaborate
+            in the same session without being added to a shared ownership team.
+        When omitted (None, the default), no recommendation is stored and clients
+        fall back to their usual behavior of finding or creating a private session
+        for the current user. Changing this value after the task already exists
+        resets the task's active session, so a new grid session must be opened
+        before curation can continue."""
 
     collaborator_principal_ids: Optional[list[str]] = None
     """Not actively used at this time.
@@ -213,14 +218,19 @@ class RecordBasedMetadataTaskProperties(EnumCoercionMixin):
     """The synId of the RecordSet that will contain all record-based metadata"""
 
     suggested_authorization_mode: Optional[Union[AuthorizationMode, str]] = None
-    """The authorization mode a client should use when creating a linked grid session for
-    this task. SESSION_OWNER limits access to the session owner and their team; use it
-    when curation should be scoped to a specific user or team. SOURCE_BENEFACTOR extends
-    access to anyone with EDIT rights on the source entity; use it when curation should
-    be open to all editors of the source. When omitted, clients follow legacy behavior:
-    find or create a personal, unlinked grid session. When this field changes, the server
-    automatically clears activeSessionId from the task status. Accepts either an
-    AuthorizationMode enum value or its string equivalent (e.g., "SOURCE_BENEFACTOR")."""
+    """Recommends who is allowed to access the curation
+        grid session that a client opens for this task. The value is stored on the
+        task as a suggestion; the client applies it when it creates a new session.
+        Choose from:
+        - SESSION_OWNER: only the person or team who owns the session can access it.
+        - SOURCE_BENEFACTOR: anyone with EDIT permission on the
+            data being curated can access the session. This lets editors collaborate
+            in the same session without being added to a shared ownership team.
+        When omitted (None, the default), no recommendation is stored and clients
+        fall back to their usual behavior of finding or creating a private session
+        for the current user. Changing this value after the task already exists
+        resets the task's active session, so a new grid session must be opened
+        before curation can continue."""
 
     collaborator_principal_ids: Optional[list[str]] = None
     """Not actively used at this time.

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -2149,6 +2149,7 @@ class CreateGridRequest(EnumCoercionMixin, AsynchronousCommunicator):
         grid_session.grid_json_schema_id = data.get("gridJsonSchema$Id", None)
         grid_session.source_entity_id = data.get("sourceEntityId", None)
         grid_session.owner_principal_id = data.get("ownerPrincipalId")
+        grid_session.authorization_mode = data.get("authorizationMode", None)
 
         return grid_session
 
@@ -3350,6 +3351,7 @@ class Grid(EnumCoercionMixin, GridSynchronousProtocol):
         self.grid_json_schema_id = synapse_response.get("gridJsonSchema$Id", None)
         self.source_entity_id = synapse_response.get("sourceEntityId", None)
         self.owner_principal_id = synapse_response.get("ownerPrincipalId")
+        self.authorization_mode = synapse_response.get("authorizationMode", None)
         return self
 
     @skip_async_to_sync

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -2148,7 +2148,10 @@ class CreateGridRequest(EnumCoercionMixin, AsynchronousCommunicator):
         grid_session.last_replica_id_service = data.get("lastReplicaIdService", None)
         grid_session.grid_json_schema_id = data.get("gridJsonSchema$Id", None)
         grid_session.source_entity_id = data.get("sourceEntityId", None)
-        grid_session.owner_principal_id = data.get("ownerPrincipalId")
+        owner_principal_id = data.get("ownerPrincipalId")
+        grid_session.owner_principal_id = (
+            int(owner_principal_id) if owner_principal_id is not None else None
+        )
         grid_session.authorization_mode = data.get("authorizationMode", None)
 
         return grid_session
@@ -3350,7 +3353,10 @@ class Grid(EnumCoercionMixin, GridSynchronousProtocol):
         )
         self.grid_json_schema_id = synapse_response.get("gridJsonSchema$Id", None)
         self.source_entity_id = synapse_response.get("sourceEntityId", None)
-        self.owner_principal_id = synapse_response.get("ownerPrincipalId")
+        owner_principal_id = synapse_response.get("ownerPrincipalId")
+        self.owner_principal_id = (
+            int(owner_principal_id) if owner_principal_id is not None else None
+        )
         self.authorization_mode = synapse_response.get("authorizationMode", None)
         return self
 

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -2091,7 +2091,7 @@ class CreateGridRequest(EnumCoercionMixin, AsynchronousCommunicator):
     When a team ID is provided as the owner, all members of that team will have equal access to the grid.
     Note: If a team ID is provided, the creator of the grid must be a member of the team."""
 
-    authorization_mode: Optional[AuthorizationMode] = None
+    authorization_mode: Optional[Union[AuthorizationMode, str]] = None
     """Controls access permissions and row visibility at session creation time.
     See AuthorizationMode. When omitted, the service defaults to SESSION_OWNER."""
 
@@ -3140,7 +3140,7 @@ class Grid(EnumCoercionMixin, GridSynchronousProtocol):
     """The principal ID (user or team) that will own the created grid session.
     When not provided, the principal ID of the caller is used."""
 
-    authorization_mode: Optional[AuthorizationMode] = None
+    authorization_mode: Optional[Union[AuthorizationMode, str]] = None
     """Controls access permissions and row visibility at session creation time.
     See AuthorizationMode. When not provided, the service default (SESSION_OWNER)
     is used."""

--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -205,7 +205,7 @@ class RecordBasedMetadataTaskProperties(EnumCoercionMixin):
         record_set_id: The synId of the RecordSet that will contain all record-based metadata
     """
 
-    _ENUM_FIELDS: ClassVar[Dict[str, type]] = {
+    _ENUM_FIELDS: ClassVar[dict[str, type]] = {
         "suggested_authorization_mode": AuthorizationMode
     }
 
@@ -2098,7 +2098,7 @@ class CreateGridRequest(EnumCoercionMixin, AsynchronousCommunicator):
     session_id: Optional[str] = None
     """The session ID of the created grid (populated from response)"""
 
-    _ENUM_FIELDS: ClassVar[Dict[str, type]] = {"authorization_mode": AuthorizationMode}
+    _ENUM_FIELDS: ClassVar[dict[str, type]] = {"authorization_mode": AuthorizationMode}
 
     _grid_session_data: Optional[Dict[str, Any]] = field(default=None, compare=False)
     """Internal storage of the full grid session data from the response for later use."""
@@ -3172,7 +3172,7 @@ class Grid(EnumCoercionMixin, GridSynchronousProtocol):
     validation_summary_statistics: Optional[ValidationSummary] = None
     """Summary statistics for validation results"""
 
-    _ENUM_FIELDS: ClassVar[Dict[str, type]] = {"authorization_mode": AuthorizationMode}
+    _ENUM_FIELDS: ClassVar[dict[str, type]] = {"authorization_mode": AuthorizationMode}
 
     async def create_async(
         self,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,6 +20,7 @@ from synapseclient import Entity, Project, Synapse
 from synapseclient.core import utils
 from synapseclient.core.async_utils import wrap_async_to_sync
 from synapseclient.core.logging_setup import DEFAULT_LOGGER_NAME, SILENT_LOGGER_NAME
+from synapseclient.models import Grid
 from synapseclient.models import Project as Project_Model
 from synapseclient.models import (
     SubmissionView,
@@ -195,6 +196,7 @@ async def _cleanup(syn: Synapse, items):
                 WikiHistorySnapshot,
                 WikiHeader,
                 WikiOrderHint,
+                Grid,
             ),
         ):
             try:

--- a/tests/integration/synapseclient/models/async/test_curation_async.py
+++ b/tests/integration/synapseclient/models/async/test_curation_async.py
@@ -131,6 +131,7 @@ class TestCurationTaskStoreAsync:
         task_properties = FileBasedMetadataTaskProperties(
             upload_folder_id=folder.id,
             file_view_id=entity_view.id,
+            suggested_authorization_mode=AuthorizationMode.SESSION_OWNER,
         )
 
         # AND a CurationTask
@@ -153,6 +154,10 @@ class TestCurationTaskStoreAsync:
         assert isinstance(stored_task.task_properties, FileBasedMetadataTaskProperties)
         assert stored_task.task_properties.upload_folder_id == folder.id
         assert stored_task.task_properties.file_view_id == entity_view.id
+        assert (
+            stored_task.task_properties.suggested_authorization_mode
+            == AuthorizationMode.SESSION_OWNER
+        )
         assert stored_task.etag is not None
         assert stored_task.created_on is not None
         assert stored_task.created_by is not None
@@ -188,14 +193,9 @@ class TestCurationTaskStoreAsync:
             stored_task.task_properties, RecordBasedMetadataTaskProperties
         )
         assert stored_task.task_properties.record_set_id == record_set.id
-        # AND the authorization mode round-trips through the server as the enum
         assert (
             stored_task.task_properties.suggested_authorization_mode
             == AuthorizationMode.SESSION_OWNER
-        )
-        assert isinstance(
-            stored_task.task_properties.suggested_authorization_mode,
-            AuthorizationMode,
         )
         assert stored_task.etag is not None
         assert stored_task.created_on is not None

--- a/tests/integration/synapseclient/models/async/test_curation_async.py
+++ b/tests/integration/synapseclient/models/async/test_curation_async.py
@@ -12,6 +12,7 @@ from synapseclient import Synapse
 from synapseclient.core.exceptions import SynapseHTTPError
 from synapseclient.core.utils import make_bogus_uuid_file
 from synapseclient.models import (
+    AuthorizationMode,
     CurationTask,
     CurationTaskStatus,
     EntityView,
@@ -163,6 +164,7 @@ class TestCurationTaskStoreAsync:
         # AND a RecordBasedMetadataTaskProperties
         task_properties = RecordBasedMetadataTaskProperties(
             record_set_id=record_set.id,
+            suggested_authorization_mode=AuthorizationMode.SESSION_OWNER,
         )
 
         # AND a CurationTask
@@ -186,6 +188,15 @@ class TestCurationTaskStoreAsync:
             stored_task.task_properties, RecordBasedMetadataTaskProperties
         )
         assert stored_task.task_properties.record_set_id == record_set.id
+        # AND the authorization mode round-trips through the server as the enum
+        assert (
+            stored_task.task_properties.suggested_authorization_mode
+            == AuthorizationMode.SESSION_OWNER
+        )
+        assert isinstance(
+            stored_task.task_properties.suggested_authorization_mode,
+            AuthorizationMode,
+        )
         assert stored_task.etag is not None
         assert stored_task.created_on is not None
         assert stored_task.created_by is not None
@@ -259,6 +270,7 @@ class TestCurationTaskGetAsync:
         task_properties = FileBasedMetadataTaskProperties(
             upload_folder_id=folder.id,
             file_view_id=entity_view.id,
+            suggested_authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
         )
         original_task = await CurationTask(
             data_type=data_type,
@@ -282,6 +294,10 @@ class TestCurationTaskGetAsync:
         )
         assert retrieved_task.task_properties.upload_folder_id == folder.id
         assert retrieved_task.task_properties.file_view_id == entity_view.id
+        assert (
+            retrieved_task.task_properties.suggested_authorization_mode
+            == AuthorizationMode.SOURCE_BENEFACTOR
+        )
         assert retrieved_task.etag == original_task.etag
         assert retrieved_task.created_on == original_task.created_on
         assert retrieved_task.created_by == original_task.created_by
@@ -735,6 +751,7 @@ class TestCurationTaskCreateGridSessionAsync:
         task_properties = FileBasedMetadataTaskProperties(
             upload_folder_id=folder.id,
             file_view_id=entity_view.id,
+            suggested_authorization_mode=AuthorizationMode.SESSION_OWNER,
         )
         stored_task = await CurationTask(
             data_type=data_type,
@@ -743,15 +760,22 @@ class TestCurationTaskCreateGridSessionAsync:
             task_properties=task_properties,
         ).store_async(synapse_client=syn)
 
-        # WHEN I create a grid session for the task asynchronously
+        # WHEN I create a grid session for the task asynchronously, owned by the
+        # current user
+        current_user_id = int(syn.getUserProfile()["ownerId"])
         grid = await stored_task.create_grid_session_async(
-            timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=syn
+            owner_principal_id=current_user_id,
+            timeout=ASYNC_JOB_TIMEOUT_SEC,
+            synapse_client=syn,
         )
         request.addfinalizer(lambda: grid.delete(synapse_client=syn))
 
-        # THEN a Grid is returned with a populated session_id
+        # THEN a Grid is returned with a populated session_id owned by that user
+        # AND the grid carries the task's suggested authorization mode
         assert isinstance(grid, Grid)
         assert grid.session_id is not None
+        assert grid.owner_principal_id == current_user_id
+        assert grid.authorization_mode == AuthorizationMode.SESSION_OWNER
 
         # AND the curation task status now references the new grid session
         status = await stored_task.get_status_async(synapse_client=syn)

--- a/tests/integration/synapseclient/models/async/test_grid_async.py
+++ b/tests/integration/synapseclient/models/async/test_grid_async.py
@@ -11,6 +11,7 @@ import pytest
 from synapseclient import Synapse
 from synapseclient.core.utils import make_bogus_data_file
 from synapseclient.models import (
+    AuthorizationMode,
     EntityView,
     File,
     Folder,
@@ -138,6 +139,26 @@ class TestGridAsync:
         )
         assert our_session.started_by == created_grid.started_by
         assert our_session.source_entity_id == record_set_fixture.id
+
+    async def test_create_grid_session_with_authorization_mode_async(
+        self, record_set_fixture: RecordSet
+    ) -> None:
+        # GIVEN: A Grid instance with a record_set_id and an explicit authorization mode
+        grid = Grid(
+            record_set_id=record_set_fixture.id,
+            authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
+        )
+
+        # WHEN: Creating a grid session
+        # (authorization_mode is serialized into the CreateGridRequest sent to Synapse)
+        created_grid = await grid.create_async(
+            timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
+        )
+
+        # THEN: The server accepts the request and creates the session successfully
+        assert created_grid is grid
+        assert created_grid.session_id is not None
+        assert created_grid.source_entity_id == record_set_fixture.id
 
     async def test_create_grid_session_and_reuse_session_async(
         self, record_set_fixture: RecordSet

--- a/tests/integration/synapseclient/models/async/test_grid_async.py
+++ b/tests/integration/synapseclient/models/async/test_grid_async.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 
 from synapseclient import Synapse
+from synapseclient.core.async_utils import wrap_async_to_sync
 from synapseclient.core.utils import make_bogus_data_file
 from synapseclient.models import (
     AuthorizationMode,
@@ -141,7 +142,7 @@ class TestGridAsync:
         assert our_session.source_entity_id == record_set_fixture.id
 
     async def test_create_grid_session_with_authorization_mode_async(
-        self, record_set_fixture: RecordSet
+        self, request: pytest.FixtureRequest, record_set_fixture: RecordSet
     ) -> None:
         # GIVEN: A Grid instance with a record_set_id and an explicit authorization mode
         grid = Grid(
@@ -152,6 +153,13 @@ class TestGridAsync:
         # WHEN: Creating a grid session
         created_grid = await grid.create_async(
             timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
+        )
+
+        # AND: The grid session is scheduled for cleanup
+        request.addfinalizer(
+            lambda: wrap_async_to_sync(
+                created_grid.delete_async(synapse_client=self.syn)
+            )
         )
 
         # THEN: The server accepts the request and creates the session successfully

--- a/tests/integration/synapseclient/models/async/test_grid_async.py
+++ b/tests/integration/synapseclient/models/async/test_grid_async.py
@@ -9,7 +9,6 @@ import pandas as pd
 import pytest
 
 from synapseclient import Synapse
-from synapseclient.core.async_utils import wrap_async_to_sync
 from synapseclient.core.utils import make_bogus_data_file
 from synapseclient.models import (
     AuthorizationMode,
@@ -111,6 +110,7 @@ class TestGridAsync:
         created_grid = await grid.create_async(
             timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
         )
+        self.schedule_for_cleanup(created_grid)
 
         # THEN: The grid should be created successfully
         assert created_grid is grid  # Should return the same instance
@@ -142,7 +142,7 @@ class TestGridAsync:
         assert our_session.source_entity_id == record_set_fixture.id
 
     async def test_create_grid_session_with_authorization_mode_async(
-        self, request: pytest.FixtureRequest, record_set_fixture: RecordSet
+        self, record_set_fixture: RecordSet
     ) -> None:
         # GIVEN: A Grid instance with a record_set_id and an explicit authorization mode
         grid = Grid(
@@ -156,11 +156,7 @@ class TestGridAsync:
         )
 
         # AND: The grid session is scheduled for cleanup
-        request.addfinalizer(
-            lambda: wrap_async_to_sync(
-                created_grid.delete_async(synapse_client=self.syn)
-            )
-        )
+        self.schedule_for_cleanup(created_grid)
 
         # THEN: The server accepts the request and creates the session successfully
         assert created_grid is grid
@@ -178,6 +174,7 @@ class TestGridAsync:
         created_grid1 = await grid1.create_async(
             timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
         )
+        self.schedule_for_cleanup(created_grid1)
 
         # THEN: A session should be created
         assert created_grid1.session_id is not None
@@ -260,51 +257,48 @@ class TestGridAsync:
         query = Query(sql=f"SELECT * FROM {ev.id}")
         grid = Grid(initial_query=query)
         created_grid = await grid.create_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(created_grid)
 
-        try:
-            # AND: A file uploaded into the scoped folder
-            bogus_file = make_bogus_data_file()
-            self.schedule_for_cleanup(bogus_file)
-            uploaded_file = await File(
-                path=bogus_file,
-                parent_id=folder.id,
-            ).store_async(synapse_client=self.syn)
-            self.schedule_for_cleanup(uploaded_file.id)
+        # AND: A file uploaded into the scoped folder
+        bogus_file = make_bogus_data_file()
+        self.schedule_for_cleanup(bogus_file)
+        uploaded_file = await File(
+            path=bogus_file,
+            parent_id=folder.id,
+        ).store_async(synapse_client=self.syn)
+        self.schedule_for_cleanup(uploaded_file.id)
 
-            # Wait for the EntityView to index the new file
-            async def file_indexed() -> bool:
-                df = await query_async(
-                    query=f"SELECT id FROM {ev.id} WHERE id = '{uploaded_file.id}'",
-                    include_row_id_and_row_version=False,
-                    synapse_client=self.syn,
-                )
-                return not df.empty
-
-            await wait_for_condition(
-                condition_fn=file_indexed,
-                timeout_seconds=QUERY_TIMEOUT_SEC,
-            )
-
-            # WHEN: Synchronizing the same session
-            synced_grid = await created_grid.synchronize_async(synapse_client=self.syn)
-
-            # THEN: The session ID is unchanged
-            assert synced_grid.session_id == created_grid.session_id
-            assert synced_grid.source_entity_id == ev.id
-
-            # AND: The downloaded CSV reflects the newly uploaded file
-            dest = tempfile.mkdtemp()
-            self.schedule_for_cleanup(dest)
-            csv_path = await synced_grid.download_csv_async(
-                destination=dest,
-                timeout=ASYNC_JOB_TIMEOUT_SEC,
+        # Wait for the EntityView to index the new file
+        async def file_indexed() -> bool:
+            df = await query_async(
+                query=f"SELECT id FROM {ev.id} WHERE id = '{uploaded_file.id}'",
+                include_row_id_and_row_version=False,
                 synapse_client=self.syn,
             )
-            df = pd.read_csv(csv_path)
-            assert uploaded_file.id in df["id"].tolist()
-        finally:
-            if created_grid.session_id:
-                await created_grid.delete_async(synapse_client=self.syn)
+            return not df.empty
+
+        await wait_for_condition(
+            condition_fn=file_indexed,
+            timeout_seconds=QUERY_TIMEOUT_SEC,
+        )
+
+        # WHEN: Synchronizing the same session
+        synced_grid = await created_grid.synchronize_async(synapse_client=self.syn)
+
+        # THEN: The session ID is unchanged
+        assert synced_grid.session_id == created_grid.session_id
+        assert synced_grid.source_entity_id == ev.id
+
+        # AND: The downloaded CSV reflects the newly uploaded file
+        dest = tempfile.mkdtemp()
+        self.schedule_for_cleanup(dest)
+        csv_path = await synced_grid.download_csv_async(
+            destination=dest,
+            timeout=ASYNC_JOB_TIMEOUT_SEC,
+            synapse_client=self.syn,
+        )
+        df = pd.read_csv(csv_path)
+        assert uploaded_file.id in df["id"].tolist()
 
     async def test_import_csv_to_grid_session_async(
         self,
@@ -314,90 +308,80 @@ class TestGridAsync:
 
         # GIVEN: Create a grid session first
         grid = Grid(record_set_id=record_set_fixture.id)
-        created_grid = None
-        try:
-            created_grid = await grid.create_async(
-                timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
-            )
+        created_grid = await grid.create_async(
+            timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
+        )
+        self.schedule_for_cleanup(created_grid)
 
-            assert created_grid.session_id is not None
+        assert created_grid.session_id is not None
 
-            # AND a CSV file uploaded to Synapse
-            test_data = pd.DataFrame(
-                {
-                    "id": [6, 7, 8, 9, 10],
-                    "name": ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"],
-                    "value": [10.5, 20.3, 30.7, 40.1, 50.9],
-                    "category": ["A", "B", "A", "C", "B"],
-                    "active": [True, False, False, True, True],
-                }
-            )
+        # AND a CSV file uploaded to Synapse
+        test_data = pd.DataFrame(
+            {
+                "id": [6, 7, 8, 9, 10],
+                "name": ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"],
+                "value": [10.5, 20.3, 30.7, 40.1, 50.9],
+                "category": ["A", "B", "A", "C", "B"],
+                "active": [True, False, False, True, True],
+            }
+        )
 
-            # Create a temporary CSV file.
-            with tempfile.NamedTemporaryFile(
-                "w", suffix=".csv", delete=False
-            ) as temp_csv:
-                temp_csv_path = temp_csv.name
+        # Create a temporary CSV file.
+        with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as temp_csv:
+            temp_csv_path = temp_csv.name
 
-            test_data.to_csv(temp_csv_path, index=False)
-            self.schedule_for_cleanup(temp_csv_path)
+        test_data.to_csv(temp_csv_path, index=False)
+        self.schedule_for_cleanup(temp_csv_path)
 
-            # WHEN: Importing the CSV into the grid session
-            imported_grid = await created_grid.import_csv_async(
-                path=temp_csv_path,
-                timeout=ASYNC_JOB_TIMEOUT_SEC,
-                synapse_client=self.syn,
-            )
+        # WHEN: Importing the CSV into the grid session
+        imported_grid = await created_grid.import_csv_async(
+            path=temp_csv_path,
+            timeout=ASYNC_JOB_TIMEOUT_SEC,
+            synapse_client=self.syn,
+        )
 
-            # THEN: The import should complete and return the Grid with the same session
-            assert imported_grid.session_id == created_grid.session_id
+        # THEN: The import should complete and return the Grid with the same session
+        assert imported_grid.session_id == created_grid.session_id
 
-            # WHEN: Exporting the grid back to the record set
-            exported_grid = await imported_grid.export_to_record_set_async(
-                timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
-            )
+        # WHEN: Exporting the grid back to the record set
+        exported_grid = await imported_grid.export_to_record_set_async(
+            timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
+        )
 
-            # THEN: The export should contain 10 total rows
-            # (5 from the original record set + 5 imported)
-            assert exported_grid.validation_summary_statistics is not None
-            assert (
-                exported_grid.validation_summary_statistics.total_number_of_children
-                == 10
-            )
-        finally:
-            if created_grid is not None and created_grid.session_id:
-                await created_grid.delete_async(synapse_client=self.syn)
+        # THEN: The export should contain 10 total rows
+        # (5 from the original record set + 5 imported)
+        assert exported_grid.validation_summary_statistics is not None
+        assert (
+            exported_grid.validation_summary_statistics.total_number_of_children == 10
+        )
 
     async def test_download_csv_async(self, record_set_fixture: RecordSet) -> None:
         # GIVEN: Create a grid session first
         grid = Grid(record_set_id=record_set_fixture.id)
-        try:
-            created_grid = await grid.create_async(
-                timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
-            )
+        created_grid = await grid.create_async(
+            timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
+        )
+        self.schedule_for_cleanup(created_grid)
 
-            # WHEN: Downloading the grid results as CSV
-            temp_dir = tempfile.mkdtemp()
-            self.schedule_for_cleanup(temp_dir)
-            csv_path = await created_grid.download_csv_async(
-                synapse_client=self.syn,
-                timeout=ASYNC_JOB_TIMEOUT_SEC,
-                destination=temp_dir,
-            )
+        # WHEN: Downloading the grid results as CSV
+        temp_dir = tempfile.mkdtemp()
+        self.schedule_for_cleanup(temp_dir)
+        csv_path = await created_grid.download_csv_async(
+            synapse_client=self.syn,
+            timeout=ASYNC_JOB_TIMEOUT_SEC,
+            destination=temp_dir,
+        )
 
-            # THEN: The CSV content should be returned and match the original data
-            assert os.path.exists(csv_path)
-            df = pd.read_csv(csv_path)
-            expected_df = pd.DataFrame(
-                {
-                    "id": [1, 2, 3, 4, 5],
-                    "name": ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"],
-                    "value": [10.5, 20.3, 30.7, 40.1, 50.9],
-                    "category": ["A", "B", "A", "C", "B"],
-                    "active": [True, False, True, True, False],
-                }
-            )
-            pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
-        finally:
-            if created_grid is not None and created_grid.session_id:
-                await created_grid.delete_async(synapse_client=self.syn)
+        # THEN: The CSV content should be returned and match the original data
+        assert os.path.exists(csv_path)
+        df = pd.read_csv(csv_path)
+        expected_df = pd.DataFrame(
+            {
+                "id": [1, 2, 3, 4, 5],
+                "name": ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"],
+                "value": [10.5, 20.3, 30.7, 40.1, 50.9],
+                "category": ["A", "B", "A", "C", "B"],
+                "active": [True, False, True, True, False],
+            }
+        )
+        pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)

--- a/tests/integration/synapseclient/models/async/test_grid_async.py
+++ b/tests/integration/synapseclient/models/async/test_grid_async.py
@@ -150,7 +150,6 @@ class TestGridAsync:
         )
 
         # WHEN: Creating a grid session
-        # (authorization_mode is serialized into the CreateGridRequest sent to Synapse)
         created_grid = await grid.create_async(
             timeout=ASYNC_JOB_TIMEOUT_SEC, synapse_client=self.syn
         )
@@ -159,6 +158,7 @@ class TestGridAsync:
         assert created_grid is grid
         assert created_grid.session_id is not None
         assert created_grid.source_entity_id == record_set_fixture.id
+        assert created_grid.authorization_mode == AuthorizationMode.SOURCE_BENEFACTOR
 
     async def test_create_grid_session_and_reuse_session_async(
         self, record_set_fixture: RecordSet

--- a/tests/unit/synapseclient/extensions/unit_test_curator.py
+++ b/tests/unit/synapseclient/extensions/unit_test_curator.py
@@ -54,6 +54,7 @@ from synapseclient.extensions.curator.schema_registry import (
 )
 from synapseclient.models import Column, ColumnType, ViewTypeMask
 from synapseclient.models.curation import (
+    AuthorizationMode,
     FileBasedMetadataTaskProperties,
     RecordBasedMetadataTaskProperties,
 )
@@ -484,6 +485,62 @@ class TestCreateFileBasedMetadataTask(unittest.TestCase):
                     view_type_mask=ViewTypeMask.FILE,
                 )
 
+    @patch(
+        "synapseclient.extensions.curator.file_based_metadata_task.project_id_from_entity_id"
+    )
+    @patch(
+        "synapseclient.extensions.curator.file_based_metadata_task.Synapse.get_client"
+    )
+    @patch(
+        "synapseclient.extensions.curator.file_based_metadata_task.create_json_schema_entity_view"
+    )
+    @patch("synapseclient.extensions.curator.file_based_metadata_task.Folder")
+    @patch("synapseclient.extensions.curator.file_based_metadata_task.CurationTask")
+    def test_create_file_based_metadata_task_with_authorization_mode(
+        self,
+        mock_curation_task_cls,
+        mock_folder_cls,
+        mock_create_entity_view,
+        mock_get_client,
+        mock_get_project_id_from_entity_id,
+    ):
+        """The authorization params are forwarded into FileBasedMetadataTaskProperties."""
+        # GIVEN a file-based metadata task with authorization params
+        mock_get_client.return_value = self.mock_syn
+        mock_create_entity_view.return_value = "test_entity_view_id"
+        mock_get_project_id_from_entity_id.return_value = self.project_id
+
+        mock_folder = Mock()
+        mock_folder_cls.return_value = mock_folder
+        mock_folder.get.return_value = mock_folder
+        mock_folder.parent_id = "syn11111111"
+
+        mock_task = Mock()
+        mock_task.task_id = "task123"
+        mock_curation_task = Mock()
+        mock_curation_task.store.return_value = mock_task
+        mock_curation_task_cls.return_value = mock_curation_task
+
+        # WHEN I create the task with an authorization mode
+        create_file_based_metadata_task(
+            folder_id=self.folder_id,
+            curation_task_name=self.curation_task_name,
+            instructions=self.instructions,
+            attach_wiki=False,
+            entity_view_name=self.entity_view_name,
+            schema_uri=self.schema_uri,
+            suggested_authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
+            synapse_client=self.mock_syn,
+        )
+
+        # THEN the CurationTask is built with that mode on its task_properties
+        _, kwargs = mock_curation_task_cls.call_args
+        assert kwargs["task_properties"] == FileBasedMetadataTaskProperties(
+            upload_folder_id=self.folder_id,
+            file_view_id="test_entity_view_id",
+            suggested_authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
+        )
+
 
 class TestCreateRecordBasedMetadataTask(unittest.TestCase):
     """Test cases for create_record_based_metadata_task function."""
@@ -604,6 +661,77 @@ class TestCreateRecordBasedMetadataTask(unittest.TestCase):
         # AND the Grid deprecation warning was emitted
         self.mock_syn.logger.warning.assert_any_call(
             "A Grid object will no longer be created by this function starting in v5.0.0."
+        )
+
+    @patch(
+        "synapseclient.extensions.curator.record_based_metadata_task.project_id_from_entity_id"
+    )
+    @patch(
+        "synapseclient.extensions.curator.record_based_metadata_task.Synapse.get_client"
+    )
+    @patch(
+        "synapseclient.extensions.curator.record_based_metadata_task.extract_schema_properties_from_web"
+    )
+    @patch(
+        "synapseclient.extensions.curator.record_based_metadata_task.tempfile.NamedTemporaryFile"
+    )
+    @patch("synapseclient.extensions.curator.record_based_metadata_task.RecordSet")
+    @patch("synapseclient.extensions.curator.record_based_metadata_task.CurationTask")
+    @patch("synapseclient.extensions.curator.record_based_metadata_task.Grid")
+    @patch("builtins.open")
+    def test_create_record_based_metadata_task_with_authorization_mode(
+        self,
+        mock_open,
+        mock_grid_cls,
+        mock_curation_task_cls,
+        mock_record_set_cls,
+        mock_temp_file,
+        mock_extract_schema,
+        mock_get_client,
+        mock_get_project_id_from_entity_id,
+    ):
+        """The authorization params are forwarded into RecordBasedMetadataTaskProperties."""
+        # GIVEN a record-based metadata task with authorization params
+        mock_get_client.return_value = self.mock_syn
+        mock_get_project_id_from_entity_id.return_value = self.project_id
+
+        mock_extract_schema.return_value = pd.DataFrame(columns=["specimenID"])
+
+        mock_temp = Mock()
+        mock_temp.name = "/tmp/test.csv"
+        mock_temp_file.return_value = mock_temp
+
+        mock_record_set = Mock()
+        mock_record_set.id = "syn87654321"
+        mock_record_set_instance = Mock()
+        mock_record_set_instance.store.return_value = mock_record_set
+        mock_record_set_cls.return_value = mock_record_set_instance
+
+        mock_task = Mock()
+        mock_task.task_id = "task123"
+        mock_curation_task = Mock()
+        mock_curation_task.store.return_value = mock_task
+        mock_curation_task_cls.return_value = mock_curation_task
+
+        # WHEN I create the task with an authorization mode
+        create_record_based_metadata_task(
+            folder_id=self.folder_id,
+            record_set_name=self.record_set_name,
+            record_set_description=self.record_set_description,
+            curation_task_name=self.curation_task_name,
+            upsert_keys=self.upsert_keys,
+            instructions=self.instructions,
+            schema_uri=self.schema_uri,
+            suggested_authorization_mode="SESSION_OWNER",
+            create_grid=False,
+            synapse_client=self.mock_syn,
+        )
+
+        # THEN the CurationTask is built with that mode on its task_properties
+        _, kwargs = mock_curation_task_cls.call_args
+        assert kwargs["task_properties"] == RecordBasedMetadataTaskProperties(
+            record_set_id="syn87654321",
+            suggested_authorization_mode=AuthorizationMode.SESSION_OWNER,
         )
 
     @patch(

--- a/tests/unit/synapseclient/extensions/unit_test_curator.py
+++ b/tests/unit/synapseclient/extensions/unit_test_curator.py
@@ -407,7 +407,7 @@ class TestCreateFileBasedMetadataTask(unittest.TestCase):
     )
     @patch("synapseclient.extensions.curator.file_based_metadata_task.Folder")
     @patch("synapseclient.extensions.curator.file_based_metadata_task.CurationTask")
-    def test_create_file_based_metadata_task_with_assignee(
+    def test_create_file_based_metadata_task_forwards_all_params_to_curation_task(
         self,
         mock_curation_task_cls,
         mock_folder_cls,
@@ -415,15 +415,34 @@ class TestCreateFileBasedMetadataTask(unittest.TestCase):
         mock_get_client,
         mock_get_project_id_from_entity_id,
     ):
-        """Test successful creation of file-based metadata task with assignee_principal_id."""
-        # Test both string and int inputs - int should be converted to string
+        """Every parameter is forwarded to CurationTask. The assignee int is coerced
+        to a string, and suggested_authorization_mode supplied as a string is coerced
+        to the AuthorizationMode enum by FileBasedMetadataTaskProperties."""
+        # (assignee_input, expected_assignee, auth_mode_input, expected_auth_mode)
         test_cases = [
-            ("1234", "1234"),
-            (1234, "1234"),
+            (
+                "1234",
+                "1234",
+                AuthorizationMode.SOURCE_BENEFACTOR,
+                AuthorizationMode.SOURCE_BENEFACTOR,
+            ),
+            (
+                1234,
+                "1234",
+                "SESSION_OWNER",
+                AuthorizationMode.SESSION_OWNER,
+            ),
         ]
 
-        for input_assignee, expected_assignee in test_cases:
-            with self.subTest(input_assignee=input_assignee):
+        for (
+            input_assignee,
+            expected_assignee,
+            input_auth_mode,
+            expected_auth_mode,
+        ) in test_cases:
+            with self.subTest(
+                input_assignee=input_assignee, input_auth_mode=input_auth_mode
+            ):
                 # Reset mocks for each subtest
                 mock_curation_task_cls.reset_mock()
                 mock_folder_cls.reset_mock()
@@ -431,7 +450,8 @@ class TestCreateFileBasedMetadataTask(unittest.TestCase):
                 mock_get_client.reset_mock()
                 mock_get_project_id_from_entity_id.reset_mock()
 
-                # GIVEN a file-based metadata task with assignee_principal_id
+                # GIVEN a file-based metadata task with an assignee and an
+                # authorization mode
                 mock_get_client.return_value = self.mock_syn
                 mock_create_entity_view.return_value = "test_entity_view_id"
                 mock_get_project_id_from_entity_id.return_value = self.project_id
@@ -441,18 +461,13 @@ class TestCreateFileBasedMetadataTask(unittest.TestCase):
                 mock_folder.get.return_value = mock_folder
                 mock_folder.parent_id = "syn11111111"
 
-                mock_project = Mock()
-                mock_project.concreteType = "org.sagebionetworks.repo.model.Project"
-                mock_project.id = "syn22222222"
-                self.mock_syn.get.return_value = mock_project
-
                 mock_task = Mock()
                 mock_task.task_id = "task123"
                 mock_curation_task = Mock()
                 mock_curation_task.store.return_value = mock_task
                 mock_curation_task_cls.return_value = mock_curation_task
 
-                # WHEN I create the file-based metadata task with assignee_principal_id
+                # WHEN I create the file-based metadata task
                 result = create_file_based_metadata_task(
                     folder_id=self.folder_id,
                     curation_task_name=self.curation_task_name,
@@ -462,10 +477,12 @@ class TestCreateFileBasedMetadataTask(unittest.TestCase):
                     schema_uri=self.schema_uri,
                     enable_derived_annotations=True,
                     assignee_principal_id=input_assignee,
+                    suggested_authorization_mode=input_auth_mode,
                     synapse_client=self.mock_syn,
                 )
 
-                # THEN the CurationTask should be called with assignee_principal_id as string
+                # THEN CurationTask is constructed with every parameter, the assignee
+                # coerced to a string and the authorization mode coerced to the enum
                 mock_curation_task_cls.assert_called_once_with(
                     data_type=self.curation_task_name,
                     project_id=self.project_id,
@@ -473,10 +490,11 @@ class TestCreateFileBasedMetadataTask(unittest.TestCase):
                     assignee_principal_id=expected_assignee,
                     task_properties=FileBasedMetadataTaskProperties(
                         upload_folder_id=self.folder_id,
-                        file_view_id=mock_create_entity_view.return_value,
+                        file_view_id="test_entity_view_id",
+                        suggested_authorization_mode=expected_auth_mode,
                     ),
                 )
-                # AND the task should be created successfully
+                # AND the task is created successfully
                 assert result == ("test_entity_view_id", "task123")
                 mock_create_entity_view.assert_called_once_with(
                     syn=self.mock_syn,
@@ -484,62 +502,6 @@ class TestCreateFileBasedMetadataTask(unittest.TestCase):
                     entity_view_name=self.entity_view_name,
                     view_type_mask=ViewTypeMask.FILE,
                 )
-
-    @patch(
-        "synapseclient.extensions.curator.file_based_metadata_task.project_id_from_entity_id"
-    )
-    @patch(
-        "synapseclient.extensions.curator.file_based_metadata_task.Synapse.get_client"
-    )
-    @patch(
-        "synapseclient.extensions.curator.file_based_metadata_task.create_json_schema_entity_view"
-    )
-    @patch("synapseclient.extensions.curator.file_based_metadata_task.Folder")
-    @patch("synapseclient.extensions.curator.file_based_metadata_task.CurationTask")
-    def test_create_file_based_metadata_task_with_authorization_mode(
-        self,
-        mock_curation_task_cls,
-        mock_folder_cls,
-        mock_create_entity_view,
-        mock_get_client,
-        mock_get_project_id_from_entity_id,
-    ):
-        """The authorization params are forwarded into FileBasedMetadataTaskProperties."""
-        # GIVEN a file-based metadata task with authorization params
-        mock_get_client.return_value = self.mock_syn
-        mock_create_entity_view.return_value = "test_entity_view_id"
-        mock_get_project_id_from_entity_id.return_value = self.project_id
-
-        mock_folder = Mock()
-        mock_folder_cls.return_value = mock_folder
-        mock_folder.get.return_value = mock_folder
-        mock_folder.parent_id = "syn11111111"
-
-        mock_task = Mock()
-        mock_task.task_id = "task123"
-        mock_curation_task = Mock()
-        mock_curation_task.store.return_value = mock_task
-        mock_curation_task_cls.return_value = mock_curation_task
-
-        # WHEN I create the task with an authorization mode
-        create_file_based_metadata_task(
-            folder_id=self.folder_id,
-            curation_task_name=self.curation_task_name,
-            instructions=self.instructions,
-            attach_wiki=False,
-            entity_view_name=self.entity_view_name,
-            schema_uri=self.schema_uri,
-            suggested_authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
-            synapse_client=self.mock_syn,
-        )
-
-        # THEN the CurationTask is built with that mode on its task_properties
-        _, kwargs = mock_curation_task_cls.call_args
-        assert kwargs["task_properties"] == FileBasedMetadataTaskProperties(
-            upload_folder_id=self.folder_id,
-            file_view_id="test_entity_view_id",
-            suggested_authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
-        )
 
 
 class TestCreateRecordBasedMetadataTask(unittest.TestCase):
@@ -679,7 +641,7 @@ class TestCreateRecordBasedMetadataTask(unittest.TestCase):
     @patch("synapseclient.extensions.curator.record_based_metadata_task.CurationTask")
     @patch("synapseclient.extensions.curator.record_based_metadata_task.Grid")
     @patch("builtins.open")
-    def test_create_record_based_metadata_task_with_authorization_mode(
+    def test_create_record_based_metadata_task_forwards_all_params_to_curation_task(
         self,
         mock_open,
         mock_grid_cls,
@@ -690,49 +652,96 @@ class TestCreateRecordBasedMetadataTask(unittest.TestCase):
         mock_get_client,
         mock_get_project_id_from_entity_id,
     ):
-        """The authorization params are forwarded into RecordBasedMetadataTaskProperties."""
-        # GIVEN a record-based metadata task with authorization params
-        mock_get_client.return_value = self.mock_syn
-        mock_get_project_id_from_entity_id.return_value = self.project_id
+        """Every parameter is forwarded to CurationTask. The assignee int is coerced
+        to a string, and suggested_authorization_mode supplied as a string is coerced
+        to the AuthorizationMode enum by RecordBasedMetadataTaskProperties."""
+        # (assignee_input, expected_assignee, auth_mode_input, expected_auth_mode)
+        test_cases = [
+            (
+                "1234",
+                "1234",
+                AuthorizationMode.SOURCE_BENEFACTOR,
+                AuthorizationMode.SOURCE_BENEFACTOR,
+            ),
+            (
+                1234,
+                "1234",
+                "SESSION_OWNER",
+                AuthorizationMode.SESSION_OWNER,
+            ),
+        ]
 
-        mock_extract_schema.return_value = pd.DataFrame(columns=["specimenID"])
+        for (
+            input_assignee,
+            expected_assignee,
+            input_auth_mode,
+            expected_auth_mode,
+        ) in test_cases:
+            with self.subTest(
+                input_assignee=input_assignee, input_auth_mode=input_auth_mode
+            ):
+                # Reset mocks for each subtest
+                for mock_obj in (
+                    mock_grid_cls,
+                    mock_curation_task_cls,
+                    mock_record_set_cls,
+                    mock_temp_file,
+                    mock_extract_schema,
+                    mock_get_client,
+                    mock_get_project_id_from_entity_id,
+                ):
+                    mock_obj.reset_mock()
 
-        mock_temp = Mock()
-        mock_temp.name = "/tmp/test.csv"
-        mock_temp_file.return_value = mock_temp
+                # GIVEN a record-based metadata task with an assignee and an
+                # authorization mode
+                mock_get_client.return_value = self.mock_syn
+                mock_get_project_id_from_entity_id.return_value = self.project_id
 
-        mock_record_set = Mock()
-        mock_record_set.id = "syn87654321"
-        mock_record_set_instance = Mock()
-        mock_record_set_instance.store.return_value = mock_record_set
-        mock_record_set_cls.return_value = mock_record_set_instance
+                mock_extract_schema.return_value = pd.DataFrame(columns=["specimenID"])
 
-        mock_task = Mock()
-        mock_task.task_id = "task123"
-        mock_curation_task = Mock()
-        mock_curation_task.store.return_value = mock_task
-        mock_curation_task_cls.return_value = mock_curation_task
+                mock_temp = Mock()
+                mock_temp.name = "/tmp/test.csv"
+                mock_temp_file.return_value = mock_temp
 
-        # WHEN I create the task with an authorization mode
-        create_record_based_metadata_task(
-            folder_id=self.folder_id,
-            record_set_name=self.record_set_name,
-            record_set_description=self.record_set_description,
-            curation_task_name=self.curation_task_name,
-            upsert_keys=self.upsert_keys,
-            instructions=self.instructions,
-            schema_uri=self.schema_uri,
-            suggested_authorization_mode="SESSION_OWNER",
-            create_grid=False,
-            synapse_client=self.mock_syn,
-        )
+                mock_record_set = Mock()
+                mock_record_set.id = "syn87654321"
+                mock_record_set_instance = Mock()
+                mock_record_set_instance.store.return_value = mock_record_set
+                mock_record_set_cls.return_value = mock_record_set_instance
 
-        # THEN the CurationTask is built with that mode on its task_properties
-        _, kwargs = mock_curation_task_cls.call_args
-        assert kwargs["task_properties"] == RecordBasedMetadataTaskProperties(
-            record_set_id="syn87654321",
-            suggested_authorization_mode=AuthorizationMode.SESSION_OWNER,
-        )
+                mock_task = Mock()
+                mock_task.task_id = "task123"
+                mock_curation_task = Mock()
+                mock_curation_task.store.return_value = mock_task
+                mock_curation_task_cls.return_value = mock_curation_task
+
+                # WHEN I create the record-based metadata task
+                create_record_based_metadata_task(
+                    folder_id=self.folder_id,
+                    record_set_name=self.record_set_name,
+                    record_set_description=self.record_set_description,
+                    curation_task_name=self.curation_task_name,
+                    upsert_keys=self.upsert_keys,
+                    instructions=self.instructions,
+                    schema_uri=self.schema_uri,
+                    assignee_principal_id=input_assignee,
+                    suggested_authorization_mode=input_auth_mode,
+                    create_grid=False,
+                    synapse_client=self.mock_syn,
+                )
+
+                # THEN CurationTask is constructed with every parameter, the assignee
+                # coerced to a string and the authorization mode coerced to the enum
+                mock_curation_task_cls.assert_called_once_with(
+                    data_type=self.curation_task_name,
+                    project_id=self.project_id,
+                    instructions=self.instructions,
+                    assignee_principal_id=expected_assignee,
+                    task_properties=RecordBasedMetadataTaskProperties(
+                        record_set_id="syn87654321",
+                        suggested_authorization_mode=expected_auth_mode,
+                    ),
+                )
 
     @patch(
         "synapseclient.extensions.curator.record_based_metadata_task.project_id_from_entity_id"

--- a/tests/unit/synapseclient/extensions/unit_test_curator.py
+++ b/tests/unit/synapseclient/extensions/unit_test_curator.py
@@ -416,7 +416,7 @@ class TestCreateFileBasedMetadataTask(unittest.TestCase):
         mock_get_project_id_from_entity_id,
     ):
         """Every parameter is forwarded to CurationTask. The assignee int is coerced
-        to a string, and suggested_authorization_mode supplied as a string is coerced
+        to a string, and authorization_mode supplied as a string is coerced
         to the AuthorizationMode enum by FileBasedMetadataTaskProperties."""
         # (assignee_input, expected_assignee, auth_mode_input, expected_auth_mode)
         test_cases = [
@@ -477,7 +477,7 @@ class TestCreateFileBasedMetadataTask(unittest.TestCase):
                     schema_uri=self.schema_uri,
                     enable_derived_annotations=True,
                     assignee_principal_id=input_assignee,
-                    suggested_authorization_mode=input_auth_mode,
+                    authorization_mode=input_auth_mode,
                     synapse_client=self.mock_syn,
                 )
 
@@ -653,7 +653,7 @@ class TestCreateRecordBasedMetadataTask(unittest.TestCase):
         mock_get_project_id_from_entity_id,
     ):
         """Every parameter is forwarded to CurationTask. The assignee int is coerced
-        to a string, and suggested_authorization_mode supplied as a string is coerced
+        to a string, and authorization_mode supplied as a string is coerced
         to the AuthorizationMode enum by RecordBasedMetadataTaskProperties."""
         # (assignee_input, expected_assignee, auth_mode_input, expected_auth_mode)
         test_cases = [
@@ -725,7 +725,7 @@ class TestCreateRecordBasedMetadataTask(unittest.TestCase):
                     instructions=self.instructions,
                     schema_uri=self.schema_uri,
                     assignee_principal_id=input_assignee,
-                    suggested_authorization_mode=input_auth_mode,
+                    authorization_mode=input_auth_mode,
                     create_grid=False,
                     synapse_client=self.mock_syn,
                 )

--- a/tests/unit/synapseclient/extensions/unit_test_curator.py
+++ b/tests/unit/synapseclient/extensions/unit_test_curator.py
@@ -744,6 +744,22 @@ class TestCreateRecordBasedMetadataTask(unittest.TestCase):
                     ),
                 )
 
+    @patch(
+        "synapseclient.extensions.curator.record_based_metadata_task.project_id_from_entity_id"
+    )
+    @patch(
+        "synapseclient.extensions.curator.record_based_metadata_task.Synapse.get_client"
+    )
+    @patch(
+        "synapseclient.extensions.curator.record_based_metadata_task.extract_schema_properties_from_web"
+    )
+    @patch(
+        "synapseclient.extensions.curator.record_based_metadata_task.tempfile.NamedTemporaryFile"
+    )
+    @patch("synapseclient.extensions.curator.record_based_metadata_task.RecordSet")
+    @patch("synapseclient.extensions.curator.record_based_metadata_task.CurationTask")
+    @patch("synapseclient.extensions.curator.record_based_metadata_task.Grid")
+    @patch("builtins.open")
     def test_create_record_based_metadata_task_reorders_upsert_keys_first(
         self,
         mock_open,

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -110,7 +110,9 @@ def _get_grid_session_response():
         "lastReplicaIdService": -5,
         "gridJsonSchema$Id": "my-schema-id",
         "sourceEntityId": SOURCE_ENTITY_ID,
-        "ownerPrincipalId": OWNER_PRINCIPAL_ID,
+        # The server returns ownerPrincipalId as a string; the client coerces to int.
+        "ownerPrincipalId": str(OWNER_PRINCIPAL_ID),
+        "authorizationMode": "SESSION_OWNER",
     }
 
 
@@ -1386,7 +1388,12 @@ class TestGrid:
         assert grid.last_replica_id_service == -5
         assert grid.grid_json_schema_id == "my-schema-id"
         assert grid.source_entity_id == SOURCE_ENTITY_ID
+        # AND the owner principal id is coerced from the response string to an int
         assert grid.owner_principal_id == OWNER_PRINCIPAL_ID
+        assert isinstance(grid.owner_principal_id, int)
+        # AND the authorization mode is coerced from the string to the enum
+        assert grid.authorization_mode == AuthorizationMode.SESSION_OWNER
+        assert isinstance(grid.authorization_mode, AuthorizationMode)
 
     async def test_create_async_with_record_set_id(self) -> None:
         # GIVEN a Grid with a record_set_id
@@ -1406,11 +1413,13 @@ class TestGrid:
         ):
             result = await grid.create_async(synapse_client=self.syn)
 
-            # THEN the grid should be populated with session data
+            # THEN the grid should be populated with session data, including the
+            # authorization mode coerced from the response string to the enum
             assert result.session_id == SESSION_ID
             assert result.started_by == STARTED_BY
             assert result.started_on == STARTED_ON
             assert result.source_entity_id == SOURCE_ENTITY_ID
+            assert result.authorization_mode == AuthorizationMode.SESSION_OWNER
 
     async def test_create_async_no_record_set_or_query_raises(self) -> None:
         # GIVEN a Grid with neither record_set_id nor initial_query

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -15,6 +15,7 @@ from synapseclient.core.constants.concrete_types import (
 )
 from synapseclient.models import EntityView, RecordSet
 from synapseclient.models.curation import (
+    AuthorizationMode,
     CreateGridRequest,
     CurationTask,
     CurationTaskStatus,
@@ -177,8 +178,43 @@ class TestFileBasedMetadataTaskProperties:
         # WHEN I convert it to a request dict
         request = props.to_synapse_request()
 
-        # THEN the request should only contain concreteType
+        # THEN the request should only contain concreteType (all None-valued fields,
+        # including suggested_authorization_mode, are dropped)
         assert request == {"concreteType": FILE_BASED_METADATA_TASK_PROPERTIES}
+
+    def test_fill_from_dict_authorization_fields(self) -> None:
+        # GIVEN a response dict including the authorization fields
+        response = {
+            "uploadFolderId": UPLOAD_FOLDER_ID,
+            "fileViewId": FILE_VIEW_ID,
+            "suggestedAuthorizationMode": "SOURCE_BENEFACTOR",
+            "collaboratorPrincipalIds": ["111", "222"],
+        }
+
+        # WHEN I fill a FileBasedMetadataTaskProperties from the dict
+        props = FileBasedMetadataTaskProperties()
+        props.fill_from_dict(response)
+
+        # THEN the mode is coerced to the enum and collaborators pass through
+        assert props.suggested_authorization_mode == AuthorizationMode.SOURCE_BENEFACTOR
+        assert isinstance(props.suggested_authorization_mode, AuthorizationMode)
+        assert props.collaborator_principal_ids == ["111", "222"]
+
+    def test_to_synapse_request_authorization_fields(self) -> None:
+        # GIVEN properties with the authorization mode supplied as a plain string
+        props = FileBasedMetadataTaskProperties(
+            upload_folder_id=UPLOAD_FOLDER_ID,
+            file_view_id=FILE_VIEW_ID,
+            suggested_authorization_mode="SESSION_OWNER",
+            collaborator_principal_ids=["111"],
+        )
+
+        # WHEN I convert it to a request dict
+        request = props.to_synapse_request()
+
+        # THEN the enum value is serialized as a string and collaborators pass through
+        assert request["suggestedAuthorizationMode"] == "SESSION_OWNER"
+        assert request["collaboratorPrincipalIds"] == ["111"]
 
 
 class TestRecordBasedMetadataTaskProperties:
@@ -205,6 +241,38 @@ class TestRecordBasedMetadataTaskProperties:
         # THEN the request should contain the correct values
         assert request["concreteType"] == RECORD_BASED_METADATA_TASK_PROPERTIES
         assert request["recordSetId"] == RECORD_SET_ID
+
+    def test_fill_from_dict_authorization_fields(self) -> None:
+        # GIVEN a response dict including the authorization fields
+        response = {
+            "recordSetId": RECORD_SET_ID,
+            "suggestedAuthorizationMode": "SESSION_OWNER",
+            "collaboratorPrincipalIds": ["111"],
+        }
+
+        # WHEN I fill a RecordBasedMetadataTaskProperties from the dict
+        props = RecordBasedMetadataTaskProperties()
+        props.fill_from_dict(response)
+
+        # THEN the mode is coerced to the enum and collaborators pass through
+        assert props.suggested_authorization_mode == AuthorizationMode.SESSION_OWNER
+        assert isinstance(props.suggested_authorization_mode, AuthorizationMode)
+        assert props.collaborator_principal_ids == ["111"]
+
+    def test_to_synapse_request_authorization_fields(self) -> None:
+        # GIVEN properties with an AuthorizationMode enum value set
+        props = RecordBasedMetadataTaskProperties(
+            record_set_id=RECORD_SET_ID,
+            suggested_authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
+        )
+
+        # WHEN I convert it to a request dict
+        request = props.to_synapse_request()
+
+        # THEN the enum value is serialized as a string and the absent collaborators
+        # are dropped by delete_none_keys
+        assert request["suggestedAuthorizationMode"] == "SOURCE_BENEFACTOR"
+        assert "collaboratorPrincipalIds" not in request
 
 
 class TestCreateTaskPropertiesFromDict:
@@ -1092,6 +1160,97 @@ class TestCurationTask:
             match="task_properties must be a FileBasedMetadataTaskProperties",
         ):
             await task.create_grid_session_async(synapse_client=self.syn)
+
+    async def test_create_grid_session_async_passes_authorization_mode_record_based(
+        self,
+    ) -> None:
+        """A record-based task forwards its suggested_authorization_mode to the Grid."""
+        # GIVEN a record-based task in SESSION_OWNER mode
+        task = CurationTask(
+            task_id=TASK_ID,
+            task_properties=RecordBasedMetadataTaskProperties(
+                record_set_id=RECORD_SET_ID,
+                suggested_authorization_mode="SESSION_OWNER",
+            ),
+        )
+
+        with (
+            patch.object(RecordSet, "get_async", new_callable=AsyncMock),
+            patch.object(task, "set_active_grid_session_async", new_callable=AsyncMock),
+            patch("synapseclient.models.curation.Grid") as mock_grid_cls,
+        ):
+            mock_grid = mock_grid_cls.return_value
+            mock_grid.session_id = SESSION_ID
+            mock_grid.create_async = AsyncMock(return_value=mock_grid)
+
+            # WHEN I create a grid session without an explicit owner
+            await task.create_grid_session_async(synapse_client=self.syn)
+
+            # THEN the Grid is constructed with the task's authorization mode and the
+            # owner is left to the caller (None) for the server to resolve
+            kwargs = mock_grid_cls.call_args.kwargs
+            assert kwargs["authorization_mode"] == AuthorizationMode.SESSION_OWNER
+            assert kwargs["owner_principal_id"] is None
+
+    async def test_create_grid_session_async_passes_authorization_mode_file_based(
+        self,
+    ) -> None:
+        """A file-based task forwards its suggested_authorization_mode to the Grid."""
+        # GIVEN a file-based task in SOURCE_BENEFACTOR mode
+        task = CurationTask(
+            task_id=TASK_ID,
+            task_properties=FileBasedMetadataTaskProperties(
+                upload_folder_id=UPLOAD_FOLDER_ID,
+                file_view_id=FILE_VIEW_ID,
+                suggested_authorization_mode="SOURCE_BENEFACTOR",
+            ),
+        )
+
+        with (
+            patch.object(EntityView, "get_async", new_callable=AsyncMock),
+            patch.object(task, "set_active_grid_session_async", new_callable=AsyncMock),
+            patch("synapseclient.models.curation.Grid") as mock_grid_cls,
+        ):
+            mock_grid = mock_grid_cls.return_value
+            mock_grid.session_id = SESSION_ID
+            mock_grid.create_async = AsyncMock(return_value=mock_grid)
+
+            # WHEN I create a grid session
+            await task.create_grid_session_async(synapse_client=self.syn)
+
+            # THEN the Grid is constructed with the task's authorization mode
+            assert (
+                mock_grid_cls.call_args.kwargs["authorization_mode"]
+                == AuthorizationMode.SOURCE_BENEFACTOR
+            )
+
+    async def test_create_grid_session_async_passes_explicit_owner(self) -> None:
+        """An explicit owner_principal_id is passed straight through to the Grid."""
+        # GIVEN a record-based task
+        task = CurationTask(
+            task_id=TASK_ID,
+            task_properties=RecordBasedMetadataTaskProperties(
+                record_set_id=RECORD_SET_ID,
+                suggested_authorization_mode="SESSION_OWNER",
+            ),
+        )
+
+        with (
+            patch.object(RecordSet, "get_async", new_callable=AsyncMock),
+            patch.object(task, "set_active_grid_session_async", new_callable=AsyncMock),
+            patch("synapseclient.models.curation.Grid") as mock_grid_cls,
+        ):
+            mock_grid = mock_grid_cls.return_value
+            mock_grid.session_id = SESSION_ID
+            mock_grid.create_async = AsyncMock(return_value=mock_grid)
+
+            # WHEN I create a grid session with an explicit owner
+            await task.create_grid_session_async(
+                owner_principal_id=555, synapse_client=self.syn
+            )
+
+            # THEN that owner is forwarded to the Grid unchanged
+            assert mock_grid_cls.call_args.kwargs["owner_principal_id"] == 555
 
     async def test_list_async_assigned_to_me_and_assignee_ids_raises(self) -> None:
         # GIVEN both assigned_to_me and assignee_ids are provided

--- a/tests/unit/synapseclient/models/async/unit_test_curation_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_curation_async.py
@@ -1421,6 +1421,30 @@ class TestGrid:
             assert result.source_entity_id == SOURCE_ENTITY_ID
             assert result.authorization_mode == AuthorizationMode.SESSION_OWNER
 
+    async def test_create_async_forwards_authorization_mode_to_request(self) -> None:
+        # GIVEN a Grid with a record_set_id and an explicit authorization mode
+        grid = Grid(
+            record_set_id=RECORD_SET_ID,
+            authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
+        )
+
+        # WHEN I call create_async (patching the CreateGridRequest the Grid builds)
+        with patch(
+            "synapseclient.models.curation.CreateGridRequest"
+        ) as mock_request_cls:
+            mock_request = mock_request_cls.return_value
+            mock_request.send_job_and_wait_async = AsyncMock(return_value=mock_request)
+            await grid.create_async(synapse_client=self.syn)
+
+            # THEN the request is constructed once with the grid's authorization mode
+            # forwarded alongside the other session parameters
+            mock_request_cls.assert_called_once_with(
+                record_set_id=RECORD_SET_ID,
+                initial_query=None,
+                owner_principal_id=None,
+                authorization_mode=AuthorizationMode.SOURCE_BENEFACTOR,
+            )
+
     async def test_create_async_no_record_set_or_query_raises(self) -> None:
         # GIVEN a Grid with neither record_set_id nor initial_query
         grid = Grid()
@@ -1801,6 +1825,12 @@ class TestCreateGridRequest:
         assert grid.started_by == STARTED_BY
         assert grid.etag == GRID_ETAG
         assert grid.source_entity_id == SOURCE_ENTITY_ID
+        # AND the owner principal id is coerced from the response string to an int
+        assert grid.owner_principal_id == OWNER_PRINCIPAL_ID
+        assert isinstance(grid.owner_principal_id, int)
+        # AND the authorization mode is coerced from the response string to the enum
+        assert grid.authorization_mode == AuthorizationMode.SESSION_OWNER
+        assert isinstance(grid.authorization_mode, AuthorizationMode)
 
     def test_to_synapse_request_with_record_set_id(self) -> None:
         # GIVEN a CreateGridRequest with a record_set_id
@@ -1813,6 +1843,25 @@ class TestCreateGridRequest:
         assert "concreteType" in result
         assert result["recordSetId"] == RECORD_SET_ID
         assert "initialQuery" not in result
+        # AND the absent authorization mode is dropped by delete_none_keys
+        assert "authorizationMode" not in result
+
+    def test_to_synapse_request_with_authorization_mode(self) -> None:
+        # GIVEN a CreateGridRequest with the authorization mode supplied as a string
+        request = CreateGridRequest(
+            record_set_id=RECORD_SET_ID,
+            authorization_mode="SOURCE_BENEFACTOR",
+        )
+
+        # THEN the string is coerced to the enum on assignment by EnumCoercionMixin
+        assert request.authorization_mode == AuthorizationMode.SOURCE_BENEFACTOR
+        assert isinstance(request.authorization_mode, AuthorizationMode)
+
+        # WHEN I convert it to a synapse request
+        result = request.to_synapse_request()
+
+        # THEN the enum value is serialized back to its string form
+        assert result["authorizationMode"] == "SOURCE_BENEFACTOR"
 
 
 class TestUploadToTablePreviewRequest:


### PR DESCRIPTION
# **Problem:**

Curation grid sessions could only be created with the default authorization behavior, where the user who creates the session becomes its owner (`SESSION_OWNER`). There was no way to:

- Configure a `CurationTask` to recommend a particular authorization mode for the grid sessions opened against it.
- Create a `Grid` session with `SOURCE_BENEFACTOR` authorization, which lets anyone with EDIT permission on the source data collaborate in the same session without being added to a shared ownership team.

The affected code is the curation/grid model layer (`synapseclient/models/curation.py`) and the curator extension task helpers, which previously had no concept of an authorization mode.

# **Solution:**

Added support for the grid `authorizationMode` field throughout the curation/grid models:

- Introduced a new `AuthorizationMode` enum (`SESSION_OWNER`, `SOURCE_BENEFACTOR`) mirroring the Synapse REST `AuthorizationMode` type, exported from `synapseclient.models`.
- Added a `suggested_authorization_mode` field (plus the not-yet-active `collaborator_principal_ids`) to `FileBasedMetadataTaskProperties` and `RecordBasedMetadataTaskProperties`. 
- Added an `authorization_mode` field to `Grid` and `CreateGridRequest`, and wired it through `create_async` / `to_synapse_request` so it is sent at session-creation time and populated back from the response.
- When a `CurationTask` creates a new grid session, it now forwards `task_properties.suggested_authorization_mode` to the `Grid`.
- The curator extension task helpers (`file_based_metadata_task.py`, `record_based_metadata_task.py`) accept and pass through the suggested authorization mode.

Design notes / side effects:

- `to_synapse_request` for the task properties was switched to build a full dict and then strip `None` keys via `delete_none_keys`, instead of conditionally adding keys.
- `owner_principal_id` is now coerced to `int` when populated from API responses, fixing a type inconsistency.
- Documentation was updated in the metadata curation guide and the curator API reference pages.

# **Testing:**

- Added unit tests verifying that `CurationTask` passes the correct authorization parameters when creating a grid session, and that the task properties / grid serialize and deserialize `authorizationMode` correctly (`tests/unit/synapseclient/models/async/unit_test_curation_async.py`, `tests/unit/synapseclient/extensions/unit_test_curator.py`).
- Added integration tests covering the new authorization mode behavior for grids and curation tasks (`tests/integration/.../models/async/test_grid_async.py`, `test_curation_async.py`).
