### PR TITLE
[SYNPY-1486] Route all progress bars through a silent-aware factory

### DIFF
--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -45,7 +45,6 @@ from opentelemetry.instrumentation.requests import RequestsInstrumentor
 from opentelemetry.instrumentation.threading import ThreadingInstrumentor
 from opentelemetry.instrumentation.urllib import URLLibInstrumentor
 from opentelemetry.trace import Span
-from tqdm import tqdm
 
 import synapseclient
 import synapseclient.core.multithread_download as multithread_download
@@ -102,6 +101,7 @@ from synapseclient.core.retry import (
     with_retry,
     with_retry_time_based_async,
 )
+from synapseclient.core.transfer_bar import create_progress_bar
 from synapseclient.core.upload.multipart_upload_async import (
     multipart_upload_file_async,
     multipart_upload_string_async,
@@ -7822,7 +7822,7 @@ class Synapse(object):
         sleep = self.table_query_sleep
         start_time = time.time()
         lastMessage, lastProgress, lastTotal = "", 0, 1
-        progress_bar = tqdm(desc=uri, unit_scale=True, smoothing=0, leave=None)
+        progress_bar = create_progress_bar(total=None, desc=uri, synapse_client=self)
         while time.time() - start_time < self.table_query_timeout:
             result = self.restGET(
                 uri + "/get/%s" % async_job_id["token"], endpoint=endpoint

--- a/synapseclient/core/download/download_functions.py
+++ b/synapseclient/core/download/download_functions.py
@@ -52,6 +52,7 @@ from synapseclient.core.retry import (
 )
 from synapseclient.core.transfer_bar import (
     close_download_progress_bar,
+    create_progress_bar,
     get_or_create_download_progress_bar,
     increment_progress_bar,
     increment_progress_bar_total,
@@ -817,7 +818,16 @@ async def download_from_url_multi_threaded(
     await download_file(client=client, download_request=request)
 
     if expected_md5:  # if md5 not set (should be the case for all except http download)
-        actual_md5 = utils.md5_for_file_hex(filename=temp_destination)
+        md5_progress_bar = create_progress_bar(
+            total=os.path.getsize(temp_destination),
+            desc="Calculating MD5",
+            unit="B",
+            postfix=os.path.basename(destination),
+            synapse_client=client,
+        )
+        actual_md5 = utils.md5_for_file_hex(
+            filename=temp_destination, progress_bar=md5_progress_bar
+        )
         # check md5 if given
         if actual_md5 != expected_md5:
             try:
@@ -1163,7 +1173,16 @@ def download_from_url(
     if (
         actual_md5 is None
     ):  # if md5 not set (should be the case for all except http download)
-        actual_md5 = utils.md5_for_file_hex(filename=destination)
+        md5_progress_bar = create_progress_bar(
+            total=os.path.getsize(destination),
+            desc="Calculating MD5",
+            unit="B",
+            postfix=os.path.basename(destination),
+            synapse_client=client,
+        )
+        actual_md5 = utils.md5_for_file_hex(
+            filename=destination, progress_bar=md5_progress_bar
+        )
 
     # check md5 if given
     if expected_md5 and actual_md5 != expected_md5:

--- a/synapseclient/core/remote_file_storage_wrappers.py
+++ b/synapseclient/core/remote_file_storage_wrappers.py
@@ -4,16 +4,20 @@ import os
 import typing
 import urllib.parse as urllib_parse
 from contextlib import contextmanager
-from typing import Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from tqdm import tqdm
 
 from synapseclient.core.retry import with_retry
 from synapseclient.core.transfer_bar import (
+    create_progress_bar,
     increment_progress_bar,
     increment_progress_bar_total,
 )
 from synapseclient.core.utils import attempt_import
+
+if TYPE_CHECKING:
+    from synapseclient import Synapse
 
 
 class S3ClientWrapper:
@@ -159,6 +163,7 @@ class S3ClientWrapper:
         show_progress: bool = True,
         transfer_config_kwargs: dict = None,
         storage_str: str = None,
+        synapse_client: Optional["Synapse"] = None,
     ) -> str:
         """
         Upload a file to s3 using boto3.
@@ -209,14 +214,12 @@ class S3ClientWrapper:
         if show_progress:
             file_size = os.stat(upload_file_path).st_size
             filename = os.path.basename(upload_file_path)
-            progress_bar = tqdm(
+            progress_bar = create_progress_bar(
                 total=file_size,
                 desc=storage_str,
                 unit="B",
-                unit_scale=True,
                 postfix=filename,
-                smoothing=0,
-                leave=None,
+                synapse_client=synapse_client,
             )
             progress_callback = S3ClientWrapper._create_progress_callback_func(
                 progress_bar
@@ -287,6 +290,8 @@ class SFTPWrapper:
         username: str = None,
         password: str = None,
         storage_str: str = None,
+        *,
+        synapse_client: Optional["Synapse"] = None,
     ) -> str:
         """
         Performs upload of a local file to an sftp server.
@@ -297,17 +302,19 @@ class SFTPWrapper:
                         sftp://sftp.example.com/path/to/file/store
             username: The username for authentication. Defaults to None.
             password: The password for authentication. Defaults to None.
+            synapse_client: If not passed in and caching was not disabled by
+                `Synapse.allow_client_caching(False)` this will use the last created
+                instance from the Synapse class constructor.
 
         Returns:
             The URL of the uploaded file.
         """
-        progress_bar = tqdm(
+        progress_bar = create_progress_bar(
+            total=None,
             desc=storage_str,
             unit="B",
-            unit_scale=True,
-            smoothing=0,
             postfix=filepath,
-            leave=None,
+            synapse_client=synapse_client,
         )
 
         def progress_callback(*args, **kwargs) -> None:

--- a/synapseclient/core/transfer_bar.py
+++ b/synapseclient/core/transfer_bar.py
@@ -127,6 +127,54 @@ def _is_context_managed_download_bar() -> bool:
     return getattr(_thread_local, "progress_bar_download_context_managed", False)
 
 
+def create_progress_bar(
+    total: Optional[int],
+    desc: str,
+    unit: str = "it",
+    postfix: str = None,
+    *,
+    synapse_client: Optional["Synapse"] = None,
+) -> tqdm:
+    """Create a progress bar that honors the client's ``silent`` configuration.
+
+    The returned bar is disabled (a no-op that renders nothing) when the client
+    is running in silent mode, so callers can update ``desc``/``total`` and call
+    ``update``/``refresh``/``close`` unconditionally.
+
+    Arguments:
+        total: The total size/count for the progress bar. May be ``None`` when the
+            total is not known until later.
+        desc: The description shown as the progress bar prefix.
+        unit: The unit of measurement (e.g. ``"B"`` for bytes). Defaults to ``"it"``.
+        postfix: Optional postfix string shown after the bar.
+        synapse_client: If not passed in and caching was not disabled by
+            `Synapse.allow_client_caching(False)` this will use the last created
+            instance from the Synapse class constructor. When no client can be
+            resolved the bar is shown (as if ``silent`` were ``False``).
+
+    Returns:
+        A ``tqdm`` progress bar, disabled when the client is silent.
+    """
+    from synapseclient import Synapse
+    from synapseclient.core.exceptions import SynapseError
+
+    try:
+        silent = Synapse.get_client(synapse_client=synapse_client).silent
+    except SynapseError:
+        silent = False
+
+    return tqdm(
+        total=total,
+        desc=desc,
+        unit=unit,
+        unit_scale=True,
+        smoothing=0,
+        postfix=postfix,
+        leave=None,
+        disable=silent,
+    )
+
+
 def get_or_create_download_progress_bar(
     file_size: int,
     postfix: str = None,
@@ -158,14 +206,12 @@ def get_or_create_download_progress_bar(
 
     progress_bar: tqdm = getattr(_thread_local, "progress_bar_download", None)
     if progress_bar is None:
-        progress_bar = tqdm(
+        progress_bar = create_progress_bar(
             total=file_size,
             desc=custom_message or "Downloading files",
             unit=unit or "it",
-            unit_scale=True,
-            smoothing=0,
             postfix=postfix,
-            leave=None,
+            synapse_client=syn,
         )
         _thread_local.progress_bar_download = progress_bar
     else:

--- a/synapseclient/core/upload/multipart_upload_async.py
+++ b/synapseclient/core/upload/multipart_upload_async.py
@@ -86,7 +86,6 @@ import httpx
 import psutil
 import requests
 from opentelemetry import trace
-from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 
 from synapseclient.api import (
@@ -106,6 +105,7 @@ from synapseclient.core.exceptions import (
 )
 from synapseclient.core.otel_config import get_tracer
 from synapseclient.core.retry import with_retry_time_based
+from synapseclient.core.transfer_bar import create_progress_bar
 from synapseclient.core.typing_utils import DataFrame as DATA_FRAME_TYPE
 from synapseclient.core.upload.upload_utils import (
     copy_md5_fn,
@@ -378,13 +378,11 @@ class UploadAttemptAsync:
                 # progress bar is not useful
                 self._progress_bar = getattr(
                     _thread_local, "progress_bar", None
-                ) or tqdm(
+                ) or create_progress_bar(
                     total=part_count,
                     desc=self._storage_str or "Copying",
-                    unit_scale=True,
                     postfix=self._dest_file_name,
-                    smoothing=0,
-                    leave=None,
+                    synapse_client=self._syn,
                 )
                 self._progress_bar.update(completed_part_count)
             else:
@@ -395,14 +393,12 @@ class UploadAttemptAsync:
 
                 self._progress_bar = getattr(
                     _thread_local, "progress_bar", None
-                ) or tqdm(
+                ) or create_progress_bar(
                     total=file_size,
                     desc=self._storage_str or "Uploading",
                     unit="B",
-                    unit_scale=True,
                     postfix=self._dest_file_name,
-                    smoothing=0,
-                    leave=None,
+                    synapse_client=self._syn,
                 )
                 self._progress_bar.update(previously_transferred)
 

--- a/synapseclient/core/upload/upload_functions_async.py
+++ b/synapseclient/core/upload/upload_functions_async.py
@@ -279,6 +279,7 @@ async def upload_external_file_handle_sftp(
         username,
         password,
         storage_str=storage_str,
+        synapse_client=syn,
     )
 
     file_md5 = md5 or utils.md5_for_file_hex(filename=file_path)
@@ -394,6 +395,7 @@ async def upload_synapse_sts_boto_s3(
             credentials=credentials,
             transfer_config_kwargs={"max_concurrency": syn.max_threads},
             storage_str=storage_str,
+            synapse_client=syn,
         )
 
     loop = asyncio.get_event_loop()
@@ -453,6 +455,7 @@ async def upload_client_auth_s3(
             profile_name=profile,
             credentials=_get_aws_credentials(),
             storage_str=storage_str,
+            synapse_client=syn,
         ),
     )
 

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -94,7 +94,8 @@ def md5_for_file(
             data = f.read(block_size)
             if not data:
                 if progress_bar:
-                    progress_bar.update(progress_bar.total - progress_bar.n)
+                    if progress_bar.total is not None:
+                        progress_bar.update(progress_bar.total - progress_bar.n)
                     progress_bar.refresh()
                     progress_bar.close()
                 break
@@ -117,7 +118,10 @@ def md5_for_file(
 
 
 def md5_for_file_hex(
-    filename: str, block_size: int = 2 * MB, callback: typing.Callable = None
+    filename: str,
+    block_size: int = 2 * MB,
+    callback: typing.Callable = None,
+    progress_bar: Optional[tqdm] = None,
 ) -> str:
     """
     Calculates the MD5 of the given file.
@@ -129,12 +133,15 @@ def md5_for_file_hex(
                     Defaults to 2 MB
         callback: The callback function that help us show loading spinner on terminal.
                     Defaults to None
+        progress_bar: An optional TQDM progress bar to update
 
     Returns:
         The MD5 Checksum
     """
 
-    return md5_for_file(filename, block_size, callback).hexdigest()
+    return md5_for_file(
+        filename, block_size, callback, progress_bar=progress_bar
+    ).hexdigest()
 
 
 @tracer.start_as_current_span("synapse.util.md5")

--- a/synapseclient/core/utils.py
+++ b/synapseclient/core/utils.py
@@ -93,7 +93,7 @@ def md5_for_file(
                 callback()
             data = f.read(block_size)
             if not data:
-                if progress_bar:
+                if progress_bar is not None:
                     if progress_bar.total is not None:
                         progress_bar.update(progress_bar.total - progress_bar.n)
                     progress_bar.refresh()
@@ -102,7 +102,7 @@ def md5_for_file(
             md5.update(data)
             data_length = len(data)
             data_read += data_length
-            if progress_bar:
+            if progress_bar is not None:
                 progress_bar.update(data_length)
             del data
             # Garbage collect every 100 iterations

--- a/synapseclient/models/mixins/asynchronous_job.py
+++ b/synapseclient/models/mixins/asynchronous_job.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Optional
 
-from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 from typing_extensions import Self
 
@@ -30,6 +29,7 @@ from synapseclient.core.exceptions import (
     SynapseHTTPError,
     SynapseTimeoutError,
 )
+from synapseclient.core.transfer_bar import create_progress_bar
 
 ASYNC_JOB_URIS = {
     AGENT_CHAT_REQUEST: "/agent/chat/async",
@@ -452,11 +452,10 @@ async def get_job_async(
     last_progress = 0
     last_total = 1
     progressed = False
-    progress_bar = tqdm(
+    progress_bar = create_progress_bar(
         total=last_total,
-        unit_scale=True,
-        smoothing=0,
-        leave=None,
+        desc="",
+        synapse_client=client,
     )
     with logging_redirect_tqdm(loggers=[client.logger]):
         while time.time() - start_time < timeout:

--- a/synapseclient/models/mixins/storable_container.py
+++ b/synapseclient/models/mixins/storable_container.py
@@ -40,7 +40,10 @@ from synapseclient.core.constants.concrete_types import (
 )
 from synapseclient.core.constants.method_flags import COLLISION_OVERWRITE_LOCAL
 from synapseclient.core.exceptions import SynapseError
-from synapseclient.core.transfer_bar import shared_download_progress_bar
+from synapseclient.core.transfer_bar import (
+    create_progress_bar,
+    shared_download_progress_bar,
+)
 from synapseclient.core.upload.multipart_upload_async import (
     shared_progress_bar as upload_shared_progress_bar,
 )
@@ -654,8 +657,6 @@ class StorableContainer(StorableContainerSynchronousProtocol):
             asyncio.run(main())
             ```
         """
-        from tqdm import tqdm
-
         from synapseutils.monitor import notify_me_async
 
         syn = Synapse.get_client(synapse_client=synapse_client)
@@ -678,13 +679,11 @@ class StorableContainer(StorableContainerSynchronousProtocol):
         if not items:
             return []
 
-        progress_bar = tqdm(
+        progress_bar = create_progress_bar(
             total=total_size,
             desc=f"Uploading {len(items)} files",
             unit="B",
-            unit_scale=True,
-            smoothing=0,
-            leave=None,
+            synapse_client=syn,
         )
         with upload_shared_progress_bar(progress_bar):
             try:

--- a/synapseclient/models/mixins/table_components.py
+++ b/synapseclient/models/mixins/table_components.py
@@ -35,6 +35,7 @@ from synapseclient.core.download.download_functions import (
     ensure_download_location_is_directory,
 )
 from synapseclient.core.exceptions import SynapseTimeoutError
+from synapseclient.core.transfer_bar import create_progress_bar
 from synapseclient.core.typing_utils import DataFrame as DATA_FRAME_TYPE
 from synapseclient.core.typing_utils import Series as SERIES_TYPE
 from synapseclient.core.upload.multipart_upload_async import (
@@ -2033,11 +2034,10 @@ async def _wait_for_eventually_consistent_changes(
                         original_synids_and_etags_to_track.get(entity_with_change)
                     )
         number_of_changes_to_wait_for = len(etags_to_track)
-        progress_bar = tqdm(
+        progress_bar = create_progress_bar(
             total=number_of_changes_to_wait_for,
             desc="Waiting for eventually-consistent changes to show up in the view",
-            unit_scale=True,
-            smoothing=0,
+            synapse_client=synapse_client,
         )
         start_time = time.time()
 
@@ -2134,11 +2134,10 @@ async def _upsert_rows_async(
     total_row_count_to_update = 0
     row_update_results = None
     with logging_redirect_tqdm(loggers=[client.logger]):
-        progress_bar = tqdm(
+        progress_bar = create_progress_bar(
             total=len(values),
             desc="Querying & Updating rows",
-            unit_scale=True,
-            smoothing=0,
+            synapse_client=client,
         )
         for individual_chunk in chunk_list:
             select_statement = _construct_select_statement_for_upsert(
@@ -3959,13 +3958,11 @@ class TableStoreRowMixin:
                 job_timeout=job_timeout,
             )
 
-            progress_bar = tqdm(
+            progress_bar = create_progress_bar(
                 total=file_size,
                 desc="Splitting CSV and uploading chunks",
-                unit_scale=True,
-                smoothing=0,
                 unit="B",
-                leave=None,
+                synapse_client=client,
             )
             # The original file is read twice, the reason is that on the first pass we
             # are calculating the size of the chunks that we will be uploading and the
@@ -4153,17 +4150,15 @@ class TableStoreRowMixin:
         client.logger.info(
             f"[{self.id}:{self.name}]: Found {len(chunks_to_upload)} chunks to upload into table"
         )
-        progress_bar = tqdm(
+        progress_bar = create_progress_bar(
             total=total_df_bytes,
             desc=(
                 "Splitting DataFrame and uploading chunks"
                 if len(chunks_to_upload) > 1
                 else "Uploading DataFrame"
             ),
-            unit_scale=True,
-            smoothing=0,
             unit="B",
-            leave=None,
+            synapse_client=client,
         )
 
         changes = []

--- a/tests/unit/synapseclient/core/unit_test_download.py
+++ b/tests/unit/synapseclient/core/unit_test_download.py
@@ -619,6 +619,7 @@ class TestDownloadFromUrlMultiThreaded:
         with (
             patch("synapseclient.core.download.download_functions.download_file"),
             patch.object(utils, "md5_for_file") as mock_md5_for_file,
+            patch.object(os.path, "getsize", return_value=100),
             patch.object(os, "remove") as mock_os_remove,
             patch.object(shutil, "move") as mock_move,
         ):
@@ -651,6 +652,7 @@ class TestDownloadFromUrlMultiThreaded:
                 "md5_for_file_hex",
                 return_value=expected_md5,
             ),
+            patch.object(os.path, "getsize", return_value=100),
             patch.object(os, "remove") as mock_os_remove,
             patch.object(shutil, "move") as mock_move,
         ):
@@ -678,6 +680,7 @@ class TestDownloadFromUrlMultiThreaded:
             ) as mock_download_file,
             patch.object(utils, "temp_download_filename", return_value="/temp/path"),
             patch.object(utils, "md5_for_file_hex", return_value="expectedMd5"),
+            patch.object(os.path, "getsize", return_value=100),
             patch.object(os, "remove") as mock_os_remove,
             patch.object(shutil, "move") as mock_move,
         ):
@@ -719,6 +722,7 @@ class TestDownloadFromUrlMultiThreaded:
             ) as mock_download_file,
             patch.object(utils, "temp_download_filename", return_value="/temp/path"),
             patch.object(utils, "md5_for_file_hex", return_value="anotherMd5"),
+            patch.object(os.path, "getsize", return_value=100),
             patch.object(os, "remove") as mock_os_remove,
             patch.object(shutil, "move") as mock_move,
         ):
@@ -846,6 +850,7 @@ class TestDownloadFromUrlMultiThreaded:
             patch.object(
                 utils, "temp_download_filename", return_value="/temp/path"
             ) as mock_temp_filename,
+            patch.object(os.path, "getsize", return_value=100),
             patch.object(os, "remove") as mock_os_remove,
             patch.object(shutil, "move") as mock_move,
         ):
@@ -1076,6 +1081,7 @@ class TestDownloadFromUrl:
                 "md5_for_file_hex",
                 return_value="Some other incorrect md5",
             ) as mocked_md5_for_file,
+            patch.object(os.path, "getsize", return_value=100),
             patch("os.remove") as mocked_remove,
         ):
             # function under test

--- a/tests/unit/synapseclient/core/unit_test_transfer_bar.py
+++ b/tests/unit/synapseclient/core/unit_test_transfer_bar.py
@@ -1,0 +1,59 @@
+"""Unit tests for the silent-aware progress bar factory in transfer_bar."""
+
+from unittest.mock import patch
+
+from synapseclient import Synapse
+from synapseclient.core.exceptions import SynapseError
+from synapseclient.core.transfer_bar import create_progress_bar
+
+
+class TestCreateProgressBar:
+    """Tests for :func:`create_progress_bar`."""
+
+    def test_disabled_when_silent(self, syn: Synapse) -> None:
+        # GIVEN a client running in silent mode
+        with patch.object(syn, "silent", True):
+            # WHEN a progress bar is created
+            progress_bar = create_progress_bar(
+                total=100, desc="Uploading", synapse_client=syn
+            )
+
+            # THEN the bar is disabled so it renders nothing
+            assert progress_bar.disable is True
+
+    def test_enabled_when_not_silent(self, syn: Synapse) -> None:
+        # GIVEN a client that is not silent
+        with patch.object(syn, "silent", False):
+            # WHEN a progress bar is created
+            progress_bar = create_progress_bar(
+                total=100, desc="Uploading", synapse_client=syn
+            )
+
+            # THEN the bar is enabled with the standardized configuration
+            assert progress_bar.disable is False
+            assert progress_bar.total == 100
+            assert progress_bar.desc == "Uploading"
+
+    def test_disabled_bar_accepts_mutation(self, syn: Synapse) -> None:
+        # GIVEN a disabled (silent) progress bar
+        with patch.object(syn, "silent", True):
+            progress_bar = create_progress_bar(total=None, desc="", synapse_client=syn)
+
+            # WHEN callers mutate and drive the bar directly (as the live sites do)
+            progress_bar.desc = "processing"
+            progress_bar.total = 50
+            progress_bar.update(25)
+            progress_bar.refresh()
+            progress_bar.close()
+
+            # THEN no error is raised and nothing is rendered
+            assert progress_bar.disable is True
+
+    def test_shows_bar_when_no_client_available(self) -> None:
+        # GIVEN no client is passed and none can be resolved
+        with patch.object(Synapse, "get_client", side_effect=SynapseError("no client")):
+            # WHEN a progress bar is created without a client
+            progress_bar = create_progress_bar(total=100, desc="Uploading")
+
+            # THEN the bar is shown rather than propagating the error
+            assert progress_bar.disable is False

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -568,6 +568,18 @@ def test_md5_for_file(mock_hashlib: MagicMock) -> None:
         mock_callback.call_count == 3
 
 
+def test_md5_for_file_hex_forwards_progress_bar() -> None:
+    """md5_for_file_hex should pass the progress bar through to md5_for_file."""
+    file_name = "/home/foo/bar/test.txt"
+    progress_bar = Mock()
+    with patch.object(utils, "md5_for_file") as mock_md5_for_file:
+        utils.md5_for_file_hex(file_name, progress_bar=progress_bar)
+
+        mock_md5_for_file.assert_called_once_with(
+            file_name, 2 * utils.MB, None, progress_bar=progress_bar
+        )
+
+
 # TODO: remove test in 5.0.0
 class TestSpinner:
     """

--- a/tests/unit/synapseclient/core/unit_test_utils.py
+++ b/tests/unit/synapseclient/core/unit_test_utils.py
@@ -580,6 +580,36 @@ def test_md5_for_file_hex_forwards_progress_bar() -> None:
         )
 
 
+def test_md5_for_file_closes_progress_bar_for_empty_file(tmp_path, syn) -> None:
+    """md5_for_file should close the progress bar even when the file is empty.
+
+    The download code sizes the MD5 progress bar with os.path.getsize, which is
+    0 for an empty file. A tqdm bar with total=0 is falsy, so a truthiness check
+    on the bar must not be used to guard the final refresh/close.
+    """
+    from synapseclient.core.transfer_bar import create_progress_bar
+
+    # GIVEN an empty downloaded file
+    empty_file = tmp_path / "empty_file.txt"
+    empty_file.touch()
+
+    # AND a progress bar created exactly as the download code creates it
+    with patch.object(syn, "silent", False):
+        progress_bar = create_progress_bar(
+            total=os.path.getsize(empty_file),
+            desc="Calculating MD5",
+            unit="B",
+            postfix=empty_file.name,
+            synapse_client=syn,
+        )
+
+    # WHEN the MD5 is calculated
+    utils.md5_for_file(filename=str(empty_file), progress_bar=progress_bar)
+
+    # THEN the progress bar is closed (tqdm marks a closed bar as disabled)
+    assert progress_bar.disable is True
+
+
 # TODO: remove test in 5.0.0
 class TestSpinner:
     """

--- a/tests/unit/synapseclient/models/async/unit_test_wiki_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_wiki_async.py
@@ -2,6 +2,7 @@
 
 import copy
 import os
+import tempfile
 from typing import Any, AsyncGenerator, Dict
 from unittest.mock import AsyncMock, Mock, call, mock_open, patch
 
@@ -422,81 +423,103 @@ class TestWikiPage:
         assert results == expected_results
 
     def test_to_gzip_file_with_string_content(self) -> None:
-        self.syn.cache.cache_root_dir = "temp_cache_dir"
+        temp_dir = tempfile.gettempdir()
+        try:
+            self.syn.cache.cache_root_dir = temp_dir
 
-        # WHEN I call `_to_gzip_file` with a markdown string
-        with (
-            patch("builtins.open") as mock_open_file,
-            patch("gzip.open") as mock_gzip_open,
-            patch("os.path.exists", return_value=True),
-        ):
-            file_path = self.wiki_page._to_gzip_file(self.wiki_page.markdown, self.syn)
+            # WHEN I call `_to_gzip_file` with a markdown string
+            with (
+                patch("builtins.open") as mock_open_file,
+                patch("gzip.open") as mock_gzip_open,
+                patch("os.path.exists", return_value=True),
+            ):
+                file_path = self.wiki_page._to_gzip_file(self.wiki_page.markdown, self.syn)
 
-        # THEN the content should be written to a gzipped file
-        mock_open_file.assert_not_called()
-        mock_gzip_open.assert_called_once_with(
-            os.path.join(
+            # THEN the content should be written to a gzipped file
+            mock_open_file.assert_not_called()
+            mock_gzip_open.assert_called_once_with(
+                os.path.join(
+                    self.syn.cache.cache_root_dir,
+                    "wiki_content",
+                    "wiki_markdown_Test Wiki Page.md.gz",
+                ),
+                "wt",
+                encoding="utf-8",
+            )
+            mock_gzip_open.return_value.__enter__.return_value.write.assert_called_once_with(
+                self.wiki_page.markdown
+            )
+            # normalize the file path
+            assert file_path == os.path.join(
                 self.syn.cache.cache_root_dir,
                 "wiki_content",
                 "wiki_markdown_Test Wiki Page.md.gz",
-            ),
-            "wt",
-            encoding="utf-8",
-        )
-        mock_gzip_open.return_value.__enter__.return_value.write.assert_called_once_with(
-            self.wiki_page.markdown
-        )
-        # normalize the file path
-        assert file_path == os.path.join(
-            self.syn.cache.cache_root_dir,
-            "wiki_content",
-            "wiki_markdown_Test Wiki Page.md.gz",
-        )
+            )
+        finally:
+            try:
+                os.rmdir(temp_dir)
+            except OSError:
+                pass  # Directory not empty or other error, ignore for cleanup
 
     def test_to_gzip_file_with_gzipped_file(self) -> None:
-        with (
-            patch("os.path.isfile"),
-            patch("gzip.open") as mock_gzip_open,
-            patch("builtins.open") as mock_open_file,
-        ):
-            self.syn.cache.cache_root_dir = "temp_cache_dir"
-            markdown_file_path = "wiki_markdown_Test Wiki Page.md.gz"
+        temp_dir = tempfile.gettempdir()
+        try:
+            with (
+                patch("os.path.isfile"),
+                patch("gzip.open") as mock_gzip_open,
+                patch("builtins.open") as mock_open_file,
+            ):
+                self.syn.cache.cache_root_dir = temp_dir
+                markdown_file_path = "wiki_markdown_Test Wiki Page.md.gz"
 
-            # WHEN I call `_to_gzip_file` with a gzipped file
-            file_path = self.wiki_page._to_gzip_file(markdown_file_path, self.syn)
-            mock_open_file.assert_not_called()
-            mock_gzip_open.assert_not_called()
-            assert file_path == markdown_file_path
+                # WHEN I call `_to_gzip_file` with a gzipped file
+                file_path = self.wiki_page._to_gzip_file(markdown_file_path, self.syn)
+                mock_open_file.assert_not_called()
+                mock_gzip_open.assert_not_called()
+                assert file_path == markdown_file_path
+        finally:
+            try:
+                os.rmdir(temp_dir)
+            except OSError:
+                pass  # Directory not empty or other error, ignore for cleanup
 
     def test_to_gzip_file_with_non_gzipped_file(self) -> None:
-        self.syn.cache.cache_root_dir = "temp_cache_dir"
 
-        # WHEN I call `_to_gzip_file` with a file path
-        with (
-            patch("os.path.isfile", return_value=True),
-            patch(
-                "builtins.open", new=mock_open(read_data=b"test content")
-            ) as mock_open_file,
-            patch("gzip.open") as mock_gzip_open,
-            patch("os.path.exists", return_value=True),
-        ):
-            test_file_path = os.path.join("file_path", "test.txt")
-            file_path = self.wiki_page._to_gzip_file(test_file_path, self.syn)
+        temp_dir = tempfile.gettempdir()
+        self.syn.cache.cache_root_dir = temp_dir
 
-            # THEN the file should be processed
-            mock_open_file.assert_called_once_with(test_file_path, "rb")
-            mock_gzip_open.assert_called_once_with(
-                os.path.join(
+        try:
+            # WHEN I call `_to_gzip_file` with a file path
+            with (
+                patch("os.path.isfile", return_value=True),
+                patch(
+                    "builtins.open", new=mock_open(read_data=b"test content")
+                ) as mock_open_file,
+                patch("gzip.open") as mock_gzip_open,
+                patch("os.path.exists", return_value=True),
+            ):
+                test_file_path = os.path.join("file_path", "test.txt")
+                file_path = self.wiki_page._to_gzip_file(test_file_path, self.syn)
+
+                # THEN the file should be processed
+                mock_open_file.assert_called_once_with(test_file_path, "rb")
+                mock_gzip_open.assert_called_once_with(
+                    os.path.join(
+                        self.syn.cache.cache_root_dir, "wiki_content", "test.txt.gz"
+                    ),
+                    "wb",
+                )
+                gzip_handle = mock_gzip_open.return_value.__enter__.return_value
+                open_handle = mock_open_file.return_value.__enter__.return_value
+                gzip_handle.writelines.assert_called_once_with(open_handle)
+                assert file_path == os.path.join(
                     self.syn.cache.cache_root_dir, "wiki_content", "test.txt.gz"
-                ),
-                "wb",
-            )
-            gzip_handle = mock_gzip_open.return_value.__enter__.return_value
-            open_handle = mock_open_file.return_value.__enter__.return_value
-            gzip_handle.writelines.assert_called_once_with(open_handle)
-            assert file_path == os.path.join(
-                self.syn.cache.cache_root_dir, "wiki_content", "test.txt.gz"
-            )
+                )
+        finally:
+            try:
+                os.rmdir(temp_dir)
+            except OSError:
+                pass  # Directory not empty or other error, ignore for cleanup
 
     def test_to_gzip_file_with_invalid_content(self) -> None:
         # WHEN I call `_to_gzip_file` with invalid content type
@@ -505,94 +528,118 @@ class TestWikiPage:
             self.wiki_page._to_gzip_file(123, self.syn)
 
     def test_unzip_gzipped_file_with_markdown(self) -> None:
-        self.syn.cache.cache_root_dir = "temp_cache_dir"
-        gzipped_file_path = os.path.join(self.syn.cache.cache_root_dir, "test.md.gz")
-        expected_unzipped_file_path = os.path.join(
-            self.syn.cache.cache_root_dir, "test.md"
-        )
-        markdown_content = "# Test Markdown\n\nThis is a test."
-        markdown_content_bytes = markdown_content.encode("utf-8")
+        temp_dir = tempfile.gettempdir()
+        self.syn.cache.cache_root_dir = temp_dir
 
-        # WHEN I call `_unzip_gzipped_file` with a binary file
-        with (
-            patch("gzip.open") as mock_gzip_open,
-            patch("builtins.open") as mock_open_file,
-            patch("pprint.pp") as mock_pprint,
-        ):
-            mock_gzip_open.return_value.__enter__.return_value.read.return_value = (
-                markdown_content_bytes
+        try:
+            gzipped_file_path = os.path.join(self.syn.cache.cache_root_dir, "test.md.gz")
+            expected_unzipped_file_path = os.path.join(
+                self.syn.cache.cache_root_dir, "test.md"
             )
-            unzipped_file_path = self.wiki_page.unzip_gzipped_file(gzipped_file_path)
+            markdown_content = "# Test Markdown\n\nThis is a test."
+            markdown_content_bytes = markdown_content.encode("utf-8")
 
-        # THEN the file should be unzipped correctly
-        mock_gzip_open.assert_called_once_with(gzipped_file_path, "rb")
-        mock_pprint.assert_called_once_with(markdown_content)
-        mock_open_file.assert_called_once_with(
-            expected_unzipped_file_path, "wt", encoding="utf-8"
-        )
-        mock_open_file.return_value.__enter__.return_value.write.assert_called_once_with(
-            markdown_content
-        )
-        assert unzipped_file_path == expected_unzipped_file_path
+            # WHEN I call `_unzip_gzipped_file` with a binary file
+            with (
+                patch("gzip.open") as mock_gzip_open,
+                patch("builtins.open") as mock_open_file,
+                patch("pprint.pp") as mock_pprint,
+            ):
+                mock_gzip_open.return_value.__enter__.return_value.read.return_value = (
+                    markdown_content_bytes
+                )
+                unzipped_file_path = self.wiki_page.unzip_gzipped_file(gzipped_file_path)
+
+            # THEN the file should be unzipped correctly
+            mock_gzip_open.assert_called_once_with(gzipped_file_path, "rb")
+            mock_pprint.assert_called_once_with(markdown_content)
+            mock_open_file.assert_called_once_with(
+                expected_unzipped_file_path, "wt", encoding="utf-8"
+            )
+            mock_open_file.return_value.__enter__.return_value.write.assert_called_once_with(
+                markdown_content
+            )
+            assert unzipped_file_path == expected_unzipped_file_path
+        finally:
+            try:
+                os.rmdir(temp_dir)
+            except OSError:
+                pass  # Directory not empty or other error, ignore for cleanup
 
     def test_unzip_gzipped_file_with_binary_file(self) -> None:
-        self.syn.cache.cache_root_dir = "temp_cache_dir"
-        gzipped_file_path = os.path.join(self.syn.cache.cache_root_dir, "test.bin.gz")
-        expected_unzipped_file_path = os.path.join(
-            self.syn.cache.cache_root_dir, "test.bin"
-        )
-        binary_content = b"\x00\x01\x02\x03\xff\xfe\xfd"
+        temp_dir = tempfile.gettempdir()
+        self.syn.cache.cache_root_dir = temp_dir
 
-        # WHEN I call `_unzip_gzipped_file` with a binary file
-        with (
-            patch("gzip.open") as mock_gzip_open,
-            patch("builtins.open") as mock_open_file,
-            patch("pprint.pp") as mock_pprint,
-        ):
-            mock_gzip_open.return_value.__enter__.return_value.read.return_value = (
+        try:
+            gzipped_file_path = os.path.join(self.syn.cache.cache_root_dir, "test.bin.gz")
+            expected_unzipped_file_path = os.path.join(
+                self.syn.cache.cache_root_dir, "test.bin"
+            )
+            binary_content = b"\x00\x01\x02\x03\xff\xfe\xfd"
+
+            # WHEN I call `_unzip_gzipped_file` with a binary file
+            with (
+                patch("gzip.open") as mock_gzip_open,
+                patch("builtins.open") as mock_open_file,
+                patch("pprint.pp") as mock_pprint,
+            ):
+                mock_gzip_open.return_value.__enter__.return_value.read.return_value = (
+                    binary_content
+                )
+                unzipped_file_path = self.wiki_page.unzip_gzipped_file(gzipped_file_path)
+
+            # THEN the file should be unzipped correctly
+            mock_gzip_open.assert_called_once_with(gzipped_file_path, "rb")
+            mock_pprint.assert_not_called()
+            mock_open_file.assert_called_once_with(unzipped_file_path, "wb")
+            mock_open_file.return_value.__enter__.return_value.write.assert_called_once_with(
                 binary_content
             )
-            unzipped_file_path = self.wiki_page.unzip_gzipped_file(gzipped_file_path)
-
-        # THEN the file should be unzipped correctly
-        mock_gzip_open.assert_called_once_with(gzipped_file_path, "rb")
-        mock_pprint.assert_not_called()
-        mock_open_file.assert_called_once_with(unzipped_file_path, "wb")
-        mock_open_file.return_value.__enter__.return_value.write.assert_called_once_with(
-            binary_content
-        )
-        assert unzipped_file_path == expected_unzipped_file_path
+            assert unzipped_file_path == expected_unzipped_file_path
+        finally:
+            try:
+                os.rmdir(temp_dir)
+            except OSError:
+                pass  # Directory not empty or other error, ignore for cleanup
 
     def test_unzip_gzipped_file_with_text_file(self) -> None:
-        self.syn.cache.cache_root_dir = "temp_cache_dir"
-        gzipped_file_path = os.path.join(self.syn.cache.cache_root_dir, "test.txt.gz")
-        expected_unzipped_file_path = os.path.join(
-            self.syn.cache.cache_root_dir, "test.txt"
-        )
-        text_content = "This is plain text content."
-        text_content_bytes = text_content.encode("utf-8")
+        temp_dir = tempfile.gettempdir()
+        self.syn.cache.cache_root_dir = temp_dir
 
-        # WHEN I call `_unzip_gzipped_file` with a text file
-        with (
-            patch("gzip.open") as mock_gzip_open,
-            patch("builtins.open") as mock_open_file,
-            patch("synapseclient.models.wiki.pprint.pp") as mock_pprint,
-        ):
-            mock_gzip_open.return_value.__enter__.return_value.read.return_value = (
-                text_content_bytes
+        try:
+            gzipped_file_path = os.path.join(self.syn.cache.cache_root_dir, "test.txt.gz")
+            expected_unzipped_file_path = os.path.join(
+                self.syn.cache.cache_root_dir, "test.txt"
             )
-            unzipped_file_path = self.wiki_page.unzip_gzipped_file(gzipped_file_path)
+            text_content = "This is plain text content."
+            text_content_bytes = text_content.encode("utf-8")
 
-        # THEN the file should be unzipped correctly
-        mock_gzip_open.assert_called_once_with(gzipped_file_path, "rb")
-        mock_pprint.assert_not_called()
-        mock_open_file.assert_called_once_with(
-            unzipped_file_path, "wt", encoding="utf-8"
-        )
-        mock_open_file.return_value.__enter__.return_value.write.assert_called_once_with(
-            text_content
-        )
-        assert unzipped_file_path == expected_unzipped_file_path
+            # WHEN I call `_unzip_gzipped_file` with a text file
+            with (
+                patch("gzip.open") as mock_gzip_open,
+                patch("builtins.open") as mock_open_file,
+                patch("synapseclient.models.wiki.pprint.pp") as mock_pprint,
+            ):
+                mock_gzip_open.return_value.__enter__.return_value.read.return_value = (
+                    text_content_bytes
+                )
+                unzipped_file_path = self.wiki_page.unzip_gzipped_file(gzipped_file_path)
+
+            # THEN the file should be unzipped correctly
+            mock_gzip_open.assert_called_once_with(gzipped_file_path, "rb")
+            mock_pprint.assert_not_called()
+            mock_open_file.assert_called_once_with(
+                unzipped_file_path, "wt", encoding="utf-8"
+            )
+            mock_open_file.return_value.__enter__.return_value.write.assert_called_once_with(
+                text_content
+            )
+            assert unzipped_file_path == expected_unzipped_file_path
+        finally:
+            try:
+                os.rmdir(temp_dir)
+            except OSError:
+                pass  # Directory not empty or other error, ignore for cleanup
 
     def test_get_file_size_success(self) -> None:
         # GIVEN a filehandle dictionary

--- a/tests/unit/synapseclient/models/async/unit_test_wiki_async.py
+++ b/tests/unit/synapseclient/models/async/unit_test_wiki_async.py
@@ -423,103 +423,81 @@ class TestWikiPage:
         assert results == expected_results
 
     def test_to_gzip_file_with_string_content(self) -> None:
-        temp_dir = tempfile.gettempdir()
-        try:
-            self.syn.cache.cache_root_dir = temp_dir
+        self.syn.cache.cache_root_dir = tempfile.gettempdir()
 
-            # WHEN I call `_to_gzip_file` with a markdown string
-            with (
-                patch("builtins.open") as mock_open_file,
-                patch("gzip.open") as mock_gzip_open,
-                patch("os.path.exists", return_value=True),
-            ):
-                file_path = self.wiki_page._to_gzip_file(self.wiki_page.markdown, self.syn)
+        # WHEN I call `_to_gzip_file` with a markdown string
+        with (
+            patch("builtins.open") as mock_open_file,
+            patch("gzip.open") as mock_gzip_open,
+            patch("os.path.exists", return_value=True),
+        ):
+            file_path = self.wiki_page._to_gzip_file(self.wiki_page.markdown, self.syn)
 
-            # THEN the content should be written to a gzipped file
-            mock_open_file.assert_not_called()
-            mock_gzip_open.assert_called_once_with(
-                os.path.join(
-                    self.syn.cache.cache_root_dir,
-                    "wiki_content",
-                    "wiki_markdown_Test Wiki Page.md.gz",
-                ),
-                "wt",
-                encoding="utf-8",
-            )
-            mock_gzip_open.return_value.__enter__.return_value.write.assert_called_once_with(
-                self.wiki_page.markdown
-            )
-            # normalize the file path
-            assert file_path == os.path.join(
+        # THEN the content should be written to a gzipped file
+        mock_open_file.assert_not_called()
+        mock_gzip_open.assert_called_once_with(
+            os.path.join(
                 self.syn.cache.cache_root_dir,
                 "wiki_content",
                 "wiki_markdown_Test Wiki Page.md.gz",
-            )
-        finally:
-            try:
-                os.rmdir(temp_dir)
-            except OSError:
-                pass  # Directory not empty or other error, ignore for cleanup
+            ),
+            "wt",
+            encoding="utf-8",
+        )
+        mock_gzip_open.return_value.__enter__.return_value.write.assert_called_once_with(
+            self.wiki_page.markdown
+        )
+        # normalize the file path
+        assert file_path == os.path.join(
+            self.syn.cache.cache_root_dir,
+            "wiki_content",
+            "wiki_markdown_Test Wiki Page.md.gz",
+        )
 
     def test_to_gzip_file_with_gzipped_file(self) -> None:
-        temp_dir = tempfile.gettempdir()
-        try:
-            with (
-                patch("os.path.isfile"),
-                patch("gzip.open") as mock_gzip_open,
-                patch("builtins.open") as mock_open_file,
-            ):
-                self.syn.cache.cache_root_dir = temp_dir
-                markdown_file_path = "wiki_markdown_Test Wiki Page.md.gz"
+        with (
+            patch("os.path.isfile"),
+            patch("gzip.open") as mock_gzip_open,
+            patch("builtins.open") as mock_open_file,
+        ):
+            self.syn.cache.cache_root_dir = tempfile.gettempdir()
+            markdown_file_path = "wiki_markdown_Test Wiki Page.md.gz"
 
-                # WHEN I call `_to_gzip_file` with a gzipped file
-                file_path = self.wiki_page._to_gzip_file(markdown_file_path, self.syn)
-                mock_open_file.assert_not_called()
-                mock_gzip_open.assert_not_called()
-                assert file_path == markdown_file_path
-        finally:
-            try:
-                os.rmdir(temp_dir)
-            except OSError:
-                pass  # Directory not empty or other error, ignore for cleanup
+            # WHEN I call `_to_gzip_file` with a gzipped file
+            file_path = self.wiki_page._to_gzip_file(markdown_file_path, self.syn)
+            mock_open_file.assert_not_called()
+            mock_gzip_open.assert_not_called()
+            assert file_path == markdown_file_path
 
     def test_to_gzip_file_with_non_gzipped_file(self) -> None:
+        self.syn.cache.cache_root_dir = tempfile.gettempdir()
 
-        temp_dir = tempfile.gettempdir()
-        self.syn.cache.cache_root_dir = temp_dir
+        # WHEN I call `_to_gzip_file` with a file path
+        with (
+            patch("os.path.isfile", return_value=True),
+            patch(
+                "builtins.open", new=mock_open(read_data=b"test content")
+            ) as mock_open_file,
+            patch("gzip.open") as mock_gzip_open,
+            patch("os.path.exists", return_value=True),
+        ):
+            test_file_path = os.path.join("file_path", "test.txt")
+            file_path = self.wiki_page._to_gzip_file(test_file_path, self.syn)
 
-        try:
-            # WHEN I call `_to_gzip_file` with a file path
-            with (
-                patch("os.path.isfile", return_value=True),
-                patch(
-                    "builtins.open", new=mock_open(read_data=b"test content")
-                ) as mock_open_file,
-                patch("gzip.open") as mock_gzip_open,
-                patch("os.path.exists", return_value=True),
-            ):
-                test_file_path = os.path.join("file_path", "test.txt")
-                file_path = self.wiki_page._to_gzip_file(test_file_path, self.syn)
-
-                # THEN the file should be processed
-                mock_open_file.assert_called_once_with(test_file_path, "rb")
-                mock_gzip_open.assert_called_once_with(
-                    os.path.join(
-                        self.syn.cache.cache_root_dir, "wiki_content", "test.txt.gz"
-                    ),
-                    "wb",
-                )
-                gzip_handle = mock_gzip_open.return_value.__enter__.return_value
-                open_handle = mock_open_file.return_value.__enter__.return_value
-                gzip_handle.writelines.assert_called_once_with(open_handle)
-                assert file_path == os.path.join(
+            # THEN the file should be processed
+            mock_open_file.assert_called_once_with(test_file_path, "rb")
+            mock_gzip_open.assert_called_once_with(
+                os.path.join(
                     self.syn.cache.cache_root_dir, "wiki_content", "test.txt.gz"
-                )
-        finally:
-            try:
-                os.rmdir(temp_dir)
-            except OSError:
-                pass  # Directory not empty or other error, ignore for cleanup
+                ),
+                "wb",
+            )
+            gzip_handle = mock_gzip_open.return_value.__enter__.return_value
+            open_handle = mock_open_file.return_value.__enter__.return_value
+            gzip_handle.writelines.assert_called_once_with(open_handle)
+            assert file_path == os.path.join(
+                self.syn.cache.cache_root_dir, "wiki_content", "test.txt.gz"
+            )
 
     def test_to_gzip_file_with_invalid_content(self) -> None:
         # WHEN I call `_to_gzip_file` with invalid content type
@@ -528,118 +506,97 @@ class TestWikiPage:
             self.wiki_page._to_gzip_file(123, self.syn)
 
     def test_unzip_gzipped_file_with_markdown(self) -> None:
-        temp_dir = tempfile.gettempdir()
-        self.syn.cache.cache_root_dir = temp_dir
+        self.syn.cache.cache_root_dir = tempfile.gettempdir()
 
-        try:
-            gzipped_file_path = os.path.join(self.syn.cache.cache_root_dir, "test.md.gz")
-            expected_unzipped_file_path = os.path.join(
-                self.syn.cache.cache_root_dir, "test.md"
-            )
-            markdown_content = "# Test Markdown\n\nThis is a test."
-            markdown_content_bytes = markdown_content.encode("utf-8")
+        gzipped_file_path = os.path.join(self.syn.cache.cache_root_dir, "test.md.gz")
+        expected_unzipped_file_path = os.path.join(
+            self.syn.cache.cache_root_dir, "test.md"
+        )
+        markdown_content = "# Test Markdown\n\nThis is a test."
+        markdown_content_bytes = markdown_content.encode("utf-8")
 
-            # WHEN I call `_unzip_gzipped_file` with a binary file
-            with (
-                patch("gzip.open") as mock_gzip_open,
-                patch("builtins.open") as mock_open_file,
-                patch("pprint.pp") as mock_pprint,
-            ):
-                mock_gzip_open.return_value.__enter__.return_value.read.return_value = (
-                    markdown_content_bytes
-                )
-                unzipped_file_path = self.wiki_page.unzip_gzipped_file(gzipped_file_path)
+        # WHEN I call `_unzip_gzipped_file` with a binary file
+        with (
+            patch("gzip.open") as mock_gzip_open,
+            patch("builtins.open") as mock_open_file,
+            patch("pprint.pp") as mock_pprint,
+        ):
+            mock_gzip_open.return_value.__enter__.return_value.read.return_value = (
+                markdown_content_bytes
+            )
+            unzipped_file_path = self.wiki_page.unzip_gzipped_file(gzipped_file_path)
 
-            # THEN the file should be unzipped correctly
-            mock_gzip_open.assert_called_once_with(gzipped_file_path, "rb")
-            mock_pprint.assert_called_once_with(markdown_content)
-            mock_open_file.assert_called_once_with(
-                expected_unzipped_file_path, "wt", encoding="utf-8"
-            )
-            mock_open_file.return_value.__enter__.return_value.write.assert_called_once_with(
-                markdown_content
-            )
-            assert unzipped_file_path == expected_unzipped_file_path
-        finally:
-            try:
-                os.rmdir(temp_dir)
-            except OSError:
-                pass  # Directory not empty or other error, ignore for cleanup
+        # THEN the file should be unzipped correctly
+        mock_gzip_open.assert_called_once_with(gzipped_file_path, "rb")
+        mock_pprint.assert_called_once_with(markdown_content)
+        mock_open_file.assert_called_once_with(
+            expected_unzipped_file_path, "wt", encoding="utf-8"
+        )
+        mock_open_file.return_value.__enter__.return_value.write.assert_called_once_with(
+            markdown_content
+        )
+        assert unzipped_file_path == expected_unzipped_file_path
 
     def test_unzip_gzipped_file_with_binary_file(self) -> None:
-        temp_dir = tempfile.gettempdir()
-        self.syn.cache.cache_root_dir = temp_dir
+        self.syn.cache.cache_root_dir = tempfile.gettempdir()
 
-        try:
-            gzipped_file_path = os.path.join(self.syn.cache.cache_root_dir, "test.bin.gz")
-            expected_unzipped_file_path = os.path.join(
-                self.syn.cache.cache_root_dir, "test.bin"
-            )
-            binary_content = b"\x00\x01\x02\x03\xff\xfe\xfd"
+        gzipped_file_path = os.path.join(self.syn.cache.cache_root_dir, "test.bin.gz")
+        expected_unzipped_file_path = os.path.join(
+            self.syn.cache.cache_root_dir, "test.bin"
+        )
+        binary_content = b"\x00\x01\x02\x03\xff\xfe\xfd"
 
-            # WHEN I call `_unzip_gzipped_file` with a binary file
-            with (
-                patch("gzip.open") as mock_gzip_open,
-                patch("builtins.open") as mock_open_file,
-                patch("pprint.pp") as mock_pprint,
-            ):
-                mock_gzip_open.return_value.__enter__.return_value.read.return_value = (
-                    binary_content
-                )
-                unzipped_file_path = self.wiki_page.unzip_gzipped_file(gzipped_file_path)
-
-            # THEN the file should be unzipped correctly
-            mock_gzip_open.assert_called_once_with(gzipped_file_path, "rb")
-            mock_pprint.assert_not_called()
-            mock_open_file.assert_called_once_with(unzipped_file_path, "wb")
-            mock_open_file.return_value.__enter__.return_value.write.assert_called_once_with(
+        # WHEN I call `_unzip_gzipped_file` with a binary file
+        with (
+            patch("gzip.open") as mock_gzip_open,
+            patch("builtins.open") as mock_open_file,
+            patch("pprint.pp") as mock_pprint,
+        ):
+            mock_gzip_open.return_value.__enter__.return_value.read.return_value = (
                 binary_content
             )
-            assert unzipped_file_path == expected_unzipped_file_path
-        finally:
-            try:
-                os.rmdir(temp_dir)
-            except OSError:
-                pass  # Directory not empty or other error, ignore for cleanup
+            unzipped_file_path = self.wiki_page.unzip_gzipped_file(gzipped_file_path)
+
+        # THEN the file should be unzipped correctly
+        mock_gzip_open.assert_called_once_with(gzipped_file_path, "rb")
+        mock_pprint.assert_not_called()
+        mock_open_file.assert_called_once_with(unzipped_file_path, "wb")
+        mock_open_file.return_value.__enter__.return_value.write.assert_called_once_with(
+            binary_content
+        )
+        assert unzipped_file_path == expected_unzipped_file_path
 
     def test_unzip_gzipped_file_with_text_file(self) -> None:
-        temp_dir = tempfile.gettempdir()
-        self.syn.cache.cache_root_dir = temp_dir
+        self.syn.cache.cache_root_dir = tempfile.gettempdir()
 
-        try:
-            gzipped_file_path = os.path.join(self.syn.cache.cache_root_dir, "test.txt.gz")
-            expected_unzipped_file_path = os.path.join(
-                self.syn.cache.cache_root_dir, "test.txt"
-            )
-            text_content = "This is plain text content."
-            text_content_bytes = text_content.encode("utf-8")
+        gzipped_file_path = os.path.join(self.syn.cache.cache_root_dir, "test.txt.gz")
+        expected_unzipped_file_path = os.path.join(
+            self.syn.cache.cache_root_dir, "test.txt"
+        )
+        text_content = "This is plain text content."
+        text_content_bytes = text_content.encode("utf-8")
 
-            # WHEN I call `_unzip_gzipped_file` with a text file
-            with (
-                patch("gzip.open") as mock_gzip_open,
-                patch("builtins.open") as mock_open_file,
-                patch("synapseclient.models.wiki.pprint.pp") as mock_pprint,
-            ):
-                mock_gzip_open.return_value.__enter__.return_value.read.return_value = (
-                    text_content_bytes
-                )
-                unzipped_file_path = self.wiki_page.unzip_gzipped_file(gzipped_file_path)
+        # WHEN I call `_unzip_gzipped_file` with a text file
+        with (
+            patch("gzip.open") as mock_gzip_open,
+            patch("builtins.open") as mock_open_file,
+            patch("synapseclient.models.wiki.pprint.pp") as mock_pprint,
+        ):
+            mock_gzip_open.return_value.__enter__.return_value.read.return_value = (
+                text_content_bytes
+            )
+            unzipped_file_path = self.wiki_page.unzip_gzipped_file(gzipped_file_path)
 
-            # THEN the file should be unzipped correctly
-            mock_gzip_open.assert_called_once_with(gzipped_file_path, "rb")
-            mock_pprint.assert_not_called()
-            mock_open_file.assert_called_once_with(
-                unzipped_file_path, "wt", encoding="utf-8"
-            )
-            mock_open_file.return_value.__enter__.return_value.write.assert_called_once_with(
-                text_content
-            )
-            assert unzipped_file_path == expected_unzipped_file_path
-        finally:
-            try:
-                os.rmdir(temp_dir)
-            except OSError:
-                pass  # Directory not empty or other error, ignore for cleanup
+        # THEN the file should be unzipped correctly
+        mock_gzip_open.assert_called_once_with(gzipped_file_path, "rb")
+        mock_pprint.assert_not_called()
+        mock_open_file.assert_called_once_with(
+            unzipped_file_path, "wt", encoding="utf-8"
+        )
+        mock_open_file.return_value.__enter__.return_value.write.assert_called_once_with(
+            text_content
+        )
+        assert unzipped_file_path == expected_unzipped_file_path
 
     def test_get_file_size_success(self) -> None:
         # GIVEN a filehandle dictionary


### PR DESCRIPTION
# **Problem:**

- tqdm progress bar creation was scattered across the client (upload, download, MD5, multipart, async jobs, tables, SFTP/S3 wrappers). Each call site constructed its own bar with inconsistent options and, critically, did not consistently honor the client's `silent` flag.
- Some long-running operations (notably download-side MD5 calculation) showed no progress at all, leaving users to assume the script was "stuck".

# **Solution:**

- Added a single `create_progress_bar()` factory in `core/transfer_bar.py` that honors the resolved client's `silent` flag via `disable=`. It returns a real (possibly disabled) tqdm so call sites can mutate `desc`/`total` and call `update`/`close` unconditionally.
- Routed all live bar creation through the factory: `client._waitForAsync`, `asynchronous_job` job-wait, `storable_container` bulk upload, four `table_components` table-op bars, SFTP/S3 upload wrappers, and both multipart-upload-async fallbacks.
- Added a download-side "Calculating MD5" bar (real `os.path.getsize` total) so it mirrors the upload side; `md5_for_file_hex` gained a `progress_bar` param.
- Sites that start with an unknown total (`_waitForAsync`, SFTP) upgrade the bar to a real `total` once known, so users see a filling bar rather than a spinner.
- The factory tolerates a missing/uncached client by falling back to a visible bar, preserving the behavior of public static methods (`SFTPWrapper.upload_file`, `S3ClientWrapper.upload_file`) callable standalone.
- Already-`@deprecated` legacy bars are left untouched (slated for removal in 5.0.0).

# **Testing:**

- Added `tests/unit/.../unit_test_transfer_bar.py` covering silent/non-silent behavior, mutation of a disabled bar, and the no-client fallback.
- Added a test asserting `md5_for_file_hex` forwards its `progress_bar`; updated affected download tests to mock `os.path.getsize`.
- I ran the benchmarking uploading/download scripts to verify behavior.