### PR TITLE
Fix unit test to use temp path instead of writing files locally

### DIFF
--- a/tests/unit/synapseutils/unit_test_synapseutils_sync.py
+++ b/tests/unit/synapseutils/unit_test_synapseutils_sync.py
@@ -7,6 +7,7 @@ import os
 import random
 import tempfile
 from io import StringIO
+from pathlib import Path
 from typing import Any, Dict
 from unittest.mock import AsyncMock, MagicMock, Mock, call, create_autospec, patch
 
@@ -885,6 +886,7 @@ def test_sync_from_synapse_manifest_is_suppress(
     mock_get_file_entity_provenance_dict: MagicMock,
     mock_generate_manifest: MagicMock,
     syn: Synapse,
+    tmp_path: Path,
 ) -> None:
     """
     Verify manifest argument equal to "suppress" that pass in to syncFromSynapse, it won't create any manifest file.
@@ -966,7 +968,7 @@ def test_sync_from_synapse_manifest_is_suppress(
         ) as patch_activity_from_parent,
     ):
         result = synapseutils.syncFromSynapse(
-            syn=syn, entity=project, path="./", manifest="suppress"
+            syn=syn, entity=project, path=str(tmp_path), manifest="suppress"
         )
         assert [file, file_2] == result
         expected_get_children_agrs = [
@@ -1015,7 +1017,7 @@ def test_sync_from_synapse_manifest_is_suppress(
                 if_collision=method_flags.COLLISION_OVERWRITE_LOCAL,
                 limit_search=None,
                 download_file=True,
-                download_location="./",
+                download_location=str(tmp_path),
                 md5=None,
                 synapse_client=syn,
             ),
@@ -1026,7 +1028,7 @@ def test_sync_from_synapse_manifest_is_suppress(
                 if_collision=method_flags.COLLISION_OVERWRITE_LOCAL,
                 limit_search=None,
                 download_file=True,
-                download_location=f"./{FOLDER_NAME}",
+                download_location=os.path.join(str(tmp_path), FOLDER_NAME),
                 md5=None,
                 synapse_client=syn,
             ),


### PR DESCRIPTION
# **Problem:**

Running the unit test suite left two artifacts behind in the current working directory that were never cleaned up: a `manifest.csv` file and a `folder_name/` directory (containing its own `manifest.csv`).

- Reproduced by running `pytest tests/unit` from the repo root and checking `git status` afterwards.
- The source is `test_sync_from_synapse_manifest_is_suppress` in `tests/unit/synapseutils/unit_test_synapseutils_sync.py`, which calls `syncFromSynapse` with `path="./"`.

# **Solution:**

Changed the test to use pytest's `tmp_path` fixture instead of `"./"`, so any files written by the sync land in a pytest-managed temp directory instead of the repo root:

- Added a `tmp_path: Path` parameter to the test signature (with the `pathlib.Path` import).
- Passed `path=str(tmp_path)` to `syncFromSynapse` and updated the two `download_location` assertions to match.


# **Testing:**

- Ran the affected test from the repo root: `pytest tests/unit/synapseutils/unit_test_synapseutils_sync.py::test_sync_from_synapse_manifest_is_suppress` — passes.
- Confirmed with `git status` that no `manifest.csv` or `folder_name/` artifacts are created in the working directory after the run.
