### PR TITLE
[SYNPY-1905] Fix problematic integration test

### DIFF
--- a/tests/integration/synapseclient/deprecated/test_tables.py
+++ b/tests/integration/synapseclient/deprecated/test_tables.py
@@ -380,8 +380,7 @@ def test_tables_pandas(syn, project, schedule_for_cleanup):
 
     cols = as_table_columns(df)
     cols[0].maximumSize = 20
-    # Use a unique name so reruns via pytest-rerunfailures create a fresh table
-    # instead of appending rows to the table left by a previous attempt (SYNPY-1905)
+
     schema = Schema(
         name="Nifty Table " + str(uuid.uuid4()), columns=cols, parent=project
     )

--- a/tests/integration/synapseclient/deprecated/test_tables.py
+++ b/tests/integration/synapseclient/deprecated/test_tables.py
@@ -352,7 +352,7 @@ def test_tables_csv(syn, project):
 
 
 # @skip("Skip integration tests for soon to be removed code")
-def test_tables_pandas(syn, project):
+def test_tables_pandas(syn, project, schedule_for_cleanup):
     # create a pandas DataFrame
     df = pd.DataFrame(
         {
@@ -380,11 +380,16 @@ def test_tables_pandas(syn, project):
 
     cols = as_table_columns(df)
     cols[0].maximumSize = 20
-    schema = Schema(name="Nifty Table", columns=cols, parent=project)
+    # Use a unique name so reruns via pytest-rerunfailures create a fresh table
+    # instead of appending rows to the table left by a previous attempt (SYNPY-1905)
+    schema = Schema(
+        name="Nifty Table " + str(uuid.uuid4()), columns=cols, parent=project
+    )
 
     # store in Synapse
     # datetime64 column in df also gets changed from date time to epoch time.
     table = syn.store(Table(schema, df))
+    schedule_for_cleanup(table.schema.id)
 
     # retrieve the table and verify
     results = syn.tableQuery("select * from %s" % table.schema.id, resultsAs="csv")


### PR DESCRIPTION
# **Problem:**

`test_tables_pandas` in `tests/integration/synapseclient/deprecated/test_tables.py` fails intermittently in CI with a DataFrame shape mismatch ([SYNPY-1905](https://sagebionetworks.jira.com/browse/SYNPY-1905)):

```
AssertionError: DataFrame are different
DataFrame shape mismatch
[left]:  (20, 7)
[right]: (5, 7)
```

The queried table has 20 rows instead of the expected 5 — exactly 4x. Example failure: [PR #1440 CI run](https://github.com/Sage-Bionetworks/synapsePythonClient/actions/runs/31070597728/job/92517672946?pr=1440).

Root cause: the test creates its schema with the fixed name "Nifty Table" inside the shared per-worker project, and `syn.store` uses create-or-update semantics. When the test fails once for a transient reason, pytest-rerunfailures (`--reruns 3`) re-runs it, and each attempt finds the existing table from the previous attempt and **appends** 5 more rows instead of creating a fresh table. The retries can never pass — 1 initial run + 3 reruns accumulate 4 × 5 = 20 rows, turning a one-off flake into a guaranteed failure.

# **Solution:**

- Give the schema a unique name per attempt (`"Nifty Table " + str(uuid.uuid4())`), matching the naming pattern already used by other tests in this file. Each rerun now creates a fresh, empty table, so a retry can actually succeed.
- Schedule the stored table for cleanup via the `schedule_for_cleanup` fixture. The cleanup list is processed at session teardown regardless of test outcome, so uniquely named tables left by failed attempts are also deleted (previously the test relied solely on the project fixture teardown).

No production code is affected. Note this test lives in the deprecated test module that is slated for removal after the v5.0.0 release, so this is a minimal fix to stop the flakiness until then.

# **Testing:**

- `pre-commit run --files tests/integration/synapseclient/deprecated/test_tables.py` passes (ruff, black, isort, bandit).
- The fix will be validated by the integration test run in CI on this PR; the failure mode only reproduces when pytest-rerunfailures retries the test after a transient failure.


[SYNPY-1905]: https://sagebionetworks.jira.com/browse/SYNPY-1905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ