### PR TITLE
Fix bad import of pandas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,11 @@ synapseutils/          # Legacy bulk utilities (copy, sync, migrate, walk) — s
 
 Data flow: User → `operations/` factory → model async methods → `api/` service functions → `client.py` REST calls → Synapse API. Responses deserialized via `fill_from_dict()` on model instances.
 
+### Optional dependency imports
+pandas, boto3, pysftp, and other optional extras must never be imported at the top level of any module. Always import them lazily inside the functions/methods that need them. A top-level import of an optional dependency will crash the CLI and any code path that imports the module — even for unrelated operations like `synapse --version`.
+
+For type annotations referencing pandas types, use `DATA_FRAME_TYPE` and `SERIES_TYPE` from `core/typing_utils.py` rather than `pd.DataFrame` or `pd.Series`. These aliases resolve correctly at type-check time without requiring pandas at runtime.
+
 ## Constraints
 
 - Do not use Pydantic for models — the codebase uses stdlib dataclasses with custom serialization. Mixing would break the `@async_to_sync` decorator and `fill_from_dict()` pattern.

--- a/synapseclient/models/mixins/table_components.py
+++ b/synapseclient/models/mixins/table_components.py
@@ -13,7 +13,6 @@ from datetime import datetime
 from io import BytesIO
 from typing import Any, Dict, List, Optional, Protocol, Tuple, Union
 
-import pandas as pd
 from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 from typing_extensions import Self
@@ -139,7 +138,7 @@ def row_labels_from_rows(rows: List[Row]) -> List[Row]:
     )
 
 
-def convert_dtypes_to_json_serializable(df) -> pd.DataFrame:
+def convert_dtypes_to_json_serializable(df) -> "DATA_FRAME_TYPE":
     """
     Prepare a DataFrame for JSON/CSV serialization by cleaning special values
     and normalizing dtypes. Mutates the passed-in DataFrame in place (and also
@@ -201,6 +200,7 @@ def convert_dtypes_to_json_serializable(df) -> pd.DataFrame:
         df = convert_dtypes_to_json_serializable(df)
         print(df)
     """
+    import pandas as pd
 
     def _serialize_json_value(x):
         if isinstance(x, (list, dict)):

--- a/synapseclient/models/mixins/table_components.py
+++ b/synapseclient/models/mixins/table_components.py
@@ -200,6 +200,7 @@ def convert_dtypes_to_json_serializable(df) -> "DATA_FRAME_TYPE":
         df = convert_dtypes_to_json_serializable(df)
         print(df)
     """
+    test_import_pandas()
     import pandas as pd
 
     def _serialize_json_value(x):


### PR DESCRIPTION
An import of pandas was added at the top lvel of a module. This doesn't break any tests, but it causes an import error when the check-build workflow does `synapse --version` with the test-pypi package.

This is fixed by removing the module-level import and moving it to the function. 