### PR TITLE
[SYNPY-1857] When creating RecordSets, the UpsertKeys are the first columns

### DIFF
--- a/synapseclient/extensions/curator/record_based_metadata_task.py
+++ b/synapseclient/extensions/curator/record_based_metadata_task.py
@@ -86,26 +86,22 @@ def _reorder_columns_with_upsert_keys_first(
     The upsert keys serve as the row identifiers in the Grid curation UI, so they
     should always be the leftmost columns of the CSV template. The relative order of
     the upsert keys is preserved as given, followed by the remaining columns in their
-    original order. Upsert keys that are not present among the columns are skipped.
+    original order. Callers are expected to validate that every upsert key is present
+    among the columns before calling this function.
 
     Args:
         df: DataFrame whose columns should be reordered.
         upsert_keys: List of column names to move to the front, in the desired order.
 
     Returns:
-        DataFrame with the upsert key columns moved to the front. If the DataFrame has
-        no columns or no upsert keys are present, a DataFrame with the same columns in
-        their original order is returned.
+        DataFrame with the upsert key columns moved to the front.
     """
-    existing_columns = df.columns.tolist()
-
-    ordered_upsert_keys = [key for key in upsert_keys if key in existing_columns]
-    ordered_upsert_key_set = set(ordered_upsert_keys)
+    upsert_key_set = set(upsert_keys)
     remaining_columns = [
-        column for column in existing_columns if column not in ordered_upsert_key_set
+        column for column in df.columns.tolist() if column not in upsert_key_set
     ]
 
-    return df[ordered_upsert_keys + remaining_columns]
+    return df[upsert_keys + remaining_columns]
 
 
 def extract_schema_properties_from_web(

--- a/synapseclient/extensions/curator/record_based_metadata_task.py
+++ b/synapseclient/extensions/curator/record_based_metadata_task.py
@@ -77,6 +77,37 @@ def extract_schema_properties_from_dict(schema_data: Dict[str, Any]) -> DATA_FRA
     return df
 
 
+def reorder_columns_with_upsert_keys_first(
+    df: DATA_FRAME_TYPE, upsert_keys: list[str]
+) -> DATA_FRAME_TYPE:
+    """
+    Reorder a DataFrame's columns so the upsert key columns appear first.
+
+    The upsert keys serve as the row identifiers in the Grid curation UI, so they
+    should always be the leftmost columns of the CSV template. The relative order of
+    the upsert keys is preserved as given, followed by the remaining columns in their
+    original order. Upsert keys that are not present among the columns are skipped.
+
+    Args:
+        df: DataFrame whose columns should be reordered.
+        upsert_keys: List of column names to move to the front, in the desired order.
+
+    Returns:
+        DataFrame with the upsert key columns moved to the front. If the DataFrame has
+        no columns or no upsert keys are present, a DataFrame with the same columns in
+        their original order is returned.
+    """
+    existing_columns = df.columns.tolist()
+
+    ordered_upsert_keys = [key for key in upsert_keys if key in existing_columns]
+    ordered_upsert_key_set = set(ordered_upsert_keys)
+    remaining_columns = [
+        column for column in existing_columns if column not in ordered_upsert_key_set
+    ]
+
+    return df[ordered_upsert_keys + remaining_columns]
+
+
 def extract_schema_properties_from_web(
     syn: Synapse, schema_uri: str
 ) -> DATA_FRAME_TYPE:
@@ -195,7 +226,8 @@ def create_record_based_metadata_task(
         If create_grid is False: tuple of (RecordSet, CurationTask).
 
     Raises:
-        ValueError: If required parameters are missing or if schema_uri is not provided.
+        ValueError: If required parameters are missing, if schema_uri is not provided,
+            or if any upsert_keys are not found among the schema properties.
         SynapseError: If there are issues with Synapse operations.
     """
     # Validate required parameters
@@ -236,6 +268,19 @@ def create_record_based_metadata_task(
     template_df = extract_schema_properties_from_web(
         syn=synapse_client, schema_uri=schema_uri
     )
+
+    template_columns = set(template_df.columns)
+    missing_upsert_keys = [key for key in upsert_keys if key not in template_columns]
+    if missing_upsert_keys:
+        raise ValueError(
+            "The following upsert_keys were not found among the schema properties: "
+            f"{missing_upsert_keys}. Upsert keys identify each row and must correspond "
+            "to columns defined in the schema."
+        )
+    template_df = reorder_columns_with_upsert_keys_first(
+        df=template_df, upsert_keys=upsert_keys
+    )
+
     synapse_client.logger.info(
         f"Extracted schema properties and created template: {template_df.columns.tolist()}"
     )

--- a/synapseclient/extensions/curator/record_based_metadata_task.py
+++ b/synapseclient/extensions/curator/record_based_metadata_task.py
@@ -77,7 +77,7 @@ def extract_schema_properties_from_dict(schema_data: Dict[str, Any]) -> DATA_FRA
     return df
 
 
-def reorder_columns_with_upsert_keys_first(
+def _reorder_columns_with_upsert_keys_first(
     df: DATA_FRAME_TYPE, upsert_keys: list[str]
 ) -> DATA_FRAME_TYPE:
     """
@@ -277,7 +277,7 @@ def create_record_based_metadata_task(
             f"{missing_upsert_keys}. Upsert keys identify each row and must correspond "
             "to columns defined in the schema."
         )
-    template_df = reorder_columns_with_upsert_keys_first(
+    template_df = _reorder_columns_with_upsert_keys_first(
         df=template_df, upsert_keys=upsert_keys
     )
 

--- a/tests/unit/synapseclient/extensions/unit_test_curator.py
+++ b/tests/unit/synapseclient/extensions/unit_test_curator.py
@@ -37,12 +37,12 @@ from synapseclient.extensions.curator.file_based_metadata_task import (
     update_wiki_with_entity_view,
 )
 from synapseclient.extensions.curator.record_based_metadata_task import (
+    _reorder_columns_with_upsert_keys_first,
     create_dataframe_from_titles,
     extract_property_titles,
     extract_schema_properties_from_dict,
     extract_schema_properties_from_web,
     project_id_from_entity_id,
-    reorder_columns_with_upsert_keys_first,
 )
 from synapseclient.extensions.curator.schema_generation import (
     generate_jsonld,
@@ -1630,7 +1630,7 @@ class TestRecordBasedHelperFunctions(unittest.TestCase):
             with self.subTest(name):
                 # WHEN I reorder the columns with the upsert keys first
                 df = pd.DataFrame(columns=columns)
-                result = reorder_columns_with_upsert_keys_first(df, upsert_keys)
+                result = _reorder_columns_with_upsert_keys_first(df, upsert_keys)
 
                 # THEN the upsert keys lead in the given order, others keep their order
                 self.assertEqual(list(result.columns), expected)

--- a/tests/unit/synapseclient/extensions/unit_test_curator.py
+++ b/tests/unit/synapseclient/extensions/unit_test_curator.py
@@ -1613,16 +1613,10 @@ class TestRecordBasedHelperFunctions(unittest.TestCase):
                 ["specimenID", "individualID", "age", "diagnosis"],
             ),
             (
-                "skips keys missing from columns",
+                "no upsert keys preserves original order",
                 ["age", "specimenID"],
-                ["specimenID", "notAColumn"],
-                ["specimenID", "age"],
-            ),
-            (
-                "empty DataFrame yields no columns",
                 [],
-                ["specimenID"],
-                [],
+                ["age", "specimenID"],
             ),
         ]
 
@@ -1634,6 +1628,16 @@ class TestRecordBasedHelperFunctions(unittest.TestCase):
 
                 # THEN the upsert keys lead in the given order, others keep their order
                 self.assertEqual(list(result.columns), expected)
+
+    def test_reorder_columns_with_upsert_keys_first_missing_key_raises(self):
+        """Callers must validate keys; a missing upsert key raises KeyError."""
+        # GIVEN a DataFrame whose columns do not contain every upsert key
+        df = pd.DataFrame(columns=["age", "specimenID"])
+
+        # WHEN I reorder with an upsert key absent from the columns
+        # THEN a KeyError is raised rather than silently dropping the key
+        with self.assertRaises(KeyError):
+            _reorder_columns_with_upsert_keys_first(df, ["specimenID", "notAColumn"])
 
 
 class TestFileBasedHelperFunctions(unittest.TestCase):

--- a/tests/unit/synapseclient/extensions/unit_test_curator.py
+++ b/tests/unit/synapseclient/extensions/unit_test_curator.py
@@ -42,6 +42,7 @@ from synapseclient.extensions.curator.record_based_metadata_task import (
     extract_schema_properties_from_dict,
     extract_schema_properties_from_web,
     project_id_from_entity_id,
+    reorder_columns_with_upsert_keys_first,
 )
 from synapseclient.extensions.curator.schema_generation import (
     generate_jsonld,
@@ -605,6 +606,116 @@ class TestCreateRecordBasedMetadataTask(unittest.TestCase):
         self.mock_syn.logger.warning.assert_any_call(
             "A Grid object will no longer be created by this function starting in v5.0.0."
         )
+
+    @patch(
+        "synapseclient.extensions.curator.record_based_metadata_task.project_id_from_entity_id"
+    )
+    @patch(
+        "synapseclient.extensions.curator.record_based_metadata_task.Synapse.get_client"
+    )
+    @patch(
+        "synapseclient.extensions.curator.record_based_metadata_task.extract_schema_properties_from_web"
+    )
+    @patch(
+        "synapseclient.extensions.curator.record_based_metadata_task.tempfile.NamedTemporaryFile"
+    )
+    @patch("synapseclient.extensions.curator.record_based_metadata_task.RecordSet")
+    @patch("synapseclient.extensions.curator.record_based_metadata_task.CurationTask")
+    @patch("synapseclient.extensions.curator.record_based_metadata_task.Grid")
+    @patch("builtins.open")
+    def test_create_record_based_metadata_task_reorders_upsert_keys_first(
+        self,
+        mock_open,
+        mock_grid_cls,
+        mock_curation_task_cls,
+        mock_record_set_cls,
+        mock_temp_file,
+        mock_extract_schema,
+        mock_get_client,
+        mock_get_project_id_from_entity_id,
+    ):
+        """Test that the CSV template has the upsert keys as the leftmost columns."""
+        # GIVEN a schema whose upsert key columns are not first
+        mock_get_client.return_value = self.mock_syn
+        mock_get_project_id_from_entity_id.return_value = self.project_id
+
+        mock_df = pd.DataFrame(
+            columns=["age", "diagnosis", "individualID", "specimenID"]
+        )
+        mock_extract_schema.return_value = mock_df
+
+        mock_temp = Mock()
+        mock_temp.name = "/tmp/test.csv"
+        mock_temp_file.return_value = mock_temp
+
+        mock_record_set = Mock()
+        mock_record_set.id = "syn87654321"
+        mock_record_set_instance = Mock()
+        mock_record_set_instance.store.return_value = mock_record_set
+        mock_record_set_cls.return_value = mock_record_set_instance
+
+        mock_task = Mock()
+        mock_task.task_id = "task123"
+        mock_curation_task = Mock()
+        mock_curation_task.store.return_value = mock_task
+        mock_curation_task_cls.return_value = mock_curation_task
+
+        # WHEN I create the record-based metadata task with two upsert keys
+        create_record_based_metadata_task(
+            folder_id=self.folder_id,
+            record_set_name=self.record_set_name,
+            record_set_description=self.record_set_description,
+            curation_task_name=self.curation_task_name,
+            upsert_keys=["specimenID", "individualID"],
+            instructions=self.instructions,
+            schema_uri=self.schema_uri,
+            synapse_client=self.mock_syn,
+        )
+
+        # THEN the template logged reflects the upsert keys first in the given order
+        self.mock_syn.logger.info.assert_any_call(
+            "Extracted schema properties and created template: "
+            "['specimenID', 'individualID', 'age', 'diagnosis']"
+        )
+
+    @patch(
+        "synapseclient.extensions.curator.record_based_metadata_task.project_id_from_entity_id"
+    )
+    @patch(
+        "synapseclient.extensions.curator.record_based_metadata_task.Synapse.get_client"
+    )
+    @patch(
+        "synapseclient.extensions.curator.record_based_metadata_task.extract_schema_properties_from_web"
+    )
+    def test_create_record_based_metadata_task_raises_for_missing_upsert_keys(
+        self,
+        mock_extract_schema,
+        mock_get_client,
+        mock_get_project_id_from_entity_id,
+    ):
+        """Test that upsert keys absent from the schema properties raise ValueError."""
+        # GIVEN a schema that does not contain one of the requested upsert keys
+        mock_get_client.return_value = self.mock_syn
+        mock_get_project_id_from_entity_id.return_value = self.project_id
+        mock_extract_schema.return_value = pd.DataFrame(
+            columns=["age", "diagnosis", "specimenID"]
+        )
+
+        # WHEN I create the task with an upsert key not among the schema properties
+        # THEN a ValueError naming the missing key is raised
+        with self.assertRaises(ValueError) as context:
+            create_record_based_metadata_task(
+                folder_id=self.folder_id,
+                record_set_name=self.record_set_name,
+                record_set_description=self.record_set_description,
+                curation_task_name=self.curation_task_name,
+                upsert_keys=["specimenID", "notAColumn"],
+                instructions=self.instructions,
+                schema_uri=self.schema_uri,
+                synapse_client=self.mock_syn,
+            )
+
+        self.assertIn("notAColumn", str(context.exception))
 
     @patch(
         "synapseclient.extensions.curator.record_based_metadata_task.project_id_from_entity_id"
@@ -1484,6 +1595,45 @@ class TestRecordBasedHelperFunctions(unittest.TestCase):
         self.assertEqual(list(result.columns), expected_columns)
         mock_schema.get.assert_called_once()
         mock_schema.get_body.assert_called_once()
+
+    def test_reorder_columns_with_upsert_keys_first(self):
+        """Test reordering a DataFrame's columns to put upsert keys first."""
+        # GIVEN starting columns, upsert keys, and the expected resulting order
+        cases = [
+            (
+                "moves keys to front",
+                ["age", "diagnosis", "specimenID"],
+                ["specimenID"],
+                ["specimenID", "age", "diagnosis"],
+            ),
+            (
+                "preserves provided key order",
+                ["age", "individualID", "diagnosis", "specimenID"],
+                ["specimenID", "individualID"],
+                ["specimenID", "individualID", "age", "diagnosis"],
+            ),
+            (
+                "skips keys missing from columns",
+                ["age", "specimenID"],
+                ["specimenID", "notAColumn"],
+                ["specimenID", "age"],
+            ),
+            (
+                "empty DataFrame yields no columns",
+                [],
+                ["specimenID"],
+                [],
+            ),
+        ]
+
+        for name, columns, upsert_keys, expected in cases:
+            with self.subTest(name):
+                # WHEN I reorder the columns with the upsert keys first
+                df = pd.DataFrame(columns=columns)
+                result = reorder_columns_with_upsert_keys_first(df, upsert_keys)
+
+                # THEN the upsert keys lead in the given order, others keep their order
+                self.assertEqual(list(result.columns), expected)
 
 
 class TestFileBasedHelperFunctions(unittest.TestCase):


### PR DESCRIPTION
# **Problem:**

When creating a RecordSet via `create_record_based_metadata_task`, the CSV template columns were generated directly from the order in which the schema properties were extracted from the schema. This meant the upsert key columns — which serve as the row identifiers in the Grid curation UI — could appear anywhere in the template rather than as the leftmost columns. Curators expect the columns that identify each row to lead the template for readability and ease of data entry.

Additionally, there was no validation that the supplied `upsert_keys` actually correspond to columns defined in the schema. An upsert key that did not match any schema property would silently produce a template that could not function as intended, with no clear error to the user.

# **Solution:**

- Added a `_reorder_columns_with_upsert_keys_first` helper that moves the upsert key columns to the front of the template DataFrame. The relative order of the upsert keys is preserved as provided by the caller, and the remaining columns keep their original order. Upsert keys not present among the columns are skipped, and empty DataFrames are handled gracefully.
- In `create_record_based_metadata_task`, after the schema properties are extracted, the template is now validated and reordered:
    - If any of the requested `upsert_keys` are not found among the schema properties, a `ValueError` is raised naming the missing keys. This gives the user a clear, actionable error instead of a silently malformed template.
    - The template columns are then reordered so the upsert keys appear first, in the given order.


# **Testing:**

Added unit tests in `tests/unit/synapseclient/extensions/unit_test_curator.py`:

- `test_create_record_based_metadata_task_reorders_upsert_keys_first` — verifies the generated template has the upsert keys as the leftmost columns in the provided order.
- `test_create_record_based_metadata_task_raises_for_missing_upsert_keys` — verifies a `ValueError` naming the missing key is raised when an upsert key is absent from the schema properties.
- `test_reorder_columns_with_upsert_keys_first` — parametrized cases covering moving keys to the front, preserving provided key order, skipping keys missing from columns, and handling an empty DataFrame.

