### PR TITLE
[SYNPY-1829, SYNPY-1856, SYNPY-1858] re-enable test and fix flaky integration tests

### DIFF
--- a/tests/integration/synapseclient/core/test_external_storage.py
+++ b/tests/integration/synapseclient/core/test_external_storage.py
@@ -267,10 +267,6 @@ class TestExernalStorage:
         finally:
             self._teardown_bucket_location(key_prefix=folder_in_s3_to_cleanup)
 
-    @pytest.mark.skip(
-        reason="Server-side error: STS storage token endpoint is returning errors. "
-        "Re-enable once PLFM-9604 is resolved on the server side."
-    )
     async def test_sts_external_storage_location(self) -> None:
         """Test creating and using an external STS storage location.
         A custom storage location is created with sts enabled,
@@ -352,10 +348,6 @@ class TestExernalStorage:
         finally:
             self._teardown_bucket_location(key_prefix=folder_in_s3_to_cleanup)
 
-    @pytest.mark.skip(
-        reason="Server-side error: STS storage token endpoint is returning errors. "
-        "Re-enable once PLFM-9604 is resolved on the server side."
-    )
     async def test_boto_upload_acl(self) -> None:
         """Verify when we store a Synapse object using boto we apply a
         bucket-owner-full-control ACL to the object"""

--- a/tests/integration/synapseclient/integration_test.py
+++ b/tests/integration/synapseclient/integration_test.py
@@ -115,7 +115,8 @@ def test_entity_version(syn, project, schedule_for_cleanup):
 
     # Update the Entity and make sure the version is incremented
     entity.foo = 998877
-    entity["name"] = "foobarbat"
+    unique_name = f"foobarbat-{uuid.uuid4()}"
+    entity["name"] = unique_name
     entity["description"] = "This is a test entity..."
     entity = syn.store(entity, forceVersion=True, versionLabel="Prada remix")
     assert entity.versionNumber == 2
@@ -132,7 +133,7 @@ def test_entity_version(syn, project, schedule_for_cleanup):
     returnEntity = syn.get(entity)
     assert returnEntity.versionNumber == 2
     assert returnEntity["foo"][0] == 998877
-    assert returnEntity["name"] == "foobarbat"
+    assert returnEntity["name"] == unique_name
     assert returnEntity["description"] == "This is a test entity..."
     assert returnEntity["versionLabel"] == "Prada remix"
 

--- a/tests/integration/synapseclient/integration_test_Entity.py
+++ b/tests/integration/synapseclient/integration_test_Entity.py
@@ -508,7 +508,9 @@ def test_store_is_restricted_flag(
         assert intercepted.called
 
 
-# @skip("Skip integration tests for soon to be removed code")
+@pytest.mark.skip(
+    reason="Skip integration test because it gets stuck, causing CI timeout on Github actions. "
+)
 def test_external_file_handle(syn: Synapse, project: Project) -> None:
     # Tests shouldn't have external dependencies, but this is a pretty picture of Singapore
     singapore_url = "http://upload.wikimedia.org/wikipedia/commons/thumb/3/3e/1_singapore_city_skyline_dusk_panorama_2011.jpg/1280px-1_singapore_city_skyline_dusk_panorama_2011.jpg"  # noqa

--- a/tests/integration/synapseclient/integration_test_Entity.py
+++ b/tests/integration/synapseclient/integration_test_Entity.py
@@ -508,9 +508,7 @@ def test_store_is_restricted_flag(
         assert intercepted.called
 
 
-@pytest.mark.skip(
-    reason="Skip integration test because it gets stuck, causing CI timeout on Github actions. "
-)
+# @skip("Skip integration tests for soon to be removed code")
 def test_external_file_handle(syn: Synapse, project: Project) -> None:
     # Use a stable Sage-hosted asset to avoid external rate limiting (e.g. 429s)
     singapore_url = "https://www.synapse.org/Portal/clear.cache.gif"

--- a/tests/integration/synapseclient/models/async/test_materializedview_async.py
+++ b/tests/integration/synapseclient/models/async/test_materializedview_async.py
@@ -212,14 +212,14 @@ class TestMaterializedViewWithData:
         self.syn = syn
         self.schedule_for_cleanup = schedule_for_cleanup
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture(scope="function")
     async def base_table_with_data(
         self,
         project_model: Project,
         syn: Synapse,
         schedule_for_cleanup: Callable[..., None],
     ) -> Table:
-        """Create a table with data, shared across all tests in this class."""
+        """Create a table with data for use in a single test."""
         table_name = str(uuid.uuid4())
         table = Table(
             name=table_name,

--- a/tests/integration/synapseclient/test_command_line_client.py
+++ b/tests/integration/synapseclient/test_command_line_client.py
@@ -89,6 +89,9 @@ def parse(regex, output):
         raise Exception('ERROR parsing output: "' + str(output) + '"')
 
 
+@pytest.mark.skip(
+    reason="Unbounded retry loop on Wikimedia 429 kills CI — see SYNPY-1855"
+)
 def test_command_line_client(test_state):
     print("TESTING CMD LINE CLIENT")
     # Create a Project


### PR DESCRIPTION
# Changes
* Re-enable test after platform fixes. See ticket: https://sagebionetworks.jira.com/browse/SYNPY-1829
* See ticket: https://sagebionetworks.jira.com/browse/SYNPY-1856. The fix is in this PR. 
* See ticket: https://sagebionetworks.jira.com/browse/SYNPY-1858. The fix is in this PR.



# Other tickets: 
* `test_command_line_client` failed to pass after multiple reruns, so I created this: https://sagebionetworks.jira.com/browse/SYNPY-1855
