### PR TITLE
[SYNPY-1870] Rewrite test_caching.py to not use deprecated legacy code

### DIFF
--- a/synapseclient/models/services/search.py
+++ b/synapseclient/models/services/search.py
@@ -7,21 +7,49 @@ from synapseclient.core.exceptions import SynapseNotFoundError
 from synapseclient.models.services.storable_entity_components import FailureStrategy
 
 if TYPE_CHECKING:
-    from synapseclient.models import File, Folder, Project
+    from synapseclient.models import (
+        Dataset,
+        DatasetCollection,
+        EntityView,
+        File,
+        Folder,
+        Link,
+        MaterializedView,
+        Project,
+        RecordSet,
+        SubmissionView,
+        Table,
+        VirtualTable,
+    )
 
 
 async def get_id(
-    entity: Union["Project", "Folder", "File"],
+    entity: Union[
+        "Dataset",
+        "DatasetCollection",
+        "EntityView",
+        "File",
+        "Folder",
+        "Link",
+        "MaterializedView",
+        "Project",
+        "RecordSet",
+        "SubmissionView",
+        "Table",
+        "VirtualTable",
+    ],
     failure_strategy: Optional[FailureStrategy] = FailureStrategy.RAISE_EXCEPTION,
     *,
     synapse_client: Optional[Synapse] = None,
-) -> Union[str, None]:
+) -> Optional[str]:
     """
     Get the ID of the entity from either the ID field or the name/parent of the entity.
     This is a wrapper for the [synapseclient.operations.find_entity_id_async][] function
     that is used in order to search by name/parent.
 
     Arguments:
+        entity: The entity to resolve the ID for. Resolution uses the id field if
+            set, otherwise the name and parent_id fields.
         failure_strategy: Determines how to handle failures when getting the entity
             from Synapse and an exception occurs. Only RAISE_EXCEPTION and None are
             supported.

--- a/synapseclient/models/services/search.py
+++ b/synapseclient/models/services/search.py
@@ -1,6 +1,5 @@
 """Functional interface for searching for entities in Synapse."""
 
-import asyncio
 from typing import TYPE_CHECKING, Optional, Union
 
 from synapseclient import Synapse
@@ -19,8 +18,8 @@ async def get_id(
 ) -> Union[str, None]:
     """
     Get the ID of the entity from either the ID field or the name/parent of the entity.
-    This is a wrapper for the [synapseclient.Synapse.findEntityId][] method that is
-    used in order to search by name/parent.
+    This is a wrapper for the [synapseclient.operations.find_entity_id_async][] function
+    that is used in order to search by name/parent.
 
     Arguments:
         failure_strategy: Determines how to handle failures when getting the entity
@@ -48,14 +47,12 @@ async def get_id(
             return None
         raise ValueError("Entity ID or Name/Parent is required")
 
-    # TODO: Remove this deprecated code with replacement method created in https://sagebionetworks.jira.com/browse/SYNPY-1623
-    loop = asyncio.get_event_loop()
-    entity_id = entity.id or await loop.run_in_executor(
-        None,
-        lambda: Synapse.get_client(synapse_client=synapse_client).findEntityId(
-            name=entity.name,
-            parent=entity.parent_id,
-        ),
+    from synapseclient.operations import find_entity_id_async
+
+    entity_id = entity.id or await find_entity_id_async(
+        name=entity.name,
+        parent=entity.parent_id,
+        synapse_client=synapse_client,
     )
 
     if not entity_id:

--- a/tests/integration/synapseclient/core/test_caching.py
+++ b/tests/integration/synapseclient/core/test_caching.py
@@ -30,7 +30,7 @@ def project(syn, schedule_for_cleanup):
 
 @pytest.fixture(scope="module", autouse=True)
 def syn_state(syn):
-    syn.test_keepRunning = True
+    syn.test_keep_running = True
 
     # - Child writeable objects
     syn.test_errors = Queue()
@@ -41,7 +41,7 @@ def syn_state(syn):
 async def sleep_and_end_test(syn: Synapse) -> None:
     """Exit the test after sleeping"""
     await asyncio.sleep(10)
-    syn.test_keepRunning = False
+    syn.test_keep_running = False
 
 
 async def test_threaded_access(
@@ -65,7 +65,7 @@ async def test_threaded_access(
                 asyncio.create_task(
                     wrap_function_as_child_thread(
                         syn,
-                        thread_keep_storing_one_File,
+                        thread_keep_storing_one_file,
                         syn,
                         project,
                         schedule_for_cleanup,
@@ -74,7 +74,7 @@ async def test_threaded_access(
                 asyncio.create_task(
                     wrap_function_as_child_thread(
                         syn,
-                        thread_keep_storing_one_File,
+                        thread_keep_storing_one_file,
                         syn,
                         project,
                         schedule_for_cleanup,
@@ -83,7 +83,7 @@ async def test_threaded_access(
                 asyncio.create_task(
                     wrap_function_as_child_thread(
                         syn,
-                        thread_keep_storing_one_File,
+                        thread_keep_storing_one_file,
                         syn,
                         project,
                         schedule_for_cleanup,
@@ -92,7 +92,7 @@ async def test_threaded_access(
                 asyncio.create_task(
                     wrap_function_as_child_thread(
                         syn,
-                        thread_keep_storing_one_File,
+                        thread_keep_storing_one_file,
                         syn,
                         project,
                         schedule_for_cleanup,
@@ -104,17 +104,17 @@ async def test_threaded_access(
             [
                 asyncio.create_task(
                     wrap_function_as_child_thread(
-                        syn, thread_get_files_from_Project, syn, project
+                        syn, thread_get_files_from_project, syn, project
                     )
                 ),
                 asyncio.create_task(
                     wrap_function_as_child_thread(
-                        syn, thread_get_files_from_Project, syn, project
+                        syn, thread_get_files_from_project, syn, project
                     )
                 ),
                 asyncio.create_task(
                     wrap_function_as_child_thread(
-                        syn, thread_get_files_from_Project, syn, project
+                        syn, thread_get_files_from_project, syn, project
                     )
                 ),
             ]
@@ -124,7 +124,7 @@ async def test_threaded_access(
                 asyncio.create_task(
                     wrap_function_as_child_thread(
                         syn,
-                        thread_get_and_update_file_from_Project,
+                        thread_get_and_update_file_from_project,
                         syn,
                         project,
                         schedule_for_cleanup,
@@ -133,7 +133,7 @@ async def test_threaded_access(
                 asyncio.create_task(
                     wrap_function_as_child_thread(
                         syn,
-                        thread_get_and_update_file_from_Project,
+                        thread_get_and_update_file_from_project,
                         syn,
                         project,
                         schedule_for_cleanup,
@@ -142,7 +142,7 @@ async def test_threaded_access(
                 asyncio.create_task(
                     wrap_function_as_child_thread(
                         syn,
-                        thread_get_and_update_file_from_Project,
+                        thread_get_and_update_file_from_project,
                         syn,
                         project,
                         schedule_for_cleanup,
@@ -153,7 +153,7 @@ async def test_threaded_access(
 
         await asyncio.gather(*tasks)
     finally:
-        syn.test_keepRunning = False
+        syn.test_keep_running = False
 
     # Reset the requests logging level
     requests_log.setLevel(requests_original_level)
@@ -194,7 +194,7 @@ def collect_errors_and_fail(syn: Synapse):
 ######################
 
 
-def thread_keep_storing_one_File(syn: Synapse, project: Project, schedule_for_cleanup):
+def thread_keep_storing_one_file(syn: Synapse, project: Project, schedule_for_cleanup):
     """Makes one file and stores it over and over again."""
 
     # Make a local file to continuously store
@@ -207,9 +207,9 @@ def thread_keep_storing_one_File(syn: Synapse, project: Project, schedule_for_cl
         annotations={"mwa": ["hahahah"]},
     )
 
-    while syn.test_keepRunning:
+    while syn.test_keep_running:
         stored = None
-        stored = store_catch_412_HTTPError(syn, my_precious)
+        stored = store_catch_412_http_error(syn, my_precious)
 
         if stored is not None:
             my_precious = stored
@@ -221,22 +221,22 @@ def thread_keep_storing_one_File(syn: Synapse, project: Project, schedule_for_cl
         sleep_for_a_bit()
 
 
-def thread_get_files_from_Project(syn: Synapse, project: Project):
+def thread_get_files_from_project(syn: Synapse, project: Project):
     """Continually polls and fetches items from the Project."""
 
-    while syn.test_keepRunning:
-        get_all_ids_from_Project(syn, project)
+    while syn.test_keep_running:
+        get_all_ids_from_project(syn, project)
 
         sleep_for_a_bit()
 
 
-def thread_get_and_update_file_from_Project(
+def thread_get_and_update_file_from_project(
     syn: Synapse, project: Project, schedule_for_cleanup
 ):
     """Fetches one item from the Project and updates it with a new file."""
 
-    while syn.test_keepRunning:
-        id = get_all_ids_from_Project(syn, project)
+    while syn.test_keep_running:
+        id = get_all_ids_from_project(syn, project)
 
         if len(id) == 0:
             sleep_for_a_bit()
@@ -249,7 +249,7 @@ def thread_get_and_update_file_from_Project(
         path = utils.make_bogus_data_file()
         schedule_for_cleanup(path)
         entity.path = path
-        entity = store_catch_412_HTTPError(syn, entity)
+        entity = store_catch_412_http_error(syn, entity)
 
         if entity is not None:
             assert os.stat(entity.path) == os.stat(path)
@@ -269,7 +269,7 @@ def sleep_for_a_bit() -> int:
     return time_to_sleep
 
 
-def get_all_ids_from_Project(syn: Synapse, project: Project):
+def get_all_ids_from_project(syn: Synapse, project: Project):
     """Fetches all currently available Synapse IDs from the parent Project."""
     return [
         child["id"]
@@ -279,7 +279,7 @@ def get_all_ids_from_Project(syn: Synapse, project: Project):
     ]
 
 
-def store_catch_412_HTTPError(syn: Synapse, entity: File):
+def store_catch_412_http_error(syn: Synapse, entity: File):
     """Returns the stored Entity if the function succeeds or None if the 412 is caught."""
     try:
         return entity.store(synapse_client=syn)

--- a/tests/integration/synapseclient/core/test_caching.py
+++ b/tests/integration/synapseclient/core/test_caching.py
@@ -200,7 +200,7 @@ def thread_keep_storing_one_File(syn: Synapse, project: Project, schedule_for_cl
     # Make a local file to continuously store
     path = utils.make_bogus_data_file()
     schedule_for_cleanup(path)
-    myPrecious = File(
+    my_precious = File(
         path=path,
         parent_id=project.id,
         description="This bogus file is MINE",
@@ -209,14 +209,14 @@ def thread_keep_storing_one_File(syn: Synapse, project: Project, schedule_for_cl
 
     while syn.test_keepRunning:
         stored = None
-        stored = store_catch_412_HTTPError(syn, myPrecious)
+        stored = store_catch_412_HTTPError(syn, my_precious)
 
         if stored is not None:
-            myPrecious = stored
-        elif myPrecious.id is not None:
+            my_precious = stored
+        elif my_precious.id is not None:
             # only attempt to retrieve if the entity was initially saved above without encountering a 412 error
             # and thus has a retrievable synapse id
-            myPrecious = myPrecious.get(synapse_client=syn)
+            my_precious = my_precious.get(synapse_client=syn)
 
         sleep_for_a_bit()
 

--- a/tests/integration/synapseclient/core/test_caching.py
+++ b/tests/integration/synapseclient/core/test_caching.py
@@ -14,13 +14,16 @@ from typing import Callable
 import pytest
 
 import synapseclient.core.utils as utils
-from synapseclient import Entity, File, Project, Synapse
+from synapseclient import Synapse
+from synapseclient.api import get_children
+from synapseclient.core.async_utils import wrap_async_generator_to_sync_generator
 from synapseclient.core.exceptions import SynapseError, SynapseHTTPError
+from synapseclient.models import File, Project
 
 
 @pytest.fixture(scope="module")
 def project(syn, schedule_for_cleanup):
-    project = syn.store(Project(name=str(uuid.uuid4())))
+    project = Project(name=str(uuid.uuid4())).store(synapse_client=syn)
     schedule_for_cleanup(project)
     return project
 
@@ -198,7 +201,10 @@ def thread_keep_storing_one_File(syn: Synapse, project: Project, schedule_for_cl
     path = utils.make_bogus_data_file()
     schedule_for_cleanup(path)
     myPrecious = File(
-        path, parent=project, description="This bogus file is MINE", mwa="hahahah"
+        path=path,
+        parent_id=project.id,
+        description="This bogus file is MINE",
+        annotations={"mwa": ["hahahah"]},
     )
 
     while syn.test_keepRunning:
@@ -207,10 +213,10 @@ def thread_keep_storing_one_File(syn: Synapse, project: Project, schedule_for_cl
 
         if stored is not None:
             myPrecious = stored
-        elif "id" in myPrecious:
+        elif myPrecious.id is not None:
             # only attempt to retrieve if the entity was initially saved above without encountering a 412 error
             # and thus has a retrievable synapse id
-            myPrecious = syn.get(myPrecious)
+            myPrecious = myPrecious.get(synapse_client=syn)
 
         sleep_for_a_bit()
 
@@ -237,7 +243,7 @@ def thread_get_and_update_file_from_Project(
             continue
 
         id = id[random.randrange(len(id))]
-        entity = syn.get(id)
+        entity = File(id=id).get(synapse_client=syn)
 
         # Replace the file and re-store
         path = utils.make_bogus_data_file()
@@ -265,13 +271,18 @@ def sleep_for_a_bit() -> int:
 
 def get_all_ids_from_Project(syn: Synapse, project: Project):
     """Fetches all currently available Synapse IDs from the parent Project."""
-    return [result["id"] for result in syn.getChildren(project.id)]
+    return [
+        child["id"]
+        for child in wrap_async_generator_to_sync_generator(
+            get_children, parent=project.id, synapse_client=syn
+        )
+    ]
 
 
-def store_catch_412_HTTPError(syn: Synapse, entity: Entity):
+def store_catch_412_HTTPError(syn: Synapse, entity: File):
     """Returns the stored Entity if the function succeeds or None if the 412 is caught."""
     try:
-        return syn.store(entity)
+        return entity.store(synapse_client=syn)
     except SynapseHTTPError as err:
         # Some other thread modified the Entity, so try again
         if err.response.status_code == 412:

--- a/tests/unit/synapseclient/models/async/unit_test_folder_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_folder_async.py
@@ -397,11 +397,11 @@ class TestFolder:
                 new_callable=AsyncMock,
                 return_value=(self.get_example_synapse_folder_output()),
             ) as mocked_client_call,
-            patch.object(
-                self.syn,
-                "findEntityId",
+            patch(
+                "synapseclient.operations.find_entity_id_async",
+                new_callable=AsyncMock,
                 return_value=SYN_123,
-            ) as mocked_get,
+            ) as mocked_find_entity_id,
             patch(
                 "synapseclient.api.entity_factory.get_entity_id_bundle2",
                 new_callable=AsyncMock,
@@ -420,7 +420,7 @@ class TestFolder:
             # THEN we should call the method with this data
             mocked_client_call.assert_called_once()
             call_args = mocked_client_call.call_args
-            assert call_args.kwargs["entity_id"] == SYN_123  # From findEntityId mock
+            assert call_args.kwargs["entity_id"] == SYN_123
             assert call_args.kwargs["new_version"] is False
             assert call_args.kwargs["synapse_client"] == self.syn
             # The request should be a dict with the folder properties
@@ -435,8 +435,8 @@ class TestFolder:
             # AND we should call the get method
             mocked_get.assert_called_once()
 
-            # AND findEntityId should be called
-            mocked_get.assert_called_once()
+            # AND find_entity_id_async should be called
+            mocked_find_entity_id.assert_called_once()
 
             # AND the folder should be stored
             assert result.id == SYN_123
@@ -466,11 +466,11 @@ class TestFolder:
                 new_callable=AsyncMock,
                 return_value=(self.get_example_synapse_folder_output()),
             ) as mocked_client_call,
-            patch.object(
-                self.syn,
-                "findEntityId",
+            patch(
+                "synapseclient.operations.find_entity_id_async",
+                new_callable=AsyncMock,
                 return_value=SYN_123,
-            ) as mocked_get,
+            ) as mocked_find_entity_id,
             patch(
                 "synapseclient.api.entity_factory.get_entity_id_bundle2",
                 new_callable=AsyncMock,
@@ -491,7 +491,7 @@ class TestFolder:
             # THEN we should call the method with this data
             mocked_client_call.assert_called_once()
             call_args = mocked_client_call.call_args
-            assert call_args.kwargs["entity_id"] == SYN_123  # From findEntityId mock
+            assert call_args.kwargs["entity_id"] == SYN_123
             assert call_args.kwargs["new_version"] is False
             assert call_args.kwargs["synapse_client"] == self.syn
             # The request should be a dict with the folder properties
@@ -506,8 +506,8 @@ class TestFolder:
             # AND we should call the get method
             mocked_get.assert_called_once()
 
-            # AND findEntityId should be called
-            mocked_get.assert_called_once()
+            # AND find_entity_id_async should be called
+            mocked_find_entity_id.assert_called_once()
 
             # AND the folder should be stored
             assert result.id == SYN_123
@@ -601,9 +601,9 @@ class TestFolder:
 
         # WHEN I call `get` with the Folder object
         with (
-            patch.object(
-                self.syn,
-                "findEntityId",
+            patch(
+                "synapseclient.operations.find_entity_id_async",
+                new_callable=AsyncMock,
                 return_value=(SYN_123),
             ) as mocked_client_search,
             patch(
@@ -623,6 +623,7 @@ class TestFolder:
             mocked_client_search.assert_called_once_with(
                 name=folder.name,
                 parent=folder.parent_id,
+                synapse_client=self.syn,
             )
 
             # AND the folder should be stored
@@ -644,9 +645,9 @@ class TestFolder:
         )
 
         # WHEN I call `get` with the Folder object
-        with patch.object(
-            self.syn,
-            "findEntityId",
+        with patch(
+            "synapseclient.operations.find_entity_id_async",
+            new_callable=AsyncMock,
             return_value=(None),
         ) as mocked_client_search:
             with pytest.raises(SynapseNotFoundError) as e:
@@ -659,6 +660,7 @@ class TestFolder:
             mocked_client_search.assert_called_once_with(
                 name=folder.name,
                 parent=folder.parent_id,
+                synapse_client=self.syn,
             )
 
     async def test_delete_with_id(self) -> None:

--- a/tests/unit/synapseclient/models/async/unit_test_project_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_project_async.py
@@ -398,11 +398,11 @@ class TestProject:
                 new_callable=AsyncMock,
                 return_value=(self.get_example_synapse_project_output()),
             ) as mocked_client_call,
-            patch.object(
-                self.syn,
-                "findEntityId",
+            patch(
+                "synapseclient.operations.find_entity_id_async",
+                new_callable=AsyncMock,
                 return_value=PROJECT_ID,
-            ) as mocked_get,
+            ) as mocked_find_entity_id,
             patch(
                 "synapseclient.api.entity_factory.get_entity_id_bundle2",
                 new_callable=AsyncMock,
@@ -421,7 +421,7 @@ class TestProject:
             # THEN we should call the method with this data
             mocked_client_call.assert_called_once()
             call_args = mocked_client_call.call_args
-            assert call_args.kwargs["entity_id"] == PROJECT_ID  # From findEntityId mock
+            assert call_args.kwargs["entity_id"] == PROJECT_ID
             assert call_args.kwargs["new_version"] is False
             assert call_args.kwargs["synapse_client"] == self.syn
             # The request should be a dict with the project properties
@@ -435,8 +435,8 @@ class TestProject:
             # AND we should call the get method
             mocked_get.assert_called_once()
 
-            # AND findEntityId should be called
-            mocked_get.assert_called_once()
+            # AND find_entity_id_async should be called
+            mocked_find_entity_id.assert_called_once()
 
             # AND the project should be stored
             assert result.id == PROJECT_ID
@@ -499,9 +499,9 @@ class TestProject:
 
         # WHEN I call `get` with the Project object
         with (
-            patch.object(
-                self.syn,
-                "findEntityId",
+            patch(
+                "synapseclient.operations.find_entity_id_async",
+                new_callable=AsyncMock,
                 return_value=(PROJECT_ID),
             ) as mocked_client_search,
             patch(
@@ -521,6 +521,7 @@ class TestProject:
             mocked_client_search.assert_called_once_with(
                 name=project.name,
                 parent=project.parent_id,
+                synapse_client=self.syn,
             )
 
             # AND the project should be stored
@@ -542,9 +543,9 @@ class TestProject:
         )
 
         # WHEN I call `get` with the Project object
-        with patch.object(
-            self.syn,
-            "findEntityId",
+        with patch(
+            "synapseclient.operations.find_entity_id_async",
+            new_callable=AsyncMock,
             return_value=(None),
         ) as mocked_client_search:
             with pytest.raises(SynapseNotFoundError) as e:
@@ -557,6 +558,7 @@ class TestProject:
             mocked_client_search.assert_called_once_with(
                 name=project.name,
                 parent=project.parent_id,
+                synapse_client=self.syn,
             )
 
     async def test_delete_with_id(self) -> None:

--- a/tests/unit/synapseclient/models/async/unit_test_search_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_search_async.py
@@ -1,0 +1,143 @@
+"""Unit tests for synapseclient.models.services.search.get_id."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from synapseclient import Synapse
+from synapseclient.core.exceptions import SynapseNotFoundError
+from synapseclient.models import File, Folder, Project
+from synapseclient.models.services.search import get_id
+
+ENTITY_ID = "syn123"
+PARENT_ID = "syn456"
+ENTITY_NAME = "my_test_entity"
+
+
+class TestGetId:
+    """Unit tests for the get_id service function."""
+
+    @pytest.fixture(autouse=True, scope="function")
+    def init_syn(self, syn: Synapse) -> None:
+        self.syn = syn
+
+    async def test_returns_id_when_set_without_searching(self) -> None:
+        # GIVEN a folder with an ID already set
+        folder = Folder(id=ENTITY_ID, name=ENTITY_NAME, parent_id=PARENT_ID)
+
+        with patch(
+            "synapseclient.operations.find_entity_id_async",
+            new_callable=AsyncMock,
+        ) as mocked_find:
+            # WHEN I resolve its ID
+            result = await get_id(entity=folder, synapse_client=self.syn)
+
+            # THEN the ID field is returned without searching Synapse
+            assert result == ENTITY_ID
+            mocked_find.assert_not_called()
+
+    async def test_searches_by_name_and_parent(self) -> None:
+        # GIVEN a file with a name and parent but no ID
+        file = File(name=ENTITY_NAME, parent_id=PARENT_ID)
+
+        with patch(
+            "synapseclient.operations.find_entity_id_async",
+            new_callable=AsyncMock,
+            return_value=ENTITY_ID,
+        ) as mocked_find:
+            # WHEN I resolve its ID
+            result = await get_id(entity=file, synapse_client=self.syn)
+
+            # THEN the ID is found by name/parent and set on the entity
+            assert result == ENTITY_ID
+            assert file.id == ENTITY_ID
+            mocked_find.assert_called_once_with(
+                name=ENTITY_NAME,
+                parent=PARENT_ID,
+                synapse_client=self.syn,
+            )
+
+    async def test_searches_project_by_name_without_parent(self) -> None:
+        # GIVEN a project with only a name
+        project = Project(name=ENTITY_NAME)
+
+        with patch(
+            "synapseclient.operations.find_entity_id_async",
+            new_callable=AsyncMock,
+            return_value=ENTITY_ID,
+        ) as mocked_find:
+            # WHEN I resolve its ID
+            result = await get_id(entity=project, synapse_client=self.syn)
+
+            # THEN the ID is found by name alone
+            assert result == ENTITY_ID
+            assert project.id == ENTITY_ID
+            mocked_find.assert_called_once_with(
+                name=ENTITY_NAME,
+                parent=None,
+                synapse_client=self.syn,
+            )
+
+    async def test_raises_when_name_set_but_parent_missing(self) -> None:
+        # GIVEN a folder with a name but no ID or parent
+        folder = Folder(name=ENTITY_NAME)
+
+        # WHEN I resolve its ID
+        # THEN a ValueError is raised
+        with pytest.raises(ValueError, match="Entity ID or Name/Parent is required"):
+            await get_id(entity=folder, synapse_client=self.syn)
+
+    async def test_raises_when_nothing_set(self) -> None:
+        # GIVEN a folder with no identifying fields
+        folder = Folder()
+
+        # WHEN I resolve its ID
+        # THEN a ValueError is raised
+        with pytest.raises(ValueError, match="Entity ID or Name/Parent is required"):
+            await get_id(entity=folder, synapse_client=self.syn)
+
+    async def test_returns_none_when_unsearchable_and_failure_strategy_none(
+        self,
+    ) -> None:
+        # GIVEN a folder with no identifying fields
+        folder = Folder()
+
+        # WHEN I resolve its ID with failure_strategy=None
+        result = await get_id(
+            entity=folder, failure_strategy=None, synapse_client=self.syn
+        )
+
+        # THEN None is returned instead of raising
+        assert result is None
+
+    async def test_raises_when_entity_not_found(self) -> None:
+        # GIVEN a folder whose name/parent do not exist in Synapse
+        folder = Folder(name=ENTITY_NAME, parent_id=PARENT_ID)
+
+        with patch(
+            "synapseclient.operations.find_entity_id_async",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            # WHEN I resolve its ID
+            # THEN a SynapseNotFoundError is raised
+            with pytest.raises(SynapseNotFoundError, match="Folder .* not found"):
+                await get_id(entity=folder, synapse_client=self.syn)
+
+    async def test_returns_none_when_not_found_and_failure_strategy_none(self) -> None:
+        # GIVEN a folder whose name/parent do not exist in Synapse
+        folder = Folder(name=ENTITY_NAME, parent_id=PARENT_ID)
+
+        with patch(
+            "synapseclient.operations.find_entity_id_async",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            # WHEN I resolve its ID with failure_strategy=None
+            result = await get_id(
+                entity=folder, failure_strategy=None, synapse_client=self.syn
+            )
+
+            # THEN None is returned instead of raising
+            assert result is None
+            assert folder.id is None


### PR DESCRIPTION
# **Problem:**

The integration test `tests/integration/synapseclient/core/test_caching.py` was written against the legacy pre-OOP API and emitted a large number of `DeprecationWarning`s (all slated for removal in 5.0.0) on every run. Running the test produced warnings for the legacy `Project`/`File`/`Entity` classes, `Synapse.store`, `Synapse.get`, `Synapse.getChildren`, and — indirectly, through the store path — `Synapse.findEntityId`, along with the internal legacy machinery those calls fanned out to (`_getEntityBundle`, `_check_entity_restrictions`, `_getWithEntityBundle_async`, `Annotations`/`set_annotations`, `download_file_entity`).

While migrating the test off the deprecated public API, the `findEntityId` warning turned out to originate in production code, not the test: `synapseclient/models/services/search.py::get_id()` (used by every model `store`/`get` for name+parent resolution) still called the deprecated `Synapse.findEntityId` via an `asyncio` executor shim, carrying a `# TODO: SYNPY-1623` marker. So the OOP models themselves were still routing through a deprecated method.

# **Solution:**

Migrated the test to the object-oriented models and operations layer, and fixed the underlying production code path so the models no longer depend on a deprecated method.

- `tests/integration/synapseclient/core/test_caching.py`:
    - `Project`/`File` now come from `synapseclient.models` instead of the legacy root classes.
    - `syn.store(...)` / `syn.get(...)` replaced with the model methods `entity.store(synapse_client=syn)` / `entity.get(synapse_client=syn)` (and `File(id=id).get(...)` for fetch-by-id).
    - `syn.getChildren(...)` replaced with `synapseclient.api.get_children` driven through `wrap_async_generator_to_sync_generator` (the same sync-consumption helper the `StorableContainer` mixin uses), since the workers run in sync executor threads. This preserves the lightweight "list child IDs" behavior rather than switching to the heavier `sync_from_synapse` (which would download files and change what the test exercises).
- `synapseclient/models/services/search.py`:
    - `get_id()` now calls `find_entity_id_async` (per the deprecation guidance, `from synapseclient.operations import find_entity_id`), replacing the deprecated `findEntityId` + `run_in_executor` shim. The async variant is used because `get_id` is a coroutine; it is imported lazily to avoid an `operations → models → search` circular import (mirroring how `find_entity_id_async` itself lazily imports `api.get_child`).
    - Removed the now-unused `import asyncio` and the SYNPY-1623 TODO, and updated the docstring reference. Behavior is equivalent: `find_entity_id_async` resolves the parent via `id_of()` and calls `api.get_child`, which supports `parentId=None` for the Project-by-name lookup — matching the old `findEntityId(name, parent)` contract.

This resolves the SYNPY-1623 tech debt as a side effect. `get_id()` has callers across `project`, `folder`, `file`, `link`, `recordset`, and `table_components`; the signature and return contract are unchanged, so all callers are unaffected.

# **Testing:**

- Ran the affected unit tests before the production change to confirm the failure mode: 7 tests in `unit_test_project_async.py` / `unit_test_folder_async.py` failed with `pytest_socket.SocketBlockedError` because they mocked `Synapse.findEntityId`, which `get_id` no longer calls (the real `get_child` attempted a network call).
- Updated those tests to mock the new dependency (`patch("synapseclient.operations.find_entity_id_async", new_callable=AsyncMock, ...)`) and to include `synapse_client=self.syn` in the corresponding `assert_called_once_with` assertions.
- After the fix: **83 passed** across the two model test files, and **1185 passed** across `tests/unit/synapseclient/models/` and `tests/unit/synapseclient/operations/`.
- Verified that importing the model store/get path with `DeprecationWarning` promoted to an error raises nothing, and confirmed no circular import from the lazy `find_entity_id_async` import.
