### PR TITLE
[SYNPY-1908] Fix multipart upload part retries missing connection exceptions

### DIFF
--- a/synapseclient/core/upload/multipart_upload.py
+++ b/synapseclient/core/upload/multipart_upload.py
@@ -27,7 +27,7 @@ from synapseclient.core.exceptions import (  # why is is this a single underscor
     SynapseUploadFailedException,
     _raise_for_status,
 )
-from synapseclient.core.retry import with_retry
+from synapseclient.core.retry import RETRYABLE_CONNECTION_EXCEPTIONS, with_retry
 from synapseclient.core.upload.upload_utils import (
     copy_md5_fn,
     copy_part_request_body_provider_fn,
@@ -295,7 +295,7 @@ class UploadAttempt:
                 try:
                     # use our backoff mechanism here, we have encountered 500s on puts to AWS signed urls
                     response = with_retry(
-                        put_fn, retry_exceptions=[requests.exceptions.ConnectionError]
+                        put_fn, retry_exceptions=RETRYABLE_CONNECTION_EXCEPTIONS
                     )
                     _raise_for_status(response)
 

--- a/synapseclient/core/upload/multipart_upload_async.py
+++ b/synapseclient/core/upload/multipart_upload_async.py
@@ -84,7 +84,6 @@ from typing import (
 
 import httpx
 import psutil
-import requests
 from opentelemetry import trace
 from tqdm.contrib.logging import logging_redirect_tqdm
 
@@ -104,7 +103,10 @@ from synapseclient.core.exceptions import (
     _raise_for_status_httpx,
 )
 from synapseclient.core.otel_config import get_tracer
-from synapseclient.core.retry import with_retry_time_based
+from synapseclient.core.retry import (
+    RETRYABLE_CONNECTION_EXCEPTIONS,
+    with_retry_time_based,
+)
 from synapseclient.core.transfer_bar import create_progress_bar
 from synapseclient.core.typing_utils import DataFrame as DATA_FRAME_TYPE
 from synapseclient.core.upload.upload_utils import (
@@ -606,7 +608,7 @@ class UploadAttemptAsync:
                         content=body,  # noqa: F821
                         headers=signed_headers,
                     ),
-                    retry_exceptions=[requests.exceptions.ConnectionError],
+                    retry_exceptions=RETRYABLE_CONNECTION_EXCEPTIONS,
                 )
 
                 _raise_for_status_httpx(response=response, logger=self._syn.logger)

--- a/tests/unit/synapseclient/core/upload/test_multipart_upload_async.py
+++ b/tests/unit/synapseclient/core/upload/test_multipart_upload_async.py
@@ -1,0 +1,109 @@
+from unittest import mock
+
+import httpx
+import pytest
+
+from synapseclient.core.upload.multipart_upload_async import (
+    HandlePartResult,
+    UploadAttemptAsync,
+)
+from synapseclient.core.utils import md5_fn
+
+PART_SIZE = 256
+PART_NUMBER = 1
+
+
+def _init_upload_attempt(syn):
+    upload_request_payload = {
+        "concreteType": "org.sagebionetworks.repo.model.file.MultipartUploadRequest",
+        "contentMD5Hex": "abc",
+        "contentType": "application/text",
+        "fileName": "target.txt",
+        "fileSizeBytes": 1024,
+        "generatePreview": False,
+        "storageLocationId": "1234",
+        "partSizeBytes": PART_SIZE,
+    }
+
+    def part_request_body_provider_fn(part_number):
+        return (f"{part_number}" * PART_SIZE).encode("utf-8")
+
+    upload = UploadAttemptAsync(
+        syn,
+        "target.txt",
+        upload_request_payload,
+        part_request_body_provider_fn,
+        md5_fn,
+        False,
+    )
+    upload._upload_id = "123"
+    upload._pre_signed_part_urls = {
+        PART_NUMBER: ("https://foo.com/1", {"a": 1}),
+    }
+    return upload
+
+
+class TestPutPartWithRetry:
+    """Regression coverage for the retry paths inside
+    UploadAttemptAsync._put_part_with_retry. multipart_upload_async.py previously
+    passed requests.exceptions.ConnectionError as the retryable exception allowlist,
+    but the session performing the PUT is an httpx.Client, which never raises that
+    exception type -- so a transient httpx connection error skipped the retry
+    window entirely and failed the part immediately.
+    """
+
+    def test_handle_part__httpx_connection_error_then_success(self, syn):
+        upload = _init_upload_attempt(syn)
+        mock_session = mock.Mock()
+        mock_session.put.side_effect = [
+            httpx.ConnectError("connection refused"),
+            mock.Mock(status_code=200),
+        ]
+
+        with mock.patch.object(syn, "_requests_session_storage", mock_session):
+            result = upload._handle_part(PART_NUMBER)
+
+        assert mock_session.put.call_count == 2
+        body = (f"{PART_NUMBER}" * PART_SIZE).encode("utf-8")
+        assert result == HandlePartResult(PART_NUMBER, PART_SIZE, md5_fn(body, None))
+
+    def test_handle_part__retryable_status_then_success(self, syn):
+        upload = _init_upload_attempt(syn)
+        mock_session = mock.Mock()
+        mock_503 = mock.Mock(status_code=503, headers={}, text="")
+        mock_session.put.side_effect = [mock_503, mock.Mock(status_code=200)]
+
+        with mock.patch.object(syn, "_requests_session_storage", mock_session):
+            upload._handle_part(PART_NUMBER)
+
+        assert mock_session.put.call_count == 2
+
+    def test_handle_part__expired_url_then_success(self, syn):
+        upload = _init_upload_attempt(syn)
+        mock_session = mock.Mock()
+        mock_403 = mock.Mock(status_code=403, headers={}, text="")
+        mock_session.put.side_effect = [mock_403, mock.Mock(status_code=200)]
+
+        with (
+            mock.patch.object(syn, "_requests_session_storage", mock_session),
+            mock.patch.object(
+                upload,
+                "_refresh_pre_signed_part_urls",
+                return_value=("https://bar.com/1", {"a": 2}),
+            ) as refresh_urls,
+        ):
+            upload._handle_part(PART_NUMBER)
+
+        refresh_urls.assert_called_once_with(PART_NUMBER, "https://foo.com/1")
+        assert mock_session.put.call_count == 2
+
+    def test_handle_part__non_retryable_exception_fails_immediately(self, syn):
+        upload = _init_upload_attempt(syn)
+        mock_session = mock.Mock()
+        mock_session.put.side_effect = ValueError("boom")
+
+        with mock.patch.object(syn, "_requests_session_storage", mock_session):
+            with pytest.raises(ValueError):
+                upload._handle_part(PART_NUMBER)
+
+        assert mock_session.put.call_count == 1

--- a/tests/unit/synapseclient/core/upload/test_multipart_upload_async.py
+++ b/tests/unit/synapseclient/core/upload/test_multipart_upload_async.py
@@ -52,13 +52,20 @@ class TestPutPartWithRetry:
     window entirely and failed the part immediately.
     """
 
-    def test_handle_part__httpx_connection_error_then_success(self, syn):
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            httpx.ConnectError("connection refused"),
+            httpx.ReadError("broken"),
+            httpx.ReadTimeout("timed out"),
+            httpx.ConnectTimeout("timed out"),
+            httpx.RemoteProtocolError("disconnected"),
+        ],
+    )
+    def test_handle_part__httpx_connection_error_then_success(self, syn, exception):
         upload = _init_upload_attempt(syn)
         mock_session = mock.Mock()
-        mock_session.put.side_effect = [
-            httpx.ConnectError("connection refused"),
-            mock.Mock(status_code=200),
-        ]
+        mock_session.put.side_effect = [exception, mock.Mock(status_code=200)]
 
         with mock.patch.object(syn, "_requests_session_storage", mock_session):
             result = upload._handle_part(PART_NUMBER)

--- a/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
+++ b/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
@@ -293,6 +293,41 @@ class TestUploadAttempt:
             None,
         )
 
+    def test_handle_part__timeout_error(self, syn):
+        """Test that we retry if we encounter a Timeout on a request to PUT to an
+        AWS presigned url. Regression test: retry_exceptions previously only listed
+        requests.exceptions.ConnectionError, so a Timeout would not have been
+        retried and would have propagated immediately."""
+
+        upload = self._init_upload_attempt(syn)
+        upload._upload_id = "123"
+        part_number = 1
+        chunk = b"1" * TestUploadAttempt.part_size
+
+        pre_signed_url = "https://foo.com/1"
+        signed_headers = {"a": 1}
+
+        upload._pre_signed_part_urls = {part_number: (pre_signed_url, signed_headers)}
+
+        self._handle_part_success_test(
+            syn,
+            upload,
+            part_number,
+            pre_signed_url,
+            [
+                (
+                    mock.call(pre_signed_url, chunk, headers=signed_headers),
+                    requests.exceptions.Timeout("timed out"),
+                ),
+                (
+                    mock.call(pre_signed_url, chunk, headers=signed_headers),
+                    mock.Mock(status_code=200),
+                ),
+            ],
+            chunk,
+            None,
+        )
+
     def _handle_part_success_test(
         self,
         syn,

--- a/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
+++ b/tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py
@@ -259,45 +259,20 @@ class TestUploadAttempt:
             None,
         )
 
-    def test_handle_part__connection_error(self, syn):
-        """Test that we retry if we encounter a ConnectionError on a reqeust to PUT to an AWS presigend url"""
-
-        upload = self._init_upload_attempt(syn)
-        upload._upload_id = "123"
-        part_number = 1
-        chunk = b"1" * TestUploadAttempt.part_size
-
-        pre_signed_url = "https://foo.com/1"
-        signed_headers = {"a": 1}
-
-        upload._pre_signed_part_urls = {part_number: (pre_signed_url, signed_headers)}
-
-        self._handle_part_success_test(
-            syn,
-            upload,
-            part_number,
-            pre_signed_url,
-            # initial call is expired and results in a 500
-            # second call is successful
-            [
-                (
-                    mock.call(pre_signed_url, chunk, headers=signed_headers),
-                    requests.exceptions.ConnectionError("aborted"),
-                ),
-                (
-                    mock.call(pre_signed_url, chunk, headers=signed_headers),
-                    mock.Mock(status_code=200),
-                ),
-            ],
-            chunk,
-            None,
-        )
-
-    def test_handle_part__timeout_error(self, syn):
-        """Test that we retry if we encounter a Timeout on a request to PUT to an
-        AWS presigned url. Regression test: retry_exceptions previously only listed
-        requests.exceptions.ConnectionError, so a Timeout would not have been
-        retried and would have propagated immediately."""
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            requests.exceptions.ConnectionError("aborted"),
+            ConnectionResetError("reset"),
+            requests.exceptions.Timeout("timed out"),
+            requests.exceptions.ChunkedEncodingError("truncated"),
+            requests.exceptions.ReadTimeout("read timed out"),
+            requests.exceptions.ConnectTimeout("connect timed out"),
+        ],
+    )
+    def test_handle_part__retryable_connection_exception(self, syn, exception):
+        """Test that we retry if we encounter a retryable connection exception (per
+        RETRYABLE_CONNECTION_EXCEPTIONS) on a request to PUT to an AWS presigned url."""
 
         upload = self._init_upload_attempt(syn)
         upload._upload_id = "123"
@@ -317,7 +292,7 @@ class TestUploadAttempt:
             [
                 (
                     mock.call(pre_signed_url, chunk, headers=signed_headers),
-                    requests.exceptions.Timeout("timed out"),
+                    exception,
                 ),
                 (
                     mock.call(pre_signed_url, chunk, headers=signed_headers),


### PR DESCRIPTION
# **Problem:**

A user reported an upload failing with `SynapseUploadFailedException: Part upload failed` only 3 seconds into a 10.5GB transfer — far too fast to have exhausted the intended part-level retry window.

Tracing the retry logic in `multipart_upload_async.py` found the root cause: `_put_part_with_retry` (async path) passes `retry_exceptions=[requests.exceptions.ConnectionError]` to `with_retry_time_based`, but the `session` performing the PUT is an `httpx.Client`, not a `requests.Session`. httpx never raises `requests.exceptions.ConnectionError` — it raises `httpx.ConnectError`, `httpx.ReadTimeout`, `httpx.RemoteProtocolError`, etc. The retry matcher (`_is_retryable`) checks the caught exception's class/class-name against the supplied allowlist, so none of httpx's exception types ever match, and the retry helper's default-filling logic only substitutes a default when the caller's list is empty — it doesn't merge in the correct list when a (wrong) list is already supplied.

Net effect: any genuine transient network error during a part PUT (a real socket/connect/read/timeout failure, not an HTTP status code) skipped the entire time-boxed backoff window and failed the part immediately. The only resilience left was the coarser whole-upload-attempt retry (`MAX_RETRIES = 7` in `_multipart_upload_async`), which restarts the *entire* `UploadAttemptAsync` rather than just retrying the one failed PUT.

While auditing every `retry_exceptions=` call site for the same class of bug, the **sync** upload path (`multipart_upload.py`) turned out to have a milder version of the same gap: it correctly uses `requests.exceptions.ConnectionError` (since it genuinely uses `requests.Session`), but only that one exception type — missing `requests.exceptions.Timeout` and `ChunkedEncodingError`, both of which a slow/stalled part PUT can legitimately raise. The download side (`download_async.py`, `download_threads.py`) and `client.py`'s standard retry params already use the full, correct list.

# **Solution:**

- `synapseclient/core/upload/multipart_upload_async.py`: swapped `retry_exceptions=[requests.exceptions.ConnectionError]` for the existing `RETRYABLE_CONNECTION_EXCEPTIONS` list (already defined in `core/retry.py` and used correctly on the download side). Removed the now-unused `import requests`.
- `synapseclient/core/upload/multipart_upload.py`: widened the sync path's `retry_exceptions=[requests.exceptions.ConnectionError]` to the same `RETRYABLE_CONNECTION_EXCEPTIONS` list, restoring parity with the async path and the rest of the codebase.

# **Testing:**

`tests/unit/synapseclient/core/upload/test_multipart_upload_async.py` (new file) covers each distinct path through `UploadAttemptAsync._handle_part` / `_put_part_with_retry`:
- **Regression test**: `httpx.ConnectError` on the first PUT, success on the second — confirmed this test fails without the fix (the exception propagates immediately with zero retries) and passes with it.
- Retryable HTTP status code (503) → retry → success.
- 403 expired presigned URL → refresh URL → success (confirms the existing URL-refresh path is unaffected).
- Non-retryable exception (`ValueError`) → fails immediately with no retry (confirms the fix doesn't over-widen retry behavior).

`tests/unit/synapseclient/core/upload/unit_test_multipart_upload.py`: added `test_handle_part__timeout_error`, a regression test for the sync path — `requests.exceptions.Timeout` on the first PUT, success on the second. Confirmed this fails without the sync-path fix and passes with it.

Full upload unit test suite (`tests/unit/synapseclient/core/upload/`, 29 tests) passes, and `pre-commit run --all-files` (ruff, isort, black, bandit) passes clean.