### PR TITLE
Add architecture diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,48 @@ For release information, see:
 or by sending an email to [python-announce+subscribe@sagebase.org](mailto:python-announce+subscribe@sagebase.org) -->
 
 
+## Architecture
+
+Your Python code uses `synapseclient` either as a library or through the `synapse`
+command-line interface. The client handles authentication, models Synapse entities
+(Projects, Folders, Files, Tables, and more), and manages file upload/download. It
+issues requests to the [Synapse REST API](https://rest-docs.synapse.org/rest/), which
+is backed by the Synapse platform services (metadata storage, file storage on AWS S3,
+access control, and provenance).
+
+```mermaid
+flowchart TD
+    user["Your Python code<br/>(script, notebook, or app)"]
+    cli["<b>synapse</b> CLI<br/>(synapseclient.__main__)"]
+
+    subgraph client["synapseclient library"]
+        core["Synapse client &amp; auth<br/>(client.py, core.credentials)"]
+        models["Entity models<br/>(Project, Folder, File,<br/>Table, EntityView, Team)"]
+        transfer["Upload / download<br/>(core.upload, core.download,<br/>multithread_download)"]
+        api["REST service wrappers<br/>(synapseclient.api)"]
+    end
+
+    rest["Synapse REST API<br/>(repo-prod.prod.sagebase.org/repo/v1)"]
+
+    subgraph platform["Synapse platform services"]
+        meta["Metadata &amp; entity store"]
+        s3["File storage (AWS S3)"]
+        authsvc["Authentication &amp; access control"]
+    end
+
+    user --> core
+    cli --> core
+    core --> models
+    core --> transfer
+    models --> api
+    transfer --> api
+    api -->|HTTPS / JSON| rest
+    rest --> meta
+    rest --> s3
+    rest --> authsvc
+```
+
+
 Installation
 ------------
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ or by sending an email to [python-announce+subscribe@sagebase.org](mailto:python
 
 ## Architecture
 
-Your Python code uses `synapseclient` either as a library or through the `synapse`
+This Python code may be used either as a library or through the `synapse`
 command-line interface. The client handles authentication, models Synapse entities
 (Projects, Folders, Files, Tables, and more), and manages file upload/download. It
 issues requests to the [Synapse REST API](https://rest-docs.synapse.org/rest/), which


### PR DESCRIPTION
## Summary

Adds a top-level **`## Architecture`** section to `README.md` containing a `mermaid` flowchart, satisfying the **ARPA-H BDF ENHANCE Scorecard** architecture-diagram check (which accepts a `mermaid` block under an "Architecture" / "Architecture Diagram" / "System Architecture" heading).

### What the diagram shows

The flow is kept factually accurate to how the client actually works (module names verified against the `synapseclient/` package layout):

- **Your Python code** or the **`synapse` CLI** (`synapseclient.__main__`) →
- **`synapseclient` library**: Synapse client & auth (`client.py`, `core.credentials`), entity models (`Project`, `Folder`, `File`, `Table`, `EntityView`, `Team` in `synapseclient.models`), upload/download (`core.upload`, `core.download`, `multithread_download`), and REST service wrappers (`synapseclient.api`) →
- **Synapse REST API** (`repo-prod.prod.sagebase.org/repo/v1`) →
- **Synapse platform services**: metadata/entity store, file storage on AWS S3, authentication & access control.

Two sentences of prose introduce the diagram above the code block.

### Validation
- All repo `pre-commit` hooks pass on `README.md`.
- Verified exactly one `mermaid` fenced block exists under the `## Architecture` heading and is properly closed.

### No TODOs
This PR has no placeholder fields requiring maintainer follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)