### PR TITLE
updated TaskSatus enum

### DIFF
--- a/synapseclient/models/curation.py
+++ b/synapseclient/models/curation.py
@@ -84,6 +84,12 @@ class TaskState(str, Enum):
     IN_PROGRESS = "IN_PROGRESS"
     """The assignee has actively started the task."""
 
+    EXECUTING = "EXECUTING"
+    """An automated execution (async job) is currently running for this task."""
+
+    IN_REVIEW = "IN_REVIEW"
+    """The automated execution completed successfully and the results are pending human review."""
+
     COMPLETED = "COMPLETED"
     """The task has been completed and verified."""
 


### PR DESCRIPTION
# **Problem:**

- The `TaskState` enum in `synapseclient/models/curation.py` was out of sync with the Synapse REST API.
- The API documents six task states, but the client only defined four (`NOT_STARTED`, `IN_PROGRESS`, `COMPLETED`, `CANCELED`).
- The two missing states — `EXECUTING` and `IN_REVIEW` — are returned by the API when a task has an automated async job running or awaiting review. Deserializing a `CurationTask` in one of these states would fail to coerce into a valid `TaskState`.
- Reference: [TaskState](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/curation/TaskState.html)

# **Solution:**

- Added the two missing enum members to `TaskState`, matching the names, values, and ordering in the REST docs:
    - `EXECUTING` — "An automated execution (async job) is currently running for this task."
    - `IN_REVIEW` — "The automated execution completed successfully and the results are pending human review."
- Each member carries the documented description as its docstring, consistent with the existing states.


